### PR TITLE
graph: track node names

### DIFF
--- a/src/graph/src/graph.ts
+++ b/src/graph/src/graph.ts
@@ -103,8 +103,13 @@ export class Graph {
   /**
    * Create a new node in the graph.
    */
-  newNode(id?: DepID, manifest?: ManifestMinified, spec?: Spec) {
-    const node = new Node(this.#config, id, manifest, spec)
+  newNode(
+    id?: DepID,
+    manifest?: ManifestMinified,
+    spec?: Spec,
+    name?: string,
+  ) {
+    const node = new Node(this.#config, id, manifest, spec, name)
     this.nodes.set(node.id, node)
     if (manifest) {
       this.manifests.set(node.id, manifest)
@@ -145,7 +150,7 @@ export class Graph {
 
     // creates a new node and edges to its parent
     const toNode = this.newNode(depId, manifest)
-    toNode.setResolvedFromId()
+    toNode.setResolved()
     this.newEdge(depType, spec, fromNode, toNode)
     return toNode
   }

--- a/src/graph/src/lockfile/load.ts
+++ b/src/graph/src/lockfile/load.ts
@@ -30,8 +30,8 @@ interface LoadNodesOptions {
 
 const loadNodes = ({ graph, nodesInfo }: LoadNodesOptions) => {
   for (const [id, lockfileNode] of nodesInfo) {
-    const [integrity, resolved] = lockfileNode
-    const node = graph.newNode(id)
+    const [name, integrity, resolved] = lockfileNode
+    const node = graph.newNode(id, undefined, undefined, name)
     node.integrity = integrity || undefined
     node.resolved = resolved
   }

--- a/src/graph/src/lockfile/save.ts
+++ b/src/graph/src/lockfile/save.ts
@@ -36,10 +36,9 @@ const formatNodes = (nodes: Iterable<Node>, registry?: string) => {
     const customRegistry =
       node.resolved && registry && !node.resolved.startsWith(registry)
     const resolved = customRegistry ? node.resolved : undefined
-    const lockfileNode: LockfileDataNode = [node.integrity, resolved]
-    // reduce array size in order to omit trailing `null` item for each entry
-    if (!resolved) {
-      lockfileNode.length = 1
+    const lockfileNode: LockfileDataNode = [node.name, node.integrity]
+    if (resolved) {
+      lockfileNode.push(resolved)
     }
     res[node.id] = lockfileNode
   }

--- a/src/graph/src/lockfile/types.ts
+++ b/src/graph/src/lockfile/types.ts
@@ -19,7 +19,8 @@ export type LockfileData = {
  * Lockfile representation of a node from the install graph.
  */
 export type LockfileDataNode = [
-  integrity: Integrity | null | undefined,
+  name?: string,
+  integrity?: Integrity,
   resolved?: string,
 ]
 

--- a/src/graph/tap-snapshots/test/append-nodes.ts.test.cjs
+++ b/src/graph/tap-snapshots/test/append-nodes.ts.test.cjs
@@ -31,6 +31,7 @@ Graph [@vltpkg/graph.Graph] {
         importer: true,
         integrity: undefined,
         manifest: [Object],
+        name: 'my-project',
         resolved: undefined
       },
       to: Node [@vltpkg/graph.Node] {
@@ -40,6 +41,7 @@ Graph [@vltpkg/graph.Graph] {
         importer: false,
         integrity: undefined,
         manifest: [Object],
+        name: 'foo',
         resolved: 'https://registry.npmjs.org/foo/-/foo-1.0.0.tgz'
       },
       type: 'devDependencies',
@@ -53,6 +55,7 @@ Graph [@vltpkg/graph.Graph] {
         importer: true,
         integrity: undefined,
         manifest: [Object],
+        name: 'my-project',
         resolved: undefined
       },
       to: Node [@vltpkg/graph.Node] {
@@ -62,6 +65,7 @@ Graph [@vltpkg/graph.Graph] {
         importer: false,
         integrity: undefined,
         manifest: [Object],
+        name: 'bar',
         resolved: 'https://registry.npmjs.org/bar/-/bar-1.0.0.tgz'
       },
       type: 'optionalDependencies',
@@ -75,6 +79,7 @@ Graph [@vltpkg/graph.Graph] {
         importer: true,
         integrity: undefined,
         manifest: [Object],
+        name: 'my-project',
         resolved: undefined
       },
       to: undefined,
@@ -99,6 +104,7 @@ Graph [@vltpkg/graph.Graph] {
         devDependencies: [Object],
         optionalDependencies: [Object]
       },
+      name: 'my-project',
       resolved: undefined
     },
     'registry;;foo@1.0.0' => Node [@vltpkg/graph.Node] {
@@ -108,6 +114,7 @@ Graph [@vltpkg/graph.Graph] {
       importer: false,
       integrity: undefined,
       manifest: { name: 'foo', version: '1.0.0', devDependencies: [Object] },
+      name: 'foo',
       resolved: 'https://registry.npmjs.org/foo/-/foo-1.0.0.tgz'
     },
     'registry;;bar@1.0.0' => Node [@vltpkg/graph.Node] {
@@ -117,6 +124,7 @@ Graph [@vltpkg/graph.Graph] {
       importer: false,
       integrity: undefined,
       manifest: { name: 'bar', version: '1.0.0' },
+      name: 'bar',
       resolved: 'https://registry.npmjs.org/bar/-/bar-1.0.0.tgz'
     }
   },
@@ -137,6 +145,7 @@ Graph [@vltpkg/graph.Graph] {
         devDependencies: [Object],
         optionalDependencies: [Object]
       },
+      name: 'my-project',
       resolved: undefined
     }
   },
@@ -171,6 +180,7 @@ Graph [@vltpkg/graph.Graph] {
       devDependencies: { foo: '^1.0.0' },
       optionalDependencies: { bar: '^1.0.0' }
     },
+    name: 'my-project',
     resolved: undefined
   },
   missingDependencies: Set(1) {
@@ -182,6 +192,7 @@ Graph [@vltpkg/graph.Graph] {
         importer: true,
         integrity: undefined,
         manifest: [Object],
+        name: 'my-project',
         resolved: undefined
       },
       to: undefined,

--- a/src/graph/tap-snapshots/test/edge.ts.test.cjs
+++ b/src/graph/tap-snapshots/test/edge.ts.test.cjs
@@ -23,6 +23,7 @@ Edge [@vltpkg/graph.Edge] {
     importer: false,
     integrity: undefined,
     manifest: [Object],
+    name: 'child',
     resolved: undefined
   },
   to: undefined,

--- a/src/graph/tap-snapshots/test/graph.ts.test.cjs
+++ b/src/graph/tap-snapshots/test/graph.ts.test.cjs
@@ -70,6 +70,7 @@ Graph [@vltpkg/graph.Graph] {
       importer: true,
       integrity: undefined,
       manifest: [Object],
+      name: 'my-project',
       resolved: undefined
     },
     'registry;;foo@1.0.0' => Node [@vltpkg/graph.Node] {
@@ -79,6 +80,7 @@ Graph [@vltpkg/graph.Graph] {
       importer: false,
       integrity: undefined,
       manifest: [Object],
+      name: 'foo',
       resolved: 'https://registry.npmjs.org/foo/-/foo-1.0.0.tgz'
     },
     'registry;;bar@1.0.0' => Node [@vltpkg/graph.Node] {
@@ -88,6 +90,7 @@ Graph [@vltpkg/graph.Graph] {
       importer: false,
       integrity: undefined,
       manifest: [Object],
+      name: 'bar',
       resolved: 'https://registry.npmjs.org/bar/-/bar-1.0.0.tgz'
     },
     'registry;;baz@1.0.0' => Node [@vltpkg/graph.Node] {
@@ -97,6 +100,7 @@ Graph [@vltpkg/graph.Graph] {
       importer: false,
       integrity: undefined,
       manifest: [Object],
+      name: 'baz',
       resolved: 'https://registry.vlt.sh/baz'
     }
   },
@@ -108,6 +112,7 @@ Graph [@vltpkg/graph.Graph] {
       importer: true,
       integrity: undefined,
       manifest: [Object],
+      name: 'my-project',
       resolved: undefined
     }
   },
@@ -122,6 +127,7 @@ Graph [@vltpkg/graph.Graph] {
     importer: true,
     integrity: undefined,
     manifest: { name: 'my-project', version: '1.0.0', dependencies: [Object] },
+    name: 'my-project',
     resolved: undefined
   },
   missingDependencies: Set(1) {

--- a/src/graph/tap-snapshots/test/lockfile/save.ts.test.cjs
+++ b/src/graph/tap-snapshots/test/lockfile/save.ts.test.cjs
@@ -9,7 +9,7 @@ exports[`test/lockfile/save.ts > TAP > missing registries > must match snapshot 
 {
   "registries": {},
   "nodes": {
-    "file;.": [null]
+    "file;.": ["my-project",null]
   },
   "edges": []
 }
@@ -22,10 +22,10 @@ exports[`test/lockfile/save.ts > TAP > save > must match snapshot 1`] = `
     "custom": "http://example.com"
   },
   "nodes": {
-    "file;.": [null],
-    "registry;;bar@1.0.0": [null],
-    "registry;;foo@1.0.0": ["sha512-6/mh1E2u2YgEsCHdY0Yx5oW+61gZU+1vXaoiHHrpKeuRNNgFvS+/jrwHiQhB5apAf5oB7UB7E19ol2R2LKH8hQ=="],
-    "registry;custom;baz@1.0.0": [null,"http://example.com/baz.tgz"]
+    "file;.": ["my-project",null],
+    "registry;;bar@1.0.0": ["bar",null],
+    "registry;;foo@1.0.0": ["foo","sha512-6/mh1E2u2YgEsCHdY0Yx5oW+61gZU+1vXaoiHHrpKeuRNNgFvS+/jrwHiQhB5apAf5oB7UB7E19ol2R2LKH8hQ=="],
+    "registry;custom;baz@1.0.0": ["baz",null,"http://example.com/baz.tgz"]
   },
   "edges": [
     ["file;.","prod","foo@^1.0.0","registry;;foo@1.0.0"],

--- a/src/graph/tap-snapshots/test/node.ts.test.cjs
+++ b/src/graph/tap-snapshots/test/node.ts.test.cjs
@@ -13,6 +13,7 @@ Node [@vltpkg/graph.Node] {
   importer: true,
   integrity: undefined,
   manifest: [Object],
+  name: 'root',
   resolved: undefined
 }
 `

--- a/src/graph/test/lockfile/load.ts
+++ b/src/graph/test/lockfile/load.ts
@@ -25,15 +25,17 @@ t.test('load', async t => {
         custom: 'https://registry.example.com',
       },
       nodes: {
-        'file;.': [],
+        'file;.': ['my-project'],
         'registry;;foo@1.0.0': [
+          'foo',
           'sha512-6/mh1E2u2YgEsCHdY0Yx5oW+61gZU+1vXaoiHHrpKeuRNNgFvS+/jrwHiQhB5apAf5oB7UB7E19ol2R2LKH8hQ==',
         ],
         'registry;;bar@1.0.0': [
+          'bar',
           'sha512-6/deadbeef==',
           'https://registry.example.com/bar/-/bar-1.0.0.tgz',
         ],
-        'registry;;baz@1.0.0': [null],
+        'registry;;baz@1.0.0': ['baz', null],
       },
       edges: [
         ['file;.', 'prod', 'foo@^1.0.0', 'registry;;foo@1.0.0'],
@@ -68,8 +70,9 @@ t.test('unknown dep type', async t => {
         npm: 'https://registry.npmjs.org',
       },
       nodes: {
-        'file;.': [],
+        'file;.': ['my-project'],
         'registry;;foo@1.0.0': [
+          'foo',
           'sha512-6/mh1E2u2YgEsCHdY0Yx5oW+61gZU+1vXaoiHHrpKeuRNNgFvS+/jrwHiQhB5apAf5oB7UB7E19ol2R2LKH8hQ==',
         ],
       },
@@ -127,8 +130,9 @@ t.test('missing root pkg', async t => {
         npm: 'https://registry.npmjs.org',
       },
       nodes: {
-        'file;.': [],
+        'file;.': ['my-project'],
         'registry;;foo@1.0.0': [
+          'foo',
           'sha512-6/mh1E2u2YgEsCHdY0Yx5oW+61gZU+1vXaoiHHrpKeuRNNgFvS+/jrwHiQhB5apAf5oB7UB7E19ol2R2LKH8hQ==',
         ],
       },

--- a/src/graph/test/node.ts
+++ b/src/graph/test/node.ts
@@ -95,7 +95,13 @@ t.test('Node', async t => {
     'should throw a type error',
   )
 
-  const barNoMani = new Node(configData, 'registry;;bar@1.0.0')
+  const barNoMani = new Node(
+    configData,
+    'registry;;bar@1.0.0',
+    undefined,
+    undefined,
+    'bar',
+  )
   t.strictSame(
     barNoMani.location,
     './node_modules/.vlt/registry;;bar@1.0.0/node_modules/bar',
@@ -114,23 +120,23 @@ t.test('Node', async t => {
   )
   t.strictSame(
     unnamed.location,
-    './node_modules/.vlt/registry;;@0.0.0/node_modules/@0.0.0',
+    './node_modules/.vlt/registry;;@0.0.0/node_modules/registry;;@0.0.0',
     'should have a location for unnamed manifests',
   )
 
   // different resolved values inferred from id
   const file = new Node(configData, 'file;.%2Fmy-package')
-  file.setResolvedFromId()
+  file.setResolved()
   t.strictSame(
     file.resolved,
     './my-package',
     'should set expected resolved value for a file id type',
   )
   const git = new Node(configData, 'git;github%3Avltpkg%2Ffoo;')
-  git.setResolvedFromId()
+  git.setResolved()
   t.strictSame(
     git.resolved,
-    'git+ssh://git@github.com:vltpkg/foo.git',
+    'github:vltpkg/foo',
     'should set expected resolved value for a git id type',
   )
   const reg = new Node(configData, 'registry;;foo@1.0.0', {
@@ -139,14 +145,14 @@ t.test('Node', async t => {
       integrity: 'sha512-deadbeef',
     },
   })
-  reg.setResolvedFromId()
+  reg.setResolved()
   t.strictSame(
     reg.resolved,
     '<path-to-tarball>',
     'should set expected resolved value for a registry id type',
   )
   const regNoManifest = new Node(configData, 'registry;;foo@1.0.0')
-  regNoManifest.setResolvedFromId()
+  regNoManifest.setResolved()
   t.strictSame(
     regNoManifest.resolved,
     'https://registry.npmjs.org/foo/-/foo-1.0.0.tgz',
@@ -156,7 +162,7 @@ t.test('Node', async t => {
     configData,
     'remote;https%3A%2F%2Fx.com%2Fx.tgz',
   )
-  remote.setResolvedFromId()
+  remote.setResolved()
   t.strictSame(
     remote.resolved,
     'https://x.com/x.tgz',


### PR DESCRIPTION
This PR introduces a `name` property to the Node class that can then be stored in lockfiles and used when reading graphs from them.

- `Node.location` will now use its `name` property to compute expected `location`.
- `Node.setResolved` now also uses tuple values from `splitDepID` for types that don't need a parsed spec.