### PR TITLE
use projectRoot option instead of cwd/dir

### DIFF
--- a/src/error-cause/src/index.ts
+++ b/src/error-cause/src/index.ts
@@ -58,6 +58,9 @@ export interface ErrorCauseObject {
   /** null or a signal that a process received */
   signal?: null | NodeJS.Signals
 
+  /** the root of a project */
+  projectRoot?: string
+
   /** the current working directory of a process */
   cwd?: string
 

--- a/src/graph/src/actual/load.ts
+++ b/src/graph/src/actual/load.ts
@@ -14,7 +14,7 @@ export type LoadOptions = SpecOptions & {
   /**
    * The project root dirname.
    */
-  dir: string
+  projectRoot: string
   /**
    * An inventory of seen manifests.
    */
@@ -278,11 +278,11 @@ const parseDir = (
  */
 export const load = (options: LoadOptions): Graph => {
   const packageJson = options.packageJson ?? new PackageJson()
-  const mainManifest = packageJson.read(options.dir)
-  const scurry = options.scurry ?? new PathScurry(options.dir)
+  const mainManifest = packageJson.read(options.projectRoot)
+  const scurry = options.scurry ?? new PathScurry(options.projectRoot)
   const monorepo =
     options.monorepo ??
-    Monorepo.maybeLoad(options.dir, { packageJson, scurry })
+    Monorepo.maybeLoad(options.projectRoot, { packageJson, scurry })
   const graph = new Graph({ ...options, mainManifest, monorepo })
   const depsFound = new Map<Node, Path>()
 

--- a/src/graph/src/lockfile/README.md
+++ b/src/graph/src/lockfile/README.md
@@ -5,15 +5,15 @@ reads information from stored lockfiles to rebuild a virtual `Graph`.
 
 ## USAGE
 
-```
+```js
 import { lockfile } from '@vltpkg/graph'
 import { PackageJson } from '@vltpkg/package-json'
 
-const dir = 'path/to/my-project'
+const projectRoot = '/path/to/my-project'
 const packageJson = new PackageJson()
-const mainManifest = await packageJson.read(dir)
+const mainManifest = await packageJson.read(projectRoot)
 const graph = lockfile.load({
-  dir,
+  projectRoot,
   mainManifest,
 })
 

--- a/src/graph/src/lockfile/load.ts
+++ b/src/graph/src/lockfile/load.ts
@@ -19,7 +19,7 @@ export type LoadOptions = SpecOptions & {
   /**
    * The project root dirname.
    */
-  dir: string
+  projectRoot: string
   /**
    * The project root manifest.
    */
@@ -85,8 +85,8 @@ const loadEdges = (
 }
 
 export const load = (options: LoadOptions): Graph => {
-  const { dir, mainManifest, scurry } = options
-  const file = readFileSync(resolve(dir, 'vlt-lock.json'), {
+  const { projectRoot, mainManifest, scurry } = options
+  const file = readFileSync(resolve(projectRoot, 'vlt-lock.json'), {
     encoding: 'utf8',
   })
   const lockfileData = JSON.parse(file) as LockfileData
@@ -104,7 +104,7 @@ export const load = (options: LoadOptions): Graph => {
   const packageJson = options.packageJson ?? new PackageJson()
   const monorepo =
     options.monorepo ??
-    Monorepo.maybeLoad(options.dir, { packageJson, scurry })
+    Monorepo.maybeLoad(options.projectRoot, { packageJson, scurry })
   const mergedOptions = {
     ...options,
     registries: lockfileData.registries,

--- a/src/graph/src/lockfile/save.ts
+++ b/src/graph/src/lockfile/save.ts
@@ -1,23 +1,23 @@
-import { writeFileSync } from 'node:fs'
-import { resolve } from 'node:path'
 import { DepID } from '@vltpkg/dep-id'
 import { error } from '@vltpkg/error-cause'
 import { SpecOptions } from '@vltpkg/spec'
+import { writeFileSync } from 'node:fs'
+import { resolve } from 'node:path'
 import { dependencyTypes } from '../dependencies.js'
 import { Edge } from '../edge.js'
 import { Graph } from '../graph.js'
 import { Node } from '../node.js'
 import {
   LockfileData,
-  LockfileDataNode,
   LockfileDataEdge,
+  LockfileDataNode,
 } from './types.js'
 
 export type SaveOptions = SpecOptions & {
   /**
    * The project root dirname.
    */
-  dir: string
+  projectRoot: string
   /**
    * The graph to be stored in the lockfile.
    */
@@ -74,7 +74,7 @@ const isRegistries = (
   !(!registries || typeof registries === 'string')
 
 export const save = (options: SaveOptions) => {
-  const { graph, dir, registry, registries } = options
+  const { graph, projectRoot, registry, registries } = options
   const lockfileData: LockfileData = {
     registries: isRegistries(registries) ? registries : {},
     nodes: formatNodes(graph.nodes.values(), registry),
@@ -84,5 +84,5 @@ export const save = (options: SaveOptions) => {
     // renders each node / edge as a single line entry
     .replaceAll('\n      ', '')
     .replaceAll('\n    ]', ']')
-  writeFileSync(resolve(dir, 'vlt-lock.json'), content)
+  writeFileSync(resolve(projectRoot, 'vlt-lock.json'), content)
 }

--- a/src/graph/test/actual/load.ts
+++ b/src/graph/test/actual/load.ts
@@ -1,5 +1,5 @@
-import t from 'tap'
 import { SpecOptions } from '@vltpkg/spec'
+import t from 'tap'
 import { load } from '../../src/actual/load.js'
 import { humanReadableOutput } from '../../src/visualization/human-readable-output.js'
 
@@ -12,7 +12,7 @@ const configData = {
 } satisfies SpecOptions
 
 t.test('load actual', async t => {
-  const dir = t.testdir({
+  const projectRoot = t.testdir({
     'package.json': JSON.stringify({
       name: 'my-project',
       version: '1.0.0',
@@ -212,7 +212,11 @@ t.test('load actual', async t => {
     }),
   })
 
-  const fullGraph = load({ dir, loadManifests: true, ...configData })
+  const fullGraph = load({
+    projectRoot,
+    loadManifests: true,
+    ...configData,
+  })
 
   t.strictSame(
     fullGraph.missingDependencies.size,
@@ -233,7 +237,7 @@ t.test('load actual', async t => {
 
   t.matchSnapshot(
     humanReadableOutput(
-      load({ dir, loadManifests: false, ...configData }),
+      load({ projectRoot, loadManifests: false, ...configData }),
     ),
     'should load an actual graph without any manifest info',
   )
@@ -244,7 +248,7 @@ t.test('cycle', async t => {
   // +- a
   //    +- b
   //       +- a
-  const dir = t.testdir({
+  const projectRoot = t.testdir({
     'package.json': JSON.stringify({
       name: 'my-project',
       version: '1.0.0',
@@ -297,13 +301,13 @@ t.test('cycle', async t => {
   })
   t.matchSnapshot(
     humanReadableOutput(
-      load({ dir, loadManifests: true, ...configData }),
+      load({ projectRoot, loadManifests: true, ...configData }),
     ),
     'should load an actual graph with cycle containing missing deps info',
   )
   t.matchSnapshot(
     humanReadableOutput(
-      load({ dir, loadManifests: false, ...configData }),
+      load({ projectRoot, loadManifests: false, ...configData }),
     ),
     'should load an actual graph with cycle without any manifest info',
   )

--- a/src/graph/test/lockfile/load.ts
+++ b/src/graph/test/lockfile/load.ts
@@ -1,6 +1,6 @@
+import { SpecOptions } from '@vltpkg/spec'
 import t from 'tap'
 import { load } from '../../src/lockfile/load.js'
-import { SpecOptions } from '@vltpkg/spec'
 import { humanReadableOutput } from '../../src/visualization/human-readable-output.js'
 
 const configData = {
@@ -17,7 +17,7 @@ const mainManifest = {
 }
 
 t.test('load', async t => {
-  const dir = t.testdir({
+  const projectRoot = t.testdir({
     'vlt-lock.json': JSON.stringify({
       registries: {
         npm: 'https://registry.npmjs.org',
@@ -52,14 +52,14 @@ t.test('load', async t => {
 
   const graph = load({
     ...configData,
-    dir,
+    projectRoot,
     mainManifest,
   })
   t.matchSnapshot(humanReadableOutput(graph))
 })
 
 t.test('workspaces', async t => {
-  const dir = t.testdir({
+  const projectRoot = t.testdir({
     'vlt-lock.json': JSON.stringify({
       registries: {
         npm: 'https://registry.npmjs.org',
@@ -107,14 +107,14 @@ t.test('workspaces', async t => {
 
   const graph = load({
     ...configData,
-    dir,
+    projectRoot,
     mainManifest,
   })
   t.matchSnapshot(humanReadableOutput(graph))
 })
 
 t.test('unknown dep type', async t => {
-  const dir = t.testdir({
+  const projectRoot = t.testdir({
     'vlt-lock.json': JSON.stringify({
       registries: {
         npm: 'https://registry.npmjs.org',
@@ -136,7 +136,7 @@ t.test('unknown dep type', async t => {
     () =>
       load({
         ...configData,
-        dir,
+        projectRoot,
         mainManifest,
       }),
     /Found unsupported dependency type in lockfile/,
@@ -145,7 +145,7 @@ t.test('unknown dep type', async t => {
 })
 
 t.test('missing root pkg', async t => {
-  const dir = t.testdir({
+  const projectRoot = t.testdir({
     'vlt-lock.json': JSON.stringify({
       registries: {
         npm: 'https://registry.npmjs.org',
@@ -161,7 +161,7 @@ t.test('missing root pkg', async t => {
     () =>
       load({
         ...configData,
-        dir,
+        projectRoot,
         mainManifest,
       }),
     /Missing nodes from lockfile/,
@@ -170,7 +170,7 @@ t.test('missing root pkg', async t => {
 })
 
 t.test('missing root pkg', async t => {
-  const dir = t.testdir({
+  const projectRoot = t.testdir({
     'vlt-lock.json': JSON.stringify({
       registries: {
         npm: 'https://registry.npmjs.org',
@@ -190,7 +190,7 @@ t.test('missing root pkg', async t => {
     () =>
       load({
         ...configData,
-        dir,
+        projectRoot,
         mainManifest,
       }),
     /Edge info missing its `from` node/,

--- a/src/graph/test/lockfile/save.ts
+++ b/src/graph/test/lockfile/save.ts
@@ -1,8 +1,8 @@
+import { Spec, SpecOptions } from '@vltpkg/spec'
+import { Monorepo } from '@vltpkg/workspaces'
 import { readFileSync } from 'node:fs'
 import { resolve } from 'node:path'
 import t from 'tap'
-import { Spec, SpecOptions } from '@vltpkg/spec'
-import { Monorepo } from '@vltpkg/workspaces'
 import { DependencyTypeLong } from '../../src/dependencies.js'
 import { Graph } from '../../src/graph.js'
 import { save } from '../../src/lockfile/save.js'
@@ -24,7 +24,7 @@ t.test('save', async t => {
       foo: '^1.0.0',
     },
   }
-  const dir = t.testdir()
+  const projectRoot = t.testdir()
   const graph = new Graph({
     ...configData,
     mainManifest,
@@ -66,9 +66,11 @@ t.test('save', async t => {
       },
     )
     ?.setResolved()
-  save({ ...configData, graph, dir })
+  save({ ...configData, graph, projectRoot })
   t.matchSnapshot(
-    readFileSync(resolve(dir, 'vlt-lock.json'), { encoding: 'utf8' }),
+    readFileSync(resolve(projectRoot, 'vlt-lock.json'), {
+      encoding: 'utf8',
+    }),
   )
 })
 
@@ -80,7 +82,7 @@ t.test('edge missing type', async t => {
       missing: '^1.0.0',
     },
   }
-  const dir = t.testdir()
+  const projectRoot = t.testdir()
   const graph = new Graph({
     ...configData,
     mainManifest,
@@ -91,7 +93,7 @@ t.test('edge missing type', async t => {
     graph.mainImporter,
   )
   t.throws(
-    () => save({ ...configData, graph, dir }),
+    () => save({ ...configData, graph, projectRoot }),
     /Found edge with a missing type/,
     'should throw if finds an edge with missing type',
   )
@@ -110,14 +112,16 @@ t.test('missing registries', async t => {
     registry: 'http://example.com',
     registries: undefined,
   }
-  const dir = t.testdir()
+  const projectRoot = t.testdir()
   const graph = new Graph({
     ...borkedConfigData,
     mainManifest,
   })
-  save({ ...borkedConfigData, graph, dir })
+  save({ ...borkedConfigData, graph, projectRoot })
   t.matchSnapshot(
-    readFileSync(resolve(dir, 'vlt-lock.json'), { encoding: 'utf8' }),
+    readFileSync(resolve(projectRoot, 'vlt-lock.json'), {
+      encoding: 'utf8',
+    }),
   )
 })
 
@@ -126,7 +130,7 @@ t.test('workspaces', async t => {
     name: 'my-project',
     version: '1.0.0',
   }
-  const dir = t.testdir({
+  const projectRoot = t.testdir({
     'package.json': JSON.stringify(mainManifest),
     'vlt-workspaces.json': JSON.stringify({
       packages: ['./packages/*'],
@@ -149,7 +153,7 @@ t.test('workspaces', async t => {
       },
     },
   })
-  const monorepo = Monorepo.load(dir)
+  const monorepo = Monorepo.load(projectRoot)
   const graph = new Graph({
     ...configData,
     mainManifest,
@@ -170,10 +174,12 @@ t.test('workspaces', async t => {
     })
     ?.setResolved()
 
-  save({ ...configData, graph, dir })
+  save({ ...configData, graph, projectRoot })
 
   t.matchSnapshot(
-    readFileSync(resolve(dir, 'vlt-lock.json'), { encoding: 'utf8' }),
+    readFileSync(resolve(projectRoot, 'vlt-lock.json'), {
+      encoding: 'utf8',
+    }),
     'should save lockfile with workspaces nodes',
   )
 })

--- a/src/package-info/test/index.ts
+++ b/src/package-info/test/index.ts
@@ -775,7 +775,7 @@ t.test('workspace specs', async t => {
   })
   const opts = {
     ...options,
-    cwd: dir,
+    projectRoot: dir,
   }
   t.equal(
     (await resolve('b@workspace:*', opts)).resolved,
@@ -825,7 +825,7 @@ t.test('workspace group option', async t => {
   })
   const opts = {
     ...options,
-    cwd: dir,
+    projectRoot: dir,
     // only load the ones that are 1 char
     workspace: ['p/[a-z]'],
     // even though the `'b'` group includes 'bb'

--- a/src/spec/src/index.ts
+++ b/src/spec/src/index.ts
@@ -281,7 +281,8 @@ export class Spec {
       for (const [name, origin] of Object.entries(gitHostWebsites)) {
         if (this.bareSpec.startsWith(origin)) {
           const parsed = new URL(this.bareSpec)
-          const [user, project] = parsed.pathname.replace(/\.git$/, '')
+          const [user, project] = parsed.pathname
+            .replace(/\.git$/, '')
             .replace(/\/+/g, ' ')
             .trim()
             .split(' ')

--- a/src/vlt/src/index.ts
+++ b/src/vlt/src/index.ts
@@ -8,12 +8,15 @@ export * from './config/index.js'
 // Infer the workspace by being in that directory.
 const vlt = await Config.load(process.cwd(), process.argv)
 if (vlt.get('workspace') === undefined) {
-  const cwd = process.cwd()
-  const rel = relative(vlt.cwd, process.cwd()).replace(/\\/g, '/')
-  const m = Monorepo.maybeLoad(vlt.cwd, {
+  const projectRoot = process.cwd()
+  const rel = relative(vlt.projectRoot, process.cwd()).replace(
+    /\\/g,
+    '/',
+  )
+  const m = Monorepo.maybeLoad(vlt.projectRoot, {
     load: { paths: rel },
   })
-  const ws = m?.get(cwd)
+  const ws = m?.get(projectRoot)
   if (ws) vlt.values.workspace = [ws.path]
 }
 

--- a/src/vlt/test/config/definition.ts
+++ b/src/vlt/test/config/definition.ts
@@ -10,10 +10,12 @@ t.matchSnapshot(commands, 'commands')
 const defObj = definition.toJSON()
 // strip out all the defaults, because that's platform-specific
 t.matchSnapshot(
-  Object.fromEntries(Object.entries(defObj).map(([k, v]) => {
-    const { default: _def, ...def } = v
-    return [k, def]
-  })),
+  Object.fromEntries(
+    Object.entries(defObj).map(([k, v]) => {
+      const { default: _def, ...def } = v
+      return [k, def]
+    }),
+  ),
   'definition',
 )
 

--- a/src/vlt/test/config/index.ts
+++ b/src/vlt/test/config/index.ts
@@ -38,7 +38,7 @@ t.test('read and write a project config', async t => {
   t.equal(conf, await Config.load(dir + '/a/b'), 'load is memoized')
   t.equal(conf.parse(), conf, 'parsing a second time is no-op')
   t.equal(conf.get('registry'), 'https://registry.vlt.sh/')
-  t.equal(conf.cwd, dir)
+  t.equal(conf.projectRoot, dir)
   await conf.addConfigToFile('project', { cache: dir + '/cache' })
   clearEnv()
   const c2 = await Config.load(dir + '/a/b', undefined, true)
@@ -90,7 +90,7 @@ t.test('read and write a user config', async t => {
   })
   const conf = await Config.load(dir + '/a/b')
   t.equal(conf.get('registry'), 'https://registry.vlt.sh/')
-  t.equal(conf.cwd, dir)
+  t.equal(conf.projectRoot, dir)
   await conf.addConfigToFile('user', { cache: dir + '/cache' })
   clearEnv()
   const c2 = await Config.load(dir + '/a/b', undefined, true)
@@ -505,7 +505,7 @@ t.test('do not walk to home dir', async t => {
     },
   })
   const c = await Config.load(dir + '/a/b')
-  t.equal(c.cwd, resolve(dir, 'a/b'))
+  t.equal(c.projectRoot, resolve(dir, 'a/b'))
 })
 
 t.test('do not walk past xdg config dir', async t => {
@@ -530,7 +530,7 @@ t.test('do not walk past xdg config dir', async t => {
     '@vltpkg/xdg': mockXDG,
   })
   const c = await Config.load(dir + '/a/b')
-  t.equal(c.cwd, resolve(dir, 'a/b'))
+  t.equal(c.projectRoot, resolve(dir, 'a/b'))
 })
 
 t.test('delete config values from file', async t => {

--- a/src/workspaces/test/index.ts
+++ b/src/workspaces/test/index.ts
@@ -277,13 +277,13 @@ t.test('missing/invalid vlt-workspaces.json file', t => {
     }),
   })
   const m = new Monorepo(dir)
-  t.equal(Monorepo.maybeLoad(m.cwd), undefined)
+  t.equal(Monorepo.maybeLoad(m.projectRoot), undefined)
   t.throws(() => m.load(), {
     message: 'Not in a monorepo, no vlt-workspaces.json found',
   })
 
   mkdirSync(dir + '/vlt-workspaces.json')
-  t.equal(Monorepo.maybeLoad(m.cwd), undefined)
+  t.equal(Monorepo.maybeLoad(m.projectRoot), undefined)
   t.throws(() => m.load(), {
     message: 'Not in a monorepo, no vlt-workspaces.json found',
   })
@@ -291,7 +291,7 @@ t.test('missing/invalid vlt-workspaces.json file', t => {
   rmdirSync(dir + '/vlt-workspaces.json')
 
   writeFileSync(dir + '/vlt-workspaces.json', 'hello, world')
-  t.throws(() => Monorepo.maybeLoad(m.cwd), {
+  t.throws(() => Monorepo.maybeLoad(m.projectRoot), {
     message: 'Invalid vlt-workspaces.json file',
   })
   t.throws(() => m.load(), {
@@ -303,7 +303,7 @@ t.test('missing/invalid vlt-workspaces.json file', t => {
       hello: { world: true },
     }),
   )
-  t.throws(() => Monorepo.maybeLoad(m.cwd), {
+  t.throws(() => Monorepo.maybeLoad(m.projectRoot), {
     message: 'Invalid workspace definition',
     cause: {
       path: dir,


### PR DESCRIPTION
Except where it actually refers to a "current working directory" or some arbitrary directory that isn't necessarily a projectRoot.

Fix: https://github.com/vltpkg/vltpkg/issues/65