### PR TITLE
Initial @vltkpg/graph commit

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -63,6 +63,28 @@ importers:
         specifier: ^0.25.13
         version: 0.25.13(typescript@5.2.2)
 
+  src/graph:
+    dependencies:
+      '@vltpkg/registry-client':
+        specifier: workspace:*
+        version: link:../registry-client
+    devDependencies:
+      '@types/node':
+        specifier: ^20.12.7
+        version: 20.12.7
+      prettier:
+        specifier: ^3.2.5
+        version: 3.2.5
+      tap:
+        specifier: ^18.7.2
+        version: 18.7.2(@types/node@20.12.7)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.2.2)
+      tshy:
+        specifier: ^1.14.0
+        version: 1.14.0
+      typedoc:
+        specifier: ^0.25.13
+        version: 0.25.13(typescript@5.2.2)
+
   src/registry-client:
     dependencies:
       '@vltpkg/cache':
@@ -76,7 +98,7 @@ importers:
         version: 2.0.5
       undici:
         specifier: ^6.13.0
-        version: 6.13.0
+        version: 6.14.1
     devDependencies:
       '@types/node':
         specifier: ^20.12.7
@@ -1332,9 +1354,9 @@ packages:
   undici-types@5.26.5:
     resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
 
-  undici@6.13.0:
-    resolution: {integrity: sha512-Q2rtqmZWrbP8nePMq7mOJIN98M0fYvSgV89vwl/BQRT4mDOeY2GXZngfGpcBBhtky3woM7G24wZV3Q304Bv6cw==}
-    engines: {node: '>=18.0'}
+  undici@6.14.1:
+    resolution: {integrity: sha512-mAel3i4BsYhkeVPXeIPXVGPJKeBzqCieZYoFsbWfUzd68JmHByhc1Plit5WlylxXFaGpgkZB8mExlxnt+Q1p7A==}
+    engines: {node: '>=18.17'}
 
   unique-filename@3.0.0:
     resolution: {integrity: sha512-afXhuC55wkAmZ0P18QsVE6kp8JaxrEokN2HGIoIVv2ijHQd419H0+6EigAFcIzXeMIkcIkNBpB3L/DXB3cTS/g==}
@@ -2866,7 +2888,7 @@ snapshots:
 
   undici-types@5.26.5: {}
 
-  undici@6.13.0: {}
+  undici@6.14.1: {}
 
   unique-filename@3.0.0:
     dependencies:

--- a/src/graph/.tshy/build.json
+++ b/src/graph/.tshy/build.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "../src",
+    "module": "nodenext",
+    "moduleResolution": "nodenext"
+  }
+}

--- a/src/graph/.tshy/esm.json
+++ b/src/graph/.tshy/esm.json
@@ -1,0 +1,12 @@
+{
+  "extends": "./build.json",
+  "include": [
+    "../src/**/*.ts",
+    "../src/**/*.mts",
+    "../src/**/*.tsx"
+  ],
+  "exclude": [],
+  "compilerOptions": {
+    "outDir": "../.tshy-build/esm"
+  }
+}

--- a/src/graph/README.md
+++ b/src/graph/README.md
@@ -1,0 +1,34 @@
+# @vltpkg/graph
+
+This is the graph library responsible for representing the packages
+that are involved in a given install.
+
+## API
+
+### `async buildStarterGraph({ dir: string }): Promise<Graph>`
+
+This method returns a new `Graph` object, reading from the `package.json`
+file located at `dir` and building up the graph representation of nodes
+and edges from the files read from the local file system.
+
+### `Graph`
+
+#### `inventory: Inventory`
+
+The `inventory` property holds a map reference to all packages found
+in the local file system. A `inventory.pending` property representing
+packages which are not currently found in the local file system that
+have metadata fetch from a registry, such as tarball / integrity info.
+
+## USAGE
+
+Here's a quick example of how to use the `buildStarterGraph` method that
+builds a graph representation of the install defined at the current working
+directory.
+
+```
+import { buildStarterGraph, Package } from '@vltpkg/graph'
+
+const graph = await buildStarterGraph({ dir: process.cwd() })
+const itemsToFetch: Set<Package> = graph.inventory.pending
+```

--- a/src/graph/package.json
+++ b/src/graph/package.json
@@ -1,0 +1,58 @@
+{
+  "name": "@vltpkg/graph",
+  "description": "A library that helps understanding & expressing what happens on an install",
+  "version": "0.0.0-0",
+  "devDependencies": {
+    "@types/node": "^20.12.7",
+    "prettier": "^3.2.5",
+    "tap": "^18.7.2",
+    "tshy": "^1.14.0",
+    "typedoc": "^0.25.13"
+  },
+  "dependencies": {
+    "@vltpkg/registry-client": "workspace:*"
+  },
+  "scripts": {
+    "preversion": "npm test",
+    "postversion": "npm publish",
+    "prepublishOnly": "git push origin --follow-tags",
+    "prepare": "tshy",
+    "pretest": "npm run prepare",
+    "presnap": "npm run prepare",
+    "test": "tap",
+    "snap": "tap",
+    "format": "prettier --write . --log-level warn --ignore-path ../../.prettierignore --cache",
+    "typedoc": "typedoc"
+  },
+  "prettier": {
+    "experimentalTernaries": true,
+    "semi": false,
+    "printWidth": 70,
+    "tabWidth": 2,
+    "useTabs": false,
+    "singleQuote": true,
+    "jsxSingleQuote": false,
+    "bracketSameLine": true,
+    "arrowParens": "avoid",
+    "endOfLine": "lf"
+  },
+  "tshy": {
+    "dialects": [
+      "esm"
+    ],
+    "exports": {
+      "./package.json": "./package.json",
+      ".": "./src/index.ts"
+    }
+  },
+  "exports": {
+    "./package.json": "./package.json",
+    ".": {
+      "import": {
+        "types": "./dist/esm/index.d.ts",
+        "default": "./dist/esm/index.js"
+      }
+    }
+  },
+  "type": "module"
+}

--- a/src/graph/src/append-registry-nodes.ts
+++ b/src/graph/src/append-registry-nodes.ts
@@ -1,0 +1,76 @@
+import { URL } from 'node:url'
+import { CacheEntry, RegistryClient } from '@vltpkg/registry-client'
+import { Graph } from './graph.js'
+import { Node } from './node.js'
+import {
+  DependencyTypeLong,
+  isPackageMetadata,
+  Package,
+} from './pkgs.js'
+
+const hostname = 'https://registry.npmjs.com'
+
+export const appendRegistryNodes = async (
+  graph: Graph,
+  fromNode: Node,
+  addSpecs: string[][],
+  depType: DependencyTypeLong,
+) => {
+  const registryClient = new RegistryClient({})
+
+  const reqs: Promise<[CacheEntry, string, string]>[] = []
+  for (let [name, spec] of addSpecs) {
+    if (!name) {
+      throw new Error('Trying to add a package but no name was found')
+    }
+    if (!spec) {
+      spec = 'latest'
+    }
+    // TODO: only fetching latest version of manifests for now
+    reqs.push(
+      registryClient
+        .request(`${hostname}/${name}/latest`)
+        .then(response => [response, name, spec]),
+    )
+  }
+  const res: [CacheEntry, string, string][] = await Promise.all(reqs)
+
+  const nextDeps: Set<Node> = new Set()
+  for (const [response, name, spec] of res) {
+    if (response) {
+      if (!isPackageMetadata(response.body)) {
+        throw new Error('Failed to retrieve package metadata')
+      }
+      const mani = response.body
+      const node = graph.placePackage(
+        fromNode,
+        depType,
+        name,
+        spec,
+        mani,
+      )
+      if (node) {
+        nextDeps.add(node)
+      }
+    }
+  }
+
+  const appendChildNodes = []
+  // loop through new nodes and their deps, recursively appending new nodes
+  for (const nextDepType of graph.packages.dependencyTypes.keys()) {
+    // TODO: only supporting prod deps here for now
+    if (nextDepType === 'dependencies') {
+      for (const next of nextDeps) {
+        const depRecord: Record<string, string> | undefined =
+          next.pkg[nextDepType]
+        if (depRecord) {
+          const addSpecs: string[][] = Object.entries(depRecord)
+          appendChildNodes.push(
+            appendRegistryNodes(graph, next, addSpecs, nextDepType),
+          )
+        }
+      }
+    }
+  }
+  await Promise.all(appendChildNodes)
+}

