### PR TITLE
graph: add Diff class

### DIFF
--- a/src/graph/src/diff.ts
+++ b/src/graph/src/diff.ts
@@ -1,0 +1,107 @@
+import { InspectOptions } from 'node:util'
+import { Edge } from './edge.js'
+import { Graph } from './graph.js'
+import { Node } from './node.js'
+
+const kCustomInspect = Symbol.for('nodejs.util.inspect.custom')
+
+export class Diff {
+  from: Graph
+  to: Graph
+
+  /**
+   * Collection of nodes to add and delete
+   */
+  nodes = {
+    /** Nodes in the `to` graph that are not in the `from` graph */
+    add: new Set<Node>(),
+    /** Nodes in the `from` graph that are not in the `to` graph */
+    delete: new Set<Node>(),
+  }
+
+  /**
+   * Collection of nodes to add and delete
+   */
+  edges = {
+    /** Edges in the `to` graph that are not found in the `from` graph */
+    add: new Set<Edge>(),
+    /** Edges in the `from` graph that are not found in the `to` graph */
+    delete: new Set<Edge>(),
+  }
+
+  get [Symbol.toStringTag]() {
+    return '@vltpkg/graph.Diff'
+  }
+
+  constructor(from: Graph, to: Graph) {
+    this.from = from
+    this.to = to
+
+    for (const [id, node] of this.from.nodes) {
+      if (!this.to.nodes.get(id)?.equals(node)) {
+        this.nodes.delete.add(node)
+      }
+    }
+
+    for (const [id, node] of this.to.nodes) {
+      if (!this.from.nodes.get(id)?.equals(node)) {
+        this.nodes.add.add(node)
+      }
+    }
+
+    for (const edge of this.to.edges) {
+      const fromNode = this.from.nodes.get(edge.from.id)
+      const fromEdge = fromNode?.edgesOut.get(edge.spec.name)
+      if (fromEdge?.to?.id === edge.to?.id) continue
+      if (fromEdge?.to) this.edges.delete.add(fromEdge)
+      if (edge.to) this.edges.add.add(edge)
+    }
+    for (const edge of this.from.edges) {
+      const toNode = this.to.nodes.get(edge.from.id)
+      const toEdge = toNode?.edgesOut.get(edge.spec.name)
+      if (toEdge?.to?.id === edge.to?.id) continue
+      if (edge.to) this.edges.delete.add(edge)
+      if (toNode && toEdge) this.edges.add.add(toEdge)
+    }
+  }
+
+  [kCustomInspect](_: number, options?: InspectOptions): string {
+    const red: [string, string] =
+      options?.colors ? ['\x1b[31m', '\x1b[m'] : ['', '']
+    const green: [string, string] =
+      options?.colors ? ['\x1b[32m', '\x1b[m'] : ['', '']
+    const lines: string[] = []
+    for (const node of this.nodes.add) {
+      lines.push(`+ ${node.id}`)
+    }
+    for (const node of this.nodes.delete) {
+      lines.push(`- ${node.id}`)
+    }
+    for (const edge of this.edges.add) {
+      /* c8 ignore next */
+      const to = edge.to?.id ?? ''
+      lines.push(
+        `+ ${edge.from.id} ${edge.type} ${edge.spec} ${to}`.trim(),
+      )
+    }
+    for (const edge of this.edges.delete) {
+      /* c8 ignore next */
+      const to = edge.to?.id ?? ''
+      lines.push(
+        `- ${edge.from.id} ${edge.type} ${edge.spec} ${to}`.trim(),
+      )
+    }
+    const wrap = (s: string, c: [string, string]) => c.join(s)
+    const color =
+      options?.colors ?
+        (s: string) => wrap(s, s.startsWith('+') ? green : red)
+      : (s: string) => s
+
+    return `${this[Symbol.toStringTag]} {
+${lines
+  .sort((a, b) => a.substring(1).localeCompare(b.substring(1), 'en'))
+  .map(s => '  ' + color(s))
+  .join('\n')}
+}`
+  }
+}

--- a/src/graph/src/lockfile/types.ts
+++ b/src/graph/src/lockfile/types.ts
@@ -1,6 +1,7 @@
 import { DepID } from '@vltpkg/dep-id'
-import { DependencyTypeShort } from '../dependencies.js'
 import { Integrity } from '@vltpkg/types'
