### PR TITLE
error-cause: only capture stack trace when available

### DIFF
--- a/src/error-cause/src/index.ts
+++ b/src/error-cause/src/index.ts
@@ -201,7 +201,8 @@ const create = (
     | (new (...a: any[]) => any) = defaultFrom,
 ) => {
   const er = new cls(message, cause ? { cause } : undefined)
-  Error.captureStackTrace(er, from)
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+  Error.captureStackTrace?.(er, from)
   return er
 }
 


### PR DESCRIPTION
`Error.captureStackTrace` is a non-standard V8 function. Usage of `@vltpkg/error-cause` currently fails in different engines because of its usage.

Adds a check for the method prior to calling it in order to fix usage in different engines.