### PR TITLE
graph: refactor dependencies

### DIFF
--- a/src/graph/src/edge.ts
+++ b/src/graph/src/edge.ts
@@ -1,7 +1,6 @@
-import { satisfies } from '@vltpkg/semver'
 import { Spec } from '@vltpkg/spec'
 import { Node } from './node.js'
-import { DependencyTypeLong } from './dependencies.js'
+import { DependencyTypeShort } from './dependencies.js'
 
 export class Edge {
   get [Symbol.toStringTag]() {
@@ -21,7 +20,7 @@ export class Edge {
   /**
    * What type of dependency relationship `from` and `to` nodes have.
    */
-  type: DependencyTypeLong
+  type: DependencyTypeShort
 
   /**
    * The defined spec value for `to` as parsed from the dependent metadata.
@@ -29,7 +28,7 @@ export class Edge {
   spec: Spec
 
   constructor(
-    type: DependencyTypeLong,
+    type: DependencyTypeShort,
     spec: Spec,
     from: Node,
     to?: Node,
@@ -47,39 +46,22 @@ export class Edge {
     return this.spec.name
   }
 
-  get peer(): boolean {
-    return this.type === 'peerDependencies'
-  }
-
+  /**
+   * This edge was defined as part of a `devDependencies` in `package.json`
+   */
   get dev(): boolean {
-    return this.type === 'devDependencies'
-  }
-
-  // TODO: devOptional
-
-  get peerOptional(): boolean {
-    return (
-      this.peer &&
-      this.from.manifest?.peerDependenciesMeta?.[this.spec.name]
-        ?.optional === true
-    )
+    return this.type === 'dev'
   }
 
   get optional(): boolean {
-    return this.peerOptional || this.type === 'optionalDependencies'
+    return this.type === 'peerOptional' || this.type === 'optional'
   }
 
-  get valid(): boolean {
-    if (!this.to) return this.optional
-    if (this.spec.type === 'registry') {
-      if (this.to?.manifest?.version && this.spec.range) {
-        return satisfies(this.to?.manifest?.version, this.spec.range)
-      }
-      return true
-      /* c8 ignore start */
-    }
-    // TODO: git deps, file deps, remote deps, workspace deps
-    return false
+  get peer(): boolean {
+    return this.type === 'peer' || this.type === 'peerOptional'
   }
-  /* c8 ignore stop */
+
+  get peerOptional(): boolean {
+    return this.type === 'peerOptional'
+  }
 }

--- a/src/graph/src/graph.ts
+++ b/src/graph/src/graph.ts
@@ -5,7 +5,7 @@ import { ManifestMinified } from '@vltpkg/types'
 import { Monorepo } from '@vltpkg/workspaces'
 import { Edge } from './edge.js'
 import { Node } from './node.js'
-import { DependencyTypeLong } from './dependencies.js'
+import { DependencyTypeShort } from './dependencies.js'
 
 export type ManifestInventory = Map<DepID, ManifestMinified>
 
@@ -119,7 +119,7 @@ export class Graph {
    * pointing to nothing will be created to represent that missing dependency.
    */
   newEdge(
-    type: DependencyTypeLong,
+    type: DependencyTypeShort,
     spec: Spec,
     from: Node,
     to?: Node,
@@ -159,7 +159,7 @@ export class Graph {
    */
   placePackage(
     fromNode: Node,
-    depType: DependencyTypeLong,
+    depType: DependencyTypeShort,
     spec: Spec,
     manifest?: ManifestMinified,
     id?: DepID,

--- a/src/graph/src/lockfile/load.ts
+++ b/src/graph/src/lockfile/load.ts
@@ -7,7 +7,10 @@ import { Spec, SpecOptions } from '@vltpkg/spec'
 import { ManifestMinified } from '@vltpkg/types'
 import { Monorepo } from '@vltpkg/workspaces'
 import { PathScurry } from 'path-scurry'
-import { longTypes } from '../dependencies.js'
+import {
+  longDependencyTypes,
+  shortDependencyTypes,
+} from '../dependencies.js'
 import { Graph } from '../graph.js'
 import {
   LockfileData,
@@ -65,12 +68,10 @@ const loadEdges = (
   { graph, edgesInfo }: LoadEdgesOptions,
   options: SpecOptions,
 ) => {
-  for (const [fromId, shortType, spec, toId] of edgesInfo) {
-    const type = longTypes.get(shortType)
-    if (!type) {
+  for (const [fromId, type, spec, toId] of edgesInfo) {
+    if (!type || !shortDependencyTypes.has(type)) {
       throw error('Found unsupported dependency type in lockfile', {
-        found: shortType,
-        validOptions: Object.keys(longTypes),
+        validOptions: [...longDependencyTypes],
       })
     }
     const from = graph.nodes.get(fromId)

--- a/src/graph/src/lockfile/save.ts
+++ b/src/graph/src/lockfile/save.ts
@@ -1,9 +1,7 @@
 import { DepID } from '@vltpkg/dep-id'
-import { error } from '@vltpkg/error-cause'
 import { SpecOptions } from '@vltpkg/spec'
 import { writeFileSync } from 'node:fs'
 import { resolve } from 'node:path'
-import { dependencyTypes } from '../dependencies.js'
 import { Edge } from '../edge.js'
 import { Graph } from '../graph.js'
 import { Node } from '../node.js'
@@ -58,15 +56,12 @@ const formatNodes = (nodes: Iterable<Node>, registry?: string) => {
 }
 
 const formatEdges = (edges: Set<Edge>): LockfileDataEdge[] =>
-  [...edges].map(edge => {
-    const type = dependencyTypes.get(edge.type)
-    if (!type) {
-      throw error('Found edge with a missing type', {
-        spec: edge.spec,
-      })
-    }
-    return [edge.from.id, type, String(edge.spec), edge.to?.id]
-  })
+  [...edges].map(edge => [
+    edge.from.id,
+    edge.type,
+    String(edge.spec),
+    edge.to?.id,
+  ])
 
 const isRegistries = (
   registries: unknown,

--- a/src/graph/src/node.ts
+++ b/src/graph/src/node.ts
@@ -8,7 +8,7 @@ import {
 import { typeError } from '@vltpkg/error-cause'
 import { Spec, SpecOptions } from '@vltpkg/spec'
 import { Integrity, ManifestMinified } from '@vltpkg/types'
-import { DependencyTypeLong } from './dependencies.js'
+import { DependencyTypeShort } from './dependencies.js'
 import { Edge } from './edge.js'
 
 export class Node {
@@ -148,7 +148,7 @@ export class Node {
   /**
    * Add an edge from this node connecting it to a direct dependency.
    */
-  addEdgesTo(type: DependencyTypeLong, spec: Spec, node?: Node) {
+  addEdgesTo(type: DependencyTypeShort, spec: Spec, node?: Node) {
     const edge = new Edge(type, spec, this, node)
     node?.edgesIn.add(edge)
     this.edgesOut.set(spec.name, edge)

--- a/src/graph/src/visualization/human-readable-output.ts
+++ b/src/graph/src/visualization/human-readable-output.ts
@@ -1,5 +1,4 @@
 import { inspect } from 'node:util'
-import { dependencyTypes } from '../dependencies.js'
 import { Graph } from '../graph.js'
 import { Node } from '../node.js'
 import { Edge } from '../edge.js'
@@ -47,7 +46,7 @@ function parseEdge(seenNodes: Set<Node>, graph: Graph, edge: Edge) {
             depth: Infinity,
           })
       : missingNode
-    return `Edge spec(${edge.spec}) -${dependencyTypes.get(edge.type)}-> to: ${toLabel}`
+    return `Edge spec(${edge.spec}) -${edge.type}-> to: ${toLabel}`
   }
   return edge
 }

--- a/src/graph/src/visualization/mermaid-output.ts
+++ b/src/graph/src/visualization/mermaid-output.ts
@@ -1,5 +1,4 @@
 import { DepID } from '@vltpkg/dep-id'
-import { dependencyTypes } from '../dependencies.js'
 import { Edge } from '../edge.js'
 import { Graph } from '../graph.js'
 import { Node } from '../node.js'
@@ -20,7 +19,7 @@ function parseNode(seenNodes: Set<DepID>, graph: Graph, node: Node) {
 function parseEdge(seenNodes: Set<DepID>, graph: Graph, edge: Edge) {
   const edgeResult =
     `${encodeURIComponent(edge.from.id)}(${edge.from.id})` +
-    ` -->|${dependencyTypes.get(edge.type)}| `
+    ` -->|${edge.type}| `
 
   if (!edge.to) {
     return (

--- a/src/graph/tap-snapshots/test/append-nodes.ts.test.cjs
+++ b/src/graph/tap-snapshots/test/append-nodes.ts.test.cjs
@@ -43,7 +43,7 @@ Graph [@vltpkg/graph.Graph] {
         name: 'foo',
         resolved: 'https://registry.npmjs.org/foo/-/foo-1.0.0.tgz'
       },
-      type: 'devDependencies',
+      type: 'dev',
       spec: Spec {foo@^1.0.0}
     },
     Edge [@vltpkg/graph.Edge] {
@@ -67,7 +67,7 @@ Graph [@vltpkg/graph.Graph] {
         name: 'bar',
         resolved: 'https://registry.npmjs.org/bar/-/bar-1.0.0.tgz'
       },
-      type: 'optionalDependencies',
+      type: 'optional',
       spec: Spec {bar@^1.0.0}
     },
     Edge [@vltpkg/graph.Edge] {
@@ -82,7 +82,7 @@ Graph [@vltpkg/graph.Graph] {
         resolved: undefined
       },
       to: undefined,
-      type: 'dependencies',
+      type: 'prod',
       spec: Spec {missing@^1.0.0}
     }
   },
@@ -154,19 +154,19 @@ Graph [@vltpkg/graph.Graph] {
       'foo' => Edge [@vltpkg/graph.Edge] {
         from: [Circular *1],
         to: [Node [@vltpkg/graph.Node]],
-        type: 'devDependencies',
+        type: 'dev',
         spec: Spec {foo@^1.0.0}
       },
       'bar' => Edge [@vltpkg/graph.Edge] {
         from: [Circular *1],
         to: [Node [@vltpkg/graph.Node]],
-        type: 'optionalDependencies',
+        type: 'optional',
         spec: Spec {bar@^1.0.0}
       },
       'missing' => Edge [@vltpkg/graph.Edge] {
         from: [Circular *1],
         to: undefined,
-        type: 'dependencies',
+        type: 'prod',
         spec: Spec {missing@^1.0.0}
       }
     },
@@ -196,7 +196,7 @@ Graph [@vltpkg/graph.Graph] {
         resolved: undefined
       },
       to: undefined,
-      type: 'dependencies',
+      type: 'prod',
       spec: Spec {missing@^1.0.0}
     }
   }

--- a/src/graph/tap-snapshots/test/edge.ts.test.cjs
+++ b/src/graph/tap-snapshots/test/edge.ts.test.cjs
@@ -9,7 +9,7 @@ exports[`test/edge.ts > TAP > Edge > must match snapshot 1`] = `
 Edge [@vltpkg/graph.Edge] {
   from: [Node [@vltpkg/graph.Node]],
   to: [Node [@vltpkg/graph.Node]],
-  type: 'dependencies',
+  type: 'prod',
   spec: Spec {child@^1.0.0}
 }
 `
@@ -27,7 +27,7 @@ Edge [@vltpkg/graph.Edge] {
     resolved: undefined
   },
   to: undefined,
-  type: 'dependencies',
+  type: 'prod',
   spec: Spec {missing@latest}
 }
 `

--- a/src/graph/tap-snapshots/test/graph.ts.test.cjs
+++ b/src/graph/tap-snapshots/test/graph.ts.test.cjs
@@ -29,31 +29,31 @@ Graph [@vltpkg/graph.Graph] {
     Edge [@vltpkg/graph.Edge] {
       from: [Node [@vltpkg/graph.Node]],
       to: [Node [@vltpkg/graph.Node]],
-      type: 'dependencies',
+      type: 'prod',
       spec: Spec {foo@^1.0.0}
     },
     Edge [@vltpkg/graph.Edge] {
       from: [Node [@vltpkg/graph.Node]],
       to: [Node [@vltpkg/graph.Node]],
-      type: 'dependencies',
+      type: 'prod',
       spec: Spec {bar@^1.0.0}
     },
     Edge [@vltpkg/graph.Edge] {
       from: [Node [@vltpkg/graph.Node]],
       to: [Node [@vltpkg/graph.Node]],
-      type: 'dependencies',
+      type: 'prod',
       spec: Spec {baz@^1.0.0}
     },
     Edge [@vltpkg/graph.Edge] {
       from: [Node [@vltpkg/graph.Node]],
       to: undefined,
-      type: 'dependencies',
+      type: 'prod',
       spec: Spec {missing@^1.0.0}
     },
     Edge [@vltpkg/graph.Edge] {
       from: [Node [@vltpkg/graph.Node]],
       to: [Node [@vltpkg/graph.Node]],
-      type: 'dependencies',
+      type: 'prod',
       spec: Spec {foo@^1.0.0}
     }
   },
@@ -130,7 +130,7 @@ Graph [@vltpkg/graph.Graph] {
     Edge [@vltpkg/graph.Edge] {
       from: [Node [@vltpkg/graph.Node]],
       to: undefined,
-      type: 'dependencies',
+      type: 'prod',
       spec: Spec {missing@^1.0.0}
     }
   }

--- a/src/graph/test/append-nodes.ts
+++ b/src/graph/test/append-nodes.ts
@@ -65,8 +65,12 @@ t.test('append a new node to a graph from a registry', async t => {
     packageInfo,
     graph,
     graph.mainImporter,
-    [Spec.parse('foo@^1.0.0')],
-    'dependencies',
+    [
+      {
+        spec: Spec.parse('foo@^1.0.0'),
+        type: 'prod',
+      },
+    ],
     configData,
   )
   t.strictSame(
@@ -90,8 +94,12 @@ t.test('append a new node to a graph from a registry', async t => {
     packageInfo,
     graph,
     graph.mainImporter,
-    [Spec.parse('bar')],
-    'dependencies',
+    [
+      {
+        spec: Spec.parse('bar'),
+        type: 'prod',
+      },
+    ],
     configData,
   )
   t.strictSame(
@@ -105,8 +113,12 @@ t.test('append a new node to a graph from a registry', async t => {
       packageInfo,
       graph,
       graph.mainImporter,
-      [Spec.parse('borked')],
-      'dependencies',
+      [
+        {
+          spec: Spec.parse('borked'),
+          type: 'prod',
+        },
+      ],
       configData,
     ),
     /ERR/,
@@ -156,8 +168,12 @@ t.test('append different type of dependencies', async t => {
     packageInfo,
     graph,
     graph.mainImporter,
-    [Spec.parse('foo', '^1.0.0')],
-    'devDependencies',
+    [
+      {
+        spec: Spec.parse('foo', '^1.0.0'),
+        type: 'dev',
+      },
+    ],
     configData,
   )
 
@@ -165,8 +181,12 @@ t.test('append different type of dependencies', async t => {
     packageInfo,
     graph,
     graph.mainImporter,
-    [Spec.parse('bar', '^1.0.0')],
-    'optionalDependencies',
+    [
+      {
+        spec: Spec.parse('bar', '^1.0.0'),
+        type: 'optional',
+      },
+    ],
     configData,
   )
 
@@ -174,8 +194,12 @@ t.test('append different type of dependencies', async t => {
     packageInfo,
     graph,
     graph.mainImporter,
-    [Spec.parse('missing', '^1.0.0')],
-    'dependencies',
+    [
+      {
+        spec: Spec.parse('missing', '^1.0.0'),
+        type: 'prod',
+      },
+    ],
     configData,
   )
   t.matchSnapshot(

--- a/src/graph/test/dependencies.ts
+++ b/src/graph/test/dependencies.ts
@@ -1,0 +1,57 @@
+import t from 'tap'
+import {
+  DependencyTypeLong,
+  dependencyTypes,
+  longDependencyTypes,
+  shorten,
+} from '../src/dependencies.js'
+
+t.test('dependencyTypes', async t => {
+  t.strictSame(
+    [...longDependencyTypes],
+    [...dependencyTypes.keys()],
+    'should have the exact same long dependency types as keys of long types map',
+  )
+})
+
+t.test('shorten', async t => {
+  t.strictSame(
+    shorten('dependencies'),
+    'prod',
+    'should retrieve prod dep',
+  )
+  t.strictSame(
+    shorten('devDependencies'),
+    'dev',
+    'should retrieve dev dep',
+  )
+  t.strictSame(
+    shorten('optionalDependencies'),
+    'optional',
+    'should retrieve optional dep',
+  )
+  t.strictSame(
+    shorten('peerDependencies'),
+    'peer',
+    'should retrieve peer dep',
+  )
+  t.strictSame(
+    shorten('peerDependencies', 'foo', {
+      peerDependenciesMeta: { foo: { optional: true } },
+    }),
+    'peerOptional',
+    'should retrieve peerOptional dep',
+  )
+  t.strictSame(
+    shorten('peerDependencies', undefined, {
+      peerDependenciesMeta: { foo: { optional: true } },
+    }),
+    'peer',
+    'should retrieve peer dep if there is no name to look up key on meta object',
+  )
+  t.throws(
+    () => shorten('unknown' as DependencyTypeLong),
+    /Invalid dependency type name/,
+    'should throw if trying to retrieve from an unkown type',
+  )
+})

--- a/src/graph/test/edge.ts
+++ b/src/graph/test/edge.ts
@@ -33,45 +33,27 @@ t.test('Edge', async t => {
   const child = new Node(configData, undefined, childMani, childSpec)
 
   const edge = new Edge(
-    'dependencies',
+    'prod',
     Spec.parse('child@^1.0.0'),
     root,
     child,
   )
-  t.equal(edge.valid, true)
   t.equal(edge.name, 'child')
   t.equal(edge.dev, false)
   t.equal(edge.optional, false)
   t.matchSnapshot(inspect(edge, { depth: 0 }))
-  const validDistTag = new Edge(
-    'devDependencies',
-    Spec.parse('child', 'latest'),
-    root,
-    child,
-  )
-  t.equal(validDistTag.dev, true)
-  t.equal(validDistTag.valid, true)
-  const invalid = new Edge(
-    'dependencies',
-    Spec.parse('child', '^9.0.0'),
-    root,
-    child,
-  )
-  t.equal(invalid.valid, false)
   const dangling = new Edge(
-    'dependencies',
+    'prod',
     Spec.parse('missing', 'latest'),
     child,
   )
-  t.equal(dangling.valid, false)
   t.matchSnapshot(inspect(dangling, { depth: 1 }))
   const optional = new Edge(
-    'optionalDependencies',
+    'optional',
     Spec.parse('missing', 'latest'),
     child,
   )
   t.equal(optional.optional, true)
-  t.equal(optional.valid, true)
 
   const pdmMani = {
     name: 'pdm',
@@ -81,11 +63,7 @@ t.test('Edge', async t => {
   }
   const pdmSpec = Spec.parse('pdm@1.2.3')
   const pdm = new Node(configData, undefined, pdmMani, pdmSpec)
-  const pdmEdge = new Edge(
-    'peerDependencies',
-    Spec.parse('foo@*'),
-    pdm,
-  )
+  const pdmEdge = new Edge('peerOptional', Spec.parse('foo@*'), pdm)
+  t.equal(pdmEdge.peer, true)
   t.equal(pdmEdge.peerOptional, true)
-  t.equal(pdmEdge.valid, true, 'optional is valid even if missing')
 })

--- a/src/graph/test/graph.ts
+++ b/src/graph/test/graph.ts
@@ -51,7 +51,7 @@ t.test('Graph', async t => {
     'should create and add the new node to the graph',
   )
   graph.newEdge(
-    'dependencies',
+    'prod',
     Spec.parse('foo', '^1.0.0'),
     graph.mainImporter,
     newNode,
@@ -62,7 +62,7 @@ t.test('Graph', async t => {
     'should add edge to the list of edgesOut in its origin node',
   )
   graph.newEdge(
-    'dependencies',
+    'prod',
     Spec.parse('foo@^1.0.0'),
     graph.mainImporter,
     newNode,
@@ -72,11 +72,7 @@ t.test('Graph', async t => {
     1,
     'should not allow for adding new edges between same nodes',
   )
-  graph.newEdge(
-    'dependencies',
-    Spec.parse('missing@*'),
-    graph.mainImporter,
-  )
+  graph.newEdge('prod', Spec.parse('missing@*'), graph.mainImporter)
   t.strictSame(
     graph.missingDependencies.size,
     1,
@@ -100,7 +96,7 @@ t.test('using placePackage', async t => {
   })
   const foo = graph.placePackage(
     graph.mainImporter,
-    'dependencies',
+    'prod',
     Spec.parse('foo', '^1.0.0'),
     {
       name: 'foo',
@@ -110,7 +106,7 @@ t.test('using placePackage', async t => {
   t.ok(foo)
   const bar = graph.placePackage(
     graph.mainImporter,
-    'dependencies',
+    'prod',
     Spec.parse('bar', '^1.0.0'),
     {
       name: 'bar',
@@ -123,7 +119,7 @@ t.test('using placePackage', async t => {
   if (!bar) throw new Error('failed to place bar')
   const baz = graph.placePackage(
     bar,
-    'dependencies',
+    'prod',
     Spec.parse('baz', '^1.0.0'),
     {
       name: 'baz',
@@ -136,18 +132,13 @@ t.test('using placePackage', async t => {
   if (!baz) throw new Error('failed to place baz')
   graph.placePackage(
     graph.mainImporter,
-    'dependencies',
+    'prod',
     Spec.parse('missing', '^1.0.0'),
   )
-  graph.placePackage(
-    baz,
-    'dependencies',
-    Spec.parse('foo', '^1.0.0'),
-    {
-      name: 'foo',
-      version: '1.0.0',
-    },
-  )
+  graph.placePackage(baz, 'prod', Spec.parse('foo', '^1.0.0'), {
+    name: 'foo',
+    version: '1.0.0',
+  })
   t.matchSnapshot(inspect(graph, { depth: 2 }), 'the graph')
 })
 

--- a/src/graph/test/lockfile/save.ts
+++ b/src/graph/test/lockfile/save.ts
@@ -1,9 +1,8 @@
-import { Spec, SpecOptions } from '@vltpkg/spec'
-import { Monorepo } from '@vltpkg/workspaces'
 import { readFileSync } from 'node:fs'
 import { resolve } from 'node:path'
 import t from 'tap'
-import { DependencyTypeLong } from '../../src/dependencies.js'
+import { Spec, SpecOptions } from '@vltpkg/spec'
+import { Monorepo } from '@vltpkg/workspaces'
 import { Graph } from '../../src/graph.js'
 import { save } from '../../src/lockfile/save.js'
 
@@ -31,7 +30,7 @@ t.test('save', async t => {
   })
   const foo = graph.placePackage(
     graph.mainImporter,
-    'dependencies',
+    'prod',
     Spec.parse('foo@^1.0.0'),
     {
       name: 'foo',
@@ -47,7 +46,7 @@ t.test('save', async t => {
   }
   foo.setResolved()
   graph
-    .placePackage(foo, 'dependencies', Spec.parse('bar@^1.0.0'), {
+    .placePackage(foo, 'prod', Spec.parse('bar@^1.0.0'), {
       name: 'bar',
       version: '1.0.0',
     })
@@ -55,7 +54,7 @@ t.test('save', async t => {
   graph
     .placePackage(
       graph.mainImporter,
-      'dependencies',
+      'prod',
       Spec.parse('baz@custom:baz@^1.0.0', configData as SpecOptions),
       {
         name: 'baz',
@@ -71,31 +70,6 @@ t.test('save', async t => {
     readFileSync(resolve(projectRoot, 'vlt-lock.json'), {
       encoding: 'utf8',
     }),
-  )
-})
-
-t.test('edge missing type', async t => {
-  const mainManifest = {
-    name: 'my-project',
-    version: '1.0.0',
-    dependencies: {
-      missing: '^1.0.0',
-    },
-  }
-  const projectRoot = t.testdir()
-  const graph = new Graph({
-    ...configData,
-    mainManifest,
-  })
-  graph.newEdge(
-    '' as DependencyTypeLong,
-    Spec.parse('missing', '^1.0.0'),
-    graph.mainImporter,
-  )
-  t.throws(
-    () => save({ ...configData, graph, projectRoot }),
-    /Found edge with a missing type/,
-    'should throw if finds an edge with missing type',
   )
 })
 
@@ -164,7 +138,7 @@ t.test('workspaces', async t => {
     throw new Error('Missing workspace b')
   }
   graph
-    .placePackage(b, 'dependencies', Spec.parse('c@^1.0.0'), {
+    .placePackage(b, 'prod', Spec.parse('c@^1.0.0'), {
       name: 'c',
       version: '1.0.0',
       dist: {

--- a/src/graph/test/node.ts
+++ b/src/graph/test/node.ts
@@ -65,8 +65,8 @@ t.test('Node', async t => {
   const barId = getId(barSpec, barMani)
   const bar = new Node(configData, barId, barMani)
 
-  root.addEdgesTo('dependencies', new Spec('foo', '^1.0.0'), foo)
-  root.addEdgesTo('dependencies', new Spec('bar', '^1.0.0'), bar)
+  root.addEdgesTo('prod', new Spec('foo', '^1.0.0'), foo)
+  root.addEdgesTo('prod', new Spec('bar', '^1.0.0'), bar)
 
   t.strictSame(
     root.edgesOut.size,

--- a/src/graph/test/visualization/human-readable-output.ts
+++ b/src/graph/test/visualization/human-readable-output.ts
@@ -27,7 +27,7 @@ t.test('human-readable-output', async t => {
   })
   const foo = graph.placePackage(
     graph.mainImporter,
-    'dependencies',
+    'prod',
     Spec.parse('foo', '^1.0.0'),
     {
       name: 'foo',
@@ -37,7 +37,7 @@ t.test('human-readable-output', async t => {
   t.ok(foo)
   const bar = graph.placePackage(
     graph.mainImporter,
-    'dependencies',
+    'prod',
     Spec.parse('bar', '^1.0.0'),
     {
       name: 'bar',
@@ -50,7 +50,7 @@ t.test('human-readable-output', async t => {
   if (!bar) throw new Error('failed to place bar')
   const baz = graph.placePackage(
     bar,
-    'dependencies',
+    'prod',
     Spec.parse('baz', 'custom:bar@^1.0.0', configData as SpecOptions),
     {
       name: 'baz',
@@ -65,21 +65,16 @@ t.test('human-readable-output', async t => {
   baz.setResolved()
   graph.placePackage(
     graph.mainImporter,
-    'dependencies',
+    'prod',
     Spec.parse('missing', '^1.0.0'),
   )
-  graph.placePackage(
-    baz,
-    'dependencies',
-    Spec.parse('foo', '^1.0.0'),
-    {
-      name: 'foo',
-      version: '1.0.0',
-    },
-  )
+  graph.placePackage(baz, 'prod', Spec.parse('foo', '^1.0.0'), {
+    name: 'foo',
+    version: '1.0.0',
+  })
   const extraneous = graph.placePackage(
     bar,
-    'dependencies',
+    'prod',
     Spec.parse(
       'extraneous',
       'extraneous@^1.0.0',
@@ -152,7 +147,7 @@ t.test('cycle', async t => {
   })
   const a = graph.placePackage(
     graph.mainImporter,
-    'dependencies',
+    'prod',
     Spec.parse('a', '^1.0.0'),
     {
       name: 'a',
@@ -162,22 +157,17 @@ t.test('cycle', async t => {
   if (!a) {
     throw new Error('missing package a')
   }
-  const b = graph.placePackage(
-    a,
-    'dependencies',
-    Spec.parse('b', '^1.0.0'),
-    {
-      name: 'b',
-      version: '1.0.0',
-      dependencies: {
-        a: '^1.0.0',
-      },
+  const b = graph.placePackage(a, 'prod', Spec.parse('b', '^1.0.0'), {
+    name: 'b',
+    version: '1.0.0',
+    dependencies: {
+      a: '^1.0.0',
     },
-  )
+  })
   if (!b) {
     throw new Error('missing package b')
   }
-  graph.placePackage(b, 'dependencies', Spec.parse('a', '^1.0.0'), {
+  graph.placePackage(b, 'prod', Spec.parse('a', '^1.0.0'), {
     name: 'a',
     version: '1.0.0',
   })

--- a/src/graph/test/visualization/mermaid-output.ts
+++ b/src/graph/test/visualization/mermaid-output.ts
@@ -26,7 +26,7 @@ t.test('human-readable-output', async t => {
   })
   const foo = graph.placePackage(
     graph.mainImporter,
-    'dependencies',
+    'prod',
     Spec.parse('foo', '^1.0.0'),
     {
       name: 'foo',
@@ -36,7 +36,7 @@ t.test('human-readable-output', async t => {
   t.ok(foo)
   const bar = graph.placePackage(
     graph.mainImporter,
-    'dependencies',
+    'prod',
     Spec.parse('bar', '^1.0.0'),
     {
       name: 'bar',
@@ -49,7 +49,7 @@ t.test('human-readable-output', async t => {
   if (!bar) throw new Error('failed to place bar')
   const baz = graph.placePackage(
     bar,
-    'dependencies',
+    'prod',
     Spec.parse('baz', '^1.0.0'),
     {
       name: 'baz',
@@ -62,18 +62,13 @@ t.test('human-readable-output', async t => {
   if (!baz) throw new Error('failed to place baz')
   graph.placePackage(
     graph.mainImporter,
-    'dependencies',
+    'prod',
     Spec.parse('missing', '^1.0.0'),
   )
-  graph.placePackage(
-    baz,
-    'dependencies',
-    Spec.parse('foo', '^1.0.0'),
-    {
-      name: 'foo',
-      version: '1.0.0',
-    },
-  )
+  graph.placePackage(baz, 'prod', Spec.parse('foo', '^1.0.0'), {
+    name: 'foo',
+    version: '1.0.0',
+  })
   t.matchSnapshot(mermaidOutput(graph), 'should print mermaid output')
 })
 


### PR DESCRIPTION
Refactor the definitions of raw & parsed dependencies. This cleans up a bit of the story on how to handle the type+spec pair of definitions that describe a new dependency, particularly on the `appendNodes` method but also refactored `Graph` to start using the short dependency type instead.