### PR TITLE
graph: add lockfile save manifests option

### DIFF
--- a/src/graph/src/lockfile/types.ts
+++ b/src/graph/src/lockfile/types.ts
@@ -1,5 +1,5 @@
 import { DepID } from '@vltpkg/dep-id'
-import { Integrity } from '@vltpkg/types'
+import { Integrity, ManifestMinified } from '@vltpkg/types'
 import { DependencyTypeShort } from '../dependencies.js'
 
 /**
@@ -23,6 +23,7 @@ export type LockfileDataNode = [
   integrity?: Integrity | null,
   resolved?: string | null,
   location?: string | null,
+  manifest?: ManifestMinified | null,
 ]
 
 /**

--- a/src/graph/tap-snapshots/test/lockfile/save.ts.test.cjs
+++ b/src/graph/tap-snapshots/test/lockfile/save.ts.test.cjs
@@ -37,6 +37,152 @@ exports[`test/lockfile/save.ts > TAP > save > must match snapshot 1`] = `
 
 `
 
+exports[`test/lockfile/save.ts > TAP > save > save manifests > must match snapshot 1`] = `
+{
+  "registries": {
+    "npm": "https://registry.npmjs.org",
+    "custom": "http://example.com"
+  },
+  "nodes": {
+    "file;.": [
+      "my-project",
+      null,
+      null,
+      null,
+      {
+        "name": "my-project",
+        "version": "1.0.0",
+        "dependencies": {
+          "baz": "custom:^1.0.0",
+          "foo": "^1.0.0"
+        }
+      }
+    ],
+    ";;bar@1.0.0": [
+      "bar",
+      null,
+      null,
+      null,
+      {
+        "name": "bar",
+        "version": "1.0.0"
+      }
+    ],
+    ";;foo@1.0.0": [
+      "foo",
+      "sha512-6/mh1E2u2YgEsCHdY0Yx5oW+61gZU+1vXaoiHHrpKeuRNNgFvS+/jrwHiQhB5apAf5oB7UB7E19ol2R2LKH8hQ==",
+      null,
+      "node_modules/.pnpm/foo@1.0.0/node_modules/foo",
+      {
+        "name": "foo",
+        "version": "1.0.0",
+        "dist": {
+          "integrity": "sha512-6/mh1E2u2YgEsCHdY0Yx5oW+61gZU+1vXaoiHHrpKeuRNNgFvS+/jrwHiQhB5apAf5oB7UB7E19ol2R2LKH8hQ=="
+        }
+      }
+    ],
+    ";custom;baz@1.0.0": [
+      "baz",
+      null,
+      "http://example.com/baz.tgz",
+      null,
+      {
+        "name": "baz",
+        "version": "1.0.0",
+        "dist": {
+          "tarball": "http://example.com/baz.tgz"
+        }
+      }
+    ]
+  },
+  "edges": [
+    [
+      "file;.",
+      "prod",
+      "foo@^1.0.0",
+      ";;foo@1.0.0"
+    ],
+    [
+      "file;.",
+      "prod",
+      "baz@custom:baz@^1.0.0",
+      ";custom;baz@1.0.0"
+    ],
+    [
+      ";;foo@1.0.0",
+      "prod",
+      "bar@^1.0.0",
+      ";;bar@1.0.0"
+    ]
+  ]
+}
+`
+
+exports[`test/lockfile/save.ts > TAP > workspaces > save manifests > must match snapshot 1`] = `
+{
+  "registries": {
+    "npm": "https://registry.npmjs.org",
+    "custom": "http://example.com"
+  },
+  "nodes": {
+    "file;.": [
+      "my-project",
+      null,
+      null,
+      null,
+      {
+        "name": "my-project",
+        "version": "1.0.0"
+      }
+    ],
+    "workspace;packages%2Fa": [
+      "a",
+      null,
+      null,
+      null,
+      {
+        "name": "a",
+        "version": "1.0.0"
+      }
+    ],
+    "workspace;packages%2Fb": [
+      "b",
+      null,
+      null,
+      null,
+      {
+        "name": "b",
+        "version": "1.0.0",
+        "dependencies": {
+          "c": "^1.0.0"
+        }
+      }
+    ],
+    ";;c@1.0.0": [
+      "c",
+      "sha512-6/mh1E2u2YgEsCHdY0Yx5oW+61gZU+1vXaoiHHrpKeuRNNgFvS+/jrwHiQhB5apAf5oB7UB7E19ol2R2LKH8hQ==",
+      null,
+      null,
+      {
+        "name": "c",
+        "version": "1.0.0",
+        "dist": {
+          "integrity": "sha512-6/mh1E2u2YgEsCHdY0Yx5oW+61gZU+1vXaoiHHrpKeuRNNgFvS+/jrwHiQhB5apAf5oB7UB7E19ol2R2LKH8hQ=="
+        }
+      }
+    ]
+  },
+  "edges": [
+    [
+      "workspace;packages%2Fb",
+      "prod",
+      "c@^1.0.0",
+      ";;c@1.0.0"
+    ]
+  ]
+}
+`
+
 exports[`test/lockfile/save.ts > TAP > workspaces > should save lockfile with workspaces nodes 1`] = `
 {
   "registries": {

--- a/src/graph/test/lockfile/save.ts
+++ b/src/graph/test/lockfile/save.ts
@@ -73,6 +73,15 @@ t.test('save', async t => {
       encoding: 'utf8',
     }),
   )
+
+  await t.test('save manifests', async t => {
+    save({ ...configData, graph, saveManifests: true })
+    t.matchSnapshot(
+      readFileSync(resolve(projectRoot, 'vlt-lock.json'), {
+        encoding: 'utf8',
+      }),
+    )
+  })
 })
 
 t.test('missing registries', async t => {
@@ -160,4 +169,13 @@ t.test('workspaces', async t => {
     }),
     'should save lockfile with workspaces nodes',
   )
+
+  await t.test('save manifests', async t => {
+    save({ ...configData, graph, saveManifests: true })
+    t.matchSnapshot(
+      readFileSync(resolve(projectRoot, 'vlt-lock.json'), {
+        encoding: 'utf8',
+      }),
+    )
+  })
 })


### PR DESCRIPTION
Adds an option to store manifests for each node of the lockfile. A lockfile that saves manifests also skips the extra formatting used to keep each node on a single line.