### PR TITLE
chore: rename internal vlt workspace to @vltpkg/cli

### DIFF
--- a/infra/build/package.json
+++ b/infra/build/package.json
@@ -14,6 +14,7 @@
     }
   },
   "dependencies": {
+    "@vltpkg/cli": "workspace:*",
     "@yao-pkg/pkg": "^5.15.0",
     "esbuild": "^0.23.1",
     "jscodeshift": "^17.0.0",

--- a/infra/build/src/compile.ts
+++ b/infra/build/src/compile.ts
@@ -112,6 +112,7 @@ const getCompileOptions = (
       args: [
         'compile',
         '-A',
+        '--no-check',
         `--output=${outfile}`,
         ...include.map(i => `--include=${i}`),
       ],

--- a/infra/build/src/index.ts
+++ b/infra/build/src/index.ts
@@ -9,12 +9,17 @@ const BUILD_ROOT = dirname(findPackageJson(import.meta.filename))
 const MONO_ROOT = resolve(BUILD_ROOT, '../..')
 const SRC = join(MONO_ROOT, 'src')
 const CLI = join(SRC, 'vlt')
+// TODO(source-maps): this is a ./dist/ path which might need
+// to be changed to a src path to get proper sourcemaps
+// https://github.com/vltpkg/vltpkg/issues/150
+const COMMANDS = join(CLI, 'dist/esm/commands')
 
 export const Paths = {
   BUILD_ROOT,
   MONO_ROOT,
   SRC,
   CLI,
+  COMMANDS,
 }
 
 export const Bins = (() => {
@@ -33,6 +38,9 @@ export const Bins = (() => {
   )
   return {
     PATHS: paths,
+    // TODO(source-maps): this is a ./dist/ path which might need
+    // to be changed to a src path to get proper sourcemaps
+    // https://github.com/vltpkg/vltpkg/issues/150
     DIR: join(CLI, dirname(paths[0])),
   }
 })()

--- a/infra/build/src/types.ts
+++ b/infra/build/src/types.ts
@@ -1,5 +1,9 @@
 export const All = 'all'
 
+// TODO(bins): generating a bundle/compiled binary for each bin is not
+// very efficient. Come up with a way to splice the command name based
+// on the name of the argument that will work in both bundle and compile
+// scenarios.
 export const Bins = {
   vlt: 'vlt',
   vlr: 'vlr',
@@ -7,7 +11,6 @@ export const Bins = {
   vlrx: 'vlrx',
   vlix: 'vlix',
 } as const
-export const DefaultBin = Bins.vlt
 export const BinNames = Object.values(Bins)
 export type Bin = (typeof Bins)[keyof typeof Bins]
 export const isBin = (v: unknown): v is Bin =>

--- a/infra/build/tap-snapshots/test/matrix.ts.test.cjs
+++ b/infra/build/tap-snapshots/test/matrix.ts.test.cjs
@@ -5,34 +5,20 @@
  * Make sure to inspect the output below.  Do not ignore changes!
  */
 'use strict'
-exports[`test/matrix.ts > TAP > bundle matrix > files 1`] = `
+exports[`test/matrix.ts > TAP > compile matrix > bundles 1`] = `
 Array [
-  "cache-unzip/",
-  "commands/",
-  "package.json",
-  "registry-client/",
-  "rollback-remove/",
-  "tar/",
-  "vlix.js",
-  "vlix.js.map",
-  "vlr.js",
-  "vlr.js.map",
-  "vlrx.js",
-  "vlrx.js.map",
-  "vlt.js",
-  "vlt.js.map",
-  "vlx.js",
-  "vlx.js.map",
+  "cjs",
+  "esm",
 ]
 `
 
 exports[`test/matrix.ts > TAP > compile matrix > files 1`] = `
 Array [
-  "vlix",
-  "vlr",
-  "vlrx",
   "vlt",
+  "vlr",
   "vlx",
+  "vlrx",
+  "vlix",
 ]
 `
 

--- a/infra/build/test/bin/benchmark.ts
+++ b/infra/build/test/bin/benchmark.ts
@@ -19,6 +19,17 @@ const benchmark = async (t: Test, ...argv: string[]) => {
       'node:child_process': {
         spawnSync: (_: any, a: string[]) => (args = a),
       },
+      '../../src/matrix.js': await t.mockImport(
+        '../../src/matrix.js',
+        {
+          '../../src/compile.js': {
+            default: () => {},
+          },
+          '../../src/bundle.js': {
+            default: () => {},
+          },
+        },
+      ),
     },
   )
   const benchmarkArg = args.at(-2)

--- a/infra/build/test/bin/build.ts
+++ b/infra/build/test/bin/build.ts
@@ -6,10 +6,31 @@ const build = async (t: Test, ...argv: string[]) => {
   t.intercept(process, 'argv', {
     value: [process.execPath, 'build.js', `--outdir=${dir}`, ...argv],
   })
+  let compiled = 0
+  let bundled = 0
   await t.mockImport<typeof import('../../src/bin/build.js')>(
     '../../src/bin/build.js',
+    {
+      '../../src/matrix.js': await t.mockImport(
+        '../../src/matrix.js',
+        {
+          '../../src/compile.js': {
+            default: () => {
+              compiled++
+            },
+          },
+          '../../src/bundle.js': {
+            default: () => {
+              bundled++
+            },
+          },
+        },
+      ),
+    },
   )
   return {
+    compiled,
+    bundled,
     res: JSON.parse((logs().at(-1) ?? [])[0]),
   }
 }
@@ -17,9 +38,13 @@ const build = async (t: Test, ...argv: string[]) => {
 t.test('basic', async t => {
   const r = await build(t)
   t.equal(r.res.length, 1)
+  t.equal(r.compiled, 0)
+  t.equal(r.bundled, 1)
 })
 
 t.test('runtime', async t => {
   const r = await build(t, '--format=esm,cjs')
   t.equal(r.res.length, 2)
+  t.equal(r.compiled, 0)
+  t.equal(r.bundled, 2)
 })

--- a/infra/build/test/bundle.ts
+++ b/infra/build/test/bundle.ts
@@ -27,12 +27,7 @@ const testBundle = async (
   }
 }
 
-t.test('bundle', async t => {
-  await t.resolves(
-    testBundle(t, {
-      format: types.Formats.Esm,
-    }),
-  )
+t.test('cjs', async t => {
   await t.resolves(
     testBundle(t, {
       format: types.Formats.Cjs,
@@ -40,14 +35,10 @@ t.test('bundle', async t => {
   )
 })
 
-t.test('external commands', async t => {
-  const { files: commands } = await testBundle(t, {
-    externalCommands: true,
-  })
+t.test('no external commands', async t => {
   const { files: noCommands } = await testBundle(t, {
     externalCommands: false,
   })
-  t.ok(commands.some(c => c.startsWith(`commands${sep}`)))
   t.notOk(noCommands.some(c => c.startsWith(`commands${sep}`)))
 })
 

--- a/infra/build/test/compile.ts
+++ b/infra/build/test/compile.ts
@@ -1,7 +1,5 @@
 import t, { Test } from 'tap'
 import { join } from 'path'
-import compile from '../src/compile.js'
-import bundle from '../src/bundle.js'
 import { defaultOptions } from '../src/index.js'
 import * as types from '../src/types.js'
 
@@ -9,18 +7,26 @@ const testCompile = async (
   t: Test,
   options: Partial<types.Factors>,
 ) => {
+  const { default: compile } = await t.mockImport(
+    '../src/compile.js',
+    {
+      'node:child_process': {
+        spawnSync: () => ({ status: 0 }),
+      },
+    },
+  )
   const dir = t.testdir({
-    source: {},
+    source: {
+      nested: {
+        file: '',
+      },
+      'some-file.js': '',
+    },
     compile: {},
   })
   const def = defaultOptions()
-  const { outdir: source } = await bundle({
-    outdir: join(dir, 'source'),
-    ...def,
-    ...options,
-  })
   compile({
-    source,
+    source: join(dir, 'source'),
     outdir: join(dir, 'compile'),
     bin: types.Bins.vlt,
     ...def,

--- a/infra/build/test/smoke.ts
+++ b/infra/build/test/smoke.ts
@@ -170,14 +170,8 @@ t.test('commands', async t => {
   const outdir = t.testdir()
   await bundle({ outdir, ...defaultOptions() })
 
-  const snapshots: Record<
-    typeof types.DefaultBin,
-    { [command: string]: TestCase[] }
-  > &
-    Record<
-      Exclude<types.Bin, typeof types.DefaultBin | 'vlix'>,
-      TestCase[]
-    > = {
+  const snapshots: Record<'vlt', { [command: string]: TestCase[] }> &
+    Record<Exclude<types.Bin, 'vlt' | 'vlix'>, TestCase[]> = {
     vlt: {
       pkg: [
         { args: ['get'], snapshot: true },

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0-0",
   "private": true,
   "dependencies": {
-    "vlt": "workspace:*"
+    "@vltpkg/cli": "workspace:*"
   },
   "devDependencies": {
     "@eslint/js": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -79,7 +79,7 @@ importers:
 
   .:
     dependencies:
-      vlt:
+      '@vltpkg/cli':
         specifier: workspace:*
         version: link:src/vlt
     devDependencies:
@@ -165,6 +165,9 @@ importers:
 
   infra/build:
     dependencies:
+      '@vltpkg/cli':
+        specifier: workspace:*
+        version: link:../../src/vlt
       '@yao-pkg/pkg':
         specifier: ^5.15.0
         version: 5.15.0(encoding@0.1.13)
@@ -1589,8 +1592,8 @@ packages:
     resolution: {integrity: sha512-Z9IYjuXSArkAUx3N6xj6+Bnvx8OdUSHA8YoOgyepp3+zJmtVYJIl/I18GozdJVW1p5u/CNpl3Km7/gwTJK85cw==}
     engines: {node: ^18.17.1 || ^20.3.0 || >=21.0.0}
 
-  '@astrojs/sitemap@3.2.0':
-    resolution: {integrity: sha512-SkrOCL3Z6HxdiXreZ1+aPBWgnBMJ31EgPdcscgQeLqI2Gqk/4EKLuw9q0SqKU9MmHpcPXXtcd0odfCk4barPoA==}
+  '@astrojs/sitemap@3.2.1':
+    resolution: {integrity: sha512-uxMfO8f7pALq0ADL6Lk68UV6dNYjJ2xGUzyjjVj60JLBs5a6smtlkBYv3tQ0DzoqwS7c9n4FUx5lgv0yPo/fgA==}
 
   '@astrojs/starlight@0.28.3':
     resolution: {integrity: sha512-GXXIPKSu5d50mLVtgI4jf6pb3FPQm8n4MI6ZXuQQqqnA0xg7PJQ76WFSVyrICeqM5fKABSqcBksp/glyEJes/A==}
@@ -3770,8 +3773,8 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
-  fast-uri@3.0.2:
-    resolution: {integrity: sha512-GR6f0hD7XXyNJa25Tb9BuIdN0tdr+0BMi6/CJPH3wJO1JjNG3n/VsSw38AwRdKZABm8lGbPfakLRkYzx2V9row==}
+  fast-uri@3.0.3:
+    resolution: {integrity: sha512-aLrHthzCjH5He4Z2H9YZ+v6Ujb9ocRuW6ZzkJQOrTxleEijANq4v1TsaPaVG1PZcuurEzrLcWRyYBYXD5cEiaw==}
 
   fastq@1.17.1:
     resolution: {integrity: sha512-sRVD3lWVIXWg6By68ZN7vho9a1pQcN/WBFaAAsDDFzlJjvoGx0P8z7V1t72grFJfJhu3YPZBuu25f7Kaw2jN1w==}
@@ -5536,8 +5539,8 @@ packages:
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
 
-  tinyexec@0.3.0:
-    resolution: {integrity: sha512-tVGE0mVJPGb0chKhqmsoosjsS+qUnJVGJpZgsHYQcGoPlG3B51R3PouqTgEGH2Dc9jjFyOqOpix6ZHNMXp1FZg==}
+  tinyexec@0.3.1:
+    resolution: {integrity: sha512-WiCJLEECkO18gwqIp6+hJg0//p23HXp4S+gGtAKu3mI2F2/sXC4FvHvXvB0zJVVaTPhx1/tOwdbRsa1sOBIKqQ==}
 
   tinypool@1.0.1:
     resolution: {integrity: sha512-URZYihUbRPcGv95En+sz6MfghfIc2OJ1sv/RmhWZLouPY0/8Vo80viwPvg3dlaS9fuq7fQMEfgRRK7BBZThBEA==}
@@ -6212,7 +6215,7 @@ snapshots:
     dependencies:
       prismjs: 1.29.0
 
-  '@astrojs/sitemap@3.2.0':
+  '@astrojs/sitemap@3.2.1':
     dependencies:
       sitemap: 8.0.0
       stream-replace-string: 2.0.0
@@ -6221,7 +6224,7 @@ snapshots:
   '@astrojs/starlight@0.28.3(astro@5.0.0-beta.4(@types/node@22.5.0)(rollup@4.24.0)(typescript@5.5.4))':
     dependencies:
       '@astrojs/mdx': 4.0.0-beta.2(astro@5.0.0-beta.4(@types/node@22.5.0)(rollup@4.24.0)(typescript@5.5.4))
-      '@astrojs/sitemap': 3.2.0
+      '@astrojs/sitemap': 3.2.1
       '@pagefind/default-ui': 1.1.1
       '@types/hast': 3.0.4
       '@types/mdast': 4.0.4
@@ -7928,7 +7931,7 @@ snapshots:
   ajv@8.17.1:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.0.2
+      fast-uri: 3.0.3
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -8053,7 +8056,7 @@ snapshots:
       semver: 7.6.3
       shiki: 1.22.0
       string-width: 7.2.0
-      tinyexec: 0.3.0
+      tinyexec: 0.3.1
       tsconfck: 3.1.4(typescript@5.5.4)
       unist-util-visit: 5.0.0
       vfile: 6.0.3
@@ -8660,7 +8663,7 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
-  fast-uri@3.0.2: {}
+  fast-uri@3.0.3: {}
 
   fastq@1.17.1:
     dependencies:
@@ -11018,7 +11021,7 @@ snapshots:
 
   tinybench@2.9.0: {}
 
-  tinyexec@0.3.0: {}
+  tinyexec@0.3.1: {}
 
   tinypool@1.0.1: {}
 
@@ -11298,7 +11301,7 @@ snapshots:
       pathe: 1.1.2
       std-env: 3.7.0
       tinybench: 2.9.0
-      tinyexec: 0.3.0
+      tinyexec: 0.3.1
       tinypool: 1.0.1
       tinyrainbow: 1.2.0
       vite: 6.0.0-beta.2(@types/node@22.5.0)

--- a/scripts/consistent-package-json.js
+++ b/scripts/consistent-package-json.js
@@ -38,8 +38,7 @@ const skipCatalog = ({ name, spec, from, type }) => {
   return false
 }
 
-const isInternal = name =>
-  name.startsWith('@vltpkg/') || name === 'vlt'
+const isInternal = name => name.startsWith('@vltpkg/')
 
 const format = async (source, filepath) => {
   const options = await prettier.resolveConfig(filepath)
@@ -373,7 +372,7 @@ const fixPackage = async (ws, opts) => {
   ws.pj.private =
     (
       ws.isRoot ||
-      ws.pj.name === 'vlt' ||
+      ws.pj.name === '@vltpkg/cli' ||
       ws.workspaceDir === 'infra' ||
       ws.workspaceDir === 'www'
     ) ?

--- a/src/vlt/package.json
+++ b/src/vlt/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "vlt",
-  "description": "A very fast JavaScript package manager",
+  "name": "@vltpkg/cli",
+  "description": "The vlt CLI",
   "version": "0.0.0-0",
   "private": true,
   "tshy": {
@@ -10,7 +10,11 @@
     ],
     "exports": {
       "./package.json": "./package.json",
-      ".": "./src/index.ts"
+      ".": "./src/index.ts",
+      "./commands/*.js": "./commands/*.ts",
+      "./config.js": "./config/index.ts",
+      "./config/definition.js": "./config/definition.ts",
+      "./types.js": "./types.ts"
     }
   },
   "bin": {
@@ -85,7 +89,11 @@
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
       }
-    }
+    },
+    "./commands/*.js": "./commands/*.ts",
+    "./config.js": "./config/index.ts",
+    "./config/definition.js": "./config/definition.ts",
+    "./types.js": "./types.ts"
   },
   "module": "./dist/esm/index.js"
 }


### PR DESCRIPTION
`src/vlt` was already a private workspace, and the name `vlt` in the package.json was not being used anywhere since the workspace was not being published directly. In preparation for the docs, I've renamed it and added some exports that will be used by the docs site.

This also explicitly adds a relationship between `infra/build` and `src/vlt` so the tests will run when the CLI changes. The tests were pretty slow though so I added some mocks so they run faster.