--- a/src/graph/src/build-actual.ts
+++ b/src/graph/src/build-actual.ts
@@ -1,0 +1,56 @@
+import { resolve } from 'node:path'
+import { Graph } from './graph.js'
+import { Node } from './node.js'
+import { Package } from './pkgs.js'
+import { readPackageJson } from './read-package-json.js'
+import { realpath } from './realpath.js'
+
+/**
+ * Populates a given `graph` with nodes and edges that represents
+ * the current state of a given install found in node_modules folders
+ * at a given directory `basepath`.
+ */
+export const buildActual = (
+  graph: Graph,
+  fromNode: Node,
+  basepath: string,
+) => {
+  const nextDeps: Set<Node> = new Set()
+  for (const depType of graph.packages.dependencyTypes.keys()) {
+    const deps = fromNode.pkg[depType]
+    const followRootDevDepsOnly =
+      (depType !== 'peerDependencies' &&
+        depType !== 'devDependencies') ||
+      (depType === 'devDependencies' && fromNode.isRoot)
+
+    if (deps && followRootDevDepsOnly) {
+      for (const [name, spec] of Object.entries(deps)) {
+        let dir, packageJson
+        try {
+          dir = realpath(resolve(basepath, name))
+          packageJson = readPackageJson(dir)
+        } catch (err) {
+          graph.placePackage(fromNode, depType, name, spec)
+          continue
+        }
+
+        const node = graph.placePackage(
+          fromNode,
+          depType,
+          name,
+          spec,
+          packageJson,
+          dir,
+        )
+        if (node) {
+          nextDeps.add(node)
+        }
+      }
+    }
+  }
+
+  for (const next of nextDeps) {
+    const where = next.pkg.name.startsWith('@') ? '../..' : '..'
+    buildActual(graph, next, resolve(next.pkg.location, where))
+  }
+}

--- a/src/graph/src/build-starter-graph.ts
+++ b/src/graph/src/build-starter-graph.ts
@@ -1,0 +1,40 @@
+import { resolve } from 'node:path'
+import { Graph } from './graph.js'
+import { Node } from './node.js'
+import { Edge } from './edge.js'
+import { appendRegistryNodes } from './append-registry-nodes.js'
+import { buildActual } from './build-actual.js'
+import { readPackageJson } from './read-package-json.js'
+
+export type BuildStarterGraphOptions = {
+  addSpecs: string[]
+  dir: string
+}
+
+/**
+ * Builds a graph that uses the `package.json` information found at `dir`
+ * as a start point to look for file system package contents and reach for
+ * the configured registries in order to retrieve metadata to build the
+ * rest of the graph representation of what the relationship of these
+ * packages are shaped like.
+ * The resulting `Graph` object has references to properties such as
+ * `packages.pending` that can then be used to retrieve artifacts for
+ * reifying later.
+ */
+export const buildStarterGraph = async ({
+  addSpecs,
+  dir,
+}: BuildStarterGraphOptions): Promise<Graph> => {
+  const rootPackageJson = readPackageJson(dir)
+  const graph = new Graph(rootPackageJson)
+
+  buildActual(graph, graph.root, resolve(dir, 'node_modules'))
+
+  const missing: Set<Edge> = graph.missingDirectDependencies
+  const specs: string[][] = [...missing].map(e => [e.name, e.spec])
+  missing.clear()
+
+  await appendRegistryNodes(graph, graph.root, specs, 'dependencies')
+
+  return graph
+}

--- a/src/graph/src/edge.ts
+++ b/src/graph/src/edge.ts
@@ -1,0 +1,47 @@
+import { DependencyTypeLong } from './pkgs.js'
+import { Node } from './node.js'
+
+export class Edge {
+  get [Symbol.toStringTag]() {
+    return '@vltpkg/graph.Edge'
+  }
+
+  /**
+   * The Node this Edge is connecting from, this is usually the dependent.
+   */
+  from: Node
+
+  /**
+   * The node this Edge is connecting to, this is usually a direct dependency.
+   */
+  to: Node | undefined
+
+  /**
+   * What type of dependency relationship `from` and `to` nodes have.
+   */
+  type: DependencyTypeLong
+
+  /**
+   * The name of the dependency `to` as defined in the dependent metadata.
+   */
+  name: string
+
+  /**
+   * The defined spec value for `to` as defined in the dependent metadata.
+   */
+  spec: string
+
+  constructor(
+    type: DependencyTypeLong,
+    name: string,
+    spec: string,
+    from: Node,
+    to?: Node,
+  ) {
+    this.from = from
+    this.to = to
+    this.type = type
+    this.name = name
+    this.spec = spec
+  }
+}

