### PR TITLE
graph: add workspaces support to lockfile 

### DIFF
--- a/src/graph/src/visualization/human-readable-output.ts
+++ b/src/graph/src/visualization/human-readable-output.ts
@@ -14,6 +14,7 @@ function parseNode(seenNodes: Set<Node>, graph: Graph, node: Node) {
         : {
             id: node.id,
             location: node.location,
+            ...(node.importer ? { importer: true } : null),
             ...(node.resolved ? { resolved: node.resolved } : null),
             ...(node.integrity ?
               { integrity: node.integrity }

--- a/src/graph/tap-snapshots/test/actual/load.ts.test.cjs
+++ b/src/graph/tap-snapshots/test/actual/load.ts.test.cjs
@@ -10,6 +10,7 @@ exports[`test/actual/load.ts > TAP > cycle > should load an actual graph with cy
   Node {
     id: 'file;.',
     location: '.',
+    importer: true,
     edgesOut: [
       Edge spec(a@^1.0.0) -prod-> to: Node {
         id: 'registry;;a@1.0.0',
@@ -32,6 +33,7 @@ exports[`test/actual/load.ts > TAP > cycle > should load an actual graph with cy
   Node {
     id: 'file;.',
     location: '.',
+    importer: true,
     edgesOut: [
       Edge spec(a@1.0.0) -prod-> to: Node {
         id: 'registry;;a@1.0.0',
@@ -54,6 +56,7 @@ exports[`test/actual/load.ts > TAP > load actual > should load an actual graph c
   Node {
     id: 'file;.',
     location: '.',
+    importer: true,
     edgesOut: [
       Edge spec(link@file:./linked) -prod-> to: Node { id: 'file;.%2Flinked', location: './linked' },
       Edge spec(foo@^1.0.0) -prod-> to: Node {
@@ -94,11 +97,13 @@ exports[`test/actual/load.ts > TAP > load actual > should load an actual graph c
   },
   Node {
     id: 'workspace;packages%2Fworkspace-b',
-    location: './packages/workspace-b'
+    location: './packages/workspace-b',
+    importer: true
   },
   Node {
     id: 'workspace;packages%2Fworkspace-a',
     location: './packages/workspace-a',
+    importer: true,
     edgesOut: [
       Edge spec(workspace-b@workspace:*) -dev-> to: Node { id: 'workspace;workspace-b', location: './packages/workspace-b' },
       Edge spec(ipsum@^1.0.0) -dev-> to: Node {
@@ -119,6 +124,7 @@ exports[`test/actual/load.ts > TAP > load actual > should load an actual graph w
   Node {
     id: 'file;.',
     location: '.',
+    importer: true,
     edgesOut: [
       Edge spec(link@file:./linked) -prod-> to: Node { id: 'file;.%2Flinked', location: './linked' },
       Edge spec(foo@1.0.0) -prod-> to: Node {
@@ -162,11 +168,13 @@ exports[`test/actual/load.ts > TAP > load actual > should load an actual graph w
   },
   Node {
     id: 'workspace;packages%2Fworkspace-b',
-    location: './packages/workspace-b'
+    location: './packages/workspace-b',
+    importer: true
   },
   Node {
     id: 'workspace;packages%2Fworkspace-a',
     location: './packages/workspace-a',
+    importer: true,
     edgesOut: [
       Edge spec(workspace-b@workspace:*) -dev-> to: Node { id: 'workspace;workspace-b', location: './packages/workspace-b' },
       Edge spec(ipsum@1.0.0) -prod-> to: Node {

--- a/src/graph/tap-snapshots/test/lockfile/load.ts.test.cjs
+++ b/src/graph/tap-snapshots/test/lockfile/load.ts.test.cjs
@@ -10,6 +10,7 @@ exports[`test/lockfile/load.ts > TAP > load > must match snapshot 1`] = `
   Node {
     id: 'file;.',
     location: '.',
+    importer: true,
     edgesOut: [
       Edge spec(foo@^1.0.0) -prod-> to: Node {
         id: 'registry;;foo@1.0.0',
@@ -30,6 +31,29 @@ exports[`test/lockfile/load.ts > TAP > load > must match snapshot 1`] = `
       },
       Edge spec(missing@^1.0.0) -prod-> to: [missing package]: <missing@^1.0.0>
     ]
+  }
+]
+`
+
+exports[`test/lockfile/load.ts > TAP > workspaces > must match snapshot 1`] = `
+[
+  Node { id: 'file;.', location: '.', importer: true },
+  Node {
+    id: 'workspace;packages%2Fb',
+    location: './packages/b',
+    importer: true,
+    edgesOut: [
+      Edge spec(c@^1.0.0) -prod-> to: Node {
+        id: 'registry;;c@1.0.0',
+        location: './node_modules/.vlt/registry;;c@1.0.0/node_modules/c',
+        integrity: 'sha512-6/mh1E2u2YgEsCHdY0Yx5oW+61gZU+1vXaoiHHrpKeuRNNgFvS+/jrwHiQhB5apAf5oB7UB7E19ol2R2LKH8hQ=='
+      }
+    ]
+  },
+  Node {
+    id: 'workspace;packages%2Fa',
+    location: './packages/a',
+    importer: true
   }
 ]
 `

--- a/src/graph/tap-snapshots/test/lockfile/save.ts.test.cjs
+++ b/src/graph/tap-snapshots/test/lockfile/save.ts.test.cjs
@@ -9,10 +9,11 @@ exports[`test/lockfile/save.ts > TAP > missing registries > must match snapshot 
 {
   "registries": {},
   "nodes": {
-    "file;.": ["my-project",null]
+    "file;.": ["my-project"]
   },
   "edges": []
 }
+
 `
 
 exports[`test/lockfile/save.ts > TAP > save > must match snapshot 1`] = `
@@ -22,8 +23,8 @@ exports[`test/lockfile/save.ts > TAP > save > must match snapshot 1`] = `
     "custom": "http://example.com"
   },
   "nodes": {
-    "file;.": ["my-project",null],
-    "registry;;bar@1.0.0": ["bar",null],
+    "file;.": ["my-project"],
+    "registry;;bar@1.0.0": ["bar"],
     "registry;;foo@1.0.0": ["foo","sha512-6/mh1E2u2YgEsCHdY0Yx5oW+61gZU+1vXaoiHHrpKeuRNNgFvS+/jrwHiQhB5apAf5oB7UB7E19ol2R2LKH8hQ=="],
     "registry;custom;baz@1.0.0": ["baz",null,"http://example.com/baz.tgz"]
   },
@@ -33,4 +34,24 @@ exports[`test/lockfile/save.ts > TAP > save > must match snapshot 1`] = `
     ["file;.","prod","baz@custom:baz@^1.0.0","registry;custom;baz@1.0.0"]
   ]
 }
+
+`
+
+exports[`test/lockfile/save.ts > TAP > workspaces > should save lockfile with workspaces nodes 1`] = `
+{
+  "registries": {
+    "npm": "https://registry.npmjs.org",
+    "custom": "http://example.com"
+  },
+  "nodes": {
+    "file;.": ["my-project"],
+    "registry;;c@1.0.0": ["c","sha512-6/mh1E2u2YgEsCHdY0Yx5oW+61gZU+1vXaoiHHrpKeuRNNgFvS+/jrwHiQhB5apAf5oB7UB7E19ol2R2LKH8hQ=="],
+    "workspace;packages%2Fa": ["a"],
+    "workspace;packages%2Fb": ["b"]
+  },
+  "edges": [
+    ["workspace;packages%2Fb","prod","c@^1.0.0","registry;;c@1.0.0"]
+  ]
+}
+
 `

--- a/src/graph/tap-snapshots/test/visualization/human-readable-output.ts.test.cjs
+++ b/src/graph/tap-snapshots/test/visualization/human-readable-output.ts.test.cjs
@@ -10,6 +10,7 @@ exports[`test/visualization/human-readable-output.ts > TAP > cycle > should prin
   Node {
     id: 'file;.',
     location: '.',
+    importer: true,
     edgesOut: [
       Edge spec(a@^1.0.0) -prod-> to: Node {
         id: 'registry;;a@1.0.0',
@@ -32,6 +33,7 @@ exports[`test/visualization/human-readable-output.ts > TAP > human-readable-outp
   Node {
     id: 'file;.',
     location: '.',
+    importer: true,
     edgesOut: [
       Edge spec(foo@^1.0.0) -prod-> to: Node {
         id: 'registry;;foo@1.0.0',
@@ -64,8 +66,16 @@ exports[`test/visualization/human-readable-output.ts > TAP > human-readable-outp
 
 exports[`test/visualization/human-readable-output.ts > TAP > workspaces > should print human readable workspaces output 1`] = `
 [
-  Node { id: 'file;.', location: '.' },
-  Node { id: 'workspace;packages%2Fb', location: './packages/b' },
-  Node { id: 'workspace;packages%2Fa', location: './packages/a' }
+  Node { id: 'file;.', location: '.', importer: true },
+  Node {
+    id: 'workspace;packages%2Fb',
+    location: './packages/b',
+    importer: true
+  },
+  Node {
+    id: 'workspace;packages%2Fa',
+    location: './packages/a',
+    importer: true
+  }
 ]
 `


### PR DESCRIPTION
Based on top of #56 land that first.

Lockfile save / load are now aware of workspaces and store their nodes
and dependencies to a lockfile as well as being able to load a graph
from lockfiles containing workspaces nodes.