+import { DependencyTypeShort } from '../dependencies.js'
+import type { Graph } from '../graph.js'
 
 /**
  * This is the main type definition for the contents of the
@@ -19,10 +20,10 @@ export type LockfileData = {
  * Lockfile representation of a node from the install graph.
  */
 export type LockfileDataNode = [
-  name?: string,
-  integrity?: Integrity,
-  resolved?: string,
-  location?: string,
+  name?: string | null,
+  integrity?: Integrity | null,
+  resolved?: string | null,
+  location?: string | null,
 ]
 
 /**

--- a/src/graph/src/node.ts
+++ b/src/graph/src/node.ts
@@ -146,6 +146,10 @@ export class Node {
     this.integrity ??= this.manifest?.dist?.integrity
   }
 
+  equals (other: Node) {
+    return this.id === other.id && this.location === other.location
+  }
+
   /**
    * Sets the node as an importer along with its location.
    */

--- a/src/graph/tap-snapshots/test/diff.ts.test.cjs
+++ b/src/graph/tap-snapshots/test/diff.ts.test.cjs
@@ -1,0 +1,44 @@
+/* IMPORTANT
+ * This snapshot file is auto-generated, but designed for humans.
+ * It should be checked into source control and tracked carefully.
+ * Re-generate by setting TAP_SNAPSHOT=1 and running tests.
+ * Make sure to inspect the output below.  Do not ignore changes!
+ */
+'use strict'
+exports[`test/diff.ts > TAP > diff two graphs > diff no color 1`] = `
+@vltpkg/graph.Diff {
+  - ;;a@1.0.0
+  + ;;b@1.0.0
+  + ;;b@1.0.0 prod c@^1.0.0 ;;c@1.0.0
+  + ;;bar@1.0.0 optional ooo@^1.0.1 ;;ooo@1.0.1
+  - ;;bar@1.0.0 prod baz@^1.0.0 ;;baz@1.0.0
+  + ;;bar@1.0.0 prod baz@^1.0.1 ;;baz@1.0.1
+  - ;;baz@1.0.0
+  + ;;baz@1.0.1
+  + ;;c@1.0.0
+  + ;;foo@1.0.0
+  - ;;foo@1.0.0
+  + ;;ooo@1.0.1
+  - file;. prod a@^1.0.0 ;;a@1.0.0
+  + file;. prod b@^1.0.0 ;;b@1.0.0
+}
+`
+
+exports[`test/diff.ts > TAP > diff two graphs > diff with color 1`] = `
+@vltpkg/graph.Diff {
+  [31m- ;;a@1.0.0[m
+  [32m+ ;;b@1.0.0[m
+  [32m+ ;;b@1.0.0 prod c@^1.0.0 ;;c@1.0.0[m
+  [32m+ ;;bar@1.0.0 optional ooo@^1.0.1 ;;ooo@1.0.1[m
+  [31m- ;;bar@1.0.0 prod baz@^1.0.0 ;;baz@1.0.0[m
+  [32m+ ;;bar@1.0.0 prod baz@^1.0.1 ;;baz@1.0.1[m
+  [31m- ;;baz@1.0.0[m
+  [32m+ ;;baz@1.0.1[m
+  [32m+ ;;c@1.0.0[m
+  [32m+ ;;foo@1.0.0[m
+  [31m- ;;foo@1.0.0[m
+  [32m+ ;;ooo@1.0.1[m
+  [31m- file;. prod a@^1.0.0 ;;a@1.0.0[m
+  [32m+ file;. prod b@^1.0.0 ;;b@1.0.0[m
+}
+`

