### PR TITLE
Add turbo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,11 +1,13 @@
 .DS_Store
 
+/.turbo
 /docs
 /node_modules
 /pnpm-exec-summary.json
 
 /src/*/.tap
 /src/*/.tshy-build
+/src/*/.turbo
 /src/*/dist
 /src/*/docs
 /src/*/node_modules

--- a/package.json
+++ b/package.json
@@ -11,12 +11,14 @@
     "eslint": "catalog:",
     "globals": "^15.9.0",
     "prettier": "catalog:",
+    "turbo": "^2.0.11",
     "typedoc": "catalog:",
     "typescript": "catalog:",
     "typescript-eslint": "catalog:",
     "yaml": "^2.5.0"
   },
   "scripts": {
+    ".": "./scripts/local-cli vlt",
     "devPreinstall": "node scripts/consistent-package-json.js",
     "fix": "pnpm devPreinstall && pnpm lint && pnpm format",
     "format": "prettier --write . --log-level warn --ignore-path ./.prettierignore --cache",
@@ -25,7 +27,12 @@
     "lint:check": "eslint .",
     "snap": "pnpm --silent --no-bail --report-summary run -r snap -Rsilent || node scripts/report-test-failures.js",
     "test": "pnpm --silent --no-bail --report-summary -r test -- -Rsilent || node scripts/report-test-failures.js",
-    "typedoc": "typedoc"
+    "typedoc": "typedoc",
+    "vlix": "./scripts/local-cli vlix",
+    "vlr": "./scripts/local-cli vlr",
+    "vlrx": "./scripts/local-cli vlrx",
+    "vlt": "./scripts/local-cli vlt",
+    "vlx": "./scripts/local-cli vlx"
   },
   "prettier": "./.prettierrc.json",
   "type": "module",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -66,6 +66,9 @@ importers:
       prettier:
         specifier: 'catalog:'
         version: 3.3.2
+      turbo:
+        specifier: ^2.0.11
+        version: 2.0.11
       typedoc:
         specifier: 'catalog:'
         version: 0.26.2(typescript@5.5.4)
@@ -2725,6 +2728,40 @@ packages:
     resolution: {integrity: sha512-GwIJau9XaA8nLVbUXsN3IlFi7WmQ48gBUrl3FTkkL/XLu/POhBzfmX9hd33FNMX1qAsfl6ozO1iMmW9NC8YniA==}
     engines: {node: ^16.14.0 || >=18.0.0}
 
+  turbo-darwin-64@2.0.11:
+    resolution: {integrity: sha512-YlHEEhcm+jI1BSZoLugGHUWDfRXaNaQIv7tGQBfadYjo9kixBnqoTOU6s1ubOrQMID+lizZZQs79GXwqM6vohg==}
+    cpu: [x64]
+    os: [darwin]
+
+  turbo-darwin-arm64@2.0.11:
+    resolution: {integrity: sha512-K/YW+hWzRQ/wGmtffxllH4M1tgy8OlwgXODrIiAGzkSpZl9+pIsem/F86UULlhsIeavBYK/LS5+dzV3DPMjJ9w==}
+    cpu: [arm64]
+    os: [darwin]
+
+  turbo-linux-64@2.0.11:
+    resolution: {integrity: sha512-mv8CwGP06UPweMh1Vlp6PI6OWnkuibxfIJ4Vlof7xqjohAaZU5FLqeOeHkjQflH/6YrCVuS9wrK0TFOu+meTtA==}
+    cpu: [x64]
+    os: [linux]
+
+  turbo-linux-arm64@2.0.11:
+    resolution: {integrity: sha512-wLE5tl4oriTmHbuayc0ki0csaCplmVLj+uCWtecM/mfBuZgNS9ICNM9c4sB+Cfl5tlBBFeepqRNgvRvn8WeVZg==}
+    cpu: [arm64]
+    os: [linux]
+
+  turbo-windows-64@2.0.11:
+    resolution: {integrity: sha512-tja3zvVCSWu3HizOoeQv0qDJ+GeWGWRFOOM6a8i3BYnXLgGKAaDZFcjwzgC50tWiAw4aowIVR4OouwIyRhLBaQ==}
+    cpu: [x64]
+    os: [win32]
+
+  turbo-windows-arm64@2.0.11:
+    resolution: {integrity: sha512-sYjXP6k94Bqh99R+y3M1Ks6LRIEZybMz+7enA8GKl6JJ2ZFaXxTnS6q+/2+ii1+rRwxohj5OBb4gxODcF8Jd4w==}
+    cpu: [arm64]
+    os: [win32]
+
+  turbo@2.0.11:
+    resolution: {integrity: sha512-imDlFFAvitbCm1JtDFJ6eG882qwxHUmVT2noPb3p2jq5o5DuXOchMbkVS9kUeC3/4WpY5N0GBZ3RvqNyjHZw1Q==}
+    hasBin: true
+
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
@@ -4627,6 +4664,33 @@ snapshots:
       make-fetch-happen: 13.0.1
     transitivePeerDependencies:
       - supports-color
+
+  turbo-darwin-64@2.0.11:
+    optional: true
+
+  turbo-darwin-arm64@2.0.11:
+    optional: true
+
+  turbo-linux-64@2.0.11:
+    optional: true
+
+  turbo-linux-arm64@2.0.11:
+    optional: true
+
+  turbo-windows-64@2.0.11:
+    optional: true
+
+  turbo-windows-arm64@2.0.11:
+    optional: true
+
+  turbo@2.0.11:
+    optionalDependencies:
+      turbo-darwin-64: 2.0.11
+      turbo-darwin-arm64: 2.0.11
+      turbo-linux-64: 2.0.11
+      turbo-linux-arm64: 2.0.11
+      turbo-windows-64: 2.0.11
+      turbo-windows-arm64: 2.0.11
 
   type-check@0.4.0:
     dependencies:

--- a/scripts/local-cli
+++ b/scripts/local-cli
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+TURBO="$(turbo prepare --output-logs=errors-only 2> /dev/null)"
+if [ "$?" != "0" ]; then
+  echo "$TURBO"
+else
+  ./node_modules/.bin/$1 "${@:2}"
+fi

--- a/turbo.json
+++ b/turbo.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://turbo.build/schema.json",
+  "dangerouslyDisablePackageManagerCheck": true,
+  "ui": "stream",
+  "tasks": {
+    "prepare": {
+      "outputs": ["dist/**"]
+    }
+  }
+}


### PR DESCRIPTION
Experimenting with a relatively simple turbo setup that gives as close to the old `node . CMD` as possible that I got used to working on `npm`.

This adds root level scripts that match all the bins from `src/vlt` as well as `.` which is an alias for `vlt`.

There's a small shell script that runs `turbo prepare` and suppresses all output when it is successful.

```
$ pnpm . pkg get
todo: show some helpful output [ 'pkg', 'get' ]
```