--- a/src/graph/src/graph.ts
+++ b/src/graph/src/graph.ts
@@ -1,0 +1,132 @@
+import {
+  DependencyTypeLong,
+  PackageInventory,
+  Package,
+  PackageMetadata,
+} from './pkgs.js'
+import { Node } from './node.js'
+import { Edge } from './edge.js'
+
+export class Graph {
+  get [Symbol.toStringTag]() {
+    return '@vltpkg/graph.Graph'
+  }
+
+  /**
+   * An inventory with all packages related to an install.
+   */
+  packages: PackageInventory
+
+  /**
+   * Set of nodes in this graph.
+   */
+  nodes: Set<Node>
+
+  /**
+   * Map registered package ids to the node that represent them in the graph.
+   */
+  pkgNodes: Map<string, Node>
+
+  /**
+   * The root node of the graph.
+   */
+  root: Node
+
+  /**
+   * A list of dangling edges from the root node, representing
+   * missing direct dependencies of a given install.
+   */
+  missingDirectDependencies: Set<Edge> = new Set()
+
+  /**
+   * Keeps a reference of connected edges in order to avoid duplicating edges.
+   */
+  #seenEdges: Set<string> = new Set()
+
+  constructor(rootPackageJson: PackageMetadata) {
+    this.nodes = new Set()
+    this.pkgNodes = new Map()
+    this.packages = new PackageInventory()
+    const pkg = this.packages.registerPackage(rootPackageJson)
+    this.root = this.newNode(pkg)
+    this.root.isRoot = true
+  }
+
+  /**
+   * Create a new edge between two nodes of the graph in case both exist,
+   * in case the destination node does not exists, then a dangling edge,
+   * pointing to nothing will be created to represent that missing dependency.
+   */
+  newEdge(
+    type: DependencyTypeLong,
+    name: string,
+    spec: string,
+    from: Node,
+    to?: Node,
+  ) {
+    const toRef = to ? `:${to.id}` : ''
+    const edgeId = `${type}:${name}@${spec}:${from.id}${toRef}`
+    if (this.#seenEdges.has(edgeId)) {
+      return
+    }
+
+    if (to) {
+      to.addEdgeIn(type, name, spec, from)
+    }
+
+    const edgeOut = from.addEdgeOut(type, name, spec, to)
+    if (!to && from.isRoot) {
+      this.missingDirectDependencies.add(edgeOut)
+    }
+
+    this.#seenEdges.add(edgeId)
+  }
+
+  /**
+   * Create a new node in the graph.
+   */
+  newNode(pkg: Package) {
+    const node = new Node(this.nodes.size, pkg)
+    this.nodes.add(node)
+    this.pkgNodes.set(pkg.id, node)
+    return node
+  }
+
+  /**
+   * Place a new package into the graph representation, creating the new
+   * edges and possibly new nodes required for it.
+   */
+  placePackage(
+    fromNode: Node,
+    depType: DependencyTypeLong,
+    name: string,
+    spec: string,
+    metadata?: PackageMetadata,
+    location?: string,
+  ) {
+    // if no package metadata is available, then create an edge that
+    // has no reference to any other node, representing a missing dependency
+    if (!metadata) {
+      this.newEdge(depType, name, spec, fromNode)
+      return
+    }
+
+    const pkg =
+      location ?
+        this.packages.registerPackage(metadata, { location })
+      : this.packages.registerPending(metadata)
+
+    // if a node for this package is already represented by a node
+    // in the graph, then just creates a new edge to that node
+    const fromGraph = this.pkgNodes.get(pkg.id)
+    if (fromGraph) {
+      this.newEdge(depType, name, spec, fromNode, fromGraph)
+      return fromGraph
+    }
+
+    // creates a new node and the edges to its parent
+    const toNode = this.newNode(pkg)
+    this.newEdge(depType, name, spec, fromNode, toNode)
+    return toNode
+  }
+}

--- a/src/graph/src/index.ts
+++ b/src/graph/src/index.ts
@@ -1,0 +1,3 @@
+export * from './build-starter-graph.js'
+export * from './graph.js'
+export * from './pkgs.js'

--- a/src/graph/src/node.ts
+++ b/src/graph/src/node.ts
@@ -1,0 +1,67 @@
+import { DependencyTypeLong, Package } from './pkgs.js'
+import { Edge } from './edge.js'
+
+export class Node {
+  get [Symbol.toStringTag]() {
+    return '@vltpkg/graph.Node'
+  }
+
+  /**
+   * List of edges coming into this node.
+   */
+  edgesIn: Set<Edge> = new Set()
+
+  /**
+   * List of edges from this node into other nodes. This usually represents
+   * that the connected node is a direct dependency of this node.
+   */
+  edgesOut: Map<string, Edge> = new Map()
+
+  /**
+   * A unique id to represent this node in the graph.
+   */
+  id: number = NaN
+
+  /**
+   * True if this is the root node of the graph.
+   */
+  isRoot: boolean = false
+
+  /**
+   * The pkg property holds a reference to the package this node represents
+   * in a given graph structure.
+   */
+  pkg: Package
+
+  constructor(id: number, pkg: Package) {
+    this.id = id
+    this.isRoot = false
+    this.pkg = pkg
+  }
+
+  /**
+   * Add an edge from this node connecting it to a dependent.
+   */
+  addEdgeIn(
+    type: DependencyTypeLong,
+    name: string,
+    spec: string,
+    node: Node,
+  ) {
+    this.edgesIn.add(new Edge(type, spec, name, this, node))
+  }
+
+  /**
+   * Add an edge from this node connecting it to a direct dependency.
+   */
+  addEdgeOut(
+    type: DependencyTypeLong,
+    name: string,
+    spec: string,
+    node?: Node,
+  ) {
+    const edge = new Edge(type, name, spec, this, node)
+    this.edgesOut.set(name, edge)
+    return edge
+  }
+}

