### PR TITLE
graph: rename build ideal public method

### DIFF
--- a/src/graph/README.md
+++ b/src/graph/README.md
@@ -5,20 +5,29 @@ that are involved in a given install.
 
 ## API
 
-### `async buildIdeal({ projectRoot: string }): Promise<Graph>`
+### `actual.load({ projectRoot: string }): Graph`
+
+Recursively loads the `node_modules` folder found at `projectRoot` in order to
+create a graph representation of the current installed packages.
+
+### `async ideal.build({ projectRoot: string }): Promise<Graph>`
 
 This method returns a new `Graph` object, reading from the `package.json`
 file located at `projectRoot` dir and building up the graph representation
 of nodes and edges from the files read from the local file system.
 
+### `lockfile.load({ mainManifest: Manifest, projectRoot: string }): Graph`
+
+Loads the lockfile file found at `projectRoot` and returns the graph.
+
 ## USAGE
 
-Here's a quick example of how to use the `buildIdeal` method that
-builds a graph representation of the install defined at the current working
+Here's a quick example of how to use the `@vltpkg/graph.ideal.build` method to
+build a graph representation of the install defined at the `projectRoot`
 directory.
 
 ```
-import { buildIdeal } from '@vltpkg/graph'
+import { ideal } from '@vltpkg/graph'
 
-const graph = await buildIdeal({ projectRoot: process.cwd() })
+const graph = await ideal.build({ projectRoot: process.cwd() })
 ```

--- a/src/graph/src/index.ts
+++ b/src/graph/src/index.ts
@@ -18,4 +18,4 @@ export type { ActualLoadOptions, LockfileLoadOptions }
 
 import { BuildIdealOptions, build } from './ideal/build.js'
 export type { BuildIdealOptions }
-export const buildIdeal = build
+export const ideal = { build }


### PR DESCRIPTION
Moves `graph.buildIdeal` -> `graph.ideal.build` to better align with the rest of the API: `graph.actual.load` & `graph.lockfile.load`.