--- a/src/graph/test/diff.ts
+++ b/src/graph/test/diff.ts
@@ -1,0 +1,141 @@
+import t from 'tap'
+import { inspect } from 'util'
+import { Diff } from '../src/diff.js'
+import { loadObject } from '../src/lockfile/load.js'
+
+t.test('diff two graphs', async t => {
+  const projectRoot = t.testdir({
+    'vlt-workspaces.json': JSON.stringify({
+      packages: ['./packages/*'],
+    }),
+    packages: {
+      a: {
+        'package.json': JSON.stringify({
+          name: 'a',
+          version: '1.0.0',
+        }),
+      },
+      b: {
+        'package.json': JSON.stringify({
+          name: 'b',
+          version: '1.0.0',
+          dependencies: {
+            c: '^1.0.0',
+          },
+        }),
+      },
+    },
+  })
+
+  // foo: no changes
+  // a: in graphA, not in graphB
+  // b: in graphB, not in graphA
+  // bar: edge changes
+  // baz: change version
+
+  const graphA = loadObject(
+    {
+      projectRoot,
+      mainManifest: {
+        name: 'foo',
+        version: '1.2.3',
+      },
+    },
+    {
+      registries: {
+        npm: 'https://registry.npmjs.org',
+        custom: 'https://registry.example.com',
+      },
+      nodes: {
+        'file;.': ['my-project'],
+        ';;foo@1.0.0': ['foo', 'sha512-foofoofoo==', null, './node_modules/.pnpm/foo@1.0.0/node_modules/foo'],
+        ';;a@1.0.0': ['foo', 'sha512-aaaaaaaaa=='],
+        ';;bar@1.0.0': [
+          'bar',
+          'sha512-barbarbar==',
+          'https://registry.example.com/bar/-/bar-1.0.0.tgz',
+        ],
+        ';;baz@1.0.0': [
+          'baz',
+          'sha512-bazbazbaz==',
+          'https://registry.example.com/baz/-/baz-1.0.0.tgz',
+        ],
+      },
+      edges: [
+        ['file;.', 'prod', 'foo@^1.0.0', ';;foo@1.0.0'],
+        ['file;.', 'prod', 'a@^1.0.0', ';;a@1.0.0'],
+        ['file;.', 'prod', 'bar@^1.0.0', ';;bar@1.0.0'],
+        [
+          ';;bar@1.0.0',
+          'prod',
+          'baz@^1.0.0',
+          ';;baz@1.0.0',
+        ],
+      ],
+    },
+  )
+
+  const graphB = loadObject(
+    {
+      projectRoot,
+      mainManifest: {
+        name: 'foo',
+        version: '1.2.3',
+      },
+    },
+    {
+      registries: {
+        npm: 'https://registry.npmjs.org',
+        custom: 'https://registry.example.com',
+      },
+      nodes: {
+        'file;.': ['my-project'],
+        ';;foo@1.0.0': ['foo', 'sha512-foofoofoo=='],
+        ';;b@1.0.0': ['foo', 'sha512-bbbbbbbbb=='],
+        ';;c@1.0.0': ['foo', 'sha512-ccccccccc=='],
+        ';;bar@1.0.0': [
+          'bar',
+          'sha512-barbarbar==',
+          'https://registry.example.com/bar/-/bar-1.0.0.tgz',
+        ],
+        ';;baz@1.0.1': [
+          'baz',
+          'sha512-baz101baz101baz101==',
+          'https://registry.example.com/baz/-/baz-1.0.1.tgz',
+        ],
+        ';;ooo@1.0.1': [
+          'ooo',
+          'sha512-ooo420ooo420ooo420==',
+          'https://registry.example.com/ooo/-/ooo-1.0.1.tgz',
+        ],
+      },
+      edges: [
+        ['file;.', 'prod', 'foo@^1.0.0', ';;foo@1.0.0'],
+        ['file;.', 'prod', 'b@^1.0.0', ';;b@1.0.0'],
+        [
+          ';;b@1.0.0',
+          'prod',
+          'c@^1.0.0',
+          ';;c@1.0.0',
+        ],
+        ['file;.', 'prod', 'bar@^1.0.0', ';;bar@1.0.0'],
+        [
+          ';;bar@1.0.0',
+          'prod',
+          'baz@^1.0.1',
+          ';;baz@1.0.1',
+        ],
+        [
+          ';;bar@1.0.0',
+          'optional',
+          'ooo@^1.0.1',
+          ';;ooo@1.0.1',
+        ],
+      ],
+    },
+  )
+
+  const diff = new Diff(graphA, graphB)
+  t.matchSnapshot(inspect(diff, { colors: true }), 'diff with color')
+  t.matchSnapshot(inspect(diff, { colors: false }), 'diff no color')
+})

--- a/src/graph/test/node.ts
+++ b/src/graph/test/node.ts
@@ -100,6 +100,20 @@ t.test('Node', async t => {
   bar.setDefaultLocation()
   t.equal(bar.location, defaultBarLoc)
 
+  const otherBar = new Node(
+    {
+      ...options,
+      projectRoot: t.testdirName,
+    },
+    barId,
+    barMani,
+  )
+  t.equal(bar.equals(otherBar), true)
+  t.equal(otherBar.equals(bar), true)
+  otherBar.location = './other/location'
+  t.equal(bar.equals(otherBar), false)
+  t.equal(otherBar.equals(bar), false)
+
   root.addEdgesTo('prod', new Spec('foo', '^1.0.0'), foo)
   root.addEdgesTo('prod', new Spec('bar', '^1.0.0'), bar)
 


### PR DESCRIPTION
Based on #83, land that first. Only the top commit needs review.

Given two graphs, a `Diff` object will tell you how to turn one into the
other, by listing the nodes and edges that need to be added or removed.

Typically, the `graphFrom` will be the result of a `actual.load()`, but
the `Diff` class is agnostic as to what the graphs actually represent.