### PR TITLE
graph: fix missing dependencies

### DIFF
--- a/src/graph/src/build-starter-graph.ts
+++ b/src/graph/src/build-starter-graph.ts
@@ -31,7 +31,7 @@ export const buildStarterGraph = async ({
 
   buildActual(graph, graph.root, resolve(dir, 'node_modules'))
 
-  const missing: Set<Edge> = graph.missingDirectDependencies
+  const missing: Set<Edge> = graph.missingDependencies
   const specs: Spec[] = []
   for (const e of missing) {
     specs.push(e.spec)

--- a/src/graph/src/graph.ts
+++ b/src/graph/src/graph.ts
@@ -37,7 +37,7 @@ export class Graph {
    * A list of dangling edges from the root node, representing
    * missing direct dependencies of a given install.
    */
-  missingDirectDependencies: Set<Edge> = new Set()
+  missingDependencies: Set<Edge> = new Set()
 
   /**
    * Keeps a reference of connected edges in order to avoid duplicating edges.
@@ -76,8 +76,8 @@ export class Graph {
     }
 
     const edgeOut = from.addEdgeOut(type, name, spec, to)
-    if (!to && from.isRoot) {
-      this.missingDirectDependencies.add(edgeOut)
+    if (!to) {
+      this.missingDependencies.add(edgeOut)
     }
 
     this.#seenEdges.add(edgeId)

--- a/src/graph/tap-snapshots/test/graph.ts.test.cjs
+++ b/src/graph/tap-snapshots/test/graph.ts.test.cjs
@@ -11,6 +11,6 @@ Graph [@vltpkg/graph.Graph] {
   nodes: [Set],
   pkgNodes: [Map],
   root: [Node [@vltpkg/graph.Node]],
-  missingDirectDependencies: Set(0) {}
+  missingDependencies: Set(0) {}
 }
 `

--- a/src/graph/test/build-actual.ts
+++ b/src/graph/test/build-actual.ts
@@ -112,7 +112,7 @@ t.test('build a graph with missing direct dependencies', async t => {
     'should have only root package in inventory',
   )
   t.match(
-    [...graph.missingDirectDependencies].map(e => ({
+    [...graph.missingDependencies].map(e => ({
       name: e.name,
       spec: e.spec,
     })),

--- a/src/graph/test/graph.ts
+++ b/src/graph/test/graph.ts
@@ -40,7 +40,7 @@ t.test('Graph', async t => {
   )
   graph.newEdge('prod', 'missing', '*', graph.root)
   t.strictSame(
-    graph.missingDirectDependencies.size,
+    graph.missingDependencies.size,
     1,
     'should add edge to list of missing dependencies',
   )


### PR DESCRIPTION
We do want to install _any_ missing dependency found during a new install.