### PR TITLE
graph: refactor options

### DIFF
--- a/src/graph/src/actual/load.ts
+++ b/src/graph/src/actual/load.ts
@@ -283,10 +283,7 @@ export const load = (options: LoadOptions): Graph => {
   const monorepo =
     options.monorepo ??
     Monorepo.maybeLoad(options.dir, { packageJson, scurry })
-  const graph = new Graph(
-    { mainManifest, manifests: options.manifests, monorepo },
-    options,
-  )
+  const graph = new Graph({ ...options, mainManifest, monorepo })
   const depsFound = new Map<Node, Path>()
 
   // starts the list of initial folders to parse using the importer nodes

--- a/src/graph/src/graph.ts
+++ b/src/graph/src/graph.ts
@@ -1,15 +1,15 @@
-import { error } from '@vltpkg/error-cause'
 import { getId, DepID } from '@vltpkg/dep-id'
+import { error } from '@vltpkg/error-cause'
 import { Spec, SpecOptions } from '@vltpkg/spec'
+import { ManifestMinified } from '@vltpkg/types'
 import { Monorepo } from '@vltpkg/workspaces'
 import { Edge } from './edge.js'
 import { Node } from './node.js'
 import { DependencyTypeLong } from './dependencies.js'
-import { ManifestMinified } from '@vltpkg/types'
 
 export type ManifestInventory = Map<DepID, ManifestMinified>
 
-export interface GraphOptions {
+export type GraphOptions = SpecOptions & {
   /**
    * The main importer manifest info.
    */
@@ -72,11 +72,9 @@ export class Graph {
    */
   missingDependencies: Set<Edge> = new Set()
 
-  constructor(
-    { mainManifest, manifests, monorepo }: GraphOptions,
-    config: SpecOptions,
-  ) {
-    this.#config = config
+  constructor(options: GraphOptions) {
+    const { mainManifest, manifests, monorepo } = options
+    this.#config = options
     this.manifests = manifests ?? (new Map() as ManifestInventory)
 
     // add the project root node

--- a/src/graph/src/lockfile/load.ts
+++ b/src/graph/src/lockfile/load.ts
@@ -109,7 +109,11 @@ export const load = (options: LoadOptions): Graph => {
     ...options,
     registries: lockfileData.registries,
   } as SpecOptions
-  const graph = new Graph({ mainManifest, monorepo }, mergedOptions)
+  const graph = new Graph({
+    ...mergedOptions,
+    mainManifest,
+    monorepo,
+  })
 
   loadNodes({ graph, nodesInfo })
   loadEdges({ graph, edgesInfo }, mergedOptions)

--- a/src/graph/test/append-nodes.ts
+++ b/src/graph/test/append-nodes.ts
@@ -38,12 +38,10 @@ t.test('append a new node to a graph from a registry', async t => {
       foo: '^1.0.0',
     },
   }
-  const graph = new Graph(
-    {
-      mainManifest,
-    },
-    configData,
-  )
+  const graph = new Graph({
+    ...configData,
+    mainManifest,
+  })
   const packageInfo = {
     async manifest(spec: Spec) {
       switch (spec.name) {
@@ -138,12 +136,10 @@ t.test('append different type of dependencies', async t => {
       bar: '^1.0.0',
     },
   }
-  const graph = new Graph(
-    {
-      mainManifest,
-    },
-    configData,
-  )
+  const graph = new Graph({
+    ...configData,
+    mainManifest,
+  })
   const packageInfo = {
     async manifest(spec: Spec) {
       switch (spec.name) {

--- a/src/graph/test/graph.ts
+++ b/src/graph/test/graph.ts
@@ -1,8 +1,8 @@
 import { inspect } from 'node:util'
 import t from 'tap'
+import { hydrate } from '@vltpkg/dep-id'
 import { Spec, SpecOptions } from '@vltpkg/spec'
 import { Monorepo } from '@vltpkg/workspaces'
-import { hydrate } from '@vltpkg/dep-id'
 import { Graph } from '../src/graph.js'
 
 const kCustomInspect = Symbol.for('nodejs.util.inspect.custom')
@@ -24,12 +24,10 @@ t.test('Graph', async t => {
     name: 'my-project',
     version: '1.0.0',
   }
-  const graph = new Graph(
-    {
-      mainManifest,
-    },
-    configData,
-  )
+  const graph = new Graph({
+    ...configData,
+    mainManifest,
+  })
   t.strictSame(
     graph.mainImporter.manifest?.name,
     'my-project',
@@ -96,12 +94,10 @@ t.test('using placePackage', async t => {
       missing: '^1.0.0',
     },
   }
-  const graph = new Graph(
-    {
-      mainManifest,
-    },
-    configData,
-  )
+  const graph = new Graph({
+    ...configData,
+    mainManifest,
+  })
   const foo = graph.placePackage(
     graph.mainImporter,
     'dependencies',
@@ -159,12 +155,10 @@ t.test('main manifest missing name', async t => {
   const mainManifest = {
     version: '1.0.0',
   }
-  const graph = new Graph(
-    {
-      mainManifest,
-    },
-    configData,
-  )
+  const graph = new Graph({
+    ...configData,
+    mainManifest,
+  })
   const hydrateId = hydrate(graph.mainImporter.id)
   t.strictSame(
     hydrateId.type,
@@ -204,13 +198,11 @@ t.test('workspaces', async t => {
     },
   })
   const monorepo = Monorepo.maybeLoad(dir)
-  const graph = new Graph(
-    {
-      mainManifest,
-      monorepo,
-    },
-    configData,
-  )
+  const graph = new Graph({
+    ...configData,
+    mainManifest,
+    monorepo,
+  })
   t.matchSnapshot(
     graph.importers,
     'should have root and workspaces as importers',

--- a/src/graph/test/lockfile/save.ts
+++ b/src/graph/test/lockfile/save.ts
@@ -25,12 +25,10 @@ t.test('save', async t => {
     },
   }
   const dir = t.testdir()
-  const graph = new Graph(
-    {
-      mainManifest,
-    },
-    configData,
-  )
+  const graph = new Graph({
+    ...configData,
+    mainManifest,
+  })
   const foo = graph.placePackage(
     graph.mainImporter,
     'dependencies',
@@ -83,12 +81,10 @@ t.test('edge missing type', async t => {
     },
   }
   const dir = t.testdir()
-  const graph = new Graph(
-    {
-      mainManifest,
-    },
-    configData,
-  )
+  const graph = new Graph({
+    ...configData,
+    mainManifest,
+  })
   graph.newEdge(
     '' as DependencyTypeLong,
     Spec.parse('missing', '^1.0.0'),
@@ -115,12 +111,10 @@ t.test('missing registries', async t => {
     registries: undefined,
   }
   const dir = t.testdir()
-  const graph = new Graph(
-    {
-      mainManifest,
-    },
-    borkedConfigData,
-  )
+  const graph = new Graph({
+    ...borkedConfigData,
+    mainManifest,
+  })
   save({ ...borkedConfigData, graph, dir })
   t.matchSnapshot(
     readFileSync(resolve(dir, 'vlt-lock.json'), { encoding: 'utf8' }),
@@ -156,13 +150,11 @@ t.test('workspaces', async t => {
     },
   })
   const monorepo = Monorepo.load(dir)
-  const graph = new Graph(
-    {
-      mainManifest,
-      monorepo,
-    },
-    configData,
-  )
+  const graph = new Graph({
+    ...configData,
+    mainManifest,
+    monorepo,
+  })
   const b = graph.nodes.get('workspace;packages%2Fb')
   if (!b) {
     throw new Error('Missing workspace b')

--- a/src/graph/test/visualization/human-readable-output.ts
+++ b/src/graph/test/visualization/human-readable-output.ts
@@ -13,20 +13,18 @@ const configData = {
 } satisfies SpecOptions
 
 t.test('human-readable-output', async t => {
-  const graph = new Graph(
-    {
-      mainManifest: {
-        name: 'my-project',
-        version: '1.0.0',
-        dependencies: {
-          foo: '^1.0.0',
-          bar: '^1.0.0',
-          missing: '^1.0.0',
-        },
+  const graph = new Graph({
+    ...configData,
+    mainManifest: {
+      name: 'my-project',
+      version: '1.0.0',
+      dependencies: {
+        foo: '^1.0.0',
+        bar: '^1.0.0',
+        missing: '^1.0.0',
       },
     },
-    configData,
-  )
+  })
   const foo = graph.placePackage(
     graph.mainImporter,
     'dependencies',
@@ -130,13 +128,11 @@ t.test('workspaces', async t => {
     },
   })
   const monorepo = Monorepo.load(dir)
-  const graph = new Graph(
-    {
-      mainManifest,
-      monorepo,
-    },
-    configData,
-  )
+  const graph = new Graph({
+    ...configData,
+    mainManifest,
+    monorepo,
+  })
   t.matchSnapshot(
     humanReadableOutput(graph),
     'should print human readable workspaces output',
@@ -144,18 +140,16 @@ t.test('workspaces', async t => {
 })
 
 t.test('cycle', async t => {
-  const graph = new Graph(
-    {
-      mainManifest: {
-        name: 'my-project',
-        version: '1.0.0',
-        dependencies: {
-          a: '^1.0.0',
-        },
+  const graph = new Graph({
+    ...configData,
+    mainManifest: {
+      name: 'my-project',
+      version: '1.0.0',
+      dependencies: {
+        a: '^1.0.0',
       },
     },
-    configData,
-  )
+  })
   const a = graph.placePackage(
     graph.mainImporter,
     'dependencies',

--- a/src/graph/test/visualization/mermaid-output.ts
+++ b/src/graph/test/visualization/mermaid-output.ts
@@ -12,20 +12,18 @@ const configData = {
 } satisfies SpecOptions
 
 t.test('human-readable-output', async t => {
-  const graph = new Graph(
-    {
-      mainManifest: {
-        name: 'my-project',
-        version: '1.0.0',
-        dependencies: {
-          foo: '^1.0.0',
-          bar: '^1.0.0',
-          missing: '^1.0.0',
-        },
+  const graph = new Graph({
+    ...configData,
+    mainManifest: {
+      name: 'my-project',
+      version: '1.0.0',
+      dependencies: {
+        foo: '^1.0.0',
+        bar: '^1.0.0',
+        missing: '^1.0.0',
       },
     },
-    configData,
-  )
+  })
   const foo = graph.placePackage(
     graph.mainImporter,
     'dependencies',
@@ -105,13 +103,11 @@ t.test('workspaces', async t => {
     },
   })
   const monorepo = Monorepo.load(dir)
-  const graph = new Graph(
-    {
-      mainManifest,
-      monorepo,
-    },
-    configData,
-  )
+  const graph = new Graph({
+    ...configData,
+    mainManifest,
+    monorepo,
+  })
   t.matchSnapshot(
     mermaidOutput(graph),
     'should print workspaces mermaid output',


### PR DESCRIPTION
Based on top of https://github.com/vltpkg/vltpkg/pull/66 land that first.

Refactor options for `Graph` in order to have a single object that
should contain the `SpecOptions` needed by the `Node` class.