### PR TITLE
vlt, graph: consolidate setting of common options

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1265,6 +1265,9 @@ importers:
       '@vltpkg/graph':
         specifier: workspace:*
         version: link:../graph
+      '@vltpkg/package-info':
+        specifier: workspace:*
+        version: link:../package-info
       '@vltpkg/package-json':
         specifier: workspace:*
         version: link:../package-json

--- a/src/graph/src/actual/load.ts
+++ b/src/graph/src/actual/load.ts
@@ -34,11 +34,11 @@ export type LoadOptions = SpecOptions & {
   /**
    * A {@link PackageJson} object, for sharing manifest caches
    */
-  packageJson?: PackageJson
+  packageJson: PackageJson
   /**
    * A {@link PathScurry} object, for use in globs
    */
-  scurry?: PathScurry
+  scurry: PathScurry
   /**
    * If set to `false`, `actual.load` will not load any `package.json`
    * files while traversing the file system.
@@ -335,14 +335,15 @@ const parseDir = (
  */
 export const load = (options: LoadOptions): Graph => {
   // TODO: once hidden lockfile is more reliable, default to false here
-  const { skipHiddenLockfile = true, projectRoot } = options
-  const packageJson = options.packageJson ?? new PackageJson()
+  const {
+    skipHiddenLockfile = true,
+    projectRoot,
+    packageJson,
+    scurry,
+    monorepo,
+  } = options
   const mainManifest =
     options.mainManifest ?? packageJson.read(projectRoot)
-  const scurry = options.scurry ?? new PathScurry(projectRoot)
-  const monorepo =
-    options.monorepo ??
-    Monorepo.maybeLoad(projectRoot, { packageJson, scurry })
 
   if (!skipHiddenLockfile) {
     try {
@@ -353,13 +354,12 @@ export const load = (options: LoadOptions): Graph => {
         monorepo,
         scurry,
       })
-      // TODO: merge in the monorepo workspaces
       // TODO: check mtime of lockfile vs .vlt folder
       return graph
     } catch {}
   }
 
-  const graph = new Graph({ ...options, mainManifest, monorepo })
+  const graph = new Graph({ ...options, mainManifest })
   const depsFound = new Map<Node, Path>()
 
   // starts the list of initial folders to parse using the importer nodes

--- a/src/graph/src/ideal/build.ts
+++ b/src/graph/src/ideal/build.ts
@@ -1,18 +1,15 @@
-import { Graph } from '../graph.js'
-import {
-  LoadOptions as LoadActualOptions,
-  load as loadActual,
-} from '../actual/load.js'
-import { load as loadVirtual } from '../lockfile/load.js'
-import { buildIdealFromStartingGraph } from './build-ideal-from-starting-graph.js'
 import { PackageInfoClient } from '@vltpkg/package-info'
-import { PackageJson } from '@vltpkg/package-json'
-import { PathScurry } from 'path-scurry'
-import { Monorepo } from '@vltpkg/workspaces'
+import {
+  load as loadActual,
+  LoadOptions as LoadActualOptions,
+} from '../actual/load.js'
 import {
   AddImportersDependenciesMap,
   RemoveImportersDependenciesMap,
 } from '../dependencies.js'
+import { Graph } from '../graph.js'
+import { load as loadVirtual } from '../lockfile/load.js'
+import { buildIdealFromStartingGraph } from './build-ideal-from-starting-graph.js'
 
 export type BuildIdealOptions = LoadActualOptions & {
   /**
@@ -31,7 +28,7 @@ export type BuildIdealOptions = LoadActualOptions & {
   /**
    * A {@link PackageInfoClient} instance to read manifest info from.
    */
-  packageInfo?: PackageInfoClient
+  packageInfo: PackageInfoClient
 }
 
 /**
@@ -46,16 +43,9 @@ export const build = async (
 ): Promise<Graph> => {
   // Creates the shared instances that are going to be used
   // in both the loader methods and the build graph
-  const packageJson = options.packageJson ?? new PackageJson()
+  const { packageInfo, packageJson, scurry, monorepo } = options
   const mainManifest =
     options.mainManifest ?? packageJson.read(options.projectRoot)
-  const scurry = options.scurry ?? new PathScurry(options.projectRoot)
-  const monorepo =
-    options.monorepo ??
-    Monorepo.maybeLoad(options.projectRoot, { packageJson, scurry })
-  const packageInfo =
-    options.packageInfo ??
-    new PackageInfoClient({ ...options, monorepo, packageJson })
   const add = options.add ?? new Map()
   const remove = options.remove ?? new Map()
 
@@ -65,16 +55,12 @@ export const build = async (
       ...options,
       mainManifest,
       monorepo,
-      packageJson,
-      scurry,
     })
   } catch {
     graph = loadActual({
       ...options,
       mainManifest,
       monorepo,
-      packageJson,
-      scurry,
     })
   }
 

--- a/src/graph/src/reify/index.ts
+++ b/src/graph/src/reify/index.ts
@@ -1,18 +1,14 @@
 import { PackageInfoClient } from '@vltpkg/package-info'
-import { PackageJson } from '@vltpkg/package-json'
 import { RollbackRemove } from '@vltpkg/rollback-remove'
-import { Monorepo } from '@vltpkg/workspaces'
 import { availableParallelism } from 'node:os'
-import { PathScurry } from 'path-scurry'
-import { updatePackageJson } from './update-importers-package-json.js'
 import { callLimit } from 'promise-call-limit'
 import { load as loadActual, LoadOptions } from '../actual/load.js'
-import { Diff } from '../diff.js'
-import { Graph } from '../graph.js'
 import {
   AddImportersDependenciesMap,
   RemoveImportersDependenciesMap,
 } from '../dependencies.js'
+import { Diff } from '../diff.js'
+import { Graph } from '../graph.js'
 import { lockfile } from '../index.js'
 import {
   lockfileData,
@@ -25,12 +21,11 @@ import { build } from './build.js'
 import { deleteEdges } from './delete-edges.js'
 import { deleteNodes } from './delete-nodes.js'
 import { rollback } from './rollback.js'
+import { updatePackageJson } from './update-importers-package-json.js'
 
 const limit = Math.max(availableParallelism() - 1, 1) * 8
 
 // - [ ] depid's with peer resolutions
-// - [ ] ensure that failures for optional deps don't reify the dep,
-// - [ ] do get removed from actual graph, but stay in main lockfile.
 // - [ ] depid shortening
 
 export type ReifyOptions = LoadOptions & {
@@ -38,73 +33,44 @@ export type ReifyOptions = LoadOptions & {
   remove?: RemoveImportersDependenciesMap
   graph: Graph
   actual?: Graph
-  packageInfo?: PackageInfoClient
+  packageInfo: PackageInfoClient
 }
-
-// const start = performance.now()
 
 /**
  * Make the current project match the supplied graph.
  */
 export const reify = async (options: ReifyOptions) => {
-  const {
-    projectRoot,
-    graph,
-    scurry = new PathScurry(projectRoot),
-    packageJson = new PackageJson(),
-    monorepo = Monorepo.maybeLoad(projectRoot, options),
-  } = options
-
-  /* c8 ignore start - have to override in tests to use mocks */
-  const packageInfo =
-    options.packageInfo ??
-    new PackageInfoClient({
-      ...options,
-      monorepo,
-      packageJson,
-    })
-  /* c8 ignore stop */
+  const { graph, scurry } = options
 
   const actual =
     options.actual ??
     loadActual({
       ...options,
       loadManifests: true,
-      scurry,
-      packageJson,
-      monorepo,
     })
 
   const diff = new Diff(actual, graph)
   const remover = new RollbackRemove()
   let success = false
   try {
-    await reify_(
-      options,
-      packageInfo,
-      diff,
-      remover,
-      scurry,
-      packageJson,
-    )
+    await reify_(options, diff, remover)
     remover.confirm()
     success = true
   } finally {
+    /* c8 ignore start */
     if (!success) {
-      /* c8 ignore next */
       await rollback(remover, diff, scurry).catch(() => {})
     }
+    /* c8 ignore stop */
   }
 }
 
 const reify_ = async (
   options: ReifyOptions,
-  packageInfo: PackageInfoClient,
   diff: Diff,
   remover: RollbackRemove,
-  scurry: PathScurry,
-  packageJson: PackageJson,
 ) => {
+  const { packageInfo, packageJson, scurry } = options
   const saveImportersPackageJson = updatePackageJson({
     add: options.add,
     remove: options.remove,

--- a/src/graph/test/actual/load.ts
+++ b/src/graph/test/actual/load.ts
@@ -1,5 +1,8 @@
 import { joinDepIDTuple } from '@vltpkg/dep-id'
+import { PackageJson } from '@vltpkg/package-json'
 import { SpecOptions } from '@vltpkg/spec'
+import { Monorepo } from '@vltpkg/workspaces'
+import { PathScurry } from 'path-scurry'
 import t from 'tap'
 import { load } from '../../src/actual/load.js'
 import { humanReadableOutput } from '../../src/visualization/human-readable-output.js'
@@ -269,6 +272,9 @@ t.test('load actual', async t => {
 
   const fullGraph = load({
     projectRoot,
+    scurry: new PathScurry(projectRoot),
+    packageJson: new PackageJson(),
+    monorepo: Monorepo.maybeLoad(projectRoot),
     loadManifests: true,
     skipHiddenLockfile: false,
     ...configData,
@@ -287,7 +293,14 @@ t.test('load actual', async t => {
 
   t.matchSnapshot(
     humanReadableOutput(
-      load({ projectRoot, loadManifests: false, ...configData }),
+      load({
+        scurry: new PathScurry(projectRoot),
+        packageJson: new PackageJson(),
+        monorepo: Monorepo.maybeLoad(projectRoot),
+        projectRoot,
+        loadManifests: false,
+        ...configData,
+      }),
     ),
     'should load an actual graph without any manifest info',
   )
@@ -357,13 +370,27 @@ t.test('cycle', async t => {
   })
   t.matchSnapshot(
     humanReadableOutput(
-      load({ projectRoot, loadManifests: true, ...configData }),
+      load({
+        scurry: new PathScurry(projectRoot),
+        packageJson: new PackageJson(),
+        monorepo: Monorepo.maybeLoad(projectRoot),
+        projectRoot,
+        loadManifests: true,
+        ...configData,
+      }),
     ),
     'should load an actual graph with cycle containing missing deps info',
   )
   t.matchSnapshot(
     humanReadableOutput(
-      load({ projectRoot, loadManifests: false, ...configData }),
+      load({
+        scurry: new PathScurry(projectRoot),
+        packageJson: new PackageJson(),
+        monorepo: Monorepo.maybeLoad(projectRoot),
+        projectRoot,
+        loadManifests: false,
+        ...configData,
+      }),
     ),
     'should load an actual graph with cycle without any manifest info',
   )
@@ -381,13 +408,27 @@ t.test('uninstalled dependencies', async t => {
   })
   t.matchSnapshot(
     humanReadableOutput(
-      load({ projectRoot, loadManifests: true, ...configData }),
+      load({
+        scurry: new PathScurry(projectRoot),
+        packageJson: new PackageJson(),
+        monorepo: Monorepo.maybeLoad(projectRoot),
+        projectRoot,
+        loadManifests: true,
+        ...configData,
+      }),
     ),
     'should load an actual graph with missing deps with manifest info',
   )
   t.matchSnapshot(
     humanReadableOutput(
-      load({ projectRoot, loadManifests: false, ...configData }),
+      load({
+        scurry: new PathScurry(projectRoot),
+        packageJson: new PackageJson(),
+        monorepo: Monorepo.maybeLoad(projectRoot),
+        projectRoot,
+        loadManifests: false,
+        ...configData,
+      }),
     ),
     'should load an actual graph with missing deps with no manifest info',
   )

--- a/src/graph/test/fixtures/reify/map.json
+++ b/src/graph/test/fixtures/reify/map.json
@@ -73,5 +73,6 @@
   "is-fullwidth-code-point@^3.0.0": "is-fullwidth-code-point-3.0.0",
   "emoji-regex@^8.0.0": "emoji-regex-8.0.0",
   "color-convert@^2.0.1": "color-convert-2.0.1",
-  "color-name@~1.1.4": "color-name-1.1.4"
+  "color-name@~1.1.4": "color-name-1.1.4",
+  "lodash@4": "lodash-4.17.21"
 }

--- a/src/graph/test/fixtures/reify/resolutions.json
+++ b/src/graph/test/fixtures/reify/resolutions.json
@@ -772,13 +772,13 @@
       }
     ]
   },
-  "ansi-regex@6.1.0": {
-    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
-    "integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
+  "lodash@4": {
+    "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+    "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
     "signatures": [
       {
-        "keyid": "SHA256:jl3bwswu80PjjokCgh0o2w5c2U4LhQAE57gj9cz1kzA",
-        "sig": "MEQCIDGQvwQxWIDhiEnJTo1Tb35X3bxVWxMjBoPaj+qTxlfnAiA3pztqy3OFgYbMqWZC5GdWT1yG2frnePf72yHSrhynBw=="
+        "sig": "MEUCIF3Yithbtmy1aEBNlfNWbLswAfPIyQUuNUGARD3Ex2t4AiEA6TlN2ZKJCUpS/Sf2Z6MduF1BNSvayHIpu5wAcICcKXw=",
+        "keyid": "SHA256:jl3bwswu80PjjokCgh0o2w5c2U4LhQAE57gj9cz1kzA"
       }
     ]
   }

--- a/src/graph/test/ideal/build-ideal-from-starting-graph.ts
+++ b/src/graph/test/ideal/build-ideal-from-starting-graph.ts
@@ -1,6 +1,8 @@
 import { DepID, DepIDTuple, joinDepIDTuple } from '@vltpkg/dep-id'
 import { manifest, PackageInfoClient } from '@vltpkg/package-info'
+import { PackageJson } from '@vltpkg/package-json'
 import { Spec, SpecOptions } from '@vltpkg/spec'
+import { Monorepo } from '@vltpkg/workspaces'
 import { PathScurry } from 'path-scurry'
 import t from 'tap'
 import { load as loadActual } from '../../src/actual/load.js'
@@ -377,6 +379,9 @@ t.test('build from an actual graph', async t => {
   })
 
   const actual = loadActual({
+    scurry: new PathScurry(projectRoot),
+    packageJson: new PackageJson(),
+    monorepo: Monorepo.maybeLoad(projectRoot),
     projectRoot,
     loadManifests: true,
     ...configData,

--- a/src/graph/test/ideal/build.ts
+++ b/src/graph/test/ideal/build.ts
@@ -1,4 +1,8 @@
 import { joinDepIDTuple } from '@vltpkg/dep-id'
+import { PackageInfoClient } from '@vltpkg/package-info'
+import { PackageJson } from '@vltpkg/package-json'
+import { Monorepo } from '@vltpkg/workspaces'
+import { PathScurry } from 'path-scurry'
 import t from 'tap'
 import { build } from '../../src/ideal/build.js'
 import { humanReadableOutput } from '../../src/visualization/human-readable-output.js'
@@ -35,6 +39,10 @@ t.test('build from lockfile', async t => {
   })
 
   const graph = await build({
+    scurry: new PathScurry(projectRoot),
+    monorepo: Monorepo.maybeLoad(projectRoot),
+    packageJson: new PackageJson(),
+    packageInfo: new PackageInfoClient({ projectRoot }),
     projectRoot,
     add: new Map([[joinDepIDTuple(['file', '.']), new Map()]]),
     remove: new Map(),
@@ -78,6 +86,10 @@ t.test('build from actual files', async t => {
   })
 
   const graph = await build({
+    scurry: new PathScurry(projectRoot),
+    monorepo: Monorepo.maybeLoad(projectRoot),
+    packageJson: new PackageJson(),
+    packageInfo: new PackageInfoClient({ projectRoot }),
     projectRoot,
   })
 

--- a/src/graph/test/ideal/get-importer-specs.ts
+++ b/src/graph/test/ideal/get-importer-specs.ts
@@ -1,6 +1,9 @@
 import { joinDepIDTuple } from '@vltpkg/dep-id'
+import { PackageJson } from '@vltpkg/package-json'
 import { kCustomInspect, Spec } from '@vltpkg/spec'
+import { Monorepo } from '@vltpkg/workspaces'
 import { inspect } from 'node:util'
+import { PathScurry } from 'path-scurry'
 import t from 'tap'
 import { load } from '../../src/actual/load.js'
 import { asDependency } from '../../src/dependencies.js'
@@ -17,6 +20,7 @@ t.test('empty graph and nothing to add', async t => {
   const graph = new Graph({
     projectRoot: t.testdirName,
     mainManifest: {},
+    monorepo: Monorepo.maybeLoad(t.testdirName),
   })
   const add = new Map()
   const remove = new Map()
@@ -46,7 +50,11 @@ t.test('empty graph with workspaces and nothing to add', async t => {
       packages: ['./packages/*'],
     }),
   })
-  const graph = load({ projectRoot })
+  const graph = load({
+    projectRoot,
+    scurry: new PathScurry(projectRoot),
+    packageJson: new PackageJson(),
+  })
   const add = new Map()
   const remove = new Map()
   const specs = getImporterSpecs({ add, graph, remove })
@@ -57,6 +65,7 @@ t.test('empty graph and something to add', async t => {
   const graph = new Graph({
     projectRoot: t.testdirName,
     mainManifest: {},
+    monorepo: Monorepo.maybeLoad(t.testdirName),
   })
   const add = new Map([
     [
@@ -97,7 +106,11 @@ t.test('graph specs and nothing to add', async t => {
   const projectRoot = t.testdir({
     'package.json': JSON.stringify(mainManifest),
   })
-  const graph = load({ projectRoot })
+  const graph = load({
+    projectRoot,
+    scurry: new PathScurry(projectRoot),
+    packageJson: new PackageJson(),
+  })
   const add = new Map()
   const remove = new Map()
   const specs = getImporterSpecs({ add, graph, remove })
@@ -118,7 +131,11 @@ t.test('graph specs and new things to add', async t => {
   const projectRoot = t.testdir({
     'package.json': JSON.stringify(mainManifest),
   })
-  const graph = load({ projectRoot })
+  const graph = load({
+    projectRoot,
+    scurry: new PathScurry(projectRoot),
+    packageJson: new PackageJson(),
+  })
   const add = new Map([
     [
       joinDepIDTuple(['file', '.']),
@@ -155,7 +172,11 @@ t.test('graph specs and something to update', async t => {
   const projectRoot = t.testdir({
     'package.json': JSON.stringify(mainManifest),
   })
-  const graph = load({ projectRoot })
+  const graph = load({
+    projectRoot,
+    scurry: new PathScurry(projectRoot),
+    packageJson: new PackageJson(),
+  })
   const add = new Map([
     [
       joinDepIDTuple(['file', '.']),
@@ -213,7 +234,12 @@ t.test(
         packages: ['./packages/*'],
       }),
     })
-    const graph = load({ projectRoot })
+    const graph = load({
+      projectRoot,
+      scurry: new PathScurry(projectRoot),
+      packageJson: new PackageJson(),
+      monorepo: Monorepo.maybeLoad(projectRoot),
+    })
     const add = new Map([
       [
         joinDepIDTuple(['file', '.']),
@@ -262,6 +288,7 @@ t.test('adding to a non existing importer', async t => {
   const graph = new Graph({
     projectRoot: t.testdirName,
     mainManifest: {},
+    monorepo: Monorepo.maybeLoad(t.testdirName),
   })
   const add = new Map([
     // this workspace id does not exist in the given graph
@@ -332,7 +359,11 @@ t.test('graph specs and something to remove', async t => {
       ),
     },
   })
-  const graph = load({ projectRoot })
+  const graph = load({
+    projectRoot,
+    scurry: new PathScurry(projectRoot),
+    packageJson: new PackageJson(),
+  })
   const add = new Map()
   const remove = new Map()
   const specs = getImporterSpecs({ add, graph, remove })
@@ -416,7 +447,12 @@ t.test(
         packages: ['./packages/*'],
       }),
     })
-    const graph = load({ projectRoot })
+    const graph = load({
+      projectRoot,
+      scurry: new PathScurry(projectRoot),
+      packageJson: new PackageJson(),
+      monorepo: Monorepo.maybeLoad(projectRoot),
+    })
     const add = new Map()
     const remove = new Map([
       [joinDepIDTuple(['workspace', 'packages/b']), new Set(['a'])],

--- a/src/graph/test/ideal/remove-satisfied-specs.ts
+++ b/src/graph/test/ideal/remove-satisfied-specs.ts
@@ -1,6 +1,9 @@
 import { joinDepIDTuple } from '@vltpkg/dep-id'
+import { PackageJson } from '@vltpkg/package-json'
 import { kCustomInspect, Spec } from '@vltpkg/spec'
+import { Monorepo } from '@vltpkg/workspaces'
 import { inspect } from 'node:util'
+import { PathScurry } from 'path-scurry'
 import t from 'tap'
 import { load } from '../../src/actual/load.js'
 import { asDependency } from '../../src/dependencies.js'
@@ -55,7 +58,12 @@ t.test('graph with an actual node', async t => {
   })
 
   await t.test('add spec is satisfied', async t => {
-    const graph = load({ projectRoot })
+    const graph = load({
+      projectRoot,
+      scurry: new PathScurry(projectRoot),
+      monorepo: Monorepo.maybeLoad(projectRoot),
+      packageJson: new PackageJson(),
+    })
     const add = new Map([
       [
         joinDepIDTuple(['file', '.']),
@@ -74,7 +82,12 @@ t.test('graph with an actual node', async t => {
   })
 
   await t.test('add a new spec item', async t => {
-    const graph = load({ projectRoot })
+    const graph = load({
+      projectRoot,
+      scurry: new PathScurry(projectRoot),
+      monorepo: Monorepo.maybeLoad(projectRoot),
+      packageJson: new PackageJson(),
+    })
     const add = new Map([
       [
         joinDepIDTuple(['file', '.']),
@@ -96,7 +109,12 @@ t.test('graph with an actual node', async t => {
   })
 
   await t.test('update existing spec', async t => {
-    const graph = load({ projectRoot })
+    const graph = load({
+      projectRoot,
+      scurry: new PathScurry(projectRoot),
+      monorepo: Monorepo.maybeLoad(projectRoot),
+      packageJson: new PackageJson(),
+    })
     const add = new Map([
       [
         joinDepIDTuple(['file', '.']),
@@ -118,7 +136,12 @@ t.test('graph with an actual node', async t => {
   })
 
   await t.test('registry tag', async t => {
-    const graph = load({ projectRoot })
+    const graph = load({
+      projectRoot,
+      scurry: new PathScurry(projectRoot),
+      monorepo: Monorepo.maybeLoad(projectRoot),
+      packageJson: new PackageJson(),
+    })
     const add = new Map([
       [
         joinDepIDTuple(['file', '.']),

--- a/src/graph/test/reify/build.ts
+++ b/src/graph/test/reify/build.ts
@@ -1,6 +1,7 @@
 import { joinDepIDTuple } from '@vltpkg/dep-id'
 import { PackageJson } from '@vltpkg/package-json'
 import { RunOptions } from '@vltpkg/run'
+import { Monorepo } from '@vltpkg/workspaces'
 import * as FSP from 'node:fs/promises'
 import { resolve } from 'node:path'
 import { PathScurry } from 'path-scurry'
@@ -133,8 +134,20 @@ t.test(
     })
 
     // pretend like we didn't have the deps, and then added them
-    const after = actual.load({ projectRoot, loadManifests: true })
-    const before = actual.load({ projectRoot, loadManifests: true })
+    const after = actual.load({
+      monorepo: Monorepo.maybeLoad(projectRoot),
+      packageJson: new PackageJson(),
+      scurry: new PathScurry(projectRoot),
+      projectRoot,
+      loadManifests: true,
+    })
+    const before = actual.load({
+      projectRoot,
+      monorepo: Monorepo.maybeLoad(projectRoot),
+      packageJson: new PackageJson(),
+      scurry: new PathScurry(projectRoot),
+      loadManifests: true,
+    })
     const bx = before.nodes.get(xid)
     const by = before.nodes.get(yid)
     if (!bx) throw new Error('no x node in before??')

--- a/src/graph/test/reify/index.ts
+++ b/src/graph/test/reify/index.ts
@@ -4,7 +4,9 @@ import {
   PackageInfoClientRequestOptions,
   Resolution,
 } from '@vltpkg/package-info'
+import { PackageJson } from '@vltpkg/package-json'
 import { Spec } from '@vltpkg/spec'
+import { Monorepo } from '@vltpkg/workspaces'
 import {
   lstatSync,
   readdirSync,
@@ -15,6 +17,7 @@ import {
 import { statSync } from 'node:fs'
 import { pathToFileURL } from 'node:url'
 import { resolve } from 'path'
+import { PathScurry } from 'path-scurry'
 import t from 'tap'
 import { inspect } from 'util'
 import {
@@ -47,10 +50,19 @@ t.test('super basic reification', async t => {
     },
   })
   const projectRoot = resolve(dir, 'project')
-  const graph = await ideal.build({ projectRoot })
+  const graph = await ideal.build({
+    projectRoot,
+    packageInfo: mockPackageInfo,
+    monorepo: Monorepo.maybeLoad(projectRoot),
+    scurry: new PathScurry(projectRoot),
+    packageJson: new PackageJson(),
+  })
   await reify({
     projectRoot,
     packageInfo: mockPackageInfo,
+    monorepo: Monorepo.maybeLoad(projectRoot),
+    scurry: new PathScurry(projectRoot),
+    packageJson: new PackageJson(),
     graph,
   })
 
@@ -135,6 +147,9 @@ t.test('super basic reification', async t => {
   await reify({
     projectRoot,
     packageInfo: mockPackageInfo,
+    monorepo: Monorepo.maybeLoad(projectRoot),
+    scurry: new PathScurry(projectRoot),
+    packageJson: new PackageJson(),
     graph,
   })
 
@@ -165,11 +180,20 @@ t.test('reify with a bin', async t => {
   })
 
   const projectRoot = resolve(dir, 'project')
-  const graph = await ideal.build({ projectRoot })
+  const graph = await ideal.build({
+    projectRoot,
+    monorepo: Monorepo.maybeLoad(projectRoot),
+    scurry: new PathScurry(projectRoot),
+    packageJson: new PackageJson(),
+    packageInfo: mockPackageInfo,
+  })
   await reify({
     projectRoot,
     packageInfo: mockPackageInfo,
     graph,
+    monorepo: Monorepo.maybeLoad(projectRoot),
+    scurry: new PathScurry(projectRoot),
+    packageJson: new PackageJson(),
   })
   t.equal(
     // note: not lstat, since this is going to be a shim on windows,
@@ -199,8 +223,19 @@ t.test('failure rolls back', async t => {
 
   const projectRoot = resolve(dir, 'project')
 
-  const before = actual.load({ projectRoot })
-  const graph = await ideal.build({ projectRoot })
+  const before = actual.load({
+    projectRoot,
+    monorepo: Monorepo.maybeLoad(projectRoot),
+    scurry: new PathScurry(projectRoot),
+    packageJson: new PackageJson(),
+  })
+  const graph = await ideal.build({
+    projectRoot,
+    packageInfo: mockPackageInfo,
+    monorepo: Monorepo.maybeLoad(projectRoot),
+    scurry: new PathScurry(projectRoot),
+    packageJson: new PackageJson(),
+  })
   const { reify } = await t.mockImport('../../src/reify/index.js', {
     '../../src/reify/build.js': {
       build: () =>
@@ -216,7 +251,12 @@ t.test('failure rolls back', async t => {
     }),
   )
 
-  const after = actual.load({ projectRoot })
+  const after = actual.load({
+    projectRoot,
+    monorepo: Monorepo.maybeLoad(projectRoot),
+    scurry: new PathScurry(projectRoot),
+    packageJson: new PackageJson(),
+  })
 
   t.strictSame(before, after, 'no changes to actual graph')
 
@@ -246,8 +286,19 @@ t.test('failure of optional node just deletes it', async t => {
 
   const projectRoot = resolve(dir, 'project')
 
-  const before = actual.load({ projectRoot })
-  const graph = await ideal.build({ projectRoot })
+  const before = actual.load({
+    projectRoot,
+    monorepo: Monorepo.maybeLoad(projectRoot),
+    scurry: new PathScurry(projectRoot),
+    packageJson: new PackageJson(),
+  })
+  const graph = await ideal.build({
+    projectRoot,
+    packageInfo: mockPackageInfo,
+    monorepo: Monorepo.maybeLoad(projectRoot),
+    scurry: new PathScurry(projectRoot),
+    packageJson: new PackageJson(),
+  })
   const globEdge = graph.mainImporter.edgesOut.get('glob')
   t.ok(globEdge, 'main importer depends on glob')
   t.equal(
@@ -258,6 +309,9 @@ t.test('failure of optional node just deletes it', async t => {
 
   await reify({
     projectRoot,
+    monorepo: Monorepo.maybeLoad(projectRoot),
+    scurry: new PathScurry(projectRoot),
+    packageJson: new PackageJson(),
     packageInfo: {
       ...mockPackageInfo,
       async extract(
@@ -275,7 +329,12 @@ t.test('failure of optional node just deletes it', async t => {
     graph,
   })
 
-  const after = actual.load({ projectRoot })
+  const after = actual.load({
+    projectRoot,
+    monorepo: Monorepo.maybeLoad(projectRoot),
+    scurry: new PathScurry(projectRoot),
+    packageJson: new PackageJson(),
+  })
 
   t.strictSame(
     inspect(before),

--- a/src/vlt/package.json
+++ b/src/vlt/package.json
@@ -25,6 +25,7 @@
     "@vltpkg/dot-prop": "workspace:*",
     "@vltpkg/error-cause": "workspace:*",
     "@vltpkg/graph": "workspace:*",
+    "@vltpkg/package-info": "workspace:*",
     "@vltpkg/package-json": "workspace:*",
     "@vltpkg/promise-spawn": "workspace:*",
     "@vltpkg/run": "workspace:*",

--- a/src/vlt/src/commands/install.ts
+++ b/src/vlt/src/commands/install.ts
@@ -1,8 +1,7 @@
 import { actual, ideal, reify } from '@vltpkg/graph'
-import { PackageJson } from '@vltpkg/package-json'
-import { PathScurry } from 'path-scurry'
-import { parseAddArgs } from '../parse-add-remove-args.js'
+import { PackageInfoClient } from '@vltpkg/package-info'
 import { LoadedConfig } from '../config/index.js'
+import { parseAddArgs } from '../parse-add-remove-args.js'
 import { CliCommandOptions } from '../types.js'
 
 export const usage = `vlt install [package ...]
@@ -12,40 +11,32 @@ export const command = async (
   conf: LoadedConfig,
   options: CliCommandOptions,
 ) => {
-  const { projectRoot } = conf.options
-  const packageJson = options.packageJson ?? new PackageJson()
-  const scurry = options.scurry ?? new PathScurry(projectRoot)
   const monorepo = options.monorepo
   const { add } = parseAddArgs(conf, monorepo)
-  const mainManifest = packageJson.read(projectRoot)
+  const mainManifest = conf.options.packageJson.read(
+    conf.options.projectRoot,
+  )
 
   const graph = await ideal.build({
     ...conf.options,
     add,
-    packageJson,
-    projectRoot,
     mainManifest,
     monorepo,
-    scurry,
     loadManifests: true,
+    packageInfo: new PackageInfoClient(conf.options),
   })
   const act = actual.load({
     ...conf.options,
-    packageJson,
-    projectRoot,
     mainManifest,
     monorepo,
-    scurry,
     loadManifests: true,
   })
   await reify({
     ...conf.options,
+    packageInfo: new PackageInfoClient(conf.options),
     add,
     actual: act,
-    packageJson,
-    projectRoot,
     monorepo,
-    scurry,
     graph,
     loadManifests: true,
   })

--- a/src/vlt/src/commands/uninstall.ts
+++ b/src/vlt/src/commands/uninstall.ts
@@ -1,8 +1,7 @@
 import { actual, ideal, reify } from '@vltpkg/graph'
-import { PackageJson } from '@vltpkg/package-json'
-import { PathScurry } from 'path-scurry'
-import { parseRemoveArgs } from '../parse-add-remove-args.js'
+import { PackageInfoClient } from '@vltpkg/package-info'
 import { LoadedConfig } from '../config/index.js'
+import { parseRemoveArgs } from '../parse-add-remove-args.js'
 import { CliCommandOptions } from '../types.js'
 
 export const usage = `vlt uninstall [package ...]
@@ -12,40 +11,32 @@ export const command = async (
   conf: LoadedConfig,
   options: CliCommandOptions,
 ) => {
-  const { projectRoot } = conf.options
   const monorepo = options.monorepo
-  const packageJson = options.packageJson ?? new PackageJson()
-  const scurry = options.scurry ?? new PathScurry(projectRoot)
   const { remove } = parseRemoveArgs(conf, monorepo)
-  const mainManifest = packageJson.read(projectRoot)
+  const mainManifest = conf.options.packageJson.read(
+    conf.options.projectRoot,
+  )
 
   const graph = await ideal.build({
     ...conf.options,
+    packageInfo: new PackageInfoClient(conf.options),
     remove,
-    packageJson,
-    projectRoot,
     mainManifest,
     monorepo,
-    scurry,
     loadManifests: true,
   })
   const act = actual.load({
     ...conf.options,
-    packageJson,
-    projectRoot,
     mainManifest,
     monorepo,
-    scurry,
     loadManifests: true,
   })
   await reify({
     ...conf.options,
+    packageInfo: new PackageInfoClient(conf.options),
     remove,
     actual: act,
-    packageJson,
-    projectRoot,
     monorepo,
-    scurry,
     graph,
     loadManifests: true,
   })

--- a/src/vlt/tap-snapshots/test/commands/install.ts.test.cjs
+++ b/src/vlt/tap-snapshots/test/commands/install.ts.test.cjs
@@ -14,6 +14,15 @@ Object {
   "graph": "buildideal result adds 0 new package(s)",
   "loadManifests": true,
   "monorepo": undefined,
+  "packageInfo": PackageInfoClient {
+    "monorepo": undefined,
+    "options": Object {
+      "packageJson": PackageJson {},
+      projectRoot: #
+      "scurry": PathScurry {},
+    },
+    "packageJson": PackageJson {},
+  },
   "packageJson": PackageJson {},
   projectRoot: #
   "scurry": PathScurry {},
@@ -52,12 +61,14 @@ Object {
               "github": "git+ssh://git@github.com:$1/$2.git",
               "gitlab": "git+ssh://git@gitlab.com:$1/$2.git",
             },
+            "packageJson": PackageJson {},
             projectRoot: #
             "registries": Object {
               "npm": "https://registry.npmjs.org/",
             },
             "registry": "https://registry.npmjs.org/",
             "scope-registries": Object {},
+            "scurry": PathScurry {},
           },
           "range": Range {
             "includePrerelease": false,
@@ -121,6 +132,15 @@ Object {
   "graph": "buildideal result adds 1 new package(s)",
   "loadManifests": true,
   "monorepo": undefined,
+  "packageInfo": PackageInfoClient {
+    "monorepo": undefined,
+    "options": Object {
+      "packageJson": PackageJson {},
+      projectRoot: #
+      "scurry": PathScurry {},
+    },
+    "packageJson": PackageJson {},
+  },
   "packageJson": PackageJson {},
   projectRoot: #
   "scurry": PathScurry {},

--- a/src/vlt/tap-snapshots/test/commands/uninstall.ts.test.cjs
+++ b/src/vlt/tap-snapshots/test/commands/uninstall.ts.test.cjs
@@ -11,6 +11,15 @@ Object {
   "graph": "buildideal result removes 0 new package(s)",
   "loadManifests": true,
   "monorepo": undefined,
+  "packageInfo": PackageInfoClient {
+    "monorepo": undefined,
+    "options": Object {
+      "packageJson": PackageJson {},
+      projectRoot: #
+      "scurry": PathScurry {},
+    },
+    "packageJson": PackageJson {},
+  },
   "packageJson": PackageJson {},
   projectRoot: #
   "remove": Map {

--- a/src/vlt/test/commands/config.ts
+++ b/src/vlt/test/commands/config.ts
@@ -1,9 +1,15 @@
 import t, { Test } from 'tap'
 
-import { definition, LoadedConfig } from '../../src/config/index.js'
+import {
+  definition,
+  LoadedConfig,
+  recordsToPairs,
+} from '../../src/config/index.js'
 
+import { PackageJson } from '@vltpkg/package-json'
 import * as CP from 'node:child_process'
 import { SpawnOptions } from 'node:child_process'
+import { PathScurry } from 'path-scurry'
 let edited: string | undefined = undefined
 const mockSpawnSync = (
   cmd: string,
@@ -26,6 +32,8 @@ class MockConfig {
   constructor(positionals: string[], values: Record<string, any>) {
     this.positionals = positionals
     this.values = values
+    this.values.packageJson = new PackageJson()
+    this.values.scurry = new PathScurry(t.testdirName)
   }
   get options() {
     return this.values
@@ -132,7 +140,9 @@ t.test('list', async t => {
       const vals = { some: 'options' }
       await run(t, [cmd], vals)
       t.strictSame(consoleErrors(), [])
-      t.strictSame(consoleLogs(), [[JSON.stringify(vals, null, 2)]])
+      t.strictSame(consoleLogs(), [
+        [JSON.stringify(recordsToPairs(vals), null, 2)],
+      ])
     })
   }
 })

--- a/src/vlt/test/commands/install.ts
+++ b/src/vlt/test/commands/install.ts
@@ -5,10 +5,6 @@ import { LoadedConfig } from '../../src/config/index.js'
 
 t.cleanSnapshot = s =>
   s.replace(/^(\s+)"?projectRoot"?: .*$/gm, '$1projectRoot: #')
-
-const options = { projectRoot: t.testdirName }
-let reifyOpts: any
-
 class PackageJson {
   read() {
     return { name: 'my-project', version: '1.0.0' }
@@ -17,6 +13,13 @@ class PackageJson {
 
 // eslint-disable-next-line @typescript-eslint/no-extraneous-class
 class PathScurry {}
+
+const options = {
+  projectRoot: t.testdirName,
+  scurry: new PathScurry(),
+  packageJson: new PackageJson(),
+}
+let reifyOpts: any
 
 const rootDepID = joinDepIDTuple(['file', '.'])
 
@@ -40,6 +43,10 @@ const { usage, command } = await t.mockImport<
   },
   'path-scurry': {
     PathScurry,
+    PathScurryDarwin: PathScurry,
+    PathScurryLinux: PathScurry,
+    PathScurryPosix: PathScurry,
+    PathScurryWin32: PathScurry,
   },
 })
 t.type(usage, 'string')
@@ -59,7 +66,7 @@ await command(
     positionals: ['abbrev@2'],
     values: { 'save-dev': true },
     options,
-  } as LoadedConfig,
+  } as unknown as LoadedConfig,
   {},
 )
 t.matchSnapshot(reifyOpts, 'should reify installing a new dependency')

--- a/src/vlt/test/commands/uninstall.ts
+++ b/src/vlt/test/commands/uninstall.ts
@@ -6,7 +6,6 @@ import { LoadedConfig } from '../../src/config/index.js'
 t.cleanSnapshot = s =>
   s.replace(/^(\s+)"?projectRoot"?: .*$/gm, '$1projectRoot: #')
 
-const options = { projectRoot: t.testdirName }
 let reifyOpts: any
 
 class PackageJson {
@@ -18,6 +17,11 @@ class PackageJson {
 // eslint-disable-next-line @typescript-eslint/no-extraneous-class
 class PathScurry {}
 
+const options = {
+  projectRoot: t.testdirName,
+  packageJson: new PackageJson(),
+  scurry: new PathScurry(),
+}
 const rootDepID = joinDepIDTuple(['file', '.'])
 
 const { usage, command } = await t.mockImport<
@@ -40,6 +44,10 @@ const { usage, command } = await t.mockImport<
   },
   'path-scurry': {
     PathScurry,
+    PathScurryDarwin: PathScurry,
+    PathScurryLinux: PathScurry,
+    PathScurryPosix: PathScurry,
+    PathScurryWin32: PathScurry,
   },
 })
 t.type(usage, 'string')

--- a/src/vlt/test/config/index.ts
+++ b/src/vlt/test/config/index.ts
@@ -208,13 +208,18 @@ t.test(
       ],
     } as ConfigData
     const opts = conf.options
-    t.strictSame(opts, {
+    const { scurry, packageJson, monorepo, ...o } = opts
+    t.strictSame(o, {
       projectRoot: t.testdirName,
       'git-hosts': {
         asdfasdf: 'https://example.com',
         github: 'https://github',
       },
     })
+    // can't check the type, because it came in via a mockImport,
+    // so tap sees a different class.
+    t.ok(scurry, 'always includes a scurry')
+    t.ok(packageJson, 'always includes a packageJson')
     t.equal(conf.options, opts, 'memoized')
 
     await conf.writeConfigFile('project', {


### PR DESCRIPTION
Since nearly everything ends up creating or accepting a monorepo, packageJson, and scurry, may as well just set them in one place in the cli.