### PR TITLE
README formatting for packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,10 @@
-<section align="center">
-    <a href="https://www.vlt.sh">
-        <img src="https://github.com/user-attachments/assets/e03cad94-9146-4b67-8644-497caf2f2267" />
-        <h1 align="center">
-            <strong>vlt</strong>
-            /vōlt/
-        </h1>
-    </a>
-</section>
+![vlt](https://github.com/user-attachments/assets/e03cad94-9146-4b67-8644-497caf2f2267)
 
-<p align="center">
-    Develop > Run > Distribute
-</p>
+# vlt /vōlt/
 
-<p align="center">
-    <a href="https://docs.vlt.sh"><strong>Documentation</strong></a>
-</p>
+Develop > Run > Distribute
+
+**[Documentation](https://docs.vlt.sh)**
 
 ## **@vltpkg**
 

--- a/infra/benchmark/README.md
+++ b/infra/benchmark/README.md
@@ -1,14 +1,7 @@
-<section align="center">
-    <a href="https://www.vlt.sh">
-        <img src="https://github.com/user-attachments/assets/26cf64ba-55e7-451b-98d2-6cca938d8f4b" />
-        <h1 align="center">
-            <strong>@vltpkg/benchmark</strong>
-        </h1>
-    </a>
-</section>
+![benchmark](https://github.com/user-attachments/assets/26cf64ba-55e7-451b-98d2-6cca938d8f4b)
 
-<p align="center">
-    An internal only workspace that is not published to any registry.
-    <br/>
-    Utilized for benchmarking.
-</p>
+# @vltpkg/benchmark
+
+> An internal only workspace that is not published to any registry.
+
+Utilized for benchmarking.

--- a/infra/build/README.md
+++ b/infra/build/README.md
@@ -1,14 +1,7 @@
-<section align="center">
-    <a href="https://www.vlt.sh">
-        <img src="https://github.com/user-attachments/assets/4ceaa394-8707-4bb3-935a-b29cd2c397ee" />
-        <h1 align="center">
-            <strong>@vltpkg/build</strong>
-        </h1>
-    </a>
-</section>
+![build](https://github.com/user-attachments/assets/4ceaa394-8707-4bb3-935a-b29cd2c397ee)
 
-<p align="center">
-    An internal only workspace that is not published to any registry.
-    <br/>
-    Utilized for building vlt.
-</p>
+# @vltpkg/build
+
+> An internal only workspace that is not published to any registry.
+
+Utilized for building vlt.

--- a/src/cache-unzip/README.md
+++ b/src/cache-unzip/README.md
@@ -1,21 +1,12 @@
-<section align="center">
-    <a href="https://www.vlt.sh">
-        <img src="https://github.com/user-attachments/assets/edbe377f-d0ae-4d48-9658-3eb91d1bd482" />
-        <h1 align="center">
-            <strong>@vltpkg/cache-unzip</strong>
-        </h1>
-    </a>
-</section>
+![cache-unzip](https://github.com/user-attachments/assets/edbe377f-d0ae-4d48-9658-3eb91d1bd482)
 
-<p align="center">
+# @vltpkg/cache-unzip
+
 This is a script that can be run as a detached background process to un-gzip any cached response bodies in the vlt cache.
-</p>
 
-<p align="center">
-  <a href="#usage"><strong>Usage</strong></a>
-	·
-  <a href="#why-do-this"><strong>Why Do This?</strong></a>
-</p>
+**[Usage](#usage)**
+·
+**[Why Do This?](#why-do-this)**
 
 ## Usage
 

--- a/src/cache/README.md
+++ b/src/cache/README.md
@@ -1,22 +1,12 @@
-<section align="center">
-    <a href="https://www.vlt.sh">
-        <img src="https://github.com/user-attachments/assets/beb8e72b-9af4-42ff-a39c-11c937bffdb6" />
-        <h1 align="center">
-            <strong>@vltpkg/cache</strong>
-        </h1>
-    </a>
-</section>
+![cache](https://github.com/user-attachments/assets/beb8e72b-9af4-42ff-a39c-11c937bffdb6)
 
-<p align="center">
-    The filesystem cache for <code>@vlt/registry-client</code>, but also, a
-    general-purpose filesystem-backed <a href="http://npm.im/lru-cache">LRUCache</a>.
-</p>
+# @vltpkg/cache
 
-<p align="center">
-    <a href="#usage"><strong>Usage</strong></a>
-    ·
-    <a href="#note"><strong>Note</strong></a>
-</p>
+The filesystem cache for `@vlt/registry-client`, but also, a general-purpose filesystem-backed [LRUCache](http://npm.im/lru-cache)
+
+**[Usage](#usage)**
+·
+**[Note](#note)**
 
 ## Overview
 

--- a/src/dep-id/README.md
+++ b/src/dep-id/README.md
@@ -1,23 +1,12 @@
-<section align="center">
-    <a href="https://www.vlt.sh">
-        <img src="https://github.com/user-attachments/assets/f44cb9f8-e778-447c-8100-9ff564427048" />
-        <h1 align="center">
-            <strong>@vltpkg/dep-id</strong>
-        </h1>
-    </a>
-</section>
+![dep-id](https://github.com/user-attachments/assets/f44cb9f8-e778-447c-8100-9ff564427048)
 
-<p align="center">
-    A library for serializing dependencies into terse string
-    identifiers, and turning those serialized identifiers back into
-    `Spec` objects.
-</p>
+# @vltpkg/dep-id
 
-<p align="center">
-  <a href="#usage"><strong>Usage</strong></a>
-	·
-  <a href="#note"><strong>Note</strong></a>
-</p>
+A library for serializing dependencies into terse string identifiers, and turning those serialized identifiers back into `Spec` objects.
+
+**[Usage](#usage)**
+·
+**[Note](#note)**
 
 ## Usage
 

--- a/src/dot-prop/README.md
+++ b/src/dot-prop/README.md
@@ -1,15 +1,8 @@
-<section align="center">
-    <a href="https://www.vlt.sh">
-        <img src="https://github.com/user-attachments/assets/2f26fc9d-5f78-49cc-bb4b-6549e2233111" />
-        <h1 align="center">
-            <strong>@vltpkg/dot-prop</strong>
-        </h1>
-    </a>
-</section>
+![dot-prop](https://github.com/user-attachments/assets/2f26fc9d-5f78-49cc-bb4b-6549e2233111)
 
-<p align="center">
-    A library that allows you to easily access, set, delete, and check deeply nested properties in objects and arrays using string-based paths.
-</p>
+# @vltpkg/dot-prop
+
+A library that allows you to easily access, set, delete, and check deeply nested properties in objects and arrays using string-based paths.
 
 ## Usage
 

--- a/src/error-cause/README.md
+++ b/src/error-cause/README.md
@@ -1,25 +1,16 @@
-<section align="center">
-    <a href="https://www.vlt.sh">
-        <img src="https://github.com/user-attachments/assets/5fa00d7e-19dd-400e-9a77-6d37ded3fe2d" />
-        <h1 align="center">
-            <strong>@vltpkg/error-cause</strong>
-        </h1>
-    </a>
-</section>
+![error-cause](https://github.com/user-attachments/assets/5fa00d7e-19dd-400e-9a77-6d37ded3fe2d)
 
-<p align="center">
-    Utility functions for `Error` creation to help enforce vlt's `Error.cause` conventions.
-</p>
+# @vltpkg/error-cause
 
-<p align="center">
-    <a href="#usage"><strong>Usage</strong></a>
-    ·
-    <a href="#challenges-of-error-reporting"><strong>Error Reporting</strong></a>
-    ·
-    <a href="#conventions"><strong>Conventions</strong></a>
-    ·
-    <a href="#error-types"><strong>Error Types</strong></a>
-</p>
+Utility functions for `Error` creation to help enforce vlt's `Error.cause` conventions.
+
+**[Usage](#usage)**
+·
+**[Error Reporting](#challenges-of-error-reporting)**
+·
+**[Conventions](#conventions)**
+·
+**[Error Types](#error-types)**
 
 ## Why
 

--- a/src/fast-split/README.md
+++ b/src/fast-split/README.md
@@ -1,33 +1,18 @@
-<section align="center">
-    <a href="https://www.vlt.sh">
-        <img src="https://github.com/user-attachments/assets/0181afb7-0e03-41e6-b85c-2b5095b5d263" />
-        <h1 align="center">
-            <strong>@vltpkg/fast-split</strong>
-        </h1>
-    </a>
-</section>
+![fast-split](https://github.com/user-attachments/assets/0181afb7-0e03-41e6-b85c-2b5095b5d263)
 
-<p align="center">
-    This is a very fast alternative to `String.split()`, which can be
-    used to quickly parse a small-to-medium sized string by a given
-    delimiter.
-</p>
+# @vltpkg/fast-split
 
-<p align="center">
-    <a href="#how-fast-is-it"><strong>It's fast</strong></a>
-    ·
-    <a href="#usage"><strong>Usage</strong></a>
-</p>
+This is a very fast alternative to `String.split()`, which can be used to quickly parse a small-to-medium sized string by a given delimiter.
+
+**[It's fast](#how-fast-is-it)**
+·
+**[Usage](#usage)**
 
 ## How Fast Is It!?
 
-This is about 10% faster for splitting short strings by a short delimiter.
-When we have to walk the resulting list for any reason, or limit the number
-of items returned, it's an even bigger difference.
+This is about 10% faster for splitting short strings by a short delimiter. When we have to walk the resulting list for any reason, or limit the number of items returned, it's an even bigger difference.
 
-2024 M1 macbook pro, using node 20.11.0, v8 version 11.3.244.8-node.17
-Counts are operations per ms, splitting the string '1.2.3-asdf+foo' by the
-delimiter '.', transforms calling part.toUpperCase(), and limits at 2 items
+2024 M1 macbook pro, using node 20.11.0, v8 version 11.3.244.8-node.17 Counts are operations per ms, splitting the string '1.2.3-asdf+foo' by the delimiter '.', transforms calling part.toUpperCase(), and limits at 2 items
 
 ```
               split 10385.779

--- a/src/git-scp-url/README.md
+++ b/src/git-scp-url/README.md
@@ -1,15 +1,8 @@
-<section align="center">
-    <a href="https://www.vlt.sh">
-        <img src="https://github.com/user-attachments/assets/55a9538d-5c29-4ee5-b740-46db8b17611a" />
-        <h1 align="center">
-            <strong>@vltpkg/git-scp-url</strong>
-        </h1>
-    </a>
-</section>
+![git-scp-url](https://github.com/user-attachments/assets/55a9538d-5c29-4ee5-b740-46db8b17611a)
 
-<p align="center">
-    Utility function for parsing git "scp-style" URLs, like `git:git@github.com:user/repo` or `git+ssh://github.com:user/repo`.
-</p>
+# @vltpkg/git-scp-url
+
+Utility function for parsing git "scp-style" URLs, like `git:git@github.com:user/repo` or `git+ssh://github.com:user/repo`.
 
 ## Usage
 

--- a/src/git/README.md
+++ b/src/git/README.md
@@ -1,23 +1,14 @@
-<section align="center">
-    <a href="https://www.vlt.sh">
-        <img src="https://github.com/user-attachments/assets/184a7d71-fbfd-4a81-8d8b-fc8a27931d20" />
-        <h1 align="center">
-            <strong>@vltpkg/git</strong>
-        </h1>
-    </a>
-</section>
+![git](https://github.com/user-attachments/assets/184a7d71-fbfd-4a81-8d8b-fc8a27931d20)
 
-<p align="center">
-    A utility for spawning git from npm CLI contexts.
-</p>
+# @vltpkg/git
 
-<p align="center">
-    <a href="#usage"><strong>Usage</strong></a>
-    ·
-    <a href="#api"><strong>API</strong></a>
-    ·
-    <a href="#options"><strong>Options</strong></a>
-</p>
+A utility for spawning git from npm CLI contexts.
+
+**[Usage](#usage)**
+·
+**[API](#api)**
+·
+**[Options](#options)**
 
 ## Overview
 

--- a/src/graph/README.md
+++ b/src/graph/README.md
@@ -1,21 +1,12 @@
-<section align="center">
-    <a href="https://www.vlt.sh">
-        <img src="https://github.com/user-attachments/assets/dfbed9e0-8ef0-4a43-993d-d3e5d1e5ae1d" />
-        <h1 align="center">
-            <strong>@vltpkg/graph</strong>
-        </h1>
-    </a>
-</section>
+![graph](https://github.com/user-attachments/assets/dfbed9e0-8ef0-4a43-993d-d3e5d1e5ae1d)
 
-<p align="center">
-    This is the graph library responsible for representing the packages that are involved in a given install.
-</p>
+# @vltpkg/graph
 
-<p align="center">
-    <a href="#api"><strong>API</strong></a>
-    ·
-    <a href="#usage"><strong>Usage</strong></a>
-</p>
+This is the graph library responsible for representing the packages that are involved in a given install.
+
+**[API](#api)**
+·
+**[Usage](#usage)**
 
 ## API
 

--- a/src/package-info/README.md
+++ b/src/package-info/README.md
@@ -1,17 +1,10 @@
-<section align="center">
-    <a href="https://www.vlt.sh">
-        <img src="https://github.com/user-attachments/assets/51412725-7bb3-4126-92b9-a6ba0d1ec18a" />
-        <h1 align="center">
-            <strong>@vltpkg/package-info</strong>
-        </h1>
-    </a>
-</section>
+![package-info](https://github.com/user-attachments/assets/51412725-7bb3-4126-92b9-a6ba0d1ec18a)
 
-<p align="center">
-    Get information about packages.
-    <br/>
-    A spiritual descendant of [pacote](http://npm.im/pacote).
-</p>
+# @vltpkg/package-info
+
+Get information about packages.
+
+A spiritual descendant of [pacote](http://npm.im/pacote).
 
 ## Usage
 

--- a/src/package-json/README.md
+++ b/src/package-json/README.md
@@ -1,17 +1,10 @@
-<section align="center">
-    <a href="https://www.vlt.sh">
-        <img src="https://github.com/user-attachments/assets/b91bae89-456d-4841-853a-e3655aa34ac4" />
-        <h1 align="center">
-            <strong>@vltpkg/package-json</strong>
-        </h1>
-    </a>
-</section>
+![package-json](https://github.com/user-attachments/assets/b91bae89-456d-4841-853a-e3655aa34ac4)
 
-<p align="center">
-    Manages reading `package.json` files.
-    <br/>
-    Caches previously seen files and augments error messages for clarity.
-</p>
+# @vltpkg/package-json
+
+Manages reading `package.json` files.
+
+Caches previously seen files and augments error messages for clarity.
 
 ## Usage
 

--- a/src/pick-manifest/README.md
+++ b/src/pick-manifest/README.md
@@ -1,12 +1,5 @@
-<section align="center">
-    <a href="https://www.vlt.sh">
-        <img src="https://github.com/user-attachments/assets/99431564-dd21-419e-8fbf-c8bfd9b155e8" />
-        <h1 align="center">
-            <strong>@vltpkg/pick-manifest</strong>
-        </h1>
-    </a>
-</section>
+![pick-manifest](https://github.com/user-attachments/assets/99431564-dd21-419e-8fbf-c8bfd9b155e8)
 
-<p align="center">
-    Selects the most appropriate version of a package’s manifest from a packument.
-</p>
+# @vltpkg/pick-manifest
+
+Selects the most appropriate version of a package’s manifest from a packument.

--- a/src/promise-spawn/README.md
+++ b/src/promise-spawn/README.md
@@ -1,26 +1,14 @@
-<section align="center">
-    <a href="https://www.vlt.sh">
-        <img src="https://github.com/user-attachments/assets/8dcb044f-7611-4db9-8042-3a964e270d61" />
-        <h1 align="center">
-            <strong>@vltpkg/promise-spawn</strong>
-        </h1>
-    </a>
-</section>
+![promise-spawn](https://github.com/user-attachments/assets/8dcb044f-7611-4db9-8042-3a964e270d61)
 
-<p align="center">
-    Spawn a process and return a promise that resolves when the process closes.
-    <br/>
-    Fork of
-    [`@npmcli/promise-spawn`](http://npm.im/@npmcli/promise-spawn)
-</p>
+# @vltpkg/promise-spawn
 
-<p align="center">
-    <a href="#usage"><strong>Usage</strong></a>
-    ·
-    <a href="#api"><strong>API</strong></a>
-    ·
-    <a href="#typescript-inference-caveats"><strong>Caveats</strong></a>
-</p>
+Spawn a process and return a promise that resolves when the process closes. Fork of [`@npmcli/promise-spawn`](http://npm.im/@npmcli/promise-spawn).
+
+**[Usage](#usage)**
+·
+**[API](#api)**
+·
+**[Caveats](#typescript-inference-caveats)**
 
 ## Differences from `@npmcli/promise-spawn`
 

--- a/src/query/README.md
+++ b/src/query/README.md
@@ -1,23 +1,14 @@
-<section align="center">
-    <a href="https://www.vlt.sh">
-        <img src="https://github.com/user-attachments/assets/5b4802b7-7567-4f50-8f77-7ee398f58d43" />
-        <h1 align="center">
-            <strong>@vltpkg/query</strong>
-        </h1>
-    </a>
-</section>
+![query](https://github.com/user-attachments/assets/5b4802b7-7567-4f50-8f77-7ee398f58d43)
 
-<p align="center">
-    The **vlt** query syntax engine.
-</p>
+# @vltpkg/query
 
-<p align="center">
-    <a href="#usage"><strong>Usage</strong></a>
-    ·
-    <a href="#examples"><strong>Examples</strong></a>
-    ·
-    <a href="#supported-syntax-reference"><strong>Supported Syntax Reference</strong></a>
-</p>
+The **vlt** query syntax engine.
+
+**[Usage](#usage)**
+·
+**[Examples](#examples)**
+·
+**[Supported Syntax Reference](#supported-syntax-reference)**
 
 ## Usage
 

--- a/src/registry-client/README.md
+++ b/src/registry-client/README.md
@@ -1,23 +1,14 @@
-<section align="center">
-    <a href="https://www.vlt.sh">
-        <img src="https://github.com/user-attachments/assets/664e4107-bf7b-4179-802d-9ec9f1499955" />
-        <h1 align="center">
-            <strong>@vltpkg/registry-client</strong>
-        </h1>
-    </a>
-</section>
+![registry-client](https://github.com/user-attachments/assets/664e4107-bf7b-4179-802d-9ec9f1499955)
 
-<p align="center">
-    This is a very light wrapper around undici, optimized for interfacing with an npm registry.
-</p>
+# @vltpkg/registry-client
 
-<p align="center">
-    <a href="#cache-unzipped"><strong>Cache Unzipped</strong></a>
-    ·
-    <a href="#integrity-options"><strong>Integrity Options</strong></a>
-    ·
-    <a href="#usage"><strong>Usage</strong></a>
-</p>
+This is a very light wrapper around undici, optimized for interfacing with an npm registry.
+
+**[Cache Unzipped](#cache-unzip)**
+·
+**[Integrity Options](#integrity-options)**
+·
+**[Usage](#usage)**
 
 ## Overview
 

--- a/src/rollback-remove/README.md
+++ b/src/rollback-remove/README.md
@@ -1,16 +1,8 @@
-<section align="center">
-    <a href="https://www.vlt.sh">
-        <img src="https://github.com/user-attachments/assets/a3c217d9-991c-4702-98f9-e14df13b03ec" />
-        <h1 align="center">
-            <strong>@vltpkg/rollback-remove</strong>
-        </h1>
-    </a>
-</section>
+![rollback-remove](https://github.com/user-attachments/assets/a3c217d9-991c-4702-98f9-e14df13b03ec)
 
-<p align="center">
-    A utility for removing stuff, in such a way that the removal can be rolled back on failure, or confirmed and executed in a
-    detached background process.
-</p>
+# @vltpkg/rollback-remove
+
+A utility for removing stuff, in such a way that the removal can be rolled back on failure, or confirmed and executed in a detached background process.
 
 ## Usage
 

--- a/src/run/README.md
+++ b/src/run/README.md
@@ -1,15 +1,8 @@
-<section align="center">
-    <a href="https://www.vlt.sh">
-        <img src="https://github.com/user-attachments/assets/7546e081-c35c-44ac-a4bc-05caf88b7a2b" />
-        <h1 align="center">
-            <strong>@vltpkg/run</strong>
-        </h1>
-    </a>
-</section>
+![run](https://github.com/user-attachments/assets/7546e081-c35c-44ac-a4bc-05caf88b7a2b)
 
-<p align="center">
-    Run a script defined in a `package.json` file (eg, `vlt run` and lifecycle scripts), or an arbitrary command as if it was (eg, `vlt exec`).
-</p>
+# @vltpkg/run
+
+Run a script defined in a `package.json` file (eg, `vlt run` and lifecycle scripts), or an arbitrary command as if it was (eg, `vlt exec`).
 
 ## Usage
 

--- a/src/satisfies/README.md
+++ b/src/satisfies/README.md
@@ -1,15 +1,8 @@
-<section align="center">
-    <a href="https://www.vlt.sh">
-        <img src="https://github.com/user-attachments/assets/5dc35dbc-c8b2-4dac-844d-81ee5569347b" />
-        <h1 align="center">
-            <strong>@vltpkg/satisfies</strong>
-        </h1>
-    </a>
-</section>
+![satisfies](https://github.com/user-attachments/assets/5dc35dbc-c8b2-4dac-844d-81ee5569347b)
 
-<p align="center">
-    Give it a DepID and a Spec, and it'll tell you whether that dep satisfies the spec.
-</p>
+# @vltpkg/satisfies
+
+Give it a DepID and a Spec, and it'll tell you whether that dep satisfies the spec.
 
 ## Usage
 

--- a/src/semver/README.md
+++ b/src/semver/README.md
@@ -1,23 +1,14 @@
-<section align="center">
-    <a href="https://www.vlt.sh">
-        <img src="https://github.com/user-attachments/assets/8ace86b8-cf67-43f0-991d-b9c1a069ffa0" />
-        <h1 align="center">
-            <strong>@vltpkg/semver</strong>
-        </h1>
-    </a>
-</section>
+![semver](https://github.com/user-attachments/assets/8ace86b8-cf67-43f0-991d-b9c1a069ffa0)
 
-<p align="center">
-    A library for parsing, validating & comparing Semantic Versions used by `vlt`.
-</p>
+# @vltpkg/semver
 
-<p align="center">
-    <a href="#usage"><strong>Usage</strong></a>
-    ·
-    <a href="#functions"><strong>Functions</strong></a>
-    ·
-    <a href="#differences"><strong>Differences from node-semver</strong></a>
-</p>
+A library for parsing, validating & comparing Semantic Versions used by `vlt`.
+
+**[Usage](#usage)**
+·
+**[Function](#function)**
+·
+**[Differences from node-semver](#differences)**
 
 ## Usage
 

--- a/src/spec/README.md
+++ b/src/spec/README.md
@@ -1,25 +1,16 @@
-<section align="center">
-    <a href="https://www.vlt.sh">
-        <img src="https://github.com/user-attachments/assets/39f3e98d-ad31-4efc-882c-1fe75c115507" />
-        <h1 align="center">
-            <strong>@vltpkg/spec</strong>
-        </h1>
-    </a>
-</section>
+![spec](https://github.com/user-attachments/assets/39f3e98d-ad31-4efc-882c-1fe75c115507)
 
-<p align="center">
-    This is a library for parsing **package specifiers**.
-</p>
+# @vltpkg/spec
 
-<p align="center">
-    <a href="#named-vs-unnamed"><strong>Namings</strong></a>
-    ·
-    <a href="#types-of-specifiers"><strong>Specifiers</strong></a>
-    ·
-    <a href="#usage"><strong>Usage</strong></a>
-    ·
-    <a href="#properties"><strong>Properties</strong></a>
-</p>
+This is a library for parsing **package specifiers**.
+
+**[Namings](#named-vs-unnamed)**
+·
+**[Specifiers](#types-of-specifiers)**
+·
+**[Usage](#usage)**
+·
+**[Properties](#properties)**
 
 ## Overview
 

--- a/src/tar/README.md
+++ b/src/tar/README.md
@@ -1,21 +1,12 @@
-<section align="center">
-    <a href="https://www.vlt.sh">
-        <img src="https://github.com/user-attachments/assets/a01d2d1e-1815-4888-bb2e-67094af74de0" />
-        <h1 align="center">
-            <strong>@vltpkg/tar</strong>
-        </h1>
-    </a>
-</section>
+![tar](https://github.com/user-attachments/assets/a01d2d1e-1815-4888-bb2e-67094af74de0)
 
-<p align="center">
-    A library for unpacking JavaScript package tarballs (gzip-compressed or raw) into a specified folder.
-</p>
+# @vltpkg/tar
 
-<p align="center">
-    <a href="#usage"><strong>Usage</strong></a>
-    ·
-    <a href="#caveats"><strong>Caveats</strong></a>
-</p>
+A library for unpacking JavaScript package tarballs (gzip-compressed or raw) into a specified folder.
+
+**[Usage](#usage)**
+·
+**[Caveats](#caveats)**
 
 ## Overview
 

--- a/src/types/README.md
+++ b/src/types/README.md
@@ -1,15 +1,8 @@
-<section align="center">
-    <a href="https://www.vlt.sh">
-        <img src="https://github.com/user-attachments/assets/67722b51-a70f-4779-be2e-405adeb55d06" />
-        <h1 align="center">
-            <strong>@vltpkg/types</strong>
-        </h1>
-    </a>
-</section>
+![types](https://github.com/user-attachments/assets/67722b51-a70f-4779-be2e-405adeb55d06)
 
-<p align="center">
-    A module for a handful of core types that are used throughout vlt extensively, and don't belong to any one particular implementation.
-</p>
+# @vltpkg/types
+
+A module for a handful of core types that are used throughout vlt extensively, and don't belong to any one particular implementation.
 
 ## Usage
 

--- a/src/vlt/README.md
+++ b/src/vlt/README.md
@@ -1,12 +1,5 @@
-<section align="center">
-    <a href="https://www.vlt.sh">
-        <img src="https://github.com/user-attachments/assets/345949ff-7150-4b97-856d-c7e42c2a4db5" />
-        <h1 align="center">
-            <strong>@vltpkg/vlt</strong>
-        </h1>
-    </a>
-</section>
+![vlt](https://github.com/user-attachments/assets/345949ff-7150-4b97-856d-c7e42c2a4db5)
 
-<p align="center">
-    The command line interface for `vlt`.
-</p>
+# @vltpkg/vlt
+
+The command line interface for `vlt`.

--- a/src/which/README.md
+++ b/src/which/README.md
@@ -1,21 +1,12 @@
-<section align="center">
-    <a href="https://www.vlt.sh">
-        <img src="https://github.com/user-attachments/assets/93b29348-69b9-4d95-a80f-f6044ba5c17c" />
-        <h1 align="center">
-            <strong>@vltpkg/which</strong>
-        </h1>
-    </a>
-</section>
+![which](https://github.com/user-attachments/assets/93b29348-69b9-4d95-a80f-f6044ba5c17c)
 
-<p align="center">
-    Like the unix `which` utility.
-</p>
+# @vltpkg/which
 
-<p align="center">
-    <a href="#usage"><strong>Usage</strong></a>
-    ·
-    <a href="#options"><strong>Options</strong></a>
-</p>
+Like the unix `which` utility.
+
+**[Usage](#usage)**
+·
+**[Options](#options)**
 
 ## Overview
 

--- a/src/workspaces/README.md
+++ b/src/workspaces/README.md
@@ -1,21 +1,12 @@
-<section align="center">
-    <a href="https://www.vlt.sh">
-        <img src="https://github.com/user-attachments/assets/1f6f73ad-bb51-461a-9f2f-efcf1b884a1a" />
-        <h1 align="center">
-            <strong>@vltpkg/workspaces</strong>
-        </h1>
-    </a>
-</section>
+![workspaces](https://github.com/user-attachments/assets/1f6f73ad-bb51-461a-9f2f-efcf1b884a1a);
 
-<p align="center">
-    Utilities for working with vlt workspaces.
-</p>
+# @vltpkg/workspaces
 
-<p align="center">
-    <a href="#usage"><strong>Usage</strong></a>
-    ·
-    <a href="#run-order"><strong>Run Order</strong></a>
-</p>
+Utilities for working with vlt workspaces.
+
+**[Usage](#usage)**
+·
+**[Run Order](#run-order)**
 
 ## Usage
 

--- a/src/xdg/README.md
+++ b/src/xdg/README.md
@@ -1,15 +1,8 @@
-<section align="center">
-    <a href="https://www.vlt.sh">
-        <img src="https://github.com/user-attachments/assets/72b3e499-40c0-4f2a-8cd7-7761303bda62" />
-        <h1 align="center">
-            <strong>@vltpkg/xdg</strong>
-        </h1>
-    </a>
-</section>
+![xdg](https://github.com/user-attachments/assets/72b3e499-40c0-4f2a-8cd7-7761303bda62)
 
-<p align="center">
-    Get appropriate data, cache, and config directories following the [XDG spec](https://wiki.archlinux.org/title/XDG_Base_Directory), namespaced to a specific app-name subfolder.
-</p>
+# @vltpkg/xdg
+
+Get appropriate data, cache, and config directories following the [XDG spec](https://wiki.archlinux.org/title/XDG_Base_Directory), namespaced to a specific app-name subfolder.
 
 ## Usage
 


### PR DESCRIPTION
### Updates the monorepo's readme files

Updates root readme file with **vlt** logo and header.

Commits each package separately for easier rollback if conflicts.

#### `src/` && `infra/`
- Formats each package's readme with an icon.
- Creates _navigation anchor links_ for readme's with multiple headers.
- If there is only one usage/example case, omits the _navigation links_.