### PR TITLE
fix(config): allow editing config when editor includes spaces

### DIFF
--- a/src/vlt/src/commands/config.ts
+++ b/src/vlt/src/commands/config.ts
@@ -98,10 +98,7 @@ const del = async (conf: LoadedConfig) => {
     console.error(usage)
     throw error('At least one key is required')
   }
-  await conf.deleteConfigKeys(
-    conf.get('config') as 'project' | 'user',
-    fields,
-  )
+  await conf.deleteConfigKeys(conf.get('config'), fields)
 }
 
 const get = (conf: LoadedConfig) => {
@@ -117,18 +114,13 @@ const get = (conf: LoadedConfig) => {
 }
 
 const edit = async (conf: LoadedConfig) => {
-  const editor = conf.get('editor')
-  /* c8 ignore start - there's a default, it can't be blank */
+  const [editor, ...args] = conf.get('editor').split(' ')
   if (!editor) {
-    throw error('no editor set in config')
+    throw error(`editor is empty`)
   }
-  /* c8 ignore stop */
-  await conf.editConfigFile(
-    conf.get('config') as 'project' | 'user',
-    async file => {
-      spawnSync(editor, [file], { stdio: 'inherit' })
-    },
-  )
+  await conf.editConfigFile(conf.get('config'), file => {
+    spawnSync(editor, [...args, file], { stdio: 'inherit' })
+  })
 }
 
 const set = async (conf: LoadedConfig) => {
@@ -138,6 +130,6 @@ const set = async (conf: LoadedConfig) => {
     throw error('At least one key=value pair is required')
   }
   const { values } = conf.jack.parseRaw(pairs.map(kv => `--${kv}`))
-  const which = conf.get('config') as 'project' | 'user'
+  const which = conf.get('config')
   await conf.addConfigToFile(which, pairsToRecords(values))
 }

--- a/src/vlt/src/config/definition.ts
+++ b/src/vlt/src/config/definition.ts
@@ -403,7 +403,7 @@ export const definition = jack({
       hint: 'user | project',
       description: `Specify whether to operate on user-level or project-level
                     configuration files when running \`vlt config\` commands.`,
-      validOptions: ['user', 'project'],
+      validOptions: ['user', 'project'] as const,
       default: 'project',
     },
 
@@ -446,7 +446,7 @@ export const definition = jack({
                     vlt config set fallback-command=run-exec
                     \`\`\``,
       default: 'help',
-      validOptions: [...new Set(Object.values(commands))],
+      validOptions: [...new Set(Object.values(commands))] as const,
     },
   })
 

--- a/src/vlt/test/commands/config.ts
+++ b/src/vlt/test/commands/config.ts
@@ -10,10 +10,10 @@ const mockSpawnSync = (
   args: string[],
   options: SpawnOptions,
 ) => {
-  t.matchOnly(args, [String])
+  t.matchOnly(args, [String, String])
   t.strictSame(options, { stdio: 'inherit' })
   t.equal(cmd, 'EDITOR')
-  edited = args[0]
+  edited = args.at(-1)
 }
 
 class MockConfig {
@@ -183,10 +183,16 @@ t.test('get', async t => {
 t.test('edit', async t => {
   for (const which of ['user', 'project']) {
     t.test(which, async t => {
-      await run(t, ['edit'], { config: which, editor: 'EDITOR' })
+      await run(t, ['edit'], {
+        config: which,
+        editor: 'EDITOR --passes-flags-to-args',
+      })
       t.equal(edited, which)
     })
   }
+  t.test('no editor', async t => {
+    t.rejects(run(t, ['edit'], { editor: '' }))
+  })
 })
 
 t.test('set', async t => {


### PR DESCRIPTION
Also use the new `jackspeak` type-safe validOptions instead of casting
config options within commands.
