### PR TITLE
limit ci to node20 only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ jobs:
   build:
     strategy:
       matrix:
-        node-version: [20.x, 22.x]
+        node-version: [20.x]
         platform:
         - os: ubuntu-latest
           shell: bash


### PR DESCRIPTION
Let's limit the footprint of ci while the repo is still in private mode.