### PR TITLE
Improve output of root test script (and thus, ci)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,4 +36,4 @@ jobs:
         run: "npx --yes pnpm i"
 
       - name: Run Tests
-        run: "npx --yes pnpm --no-bail -r test"
+        run: "npx --yes pnpm test"

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 /node_modules
 /docs
 .DS_Store
+/pnpm-exec-summary.json

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "private": true,
   "scripts": {
     "devPreinstall": "node scripts/consistent-dev-deps.js",
-    "test": "pnpm -r test -- -Rsilent",
-    "snap": "pnpm run -r snap -Rsilent",
+    "test": "pnpm --silent --no-bail --report-summary -r test -- -Rsilent || node scripts/report-test-failures.js",
+    "snap": "pnpm --silent --no-bail --report-summary run -r snap -Rsilent || node scripts/report-test-failures.js",
     "typedoc": "typedoc"
   },
   "type": "module",
@@ -14,6 +14,7 @@
     "@types/retry": "^0.12.5",
     "@types/semver": "^7.5.8",
     "@types/tar": "^6.1.13",
+    "chalk": "^5.3.0",
     "mutate-fs": "^2.1.1",
     "npm-package-arg": "^11.0.2",
     "npm-pick-manifest": "^9.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       '@types/tar':
         specifier: ^6.1.13
         version: 6.1.13
+      chalk:
+        specifier: ^5.3.0
+        version: 5.3.0
       mutate-fs:
         specifier: ^2.1.1
         version: 2.1.1

--- a/scripts/report-test-failures.js
+++ b/scripts/report-test-failures.js
@@ -1,0 +1,27 @@
+import { spawnSync } from 'child_process'
+import { readFileSync } from 'fs'
+import { relative } from 'path'
+import chalk from 'chalk'
+
+const execStatus = () => {
+  try {
+    return (
+      JSON.parse(readFileSync('./pnpm-exec-summary.json', 'utf8'))
+        .executionStatus ?? {}
+    )
+  } catch {
+    return {}
+  }
+}
+
+for (const [path, { status }] of Object.entries(execStatus())) {
+  if (status !== 'failure') continue
+  // we had failures, so exit in failure
+  process.exitCode = 1
+  const rel = './' + relative('.', path)
+  console.log('\n' + chalk.black.bold.bgWhiteBright(rel))
+  spawnSync('tap', ['-c', '-Rterse', 'replay'], {
+    cwd: path,
+    stdio: 'inherit',
+  })
+}


### PR DESCRIPTION
This uses pnpm's report summary to call `tap replay` on all the workspaces that failed. Hopefully, it can prevent us from having to scan through thousands of lines of TAP in the GitHub Actions results.