### PR TITLE
vlt(usage): use jackspeak instances to render usage

### DIFF
--- a/infra/build/tap-snapshots/test/smoke.ts.test.cjs
+++ b/infra/build/tap-snapshots/test/smoke.ts.test.cjs
@@ -19,7 +19,7 @@ exports[`test/smoke.ts > TAP > commands > vlt > pkg > get name > output 1`] = `
 
 exports[`test/smoke.ts > TAP > commands > vlt > pkg > get name version > output 1`] = `
 {ROOT}/src/vlt/src/commands/pkg.ts:{LINE_NUMBER}
-      throw error(
+      throw noArg()
             ^
 
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1692,6 +1692,9 @@ importers:
       eslint:
         specifier: 'catalog:'
         version: 9.9.0(jiti@1.21.6)
+      import-meta-resolve:
+        specifier: ^4.1.0
+        version: 4.1.0
       prettier:
         specifier: 'catalog:'
         version: 3.3.3

--- a/src/vlt/package.json
+++ b/src/vlt/package.json
@@ -11,6 +11,7 @@
     "exports": {
       "./package.json": "./package.json",
       ".": "./src/index.ts",
+      "./commands": "./src/commands",
       "./commands/*": "./src/commands/*.ts",
       "./config": "./src/config/index.ts",
       "./config/definition": "./src/config/definition.ts",
@@ -89,6 +90,12 @@
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
+      }
+    },
+    "./commands": {
+      "import": {
+        "types": "./dist/esm/commands",
+        "default": "./dist/esm/commands"
       }
     },
     "./commands/*": {

--- a/src/vlt/src/commands/exec.ts
+++ b/src/vlt/src/commands/exec.ts
@@ -1,10 +1,16 @@
 import { exec, execFG } from '@vltpkg/run'
 import { LoadedConfig } from '../config/index.js'
 import { ExecCommand } from '../exec-command.js'
+import { commandUsage } from '../config/usage.js'
+import { type CliCommand } from '../types.js'
 
-export const usage = `vlt exec [command]
-Runs the command with all installed bins in the $PATH
-If no command specified, an interactive subshell is spawned.`
+export const usage: CliCommand['usage'] = () =>
+  commandUsage({
+    command: 'exec',
+    usage: '[command]',
+    description: `Runs the command with all installed bins in the $PATH
+                  If no command specified, an interactive subshell is spawned.`,
+  })
 
 export const command = async (conf: LoadedConfig) =>
   await new ExecCommand(conf, exec, execFG).run()

--- a/src/vlt/src/commands/gui.ts
+++ b/src/vlt/src/commands/gui.ts
@@ -1,9 +1,15 @@
 import { fileURLToPath } from 'node:url'
 import type { LoadedConfig } from '../config/index.js'
 import { startGUI } from '../start-gui.js'
+import { commandUsage } from '../config/usage.js'
+import { type CliCommand } from '../types.js'
 
-export const usage = `Usage:
-  vlt gui`
+export const usage: CliCommand['usage'] = () =>
+  commandUsage({
+    command: 'gui',
+    usage: '',
+    description: 'Launch a graphical user interface in a browser',
+  })
 
 export const command = async (
   conf: LoadedConfig,

--- a/src/vlt/src/commands/help.ts
+++ b/src/vlt/src/commands/help.ts
@@ -1,7 +1,9 @@
 import { Config } from '../config/index.js'
+import { type CliCommand } from '../types.js'
 
-export const usage = async () => (await Config.load()).jack.usage()
+export const usage: CliCommand['usage'] = async () =>
+  (await Config.load()).jack
 
 export const command = async () => {
-  console.log(await usage())
+  console.log((await usage()).usage())
 }

--- a/src/vlt/src/commands/install-exec.ts
+++ b/src/vlt/src/commands/install-exec.ts
@@ -1,7 +1,14 @@
 import { LoadedConfig } from '../config/index.js'
+import { commandUsage } from '../config/usage.js'
+import { CliCommand } from '../types.js'
 
-export const usage = `vlt install-exec [--package=<pkg>] [command...]
-Run a command defined by a package, installing it if necessary`
+export const usage: CliCommand['usage'] = () =>
+  commandUsage({
+    command: 'install-exec',
+    usage: '[--package=<pkg>] [command...]',
+    description:
+      'Run a command defined by a package, installing it if necessary',
+  })
 
 export const command = async (conf: LoadedConfig) => {
   console.log('todo: exec, but install if not present')

--- a/src/vlt/src/commands/install.ts
+++ b/src/vlt/src/commands/install.ts
@@ -2,10 +2,15 @@ import { actual, ideal, reify } from '@vltpkg/graph'
 import { PackageInfoClient } from '@vltpkg/package-info'
 import { LoadedConfig } from '../config/index.js'
 import { parseAddArgs } from '../parse-add-remove-args.js'
-import { CliCommandOptions } from '../types.js'
+import { CliCommandOptions, CliCommand } from '../types.js'
+import { commandUsage } from '../config/usage.js'
 
-export const usage = `vlt install [package ...]
-Install the specified package, updating dependencies appropriately`
+export const usage: CliCommand['usage'] = () =>
+  commandUsage({
+    command: 'install',
+    usage: '[package ...]',
+    description: `Install the specified package, updating dependencies appropriately`,
+  })
 
 export const command = async (
   conf: LoadedConfig,

--- a/src/vlt/src/commands/list.ts
+++ b/src/vlt/src/commands/list.ts
@@ -10,33 +10,44 @@ import { Query } from '@vltpkg/query'
 import chalk from 'chalk'
 import { LoadedConfig } from '../config/index.js'
 import { startGUI } from '../start-gui.js'
+import { commandUsage } from '../config/usage.js'
+import { CliCommand } from '../types.js'
 
-export const usage = `Usage:
-  vlt ls
-  vlt ls <query> --view=[human | json | mermaid | gui]
-
-List installed dependencies matching the provided query.
-Defaults to listing direct dependencies of a project and
-any configured workspace.
-
-Examples:
-
-  vlt ls
-          List direct dependencies of the current project / workspace
-  vlt ls *
-          List all dependencies for the current project / workspace
-  vlt ls foo bar baz
-          List all dependencies named 'foo', 'bar', or 'baz'
-  vlt ls '[name="@scoped/package"] > *'
-          Lists direct dependencies of a specific package
-  vlt ls '*.workspace > *.peer'
-          List all peer dependencies of all workspaces
-
-Options:
-
-  --view=[human | json | mermaid | gui]
-          Output format. Defaults to human-readable or json if no tty.
-`
+export const usage: CliCommand['usage'] = () =>
+  commandUsage({
+    command: 'ls',
+    usage: ['', '<query> --view=[human | json | mermaid | gui]'],
+    description: `List installed dependencies matching the provided query.
+                  Defaults to listing direct dependencies of a project and
+                  any configured workspace.`,
+    examples: {
+      '': {
+        description:
+          'List direct dependencies of the current project / workspace',
+      },
+      '*': {
+        description:
+          'List all dependencies for the current project / workspace',
+      },
+      'foo bar baz': {
+        description: `List all dependencies named 'foo', 'bar', or 'baz'`,
+      },
+      [`'[name="@scoped/package"] > *'`]: {
+        description:
+          'Lists direct dependencies of a specific package',
+      },
+      [`'*.workspace > *.peer'`]: {
+        description: 'List all peer dependencies of all workspaces',
+      },
+    },
+    options: {
+      view: {
+        value: '[human | json | mermaid | gui]',
+        description:
+          'Output format. Defaults to human-readable or json if no tty.',
+      },
+    },
+  })
 
 export const command = async (
   conf: LoadedConfig,

--- a/src/vlt/src/commands/pkg.ts
+++ b/src/vlt/src/commands/pkg.ts
@@ -3,15 +3,42 @@ import { LoadedConfig } from '../config/index.js'
 import { PackageJson } from '@vltpkg/package-json'
 import * as dotProp from '@vltpkg/dot-prop'
 import { Manifest } from '@vltpkg/types'
-import { CliCommandOptions } from '../types.js'
+import { CliCommandOptions, CliCommand } from '../types.js'
+import assert from 'assert'
+import { commandUsage } from '../config/usage.js'
 
-export const usage = `Usage:
-  vlt pkg get [<key>]
-  vlt pkg pick [<key> [<key> ...]]
-  vlt pkg set <key>=<value> [<key>=<value> ...]
-  vlt pkg set [<array>[<index>].<key>=<value> ...]
-  vlt pkg set [<array>[].<key>=<value> ...]
-  vlt pkg <rm|remove|unset|delete> <key> [<key> ...]`
+export const usage: CliCommand['usage'] = () =>
+  commandUsage({
+    command: 'pkg',
+    usage: '[<command>] [<args>]',
+    description: 'Get or manipulate package.json values',
+    subcommands: {
+      get: {
+        usage: '[<key>]',
+        description: 'Get a single value',
+      },
+      pick: {
+        usage: '[<key> [<key> ...]]',
+        description: 'Get multiple values or the entire package',
+      },
+      set: {
+        usage: '<key>=<value> [<key>=<value> ...]',
+        description: 'Set one or more key value pairs',
+      },
+      delete: {
+        usage: '<key> [<key> ...]',
+        description: 'Delete one or more keys from the package',
+      },
+    },
+    examples: {
+      'set "array[1].key=value"': {
+        description: 'Set a value on an object inside an array',
+      },
+      'set "array[]=value"': {
+        description: 'Append a value to an array',
+      },
+    },
+  })
 
 export const command = async (
   conf: LoadedConfig,
@@ -34,7 +61,7 @@ export const command = async (
     case 'delete':
       return rm(conf, mani, pkg, args)
     default: {
-      console.error(usage)
+      console.error((await usage()).usage)
       throw error('Unrecognized pkg command', {
         found: sub,
         validOptions: ['get', 'set', 'rm'],
@@ -44,17 +71,20 @@ export const command = async (
 }
 
 const get = (mani: Manifest, args: string[]) => {
+  const noArg = () =>
+    error(
+      'get requires not more than 1 argument. use `pick` to get more than 1.',
+      undefined,
+      noArg,
+    )
   if (args.length !== 1) {
     if (args.length > 1) {
-      throw error(
-        'get requires not more than 1 argument. use `pick` to get more than 1.',
-      )
+      throw noArg()
     }
     return pick(mani, args)
   }
-  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-  const arg = args[0]!
-  console.log(JSON.stringify(dotProp.get(mani, arg), null, 2))
+  assert(args[0], noArg())
+  console.log(JSON.stringify(dotProp.get(mani, args[0]), null, 2))
 }
 
 const pick = (mani: Manifest, args: string[]) => {

--- a/src/vlt/src/commands/query.ts
+++ b/src/vlt/src/commands/query.ts
@@ -10,29 +10,39 @@ import { LoadedConfig } from '../config/index.js'
 import { Query } from '@vltpkg/query'
 import chalk from 'chalk'
 import { startGUI } from '../start-gui.js'
+import { commandUsage } from '../config/usage.js'
+import { type CliCommand } from '../types.js'
 
-export const usage = `Usage:
-  vlt query
-  vlt query <query> --view=[human | json | mermaid | gui]
-
-List installed dependencies matching the provided query.
-
-Examples:
-
-  vlt query '#foo'
-          Query packages with the name "foo"
-  vlt query '*.workspace > *.peer'
-          Query all peer dependencies of workspaces
-  vlt query ':project > *:attr(scripts, [build])'
-          Query all direct project dependencies with a "build" script
-  vlt query '[name^="@vltpkg"]'
-          Query packages with names starting with "@vltpkg"
-
-Options:
-
-  --view=[human | json | mermaid | gui]
-          Output format. Defaults to human-readable or json if no tty.
-`
+export const usage: CliCommand['usage'] = () =>
+  commandUsage({
+    command: 'query',
+    usage: ['', '<query> --view=[human | json | mermaid | gui]'],
+    description:
+      'List installed dependencies matching the provided query.',
+    examples: {
+      [`'#foo'`]: {
+        description: 'Query packages with the name "foo"',
+      },
+      [`'*.workspace > *.peer'`]: {
+        description: 'Query all peer dependencies of workspaces',
+      },
+      [`':project > *:attr(scripts, [build])'`]: {
+        description:
+          'Query all direct project dependencies with a "build" script',
+      },
+      [`'[name^="@vltpkg"]'`]: {
+        description:
+          'Query packages with names starting with "@vltpkg"',
+      },
+    },
+    options: {
+      view: {
+        value: '[human | json | mermaid | gui]',
+        description:
+          'Output format. Defaults to human-readable or json if no tty.',
+      },
+    },
+  })
 
 export const command = async (
   conf: LoadedConfig,

--- a/src/vlt/src/commands/run-exec.ts
+++ b/src/vlt/src/commands/run-exec.ts
@@ -1,9 +1,15 @@
 import { runExec, runExecFG } from '@vltpkg/run'
 import { LoadedConfig } from '../config/index.js'
 import { ExecCommand } from '../exec-command.js'
+import { commandUsage } from '../config/usage.js'
+import { type CliCommand } from '../types.js'
 
-export const usage = `vlt run-exec [command ...]
-Runs 'vlt run' if the command is a named script, 'vlt exec' otherwise`
+export const usage: CliCommand['usage'] = () =>
+  commandUsage({
+    command: 'run-exec',
+    usage: '[command ...]',
+    description: `Runs 'vlt run' if the command is a named script, 'vlt exec' otherwise`,
+  })
 
 export const command = async (conf: LoadedConfig) =>
   await new ExecCommand(conf, runExec, runExecFG).run()

--- a/src/vlt/src/commands/run.ts
+++ b/src/vlt/src/commands/run.ts
@@ -2,9 +2,15 @@ import { PackageJson } from '@vltpkg/package-json'
 import { run, runFG } from '@vltpkg/run'
 import { LoadedConfig } from '../config/index.js'
 import { ExecCommand } from '../exec-command.js'
+import { commandUsage } from '../config/usage.js'
+import { type CliCommand } from '../types.js'
 
-export const usage = `vlt run <script> [args ...]
-Run the named script from package.json`
+export const usage: CliCommand['usage'] = () =>
+  commandUsage({
+    command: 'run',
+    usage: '<script> [args ...]',
+    description: `Run the named script from package.json`,
+  })
 
 class RunCommand extends ExecCommand<typeof run, typeof runFG> {
   constructor(conf: LoadedConfig, bg = run, fg = runFG) {

--- a/src/vlt/src/commands/uninstall.ts
+++ b/src/vlt/src/commands/uninstall.ts
@@ -2,10 +2,16 @@ import { actual, ideal, reify } from '@vltpkg/graph'
 import { PackageInfoClient } from '@vltpkg/package-info'
 import { LoadedConfig } from '../config/index.js'
 import { parseRemoveArgs } from '../parse-add-remove-args.js'
-import { CliCommandOptions } from '../types.js'
+import { CliCommandOptions, CliCommand } from '../types.js'
+import { commandUsage } from '../config/usage.js'
 
-export const usage = `vlt uninstall [package ...]
-Remove the named packages from the dependency graph`
+export const usage: CliCommand['usage'] = () =>
+  commandUsage({
+    command: 'uninstall',
+    usage: '[package ...]',
+    description:
+      'Remove the named packages from the dependency graph',
+  })
 
 export const command = async (
   conf: LoadedConfig,

--- a/src/vlt/src/config/definition.ts
+++ b/src/vlt/src/config/definition.ts
@@ -1,7 +1,5 @@
 import { XDG } from '@vltpkg/xdg'
 import { jack } from 'jackspeak'
-import { homedir } from 'os'
-import { relative, sep } from 'path'
 
 /**
  * Command aliases mapped to their canonical names
@@ -42,9 +40,6 @@ export const getCommand = (
   s && s in commands ? commands[s as keyof Commands] : undefined
 
 const xdg = new XDG('vlt')
-const home = homedir()
-const confDir = xdg.config('vlt.json')
-
 const cacheDir = xdg.cache()
 
 /**
@@ -174,7 +169,7 @@ export const definition = jack({
     `If a \`vlt.json\` file is present in the root of the current project,
      then that will be used as a source of configuration information.
 
-     Next, the file at \`$HOME${sep}${relative(home, confDir)}\`
+     Next, the \`vlt.json\` file in the XDG specified config directory
      will be checked, and loaded for any fields not set in the local project.
 
      Object type values will be merged together. Set a field to \`null\` in

--- a/src/vlt/src/index.ts
+++ b/src/vlt/src/index.ts
@@ -36,7 +36,7 @@ const run = async () => {
   const { command, usage } = await loadCommand(vlt.command)
 
   if (vlt.get('help')) {
-    console.log(typeof usage === 'function' ? await usage() : usage)
+    console.log((await usage()).usage())
   } else {
     // TODO: if it throws, pass to central error handler
     await command(vlt, vlt.options)

--- a/src/vlt/src/types.ts
+++ b/src/vlt/src/types.ts
@@ -2,6 +2,7 @@ import type { PackageJson } from '@vltpkg/package-json'
 import type { Monorepo } from '@vltpkg/workspaces'
 import type { PathScurry } from 'path-scurry'
 import type { LoadedConfig } from './config/index.js'
+import type { Jack } from 'jackspeak'
 
 export type * from './config/index.js'
 
@@ -16,5 +17,5 @@ export type CliCommand = {
     conf: LoadedConfig,
     options: CliCommandOptions,
   ) => Promise<void>
-  usage: string | (() => Promise<string>)
+  usage: () => Promise<Jack>
 }

--- a/src/vlt/tap-snapshots/test/commands/config.ts.test.cjs
+++ b/src/vlt/tap-snapshots/test/commands/config.ts.test.cjs
@@ -1,0 +1,47 @@
+/* IMPORTANT
+ * This snapshot file is auto-generated, but designed for humans.
+ * It should be checked into source control and tracked carefully.
+ * Re-generate by setting TAP_SNAPSHOT=1 and running tests.
+ * Make sure to inspect the output below.  Do not ignore changes!
+ */
+'use strict'
+exports[`test/commands/config.ts > TAP > usage 1`] = `
+Usage:
+  vlt config <command> [flags]
+
+Get or manipulate the configuration for the vlt CLI
+
+  Subcommands
+
+    get
+      Get the value of a configuration key
+
+      ​vlt config get <key> [<key> ...]
+
+    ls
+      List all configuration keys and values
+
+      ​vlt config ls
+
+    set
+      Set the value of a configuration key
+
+      ​vlt config set <key>=<value> [<key>=<value> ...] [--config=<user |
+      project>]
+
+    del
+      Delete a configuration key
+
+      ​vlt config del <key> [<key> ...] [--config=<user | project>]
+
+    edit
+      Edit the configuration file
+
+      ​vlt config edit [--config=<user | project>]
+
+    help
+      Show help for a specific configuration field
+
+      ​vlt config help [field ...]
+
+`

--- a/src/vlt/tap-snapshots/test/commands/exec.ts.test.cjs
+++ b/src/vlt/tap-snapshots/test/commands/exec.ts.test.cjs
@@ -1,0 +1,15 @@
+/* IMPORTANT
+ * This snapshot file is auto-generated, but designed for humans.
+ * It should be checked into source control and tracked carefully.
+ * Re-generate by setting TAP_SNAPSHOT=1 and running tests.
+ * Make sure to inspect the output below.  Do not ignore changes!
+ */
+'use strict'
+exports[`test/commands/exec.ts > TAP > usage 1`] = `
+Usage:
+  vlt exec [command]
+
+Runs the command with all installed bins in the $PATH If no command specified,
+an interactive subshell is spawned.
+
+`

--- a/src/vlt/tap-snapshots/test/commands/gui.ts.test.cjs
+++ b/src/vlt/tap-snapshots/test/commands/gui.ts.test.cjs
@@ -1,0 +1,14 @@
+/* IMPORTANT
+ * This snapshot file is auto-generated, but designed for humans.
+ * It should be checked into source control and tracked carefully.
+ * Re-generate by setting TAP_SNAPSHOT=1 and running tests.
+ * Make sure to inspect the output below.  Do not ignore changes!
+ */
+'use strict'
+exports[`test/commands/gui.ts > TAP > starts gui data and server > usage 1`] = `
+Usage:
+  vlt gui
+
+Launch a graphical user interface in a browser
+
+`

--- a/src/vlt/tap-snapshots/test/commands/help.ts.test.cjs
+++ b/src/vlt/tap-snapshots/test/commands/help.ts.test.cjs
@@ -1,0 +1,295 @@
+/* IMPORTANT
+ * This snapshot file is auto-generated, but designed for humans.
+ * It should be checked into source control and tracked carefully.
+ * Re-generate by setting TAP_SNAPSHOT=1 and running tests.
+ * Make sure to inspect the output below.  Do not ignore changes!
+ */
+'use strict'
+exports[`test/commands/help.ts > TAP > basic > usage 1`] = `
+vlt - A New Home for JavaScript
+Usage:
+  vlt [<options>] [<cmd> [<args> ...]]
+
+Here goes a short description of the vlt command line client.
+
+Much more documentation available at <https://docs.vlt.sh>
+
+  Subcommands
+
+    ​vlt install [packages ...]
+      Install the specified packages, updating package.json and vlt-lock.json
+      appropriately.
+
+    ​vlt uninstall [packages ...]
+      The opposite of \`vlt install\`. Removes deps and updates vlt-lock.json and
+      package.json appropriately.
+
+    ​vlt run <script> [args ...]
+      Run a script defined in 'package.json', passing along any extra arguments.
+      Note that vlt config values must be specified *before* the script name,
+      because everything after that is handed off to the script process.
+
+    ​vlt exec [args ...]
+      Run an arbitrary command, with the local installed packages first in the
+      PATH. Ie, this will run your locally installed package bins.
+
+      If no command is provided, then a shell is spawned in the current working
+      directory, with the locally installed package bins first in the PATH.
+
+      Note that any vlt configs must be specified *before* the command, as the
+      remainder of the command line options are provided to the exec process.
+
+    ​vlt run-exec [args ...]
+      If the first argument is a defined script in package.json, then this is
+      equivalent to \`vlt run\`.
+
+      If not, then this is equivalent to \`vlt exec\`.
+
+    ​vlt config <subcommand>
+      Work with vlt configuration
+
+      ​vlt config get <key>
+        Print the named config value
+
+      ​vlt config list
+        Print all configuration settings currently in effect
+
+      ​vlt config set <key=value> [<key=value> ...]
+        Set config values. By default, these are written to the project config
+        file, \`vlt.json\` in the root of the project. To set things for all
+        projects, run with \`--config=user\`
+
+      ​vlt config del <key> [<key> ...]
+        Delete the named config fields. If no values remain in the config file,
+        delete the file as well. By default, operates on the \`vlt.json\` file in
+        the root of the current project. To delete a config field from the user
+        config file, specify \`--config=user\`.
+
+      ​vlt config help [field ...]
+        Get information about a config field, or show a list of known config
+        field names.
+
+  Configuration
+
+    If a \`vlt.json\` file is present in the root of the current project, then
+    that will be used as a source of configuration information.
+
+    Next, the \`vlt.json\` file in the XDG specified config directory will be
+    checked, and loaded for any fields not set in the local project.
+
+    Object type values will be merged together. Set a field to \`null\` in the
+    JSON configuration to explicitly remove it.
+
+    Command-specific fields may be set in a nested \`command\` object that
+    overrides any options defined at the top level.
+
+  -c --color           Use colors (Default for TTY)
+  -C --no-color        Do not use colors (Default for non-TTY)
+  --registry=<url>     Sets the registry for fetching packages, when no registry
+                       is explicitly set on a specifier.
+
+                       For example, \`express@latest\` will be resolved by looking
+                       up the metadata from this registry.
+
+                       Note that alias specifiers starting with \`npm:\` will
+                       still map to \`https://registry.npmjs.org/\` if this is
+                       changed, unless the a new mapping is created via the
+                       \`--registries\` option.
+
+  --registries=<name=url>
+                       Specify named registry hosts by their prefix. To set the
+                       default registry used for non-namespaced specifiers, use
+                       the \`--registry\` option.
+
+                       Prefixes can be used as a package alias. For example:
+
+                       \`\`\`
+                       ​vlt --registries loc=http://reg.local install
+                       foo@loc:foo@1.x
+                       \`\`\`
+
+                       By default, the public npm registry is registered to the
+                       \`npm:\` prefix. It is not recommended to change this
+                       mapping in most cases.
+
+                       Can be set multiple times
+
+  --scope-registries=<@scope=url>
+                       Map package name scopes to registry URLs.
+
+                       For example, \`--scope-registries
+                       @acme=https://registry.acme/\` would tell vlt to fetch any
+                       packages named \`@acme/...\` from the
+                       \`https://registry.acme/\` registry.
+
+                       Note: this way of specifying registries is more
+                       ambiguous, compared with using the \`--registries\` field
+                       and explicit prefixes, because instead of failing when
+                       the configuration is absent, it will instead attempt to
+                       fetch from the default registry.
+
+                       By comparison, using \`--registries
+                       acme=https://registry.acme/\` and then specifying
+                       dependencies such as \`"foo": "acme:foo@1.x"\` means that
+                       regardless of the name, the package will be fetched from
+                       the explicitly named registry, or fail if no registry is
+                       defined with that name.
+
+                       However, custom registry aliases are not supported by
+                       other package managers.
+
+                       Can be set multiple times
+
+  -G<name=template> --git-hosts=<name=template>
+                       Map a shorthand name to a git remote URL template.
+
+                       The \`template\` may contain placeholders, which will be
+                       swapped with the relevant values.
+
+                       \`$1\`, \`$2\`, etc. are replaced with the appropriate n-th
+                       path portion. For example, \`github:user/project\` would
+                       replace the \`$1\` in the template with \`user\`, and \`$2\`
+                       with \`project\`.
+
+                       Can be set multiple times
+
+  -A<name=template> --git-host-archives=<name=template>
+                       Similar to the \`--git-host <name>=<template>\` option,
+                       this option can define a template string that will be
+                       expanded to provide the URL to download a pre-built
+                       tarball of the git repository.
+
+                       In addition to the n-th path portion expansions performed
+                       by \`--git-host\`, this field will also expand the string
+                       \`$committish\` in the template, replacing it with the
+                       resolved git committish value to be fetched.
+
+                       Can be set multiple times
+
+  --cache=<path>       Location of the vlt on-disk cache. Defaults to the
+                       platform-specific directory recommended by the XDG
+                       specification.
+
+  --tag=<tag>          Default \`dist-tag\` to install
+  --before=<date>      Do not install any packages published after this date
+  --os=<os>            The operating system to use as the selector when choosing
+                       packages based on their \`os\` value.
+
+  --arch=<arch>        CPU architecture to use as the selector when choosing
+                       packages based on their \`cpu\` value.
+
+  --node-version=<version>
+                       Node version to use when choosing packages based on their
+                       \`engines.node\` value.
+
+  --git-shallow        Set to force \`--depth=1\` on all git clone actions. When
+                       set explicitly to false with --no-git-shallow, then
+                       \`--depth=1\` will not be used.
+
+                       When not set explicitly, \`--depth=1\` will be used for git
+                       hosts known to support this behavior.
+
+  --fetch-retries=<n>  Number of retries to perform when encountering network or
+                       other likely-transient errors from git hosts.
+
+  --fetch-retry-factor=<n>
+                       The exponential factor to use when retrying
+
+  --fetch-retry-mintimeout=<n>
+                       Number of milliseconds before starting first retry
+
+  --fetch-retry-maxtimeout=<n>
+                       Maximum number of milliseconds between two retries
+  -w<ws> --workspace=<ws>
+                       Set to limit the spaces being worked on when working on
+                       workspaces.
+
+                       Can be paths or glob patterns matching paths.
+
+                       Specifying workspaces by package.json name is not
+                       supported.
+
+                       Can be set multiple times
+
+  -g<workspace-group> --workspace-group=<workspace-group>
+                       Specify named workspace group names to load and operate
+                       on when doing recursive operations on workspaces.
+
+                       Can be set multiple times
+
+  -r --recursive       Run an operation across multiple workspaces.
+
+                       No effect when used in non-monorepo projects.
+
+                       Implied by setting --workspace or --workspace-group. If
+                       not set, then the action is run on the project root.
+
+  -b --bail            When running scripts across multiple workspaces, stop on
+                       the first failure.
+
+  -B --no-bail         When running scripts across multiple workspaces, continue
+                       on failure, running the script for all workspaces.
+
+  --config=<user | project>
+                       Specify whether to operate on user-level or project-level
+                       configuration files when running \`vlt config\` commands.
+
+                       Valid options: "user", "project"
+
+  --editor=<program>   The blocking editor to use for \`vlt config edit\` and any
+                       other cases where a file should be opened for editing.
+
+                       Defaults to the \`EDITOR\` or \`VISUAL\` env if set, or
+                       \`notepad.exe\` on Windows, or \`vi\` elsewhere.
+
+  --script-shell=<program>
+                       The shell to use when executing \`package.json#scripts\`
+                       (either as lifecycle scripts or explicitly with \`vlt
+                       run\`) and \`vlt exec\`.
+
+                       If not set, defaults to \`/bin/sh\` on POSIX systems, and
+                       \`cmd.exe\` on Windows.
+
+                       When no argument is provided to \`vlt exec\`, the \`SHELL\`
+                       environment variable takes precedence if set.
+
+  --fallback-command=<command>
+                       The command to run when the first argument doesn't match
+                       any known commands.
+
+                       For pnpm-style behavior, set this to 'run-exec'. e.g:
+
+                       \`\`\`
+                       ​vlt config set fallback-command=run-exec
+                       \`\`\`
+
+
+
+                       Valid options: "install", "uninstall", "run", "run-exec",
+                       "exec", "help", "config", "install-exec", "pkg", "list",
+                       "query", "gui"
+
+  --package=<p>        When running \`vlt install-exec\`, this allows you to
+                       explicitly set the package to search for bins. If not
+                       provided, then vlt will interpret the first argument as
+                       the package, and attempt to run the default executable.
+
+  --view=<output>      Configures the output format for ls & query commands.
+                       Valid options: "human", "json", "mermaid", "gui"
+
+  -D --save-dev        Save installed packages to a package.json file as
+                       devDependencies
+
+  -O --save-optional   Save installed packages to a package.json file as
+                       optionalDependencies
+
+  --save-peer          Save installed packages to a package.json file as
+                       peerDependencies
+
+  -P --save-prod       Save installed packages into dependencies specifically.
+                       This is useful if a package already exists in
+                       devDependencies or optionalDependencies, but you want to
+                       move it to be a non-optional production dependency.
+
+  -h --help            Print helpful information
+`

--- a/src/vlt/tap-snapshots/test/commands/install-exec.ts.test.cjs
+++ b/src/vlt/tap-snapshots/test/commands/install-exec.ts.test.cjs
@@ -1,0 +1,14 @@
+/* IMPORTANT
+ * This snapshot file is auto-generated, but designed for humans.
+ * It should be checked into source control and tracked carefully.
+ * Re-generate by setting TAP_SNAPSHOT=1 and running tests.
+ * Make sure to inspect the output below.  Do not ignore changes!
+ */
+'use strict'
+exports[`test/commands/install-exec.ts > TAP > basic > usage 1`] = `
+Usage:
+  vlt install-exec [--package=<pkg>] [command...]
+
+Run a command defined by a package, installing it if necessary
+
+`

--- a/src/vlt/tap-snapshots/test/commands/install.ts.test.cjs
+++ b/src/vlt/tap-snapshots/test/commands/install.ts.test.cjs
@@ -146,3 +146,11 @@ Object {
   "scurry": PathScurry {},
 }
 `
+
+exports[`test/commands/install.ts > TAP > usage 1`] = `
+Usage:
+  vlt install [package ...]
+
+Install the specified package, updating dependencies appropriately
+
+`

--- a/src/vlt/tap-snapshots/test/commands/list.ts.test.cjs
+++ b/src/vlt/tap-snapshots/test/commands/list.ts.test.cjs
@@ -24,27 +24,37 @@ Usage:
   vlt ls
   vlt ls <query> --view=[human | json | mermaid | gui]
 
-List installed dependencies matching the provided query.
-Defaults to listing direct dependencies of a project and
-any configured workspace.
+List installed dependencies matching the provided query. Defaults to listing
+direct dependencies of a project and any configured workspace.
 
-Examples:
+  Examples
 
-  vlt ls
-          List direct dependencies of the current project / workspace
-  vlt ls *
-          List all dependencies for the current project / workspace
-  vlt ls foo bar baz
-          List all dependencies named 'foo', 'bar', or 'baz'
-  vlt ls '[name="@scoped/package"] > *'
-          Lists direct dependencies of a specific package
-  vlt ls '*.workspace > *.peer'
-          List all peer dependencies of all workspaces
+    List direct dependencies of the current project / workspace
 
-Options:
+    ​vlt ls
 
-  --view=[human | json | mermaid | gui]
-          Output format. Defaults to human-readable or json if no tty.
+    List all dependencies for the current project / workspace
+
+    ​vlt ls *
+
+    List all dependencies named 'foo', 'bar', or 'baz'
+
+    ​vlt ls foo bar baz
+
+    Lists direct dependencies of a specific package
+
+    ​vlt ls '[name="@scoped/package"] > *'
+
+    List all peer dependencies of all workspaces
+
+    ​vlt ls '*.workspace > *.peer'
+
+  Options
+
+    view
+      Output format. Defaults to human-readable or json if no tty.
+
+      ​--view=[human | json | mermaid | gui]
 
 `
 

--- a/src/vlt/tap-snapshots/test/commands/pkg.ts.test.cjs
+++ b/src/vlt/tap-snapshots/test/commands/pkg.ts.test.cjs
@@ -1,0 +1,46 @@
+/* IMPORTANT
+ * This snapshot file is auto-generated, but designed for humans.
+ * It should be checked into source control and tracked carefully.
+ * Re-generate by setting TAP_SNAPSHOT=1 and running tests.
+ * Make sure to inspect the output below.  Do not ignore changes!
+ */
+'use strict'
+exports[`test/commands/pkg.ts > TAP > usage 1`] = `
+Usage:
+  vlt pkg [<command>] [<args>]
+
+Get or manipulate package.json values
+
+  Subcommands
+
+    get
+      Get a single value
+
+      ​vlt pkg get [<key>]
+
+    pick
+      Get multiple values or the entire package
+
+      ​vlt pkg pick [<key> [<key> ...]]
+
+    set
+      Set one or more key value pairs
+
+      ​vlt pkg set <key>=<value> [<key>=<value> ...]
+
+    delete
+      Delete one or more keys from the package
+
+      ​vlt pkg delete <key> [<key> ...]
+
+  Examples
+
+    Set a value on an object inside an array
+
+    ​vlt pkg set "array[1].key=value"
+
+    Append a value to an array
+
+    ​vlt pkg set "array[]=value"
+
+`

--- a/src/vlt/tap-snapshots/test/commands/query.ts.test.cjs
+++ b/src/vlt/tap-snapshots/test/commands/query.ts.test.cjs
@@ -26,21 +26,30 @@ Usage:
 
 List installed dependencies matching the provided query.
 
-Examples:
+  Examples
 
-  vlt query '#foo'
-          Query packages with the name "foo"
-  vlt query '*.workspace > *.peer'
-          Query all peer dependencies of workspaces
-  vlt query ':project > *:attr(scripts, [build])'
-          Query all direct project dependencies with a "build" script
-  vlt query '[name^="@vltpkg"]'
-          Query packages with names starting with "@vltpkg"
+    Query packages with the name "foo"
 
-Options:
+    ​vlt query '#foo'
 
-  --view=[human | json | mermaid | gui]
-          Output format. Defaults to human-readable or json if no tty.
+    Query all peer dependencies of workspaces
+
+    ​vlt query '*.workspace > *.peer'
+
+    Query all direct project dependencies with a "build" script
+
+    ​vlt query ':project > *:attr(scripts, [build])'
+
+    Query packages with names starting with "@vltpkg"
+
+    ​vlt query '[name^="@vltpkg"]'
+
+  Options
+
+    view
+      Output format. Defaults to human-readable or json if no tty.
+
+      ​--view=[human | json | mermaid | gui]
 
 `
 

--- a/src/vlt/tap-snapshots/test/commands/run-exec.ts.test.cjs
+++ b/src/vlt/tap-snapshots/test/commands/run-exec.ts.test.cjs
@@ -1,0 +1,14 @@
+/* IMPORTANT
+ * This snapshot file is auto-generated, but designed for humans.
+ * It should be checked into source control and tracked carefully.
+ * Re-generate by setting TAP_SNAPSHOT=1 and running tests.
+ * Make sure to inspect the output below.  Do not ignore changes!
+ */
+'use strict'
+exports[`test/commands/run-exec.ts > TAP > usage 1`] = `
+Usage:
+  vlt run-exec [command ...]
+
+Runs 'vlt run' if the command is a named script, 'vlt exec' otherwise
+
+`

--- a/src/vlt/tap-snapshots/test/commands/run.ts.test.cjs
+++ b/src/vlt/tap-snapshots/test/commands/run.ts.test.cjs
@@ -1,0 +1,14 @@
+/* IMPORTANT
+ * This snapshot file is auto-generated, but designed for humans.
+ * It should be checked into source control and tracked carefully.
+ * Re-generate by setting TAP_SNAPSHOT=1 and running tests.
+ * Make sure to inspect the output below.  Do not ignore changes!
+ */
+'use strict'
+exports[`test/commands/run.ts > TAP > usage 1`] = `
+Usage:
+  vlt run <script> [args ...]
+
+Run the named script from package.json
+
+`

--- a/src/vlt/tap-snapshots/test/commands/uninstall.ts.test.cjs
+++ b/src/vlt/tap-snapshots/test/commands/uninstall.ts.test.cjs
@@ -28,3 +28,11 @@ Object {
   "scurry": PathScurry {},
 }
 `
+
+exports[`test/commands/uninstall.ts > TAP > usage 1`] = `
+Usage:
+  vlt uninstall [package ...]
+
+Remove the named packages from the dependency graph
+
+`

--- a/src/vlt/test/commands/exec.ts
+++ b/src/vlt/test/commands/exec.ts
@@ -1,21 +1,15 @@
 import { resolve } from 'path'
 import t from 'tap'
-
 import { command, usage } from '../../src/commands/exec.js'
+import { setupEnv } from '../fixtures/run.js'
 
-t.type(usage, 'string')
+setupEnv(t)
 
 const pass = 'node -e "process.exit(0)"'
 
-// fresh process.env on every test
-const cleanEnv = Object.fromEntries(
-  Object.entries(process.env).filter(([k]) => !/^VLT_/i.test(k)),
-)
-// not sure why this is required, but Windows tests fail without it.
-cleanEnv.PATH = process.env.PATH
-t.beforeEach(t =>
-  t.intercept(process, 'env', { value: { ...cleanEnv } }),
-)
+if (process.argv[1] === import.meta.filename) {
+  t.matchSnapshot((await usage()).usage(), 'usage')
+}
 
 t.test('run script in a project', async t => {
   const dir = t.testdir({

--- a/src/vlt/test/commands/gui.ts
+++ b/src/vlt/test/commands/gui.ts
@@ -15,7 +15,7 @@ t.test('starts gui data and server', async t => {
     },
   )
 
-  t.type(usage, 'string')
+  t.matchSnapshot((await usage()).usage(), 'usage')
 
   // workaround for the import.meta.resolve issue not working with tap atm
   const assetsDir = '/path/to/assets'

--- a/src/vlt/test/commands/help.ts
+++ b/src/vlt/test/commands/help.ts
@@ -1,14 +1,13 @@
-// just a stub for now
 import t from 'tap'
 
 t.test('basic', async t => {
   const { usage, command } = await t.mockImport<
     typeof import('../../src/commands/help.js')
   >('../../src/commands/help.js')
-  t.type(usage, 'function')
-  t.type(await usage(), 'string')
+  const USAGE = (await usage()).usage()
+  t.matchSnapshot(USAGE, 'usage')
   const out = t.capture(console, 'log').args
   t.capture(console, 'error')
-  await command(),
-    t.strictSame(out()[0]?.[0], await usage(), 'should print usage')
+  await command()
+  t.strictSame(out()[0]?.[0], USAGE, 'should print usage')
 })

--- a/src/vlt/test/commands/install-exec.ts
+++ b/src/vlt/test/commands/install-exec.ts
@@ -6,7 +6,8 @@ t.test('basic', async t => {
   const { usage, command } = await t.mockImport<
     typeof import('../../src/commands/install-exec.js')
   >('../../src/commands/install-exec.js')
-  t.type(usage, 'string')
+  const USAGE = (await usage()).usage()
+  t.matchSnapshot(USAGE, 'usage')
   t.capture(console, 'log')
   t.capture(console, 'error')
   await command({ positionals: [] } as unknown as LoadedConfig)

--- a/src/vlt/test/commands/install.ts
+++ b/src/vlt/test/commands/install.ts
@@ -49,7 +49,7 @@ const { usage, command } = await t.mockImport<
     PathScurryWin32: PathScurry,
   },
 })
-t.type(usage, 'string')
+t.matchSnapshot((await usage()).usage(), 'usage')
 await command(
   {
     positionals: [],

--- a/src/vlt/test/commands/list.ts
+++ b/src/vlt/test/commands/list.ts
@@ -106,7 +106,7 @@ const { usage, command } = await t.mockImport<
 })
 
 t.test('list', async t => {
-  t.matchSnapshot(usage, 'should have usage')
+  t.matchSnapshot((await usage()).usage(), 'should have usage')
 
   sharedOptions.packageJson.read = () => graph.mainImporter.manifest!
   const options = {

--- a/src/vlt/test/commands/pkg.ts
+++ b/src/vlt/test/commands/pkg.ts
@@ -4,7 +4,7 @@ import * as Command from '../../src/commands/pkg.js'
 import { readFileSync } from 'fs'
 import { join } from 'path'
 
-t.type(Command.usage, 'string')
+t.matchSnapshot((await Command.usage()).usage(), 'usage')
 
 setupEnv(t)
 

--- a/src/vlt/test/commands/query.ts
+++ b/src/vlt/test/commands/query.ts
@@ -106,7 +106,7 @@ const { usage, command } = await t.mockImport<
 })
 
 t.test('query', async t => {
-  t.matchSnapshot(usage, 'should have usage')
+  t.matchSnapshot((await usage()).usage(), 'should have usage')
 
   sharedOptions.packageJson.read = () => graph.mainImporter.manifest!
   const options = {

--- a/src/vlt/test/commands/run-exec.ts
+++ b/src/vlt/test/commands/run-exec.ts
@@ -1,21 +1,15 @@
 import { resolve } from 'path'
 import t from 'tap'
-
 import { command, usage } from '../../src/commands/run-exec.js'
+import { setupEnv } from '../fixtures/run.js'
 
-t.type(usage, 'string')
+setupEnv(t)
 
 const pass = 'node -e "process.exit(0)"'
 
-// fresh process.env on every test
-const cleanEnv = Object.fromEntries(
-  Object.entries(process.env).filter(([k]) => !/^VLT_/i.test(k)),
-)
-// not sure why this is required, but Windows tests fail without it.
-cleanEnv.PATH = process.env.PATH
-t.beforeEach(t =>
-  t.intercept(process, 'env', { value: { ...cleanEnv } }),
-)
+if (process.argv[1] === import.meta.filename) {
+  t.matchSnapshot((await usage()).usage(), 'usage')
+}
 
 t.test('run script in a project', async t => {
   const dir = t.testdir({

--- a/src/vlt/test/commands/run.ts
+++ b/src/vlt/test/commands/run.ts
@@ -1,21 +1,16 @@
 import { resolve } from 'path'
 import t from 'tap'
-
 import { command, usage } from '../../src/commands/run.js'
-t.type(usage, 'string')
+import { setupEnv } from '../fixtures/run.js'
+
+setupEnv(t)
 
 const pass = 'node -e "process.exit(0)"'
 const fail = 'node -e "process.exit(1)"'
 
-// fresh process.env on every test
-const cleanEnv = Object.fromEntries(
-  Object.entries(process.env).filter(([k]) => !/^VLT_/i.test(k)),
-)
-// not sure why this is required, but Windows tests fail without it.
-cleanEnv.PATH = process.env.PATH
-t.beforeEach(t =>
-  t.intercept(process, 'env', { value: { ...cleanEnv } }),
-)
+if (process.argv[1] === import.meta.filename) {
+  t.matchSnapshot((await usage()).usage(), 'usage')
+}
 
 t.test('run script in a project', async t => {
   const dir = t.testdir({

--- a/src/vlt/test/commands/uninstall.ts
+++ b/src/vlt/test/commands/uninstall.ts
@@ -50,7 +50,7 @@ const { usage, command } = await t.mockImport<
     PathScurryWin32: PathScurry,
   },
 })
-t.type(usage, 'string')
+t.matchSnapshot((await usage()).usage(), 'usage')
 await command(
   {
     positionals: [],

--- a/src/vlt/test/config/definition.ts
+++ b/src/vlt/test/config/definition.ts
@@ -6,6 +6,7 @@ import {
   recordFields,
   getCommand,
 } from '../../src/config/definition.js'
+import { setupEnv } from '../fixtures/run.js'
 
 t.matchSnapshot(commands, 'commands')
 const defObj = definition.toJSON()
@@ -66,11 +67,7 @@ t.test('infer editor from env/platform', async t => {
     ],
   ]
   t.plan(cases.length)
-  const cleanEnv = Object.fromEntries(
-    Object.entries(process.env).filter(
-      ([k]) => !k.startsWith('VLT_'),
-    ),
-  )
+  const cleanEnv = setupEnv(t)
   for (const [{ platform, EDITOR, VISUAL }, expect] of cases) {
     t.test(`${platform} ${EDITOR} ${VISUAL}`, async t => {
       t.intercept(process, 'env', {

--- a/src/vlt/test/fixtures/run.ts
+++ b/src/vlt/test/fixtures/run.ts
@@ -14,6 +14,7 @@ export const setupEnv = (t: Test) => {
   t.beforeEach(t =>
     t.intercept(process, 'env', { value: { ...cleanEnv } }),
   )
+  return cleanEnv
 }
 
 export const mockConfig = (t: Test) =>

--- a/src/vlt/test/index.ts
+++ b/src/vlt/test/index.ts
@@ -1,4 +1,5 @@
 import t, { Test } from 'tap'
+import { Jack, jack } from 'jackspeak'
 import {
   setupEnv,
   mockConfig,
@@ -23,7 +24,7 @@ export const run = async (
     argv?: string[]
     command?: {
       command: () => Promise<void>
-      usage?: string | (() => Promise<string>)
+      usage?: () => Promise<Jack>
     }
   },
 ) => {
@@ -79,28 +80,10 @@ t.test('print usage', async t => {
       command: async () => {
         commandRun = true
       },
-      usage: 'im helping!!! im helping youuuuuu',
-    },
-    testdir: {
-      '.git': {},
-      'vlt.json': JSON.stringify({}),
-    },
-  })
-  t.equal(commandRun, false)
-  t.strictSame(logs, [['im helping!!! im helping youuuuuu']])
-})
-
-t.test('print async usage', async t => {
-  let commandRun = false
-  const { logs } = await run(t, {
-    commandName: 'install',
-    argv: ['-h'],
-    command: {
-      command: async () => {
-        commandRun = true
-      },
       usage: async () =>
-        'im helping!!! im helping youuuuuu asynchronously',
+        jack({
+          usage: 'im helping!!! im helping youuuuuu',
+        }),
     },
     testdir: {
       '.git': {},
@@ -108,7 +91,10 @@ t.test('print async usage', async t => {
     },
   })
   t.equal(commandRun, false)
-  t.strictSame(logs, [
-    ['im helping!!! im helping youuuuuu asynchronously'],
-  ])
+  t.equal(logs.length, 1)
+  t.equal(logs[0].length, 1)
+  t.strictSame(
+    logs[0][0].split('\n').map((l: string) => l.trim()),
+    ['Usage:', 'im helping!!! im helping youuuuuu', ''],
+  )
 })

--- a/www/docs/astro.config.mts
+++ b/www/docs/astro.config.mts
@@ -4,8 +4,16 @@ import starlight from '@astrojs/starlight'
 import vercelStatic from '@astrojs/vercel/static'
 import react from '@astrojs/react'
 import tailwind from '@astrojs/tailwind'
-import { existsSync } from 'fs'
-import { relative, resolve } from 'path'
+import { existsSync, readdirSync } from 'fs'
+import { basename, relative, resolve } from 'path'
+import { fileURLToPath } from 'url'
+import { resolve as metaResolve } from 'import-meta-resolve'
+
+const commands = readdirSync(
+  fileURLToPath(metaResolve('@vltpkg/cli/commands', import.meta.url)),
+)
+  .filter(c => c.endsWith('.js'))
+  .map(c => basename(c, '.js'))
 
 const PACKAGES = 'packages'
 
@@ -82,11 +90,16 @@ export default defineConfig({
       sidebar: [
         {
           label: 'CLI',
-          autogenerate: { directory: 'cli' },
-        },
-        {
-          label: 'API',
-          autogenerate: { directory: 'api' },
+          items: [
+            { label: 'Getting Started', link: 'cli' },
+            {
+              label: 'Commands',
+              items: commands.map(c => ({
+                label: c,
+                link: `cli/commands/${c}`,
+              })),
+            },
+          ],
         },
         {
           label: 'Packages',

--- a/www/docs/package.json
+++ b/www/docs/package.json
@@ -39,6 +39,7 @@
     "@types/eslint__js": "catalog:",
     "@types/node": "catalog:",
     "eslint": "catalog:",
+    "import-meta-resolve": "^4.1.0",
     "prettier": "catalog:",
     "typedoc-plugin-remark": "^1.0.3",
     "typescript": "catalog:",

--- a/www/docs/src/content/config.ts
+++ b/www/docs/src/content/config.ts
@@ -1,6 +1,58 @@
 import { defineCollection } from 'astro:content'
 import { docsSchema } from '@astrojs/starlight/schema'
+import { resolve } from 'import-meta-resolve'
+import { relative } from 'path'
+import { fileURLToPath } from 'url'
+import { type CliCommand } from '@vltpkg/cli/types'
+import { glob, type LoaderContext } from 'astro/loaders'
+import assert from 'assert'
+
+type EntryTypes = Map<
+  string,
+  {
+    extensions: string[]
+    getEntryInfo: (o: {
+      contents: string
+      fileUrl: string
+    }) => Promise<unknown>
+  }
+>
+
+const commandLoader = glob({
+  pattern: '*.js',
+  base: relative(
+    import.meta.dirname,
+    fileURLToPath(resolve('@vltpkg/cli/commands', import.meta.url)),
+  ),
+})
+
+const commands = defineCollection({
+  loader: {
+    ...commandLoader,
+    load: async (ctx_: LoaderContext) => {
+      const ctx = ctx_ as LoaderContext & { entryTypes: EntryTypes }
+      const md = ctx.entryTypes.get('.md')
+      assert(md, 'no md loader')
+      ctx.entryTypes.set('.js', {
+        ...md,
+        extensions: ['.js'],
+        getEntryInfo: async ({ fileUrl }) => {
+          const cmd = (await import(
+            /* @vite-ignore */ fileUrl
+          )) as CliCommand
+          const usage = await cmd.usage()
+          return md.getEntryInfo({
+            contents: usage.usageMarkdown(),
+            fileUrl,
+          })
+        },
+      })
+      await commandLoader.load(ctx)
+    },
+  },
+})
 
 export const collections = {
   docs: defineCollection({ schema: docsSchema() }),
+  commands,
 }

--- a/www/docs/src/content/docs/cli/commands/config.mdx
+++ b/www/docs/src/content/docs/cli/commands/config.mdx
@@ -1,7 +1,0 @@
----
-title: config
----
-
-import { usage } from '@vltpkg/cli/commands/config'
-
-<pre>{usage}</pre>

--- a/www/docs/src/content/docs/cli/commands/exec.mdx
+++ b/www/docs/src/content/docs/cli/commands/exec.mdx
@@ -1,7 +1,0 @@
----
-title: exec
----
-
-import { usage } from '@vltpkg/cli/commands/exec'
-
-<pre>{usage}</pre>

--- a/www/docs/src/content/docs/cli/commands/help.mdx
+++ b/www/docs/src/content/docs/cli/commands/help.mdx
@@ -1,7 +1,0 @@
----
-title: help
----
-
-import { usage } from '@vltpkg/cli/commands/help'
-
-<pre>{await usage()}</pre>

--- a/www/docs/src/content/docs/cli/commands/install-exec.mdx
+++ b/www/docs/src/content/docs/cli/commands/install-exec.mdx
@@ -1,7 +1,0 @@
----
-title: install-exec
----
-
-import { usage } from '@vltpkg/cli/commands/install-exec'
-
-<pre>{usage}</pre>

--- a/www/docs/src/content/docs/cli/commands/install.mdx
+++ b/www/docs/src/content/docs/cli/commands/install.mdx
@@ -1,7 +1,0 @@
----
-title: install
----
-
-import { usage } from '@vltpkg/cli/commands/install'
-
-<pre>{usage}</pre>

--- a/www/docs/src/content/docs/cli/commands/list.mdx
+++ b/www/docs/src/content/docs/cli/commands/list.mdx
@@ -1,7 +1,0 @@
----
-title: list
----
-
-import { usage } from '@vltpkg/cli/commands/list'
-
-<pre>{usage}</pre>

--- a/www/docs/src/content/docs/cli/commands/pkg.mdx
+++ b/www/docs/src/content/docs/cli/commands/pkg.mdx
@@ -1,7 +1,0 @@
----
-title: pkg
----
-
-import { usage } from '@vltpkg/cli/commands/pkg'
-
-<pre>{usage}</pre>

--- a/www/docs/src/content/docs/cli/commands/query.mdx
+++ b/www/docs/src/content/docs/cli/commands/query.mdx
@@ -1,7 +1,0 @@
----
-title: query
----
-
-import { usage } from '@vltpkg/cli/commands/query'
-
-<pre>{usage}</pre>

--- a/www/docs/src/content/docs/cli/commands/run-exec.mdx
+++ b/www/docs/src/content/docs/cli/commands/run-exec.mdx
@@ -1,7 +1,0 @@
----
-title: run-exec
----
-
-import { usage } from '@vltpkg/cli/commands/run-exec'
-
-<pre>{usage}</pre>

--- a/www/docs/src/content/docs/cli/commands/run.mdx
+++ b/www/docs/src/content/docs/cli/commands/run.mdx
@@ -1,7 +1,0 @@
----
-title: run
----
-
-import { usage } from '@vltpkg/cli/commands/run'
-
-<pre>{usage}</pre>

--- a/www/docs/src/content/docs/cli/commands/uninstall.mdx
+++ b/www/docs/src/content/docs/cli/commands/uninstall.mdx
@@ -1,7 +1,0 @@
----
-title: uninstall
----
-
-import { usage } from '@vltpkg/cli/commands/uninstall'
-
-<pre>{usage}</pre>

--- a/www/docs/src/content/docs/cli/configuring.mdx
+++ b/www/docs/src/content/docs/cli/configuring.mdx
@@ -1,7 +1,0 @@
----
-title: Configuring
----
-
-import { usage } from '@vltpkg/cli/commands/help'
-
-<pre>{await usage()}</pre>

--- a/www/docs/src/content/docs/cli/index.mdx
+++ b/www/docs/src/content/docs/cli/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: CLI
+title: Getting Started with the vlt CLI
 ---
 
 The `vlt` CLI.

--- a/www/docs/src/pages/cli/commands/[id].astro
+++ b/www/docs/src/pages/cli/commands/[id].astro
@@ -1,0 +1,21 @@
+---
+import StarlightPage from '@astrojs/starlight/components/StarlightPage.astro'
+import { getCollection, render } from 'astro:content'
+import { type MarkdownHeading } from 'astro'
+
+export const getStaticPaths = async () =>
+  (await getCollection('commands')).map(command => ({
+    params: { id: command.id },
+    props: { command },
+  }))
+
+const { command } = Astro.props
+const { Content } = await render(command)
+---
+
+<StarlightPage
+  frontmatter={{ title: command.id }}
+  headings={(command.rendered?.metadata
+    ?.headings as MarkdownHeading[]) ?? []}>
+  <Content />
+</StarlightPage>


### PR DESCRIPTION
This PR changes the signature of each command's `usage` to be a function that returns a `jackspeak` instance. That instance is then used to render `usage()` on the CLI and `usageMarkdown()` in the docs site.

Closes #199 