### PR TITLE
fix(config): cleanup created config file if edit fails

### DIFF
--- a/src/vlt/src/commands/config.ts
+++ b/src/vlt/src/commands/config.ts
@@ -114,12 +114,22 @@ const get = (conf: LoadedConfig) => {
 }
 
 const edit = async (conf: LoadedConfig) => {
-  const [editor, ...args] = conf.get('editor').split(' ')
-  if (!editor) {
+  const [command, ...args] = conf.get('editor').split(' ')
+  if (!command) {
     throw error(`editor is empty`)
   }
   await conf.editConfigFile(conf.get('config'), file => {
-    spawnSync(editor, [...args, file], { stdio: 'inherit' })
+    args.push(file)
+    const res = spawnSync(command, args, {
+      stdio: 'inherit',
+    })
+    if (res.status !== 0) {
+      throw error(`${command} command failed`, {
+        ...res,
+        command,
+        args,
+      })
+    }
   })
 }
 

--- a/src/vlt/src/config/index.ts
+++ b/src/vlt/src/config/index.ts
@@ -518,9 +518,9 @@ export class Config {
     if (!backup) {
       writeFileSync(file, '{\n\n}\n')
     }
-    await edit(file)
     let valid = false
     try {
+      await edit(file)
       const res = jsonParse(readFileSync(file, 'utf8'))
       if (!res || typeof res !== 'object' || Array.isArray(res)) {
         throw error('Invalid configuration, expected object', {

--- a/src/vlt/test/config/index.ts
+++ b/src/vlt/test/config/index.ts
@@ -645,6 +645,14 @@ t.test('edit config file', async t => {
   t.throws(() => statSync(f), 'no configs, deleted file')
 
   await t.rejects(
+    conf.editConfigFile('project', () => {
+      t.equal(readFileSync(f, 'utf8'), '{\n\n}\n')
+      throw new Error()
+    }),
+  )
+  t.throws(() => statSync(f), 'edit throws, deleted file')
+
+  await t.rejects(
     conf.editConfigFile('project', filename => {
       writeFileSync(filename, '"just a string"')
     }),


### PR DESCRIPTION
Also throw a better error if spawning the edit child process fails.
