### PR TITLE
graph: fix reify reocurring symlinks

### DIFF
--- a/src/graph/src/reify/add-edges.ts
+++ b/src/graph/src/reify/add-edges.ts
@@ -15,7 +15,8 @@ export const addEdges = (
     const { to } = edge
     if (!to) continue
     const mani = to.manifest ?? packageJson.read(to.location)
-    promises.push(addEdge(edge, mani, scurry, remover))
+    const seen = new Set<string>()
+    promises.push(addEdge(edge, mani, scurry, remover, seen))
   }
   return promises
 }


### PR DESCRIPTION
When trying out an install graph containing multiple edges that points to the same destination the install fails with an `EEXIST`.

Observed when trying to `vlt install` in a folder containing the following `package.json` file:

```json
{
  "dependencies": {
    "jest": "^29.7.0"
  }
}
```