--- a/src/graph/src/pkgs.ts
+++ b/src/graph/src/pkgs.ts
@@ -1,0 +1,167 @@
+import { inspect } from 'node:util'
+
+export type DependencyTypeLong =
+  | 'dependencies'
+  | 'devDependencies'
+  | 'peerDependencies'
+  | 'optionalDependencies'
+export type DependencyTypeShort = 'prod' | 'dev' | 'peer' | 'optional'
+
+const dependencyTypes: Map<DependencyTypeLong, DependencyTypeShort> =
+  new Map([
+    ['dependencies', 'prod'],
+    ['devDependencies', 'dev'],
+    ['peerDependencies', 'peer'],
+    ['optionalDependencies', 'optional'],
+  ])
+
+export interface PackageMetadataDist {
+  tarball: string
+  integrity?: string
+  shasum?: string
+}
+
+export type PackageMetadata = {
+  name?: string
+  version?: string
+  dist?: PackageMetadataDist
+  dependencies?: Record<string, string>
+  devDependencies?: Record<string, string>
+  peerDependencies?: Record<string, string>
+  optionalDependencies?: Record<string, string>
+}
+
+interface PackageOptions {
+  location?: string
+  origin?: string
+}
+
+export const isPackageMetadata = (pkg: any): pkg is PackageMetadata =>
+  !!pkg && typeof pkg === 'object' && typeof pkg.name === 'string'
+
+export class Package {
+  /**
+   * Where to find this package in the local file system.
+   */
+  location: string = ''
+  /**
+   * The package metadata, read from either a manifest file or package.json.
+   */
+  #metadata: PackageMetadata
+  /**
+   * Tracks the registry a given package was initially installed from.
+   */
+  #origin: string = ''
+
+  constructor(metadata: PackageMetadata, options?: PackageOptions) {
+    this.#metadata = metadata
+    if (options?.location) {
+      this.location = options?.location
+    }
+    this.#origin = options?.origin || ''
+  }
+
+  /**
+   * The name that identifies this package, defaults to location if missing.
+   */
+  get name(): string {
+    if (this.#metadata.name) {
+      return this.#metadata.name
+    }
+    return this.location
+  }
+
+  /**
+   * The exact semver version value of this package.
+   */
+  get version(): string {
+    return this.#metadata.version || ''
+  }
+
+  /**
+   * An unique id that identifies this package.
+   */
+  get id(): string {
+    return getId(this.#origin, this.name, this.version)
+  }
+
+  get dependencies(): Record<string, string> | undefined {
+    return this.#metadata.dependencies
+  }
+
+  get devDependencies(): Record<string, string> | undefined {
+    return this.#metadata.devDependencies
+  }
+
+  get optionalDependencies(): Record<string, string> | undefined {
+    return this.#metadata.optionalDependencies
+  }
+
+  get peerDependencies(): Record<string, string> | undefined {
+    return this.#metadata.peerDependencies
+  }
+
+  get tarball(): string | undefined {
+    return this.#metadata.dist?.tarball
+  }
+
+  get integrity(): string | undefined {
+    return this.#metadata.dist?.integrity
+  }
+
+  get shasum(): string | undefined {
+    return this.#metadata.dist?.shasum
+  }
+}
+
+function getId(
+  origin: string = '',
+  name: string = '',
+  version: string = '',
+): string {
+  return `${origin}${name}@${version}`
+}
+
+export class PackageInventory extends Map {
+  /**
+   * Reference to the supported dependency types.
+   */
+  dependencyTypes: Map<DependencyTypeLong, DependencyTypeShort> =
+    dependencyTypes
+  /**
+   * Pending is a list of packages that have manifest metadata already
+   * registered but are pending fetching and extracting tarball contents.
+   */
+  pending: Set<Package> = new Set()
+
+  /**
+   * Registers a new package to the inventory.
+   */
+  registerPackage(
+    metadata: PackageMetadata,
+    options?: PackageOptions,
+  ) {
+    const id = getId(options?.origin, metadata.name, metadata.version)
+    const cachedPkg = this.get(id)
+    if (cachedPkg) {
+      return cachedPkg
+    }
+
+    const pkg = new Package(metadata, options)
+    this.set(pkg.id, pkg)
+    return pkg
+  }
+
+  /**
+   * Register a new package to the inventory and append it to the list
+   * of packages pending artifacts.
+   */
+  registerPending(
+    metadata: PackageMetadata,
+    options?: PackageOptions,
+  ) {
+    const pkg = this.registerPackage(metadata, options)
+    this.pending.add(pkg)
+    return pkg
+  }
+}

--- a/src/graph/src/read-package-json.ts
+++ b/src/graph/src/read-package-json.ts
@@ -1,0 +1,21 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+let localPackageJsonCache = new Map()
+
+/**
+ * Reads and parses contents of a `package.json` file at a directory `dir`.
+ */
+export const readPackageJson = (
+  dir: string,
+): Record<string, string> => {
+  const cachedPackageJson = localPackageJsonCache.get(dir)
+  if (cachedPackageJson) {
+    return cachedPackageJson
+  }
+  const filename = resolve(dir, 'package.json')
+  const content = readFileSync(filename, { encoding: 'utf8' })
+  const res = JSON.parse(content)
+  localPackageJsonCache.set(dir, res)
+  return res
+}

--- a/src/graph/src/realpath.ts
+++ b/src/graph/src/realpath.ts
@@ -1,0 +1,16 @@
+import { realpathSync } from 'node:fs'
+
+let localRealPathCache: Map<string, string> = new Map()
+
+/**
+ * Returns the realpath for a given symlink path.
+ */
+export const realpath = (path: string): string => {
+  const cacheRes = localRealPathCache.get(path)
+  if (cacheRes) {
+    return cacheRes
+  }
+  const res = realpathSync(path)
+  localRealPathCache.set(path, res)
+  return res
+}

--- a/src/graph/src/visualization/human-readable-output.ts
+++ b/src/graph/src/visualization/human-readable-output.ts
@@ -1,0 +1,61 @@
+import { relative } from 'node:path'
+import { inspect } from 'node:util'
+import { Graph } from '../graph.js'
+import { Node } from '../node.js'
+import { Edge } from '../edge.js'
+import { Package } from '../pkgs.js'
+
+function parseNode(seenNodes: Set<number>, graph: Graph, node: Node) {
+  ;(node as any)[inspect.custom] = (): string => {
+    const res =
+      'Node ' +
+      inspect(
+        {
+          pkg: parsePackage(node.pkg),
+          ...((
+            node.edgesOut &&
+            node.edgesOut.size &&
+            !seenNodes.has(node.id)
+          ) ?
+            {
+              edgesOut: [...node.edgesOut.values()].map(i =>
+                parseEdge(seenNodes, graph, i),
+              ),
+            }
+          : null),
+        },
+        { depth: Infinity },
+      )
+    seenNodes.add(node.id)
+    return res
+  }
+  return node
+}
+
+function parseEdge(seenNodes: Set<number>, graph: Graph, edge: Edge) {
+  ;(edge as any)[inspect.custom] = () => {
+    const missingNode: string = `[missing package]: <${edge.name}@${edge.spec}>`
+    const toLabel: string =
+      edge.to ?
+        inspect(parseNode(seenNodes, graph, edge.to), {
+          depth: Infinity,
+        })
+      : missingNode
+    return `Edge -${graph.packages.dependencyTypes.get(edge.type)}-> to: ${toLabel}`
+  }
+  return edge
+}
+
+function parsePackage(pkg: Package) {
+  const tarballLabel = pkg.tarball ? ` ${pkg.tarball}` : ''
+  const locationLabel =
+    pkg.location ? ` ${relative(process.cwd(), pkg.location)}` : ''
+  ;(pkg as any)[inspect.custom] = (): string =>
+    `<${pkg.id}>${tarballLabel}${locationLabel}`
+  return pkg
+}
+
+export function humanReadableOutput(graph: Graph) {
+  const seenNodes: Set<number> = new Set()
+  return parseNode(seenNodes, graph, graph.root)
+}

--- a/src/graph/src/visualization/mermaid-output.ts
+++ b/src/graph/src/visualization/mermaid-output.ts
@@ -1,0 +1,40 @@
+import { Graph } from '../graph.js'
+import { Node } from '../node.js'
+import { Edge } from '../edge.js'
+
+let missingCount = 0
+
+function parseNode(seenNodes: Set<number>, graph: Graph, node: Node) {
+  if (seenNodes.has(node.id)) {
+    return ''
+  }
+  seenNodes.add(node.id)
+  const edges: string = [...node.edgesOut.values()]
+    .map(e => parseEdge(seenNodes, graph, e))
+    .join('\n')
+  return `${node.id}(${node.pkg.id})${edges.length ? '\n' : ''}${edges}`
+}
+
+function parseEdge(seenNodes: Set<number>, graph: Graph, edge: Edge) {
+  const edgeResult =
+    String(edge.from.id) +
+    ` -->|${graph.packages.dependencyTypes.get(edge.type)}| `
+
+  if (!edge.to) {
+    return (
+      edgeResult +
+      `missing-${missingCount++}(Missing package: ${edge.name}@${edge.spec})\n`
+    )
+  }
+
+  return (
+    edgeResult +
+    `${String(edge.to.id)}(${edge.to.pkg.id})\n` +
+    parseNode(seenNodes, graph, edge.to)
+  )
+}
+
+export function mermaidOutput(graph: Graph) {
+  const seenNodes: Set<number> = new Set()
+  return 'flowchart TD\n' + parseNode(seenNodes, graph, graph.root)
+}

--- a/src/graph/tap-snapshots/test/edge.ts.test.cjs
+++ b/src/graph/tap-snapshots/test/edge.ts.test.cjs
@@ -1,0 +1,32 @@
+/* IMPORTANT
+ * This snapshot file is auto-generated, but designed for humans.
+ * It should be checked into source control and tracked carefully.
+ * Re-generate by setting TAP_SNAPSHOT=1 and running tests.
+ * Make sure to inspect the output below.  Do not ignore changes!
+ */
+'use strict'
+exports[`test/edge.ts > TAP > Edge > must match snapshot 1`] = `
+Edge [@vltpkg/graph.Edge] {
+  from: [Node [@vltpkg/graph.Node]],
+  to: [Node [@vltpkg/graph.Node]],
+  type: 'dependencies',
+  name: 'child',
+  spec: '^1.0.0'
+}
+`
+
+exports[`test/edge.ts > TAP > Edge > must match snapshot 2`] = `
+Edge [@vltpkg/graph.Edge] {
+  from: Node [@vltpkg/graph.Node] {
+    edgesIn: Set(0) {},
+    edgesOut: Map(0) {},
+    id: 1,
+    isRoot: false,
+    pkg: [Object]
+  },
+  to: undefined,
+  type: 'dependencies',
+  name: 'missing',
+  spec: 'latest'
+}
+`

--- a/src/graph/tap-snapshots/test/graph.ts.test.cjs
+++ b/src/graph/tap-snapshots/test/graph.ts.test.cjs
@@ -1,0 +1,16 @@
+/* IMPORTANT
+ * This snapshot file is auto-generated, but designed for humans.
+ * It should be checked into source control and tracked carefully.
+ * Re-generate by setting TAP_SNAPSHOT=1 and running tests.
+ * Make sure to inspect the output below.  Do not ignore changes!
+ */
+'use strict'
+exports[`test/graph.ts > TAP > Graph > should print with special tag name 1`] = `
+Graph [@vltpkg/graph.Graph] {
+  packages: [PackageInventory [Map]],
+  nodes: [Set],
+  pkgNodes: [Map],
+  root: [Node [@vltpkg/graph.Node]],
+  missingDirectDependencies: Set(0) {}
+}
+`

--- a/src/graph/tap-snapshots/test/node.ts.test.cjs
+++ b/src/graph/tap-snapshots/test/node.ts.test.cjs
@@ -1,0 +1,16 @@
+/* IMPORTANT
+ * This snapshot file is auto-generated, but designed for humans.
+ * It should be checked into source control and tracked carefully.
+ * Re-generate by setting TAP_SNAPSHOT=1 and running tests.
+ * Make sure to inspect the output below.  Do not ignore changes!
+ */
+'use strict'
+exports[`test/node.ts > TAP > Node > should print with special tag name 1`] = `
+Node [@vltpkg/graph.Node] {
+  edgesIn: Set(0) {},
+  edgesOut: Map(0) {},
+  id: 0,
+  isRoot: true,
+  pkg: [Object]
+}
+`

--- a/src/graph/tap-snapshots/test/visualization/human-readable-output.ts.test.cjs
+++ b/src/graph/tap-snapshots/test/visualization/human-readable-output.ts.test.cjs
@@ -1,0 +1,25 @@
+/* IMPORTANT
+ * This snapshot file is auto-generated, but designed for humans.
+ * It should be checked into source control and tracked carefully.
+ * Re-generate by setting TAP_SNAPSHOT=1 and running tests.
+ * Make sure to inspect the output below.  Do not ignore changes!
+ */
+'use strict'
+exports[`test/visualization/human-readable-output.ts > TAP > human-readable-output > should print human readable output 1`] = `
+Node {
+  pkg: <my-project@1.0.0>,
+  edgesOut: [
+    Edge -prod-> to: Node { pkg: <foo@1.0.0> node_modules/foo },
+    Edge -prod-> to: Node {
+      pkg: <bar@1.0.0>,
+      edgesOut: [
+        Edge -prod-> to: Node {
+          pkg: <baz@1.0.0> https://registry.vlt.sh/baz,
+          edgesOut: [ Edge -prod-> to: Node { pkg: <foo@1.0.0> node_modules/foo } ]
+        }
+      ]
+    },
+    Edge -prod-> to: [missing package]: <missing@^1.0.0>
+  ]
+}
+`

--- a/src/graph/tap-snapshots/test/visualization/mermaid-output.ts.test.cjs
+++ b/src/graph/tap-snapshots/test/visualization/mermaid-output.ts.test.cjs
@@ -1,0 +1,21 @@
+/* IMPORTANT
+ * This snapshot file is auto-generated, but designed for humans.
+ * It should be checked into source control and tracked carefully.
+ * Re-generate by setting TAP_SNAPSHOT=1 and running tests.
+ * Make sure to inspect the output below.  Do not ignore changes!
+ */
+'use strict'
+exports[`test/visualization/mermaid-output.ts > TAP > human-readable-output > should print human readable output 1`] = `
+flowchart TD
+0(my-project@1.0.0)
+0 -->|prod| 1(foo@1.0.0)
+1(foo@1.0.0)
+0 -->|prod| 2(bar@1.0.0)
+2(bar@1.0.0)
+2 -->|prod| 3(baz@1.0.0)
+3(baz@1.0.0)
+3 -->|prod| 1(foo@1.0.0)
+
+0 -->|prod| missing-0(Missing package: missing@^1.0.0)
+
+`

--- a/src/graph/test/append-registry-nodes.ts
+++ b/src/graph/test/append-registry-nodes.ts
@@ -1,0 +1,103 @@
+import { resolve } from 'node:path'
+import t from 'tap'
+import { Graph } from '../src/graph.js'
+
+t.test('append a new node to a graph from a registry', async t => {
+  const fooManifest = {
+    name: 'foo',
+    version: '1.0.0',
+    dependencies: {
+      bar: '^1.0.0',
+    },
+  }
+  const barManifest = {
+    name: 'bar',
+    version: '1.0.0',
+  }
+  const { appendRegistryNodes } = await t.mockImport<
+    typeof import('../src/append-registry-nodes.js')
+  >('../src/append-registry-nodes.js', {
+    '@vltpkg/registry-client': {
+      RegistryClient: class {
+        async request(url) {
+          switch (url) {
+            case 'https://registry.npmjs.com/foo/latest':
+              return { body: fooManifest }
+            case 'https://registry.npmjs.com/bar/latest':
+              return { body: barManifest }
+            case 'https://registry.npmjs.com/borked/latest':
+              return { body: null }
+            default:
+              return null
+          }
+        }
+      },
+    },
+  })
+  const rootPkg = {
+    name: 'my-project',
+    version: '1.0.0',
+    dependencies: {
+      foo: '^1.0.0',
+    },
+  }
+  const dir = t.testdir({
+    'package.json': JSON.stringify(rootPkg),
+  })
+  const graph = new Graph(rootPkg)
+  t.strictSame(
+    graph.root.edgesOut.size,
+    0,
+    'has no direct dependency yet',
+  )
+  await appendRegistryNodes(
+    graph,
+    graph.root,
+    [['foo', '^1.0.0']],
+    'dependencies',
+  )
+  t.strictSame(
+    [...graph.root.edgesOut.values()].map(e => e.to.pkg.name),
+    ['foo'],
+    'should have a direct dependency on foo',
+  )
+  t.strictSame(
+    graph.packages.get('bar@1.0.0').name,
+    'bar',
+    'should have added to inventory transitive dependencies',
+  )
+
+  await appendRegistryNodes(
+    graph,
+    graph.root,
+    [['bar']],
+    'dependencies',
+  )
+  t.strictSame(
+    graph.root.edgesOut.get('bar').spec,
+    'latest',
+    'should add a direct dependency on latest bar',
+  )
+
+  await t.rejects(
+    appendRegistryNodes(
+      graph,
+      graph.root,
+      [['borked']],
+      'dependencies',
+    ),
+    /Failed to retrieve package metadata/,
+    'should throw an error if finding broken manifests',
+  )
+
+  await t.rejects(
+    appendRegistryNodes(
+      graph,
+      graph.root,
+      [[undefined, '^1.0.0']],
+      'dependencies',
+    ),
+    /Trying to add a package but no name was found/,
+    'should throw an error if using addSpec with no name',
+  )
+})

--- a/src/graph/test/build-actual.ts
+++ b/src/graph/test/build-actual.ts
@@ -1,0 +1,125 @@
+import { resolve } from 'node:path'
+import t from 'tap'
+import { Graph } from '../src/graph.js'
+import { buildActual } from '../src/build-actual.js'
+
+t.test(
+  'build a graph representing what is actually in the fs',
+  async t => {
+    const rootPkg = {
+      name: 'my-project',
+      version: '1.0.0',
+      dependencies: {
+        foo: '^1.0.0',
+        bar: '^1.0.0',
+      },
+    }
+    const dir = t.testdir({
+      'package.json': JSON.stringify(rootPkg),
+      node_modules: {
+        '.vlt': {
+          'registry.npmjs.com': {
+            'foo@1.0.0': {
+              node_modules: {
+                foo: {
+                  'package.json': JSON.stringify({
+                    name: 'foo',
+                    version: '1.0.0',
+                  }),
+                },
+              },
+            },
+            'bar@1.0.0': {
+              node_modules: {
+                bar: {
+                  'package.json': JSON.stringify({
+                    name: 'bar',
+                    version: '1.0.0',
+                    dependencies: {
+                      '@scoped/baz': '^1.0.0',
+                      foo: '^1.0.0',
+                    },
+                  }),
+                },
+                '@scoped': {
+                  baz: t.fixture(
+                    'symlink',
+                    '../../../@scoped+baz@1.0.0/node_modules/@scoped/baz',
+                  ),
+                },
+                foo: t.fixture(
+                  'symlink',
+                  '../../foo@1.0.0/node_modules/foo',
+                ),
+              },
+            },
+            '@scoped+baz@1.0.0': {
+              node_modules: {
+                '@scoped': {
+                  baz: {
+                    'package.json': JSON.stringify({
+                      name: '@scoped/baz',
+                      version: '1.0.0',
+                    }),
+                  },
+                },
+              },
+            },
+          },
+        },
+        foo: t.fixture(
+          'symlink',
+          '.vlt/registry.npmjs.com/foo@1.0.0/node_modules/foo',
+        ),
+        bar: t.fixture(
+          'symlink',
+          '.vlt/registry.npmjs.com/bar@1.0.0/node_modules/bar',
+        ),
+      },
+    })
+    const graph = new Graph(rootPkg)
+    await buildActual(graph, graph.root, resolve(dir, 'node_modules'))
+    t.strictSame(
+      graph.packages.size,
+      4,
+      'should have expected number of packages',
+    )
+    t.strictSame(
+      [...graph.root.edgesOut.values()].map(e => e.to.pkg.name),
+      ['foo', 'bar'],
+      'should have root edges to its direct dependency nodes',
+    )
+  },
+)
+
+t.test('build a graph with missing direct dependencies', async t => {
+  const rootPkg = {
+    name: 'my-project',
+    version: '1.0.0',
+    dependencies: {
+      foo: '^1.0.0',
+      bar: '^1.0.0',
+    },
+  }
+  const dir = t.testdir({
+    'package.json': JSON.stringify(rootPkg),
+  })
+  const graph = new Graph(rootPkg)
+  await buildActual(graph, graph.root, resolve(dir, 'node_modules'))
+  t.strictSame(
+    graph.packages.size,
+    1,
+    'should have only root package in inventory',
+  )
+  t.strictSame(
+    [...graph.missingDirectDependencies].map(e => ({
+      name: e.name,
+      spec: e.spec,
+    })),
+    [
+      { name: 'foo', spec: '^1.0.0' },
+      { name: 'bar', spec: '^1.0.0' },
+    ],
+    'should have a set of missing direct dependencies',
+  )
+})

--- a/src/graph/test/build-starter-graph.ts
+++ b/src/graph/test/build-starter-graph.ts
@@ -1,0 +1,19 @@
+import t from 'tap'
+import { buildStarterGraph } from '../src/build-starter-graph.js'
+
+t.test('build empty starter graph', async t => {
+  const dir = t.testdir({
+    'package.json': JSON.stringify({
+      name: 'my-project',
+      version: '1.0.0',
+    }),
+  })
+  const graph = await buildStarterGraph({
+    dir,
+  })
+  t.strictSame(
+    graph.root.pkg.name,
+    'my-project',
+    'should have created a root folder with expected properties',
+  )
+})

--- a/src/graph/test/edge.ts
+++ b/src/graph/test/edge.ts
@@ -1,0 +1,24 @@
+import { inspect } from 'node:util'
+import t from 'tap'
+import { Node } from '../src/node.js'
+import { Edge } from '../src/edge.js'
+
+t.test('Edge', async t => {
+  const root = new Node(0, { name: 'root', version: '1.0.0' })
+  const child = new Node(1, { name: 'child', version: '1.0.0' })
+  const edge = new Edge(
+    'dependencies',
+    'child',
+    '^1.0.0',
+    root,
+    child,
+  )
+  t.matchSnapshot(inspect(edge, { depth: 0 }))
+  const dangling = new Edge(
+    'dependencies',
+    'missing',
+    'latest',
+    child,
+  )
+  t.matchSnapshot(inspect(dangling, { depth: 1 }))
+})

--- a/src/graph/test/graph.ts
+++ b/src/graph/test/graph.ts
@@ -1,0 +1,47 @@
+import { inspect } from 'node:util'
+import t from 'tap'
+import { Graph } from '../src/graph.js'
+
+t.test('Graph', async t => {
+  const rootPackageJson = {
+    name: 'my-project',
+    version: '1.0.0',
+  }
+  const graph = new Graph(rootPackageJson)
+  t.strictSame(
+    graph.root.pkg.name,
+    'my-project',
+    'should have created a root folder with expected properties',
+  )
+  t.matchSnapshot(
+    inspect(graph, { depth: 0 }),
+    'should print with special tag name',
+  )
+  const newNode = graph.newNode({
+    name: 'foo',
+    version: '1.0.0',
+  })
+  t.strictSame(
+    graph.nodes.size,
+    2,
+    'should create and add the new node to the graph',
+  )
+  graph.newEdge('prod', 'foo', '^1.0.0', graph.root, newNode)
+  t.strictSame(
+    graph.root.edgesOut.size,
+    1,
+    'should add edge to the list of edgesOut in its origin node',
+  )
+  graph.newEdge('prod', 'foo', '^1.0.0', graph.root, newNode)
+  t.strictSame(
+    graph.root.edgesOut.size,
+    1,
+    'should not allow for adding new edges between same nodes',
+  )
+  graph.newEdge('prod', 'missing', '*', graph.root)
+  t.strictSame(
+    graph.missingDirectDependencies.size,
+    1,
+    'should add edge to list of missing dependencies',
+  )
+})

--- a/src/graph/test/node.ts
+++ b/src/graph/test/node.ts
@@ -1,0 +1,53 @@
+import { inspect } from 'node:util'
+import t from 'tap'
+import { Node } from '../src/node.js'
+import { Edge } from '../src/edge.js'
+
+t.test('Node', async t => {
+  const root = new Node(0, { name: 'root', version: '1.0.0' })
+  root.isRoot = true
+  t.strictSame(
+    root.edgesIn.size,
+    0,
+    'should have an empty list of edgesIn',
+  )
+  t.strictSame(
+    root.edgesOut.size,
+    0,
+    'should have an empty list of edgesOut',
+  )
+  t.matchSnapshot(
+    inspect(root, { depth: 0 }),
+    'should print with special tag name',
+  )
+
+  const foo = new Node(1, { name: 'foo', version: '1.0.0' })
+  const bar = new Node(2, { name: 'bar', version: '1.0.0' })
+
+  root.addEdgeOut('dependencies', 'foo', '^1.0.0', foo)
+  foo.addEdgeIn('dependencies', 'root', '^1.0.0', root)
+  root.addEdgeOut('dependencies', 'bar', '^1.0.0', bar)
+  bar.addEdgeIn('dependencies', 'root', '^1.0.0', root)
+
+  t.strictSame(
+    root.edgesOut.size,
+    2,
+    'should have a list of edgesOut',
+  )
+  t.strictSame(foo.edgesIn.size, 1, 'should have an edge')
+  t.strictSame(
+    [root.edgesOut.get('foo').to, root.edgesOut.get('bar').to],
+    [foo, bar],
+    'should have edges out properly set up',
+  )
+  t.strictSame(
+    [...foo.edgesIn][0].to,
+    root,
+    'should have edges in to root',
+  )
+  t.strictSame(
+    [...bar.edgesIn][0].to,
+    root,
+    'should have edges in to root',
+  )
+})

--- a/src/graph/test/pkgs.ts
+++ b/src/graph/test/pkgs.ts
@@ -1,0 +1,185 @@
+import t from 'tap'
+import { PackageInventory, Package } from '../src/pkgs.js'
+
+t.test('Package', async t => {
+  const pkg = new Package({
+    name: 'foo',
+    version: '1.0.0',
+  })
+  t.strictSame(pkg.id, 'foo@1.0.0', 'should retrieve a package id')
+  t.strictSame(
+    pkg.tarball,
+    undefined,
+    'should return undefined on access missing manifest info',
+  )
+  t.strictSame(
+    pkg.integrity,
+    undefined,
+    'should return undefined on access missing manifest info',
+  )
+  t.strictSame(
+    pkg.shasum,
+    undefined,
+    'should return undefined on access missing manifest info',
+  )
+  const prefixedPkg = new Package(
+    {
+      name: 'bar',
+      version: '1.0.0',
+    },
+    {
+      origin: 'vlt:',
+    },
+  )
+  t.strictSame(
+    prefixedPkg.id,
+    'vlt:bar@1.0.0',
+    'should use prefix when origin is passed as an option',
+  )
+  const depPkg = new Package({
+    name: 'lorem',
+    version: '2.0.0',
+    dependencies: {
+      a: '^1.0.0',
+    },
+    devDependencies: {
+      b: '^1.0.0',
+    },
+    optionalDependencies: {
+      c: '^1.0.0',
+    },
+  })
+  t.strictSame(depPkg.name, 'lorem', 'should retrieve pkg name')
+  t.strictSame(
+    depPkg.dependencies,
+    { a: '^1.0.0' },
+    'should retrieve prod dependencies',
+  )
+  t.strictSame(
+    depPkg.devDependencies,
+    { b: '^1.0.0' },
+    'should retrieve dev dependencies',
+  )
+  t.strictSame(
+    depPkg.optionalDependencies,
+    { c: '^1.0.0' },
+    'should retrieve optional dependencies',
+  )
+  t.strictSame(
+    depPkg.peerDependencies,
+    undefined,
+    'should retrieve no peer dependencies when undefined',
+  )
+  const locationOnly = new Package(
+    { version: '1.0.0' },
+    { location: './node_modules/foo' },
+  )
+  t.strictSame(
+    locationOnly.name,
+    './node_modules/foo',
+    'name should default to location if available',
+  )
+  const unnamed = new Package({ version: '1.0.0' })
+  t.strictSame(
+    unnamed.name,
+    '',
+    'empty name if no name | package is provided',
+  )
+  const noversion = new Package({ name: 'noversion' })
+  t.strictSame(
+    noversion.version,
+    '',
+    'empty version if no version was defined',
+  )
+})
+
+t.test('PackageInventory', async t => {
+  const inventory = new PackageInventory()
+  const pkg = inventory.registerPackage({
+    name: 'foo',
+    version: '1.0.0',
+  })
+  t.strictSame(inventory.size, 1, 'should have other Map properties')
+
+  const repeatPkg = inventory.registerPackage({
+    name: 'foo',
+    version: '1.0.0',
+  })
+  t.strictSame(
+    pkg,
+    repeatPkg,
+    'should return same package instance if duplicating package info',
+  )
+
+  const manifest = `{
+  "name": "abbrev",
+  "version": "2.0.0",
+  "description": "Like ruby's abbrev module, but in js",
+  "author": {
+    "name": "GitHub Inc."
+  },
+  "main": "lib/index.js",
+  "scripts": {
+    "test": "tap",
+    "postlint": "template-oss-check",
+    "template-oss-apply": "template-oss-apply --force",
+    "lintfix": "npm run lint -- --fix",
+    "snap": "tap",
+    "posttest": "npm run lint"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/npm/abbrev-js.git"
+  },
+  "license": "ISC",
+  "devDependencies": {
+    "@npmcli/eslint-config": "^4.0.0",
+    "@npmcli/template-oss": "4.8.0",
+    "tap": "^16.3.0"
+  },
+  "tap": {
+    "nyc-arg": [
+      "--exclude",
+      "tap-snapshots/**"
+    ]
+  },
+  "engines": {
+    "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+  },
+  "templateOSS": {
+    "//@npmcli/template-oss": "This file is partially managed by @npmcli/template-oss. Edits may be overwritten.",
+    "version": "4.8.0"
+  },
+  "gitHead": "6eaa998b4291757a34d55d815290314c4776a30a",
+  "bugs": {
+    "url": "https://github.com/npm/abbrev-js/issues"
+  },
+  "homepage": "https://github.com/npm/abbrev-js#readme",
+  "_id": "abbrev@2.0.0",
+  "_nodeVersion": "18.12.0",
+  "_npmVersion": "9.0.1",
+  "dist": {
+    "integrity": "sha512-6/mh1E2u2YgEsCHdY0Yx5oW+61gZU+1vXaoiHHrpKeuRNNgFvS+/jrwHiQhB5apAf5oB7UB7E19ol2R2LKH8hQ==",
+    "shasum": "cf59829b8b4f03f89dda2771cb7f3653828c89bf",
+    "tarball": "https://registry.npmjs.org/abbrev/-/abbrev-2.0.0.tgz",
+    "fileCount": 4,
+    "unpackedSize": 4827
+  }
+}`
+  const pending = inventory.registerPending(JSON.parse(manifest))
+  t.strictSame(
+    pending.tarball,
+    'https://registry.npmjs.org/abbrev/-/abbrev-2.0.0.tgz',
+    'should retrieve the tarball url',
+  )
+  t.strictSame(
+    pending.integrity,
+    'sha512-6/mh1E2u2YgEsCHdY0Yx5oW+61gZU+1vXaoiHHrpKeuRNNgFvS+/jrwHiQhB5apAf5oB7UB7E19ol2R2LKH8hQ==',
+    'should retrieve the integrity value',
+  )
+  t.strictSame(
+    pending.shasum,
+    'cf59829b8b4f03f89dda2771cb7f3653828c89bf',
+    'should retrieve the shasum value',
+  )
+})

--- a/src/graph/test/read-package-json.ts
+++ b/src/graph/test/read-package-json.ts
@@ -1,0 +1,58 @@
+import t from 'tap'
+import { readPackageJson } from '../src/read-package-json.js'
+
+t.test('successfully reads a valid package.jsonf file', async t => {
+  const dir = t.testdir({
+    'package.json': JSON.stringify({
+      name: 'my-project',
+      version: '1.0.0',
+    }),
+  })
+  t.strictSame(
+    readPackageJson(dir),
+    { name: 'my-project', version: '1.0.0' },
+    'should be able to read file and return parsed JSON',
+  )
+})
+
+t.test('fails on missing package.json file', async t => {
+  const dir = t.testdirName
+  t.throws(
+    () => readPackageJson(dir),
+    /ENOENT/,
+    'should throw ENOENT error on missing package.json file',
+  )
+})
+
+t.test('fails on malformed package.json file', async t => {
+  const dir = t.testdir({
+    'package.json': '{%',
+  })
+  t.throws(
+    () => readPackageJson(dir),
+    /JSON/,
+    'should throw JSON parser error on malformed package.json file',
+  )
+})
+
+t.test('read subsequent calls from in-memory cache', async t => {
+  const dir = t.testdir({
+    'package.json': JSON.stringify({
+      name: 'my-project',
+      version: '1.0.0',
+    }),
+  })
+  const packageJson = readPackageJson(dir)
+  const sameDir = t.testdir({
+    'package.json': JSON.stringify({
+      name: 'swapped-under-your-feet',
+      version: '2.0.0',
+    }),
+  })
+
+  t.strictSame(
+    readPackageJson(sameDir),
+    packageJson,
+    'should run any subsequent call from local in-memory cache',
+  )
+})

--- a/src/graph/test/realpath.ts
+++ b/src/graph/test/realpath.ts
@@ -1,0 +1,28 @@
+import { resolve } from 'node:path'
+import t from 'tap'
+import { realpath } from '../src/realpath.js'
+
+t.test('successfully returns the symlink target', async t => {
+  const dir = t.testdir({
+    a: 'a',
+    b: t.fixture('symlink', 'a'),
+  })
+  t.strictSame(
+    realpath(resolve(dir, 'b')),
+    resolve(dir, 'a'),
+    'should return realpaths',
+  )
+})
+
+t.test('should read from cache if reading same path', async t => {
+  const dir = t.testdir({
+    a: 'a',
+    b: t.fixture('symlink', 'a'),
+  })
+  realpath(resolve(dir, 'b'))
+  t.strictSame(
+    realpath(resolve(dir, 'b')),
+    resolve(dir, 'a'),
+    'should return realpath from cache',
+  )
+})

--- a/src/graph/test/visualization/human-readable-output.ts
+++ b/src/graph/test/visualization/human-readable-output.ts
@@ -1,0 +1,62 @@
+import { inspect } from 'node:util'
+import t from 'tap'
+import { Graph } from '../../src/graph.js'
+import { humanReadableOutput } from '../../src/visualization/human-readable-output.js'
+
+t.test('human-readable-output', async t => {
+  const graph = new Graph({
+    name: 'my-project',
+    version: '1.0.0',
+    dependencies: {
+      foo: '^1.0.0',
+      bar: '^1.0.0',
+      missing: '^1.0.0',
+    },
+  })
+  const foo = graph.placePackage(
+    graph.root,
+    'dependencies',
+    'foo',
+    '^1.0.0',
+    {
+      name: 'foo',
+      version: '1.0.0',
+    },
+    './node_modules/foo',
+  )
+  const bar = graph.placePackage(
+    graph.root,
+    'dependencies',
+    'bar',
+    '^1.0.0',
+    {
+      name: 'bar',
+      version: '1.0.0',
+      dependencies: {
+        baz: '^1.0.0',
+      },
+    },
+  )
+  const baz = graph.placePackage(
+    bar,
+    'dependencies',
+    'baz',
+    '^1.0.0',
+    {
+      name: 'baz',
+      version: '1.0.0',
+      dist: {
+        tarball: 'https://registry.vlt.sh/baz',
+      },
+    },
+  )
+  graph.placePackage(graph.root, 'dependencies', 'missing', '^1.0.0')
+  graph.placePackage(baz, 'dependencies', 'foo', '^1.0.0', {
+    name: 'foo',
+    version: '1.0.0',
+  })
+  t.matchSnapshot(
+    inspect(humanReadableOutput(graph)),
+    'should print human readable output',
+  )
+})

--- a/src/graph/test/visualization/mermaid-output.ts
+++ b/src/graph/test/visualization/mermaid-output.ts
@@ -1,0 +1,62 @@
+import { inspect } from 'node:util'
+import t from 'tap'
+import { Graph } from '../../src/graph.js'
+import { mermaidOutput } from '../../src/visualization/mermaid-output.js'
+
+t.test('human-readable-output', async t => {
+  const graph = new Graph({
+    name: 'my-project',
+    version: '1.0.0',
+    dependencies: {
+      foo: '^1.0.0',
+      bar: '^1.0.0',
+      missing: '^1.0.0',
+    },
+  })
+  const foo = graph.placePackage(
+    graph.root,
+    'dependencies',
+    'foo',
+    '^1.0.0',
+    {
+      name: 'foo',
+      version: '1.0.0',
+    },
+    './node_modules/foo',
+  )
+  const bar = graph.placePackage(
+    graph.root,
+    'dependencies',
+    'bar',
+    '^1.0.0',
+    {
+      name: 'bar',
+      version: '1.0.0',
+      dependencies: {
+        baz: '^1.0.0',
+      },
+    },
+  )
+  const baz = graph.placePackage(
+    bar,
+    'dependencies',
+    'baz',
+    '^1.0.0',
+    {
+      name: 'baz',
+      version: '1.0.0',
+      dist: {
+        tarball: 'https://registry.vlt.sh/baz',
+      },
+    },
+  )
+  graph.placePackage(graph.root, 'dependencies', 'missing', '^1.0.0')
+  graph.placePackage(baz, 'dependencies', 'foo', '^1.0.0', {
+    name: 'foo',
+    version: '1.0.0',
+  })
+  t.matchSnapshot(
+    mermaidOutput(graph),
+    'should print human readable output',
+  )
+})

--- a/src/graph/tsconfig.json
+++ b/src/graph/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "declaration": true,
+    "declarationMap": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "inlineSources": true,
+    "jsx": "react",
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
+    "noUncheckedIndexedAccess": true,
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "sourceMap": true,
+    "strict": true,
+    "target": "es2022"
+  }
+}


### PR DESCRIPTION
Implements a first pass at a graph library that is capable of reading info from local package.json files in order to build a graph representation of what is currently on disk while also retrieving metadata from a registry to represent what is currnetly missing so that a very rudimentary install can take place.

### API Usage:

```js
  import { buildStarterGraph, Package } from '@vltpkg/graph'

  const graph = await buildStarterGraph({ dir: process.cwd() })
  const itemsToFetch: Set<Package> = graph.inventory.pending
```