### PR TITLE
gui: add package.json rendered tab

### DIFF
--- a/infra/build/test/bundle.ts
+++ b/infra/build/test/bundle.ts
@@ -98,6 +98,8 @@ t.test('lint', async t => {
             IS_REACT_ACT_ENVIRONMENT: false,
             __REACT_DEVTOOLS_GLOBAL_HOOK__: false,
             __webpack_nonce__: false,
+            Buffer: false,
+            process: false,
           },
         },
       },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -666,6 +666,9 @@ importers:
       '@radix-ui/react-slot':
         specifier: 'catalog:'
         version: 1.1.0(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-tabs':
+        specifier: ^1.1.1
+        version: 1.1.1(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@vltpkg/dep-id':
         specifier: workspace:*
         version: link:../dep-id
@@ -702,6 +705,9 @@ importers:
       react-dom:
         specifier: 'catalog:'
         version: 18.3.1(react@18.3.1)
+      shiki:
+        specifier: ^1.22.2
+        version: 1.22.2
       tailwind-merge:
         specifier: 'catalog:'
         version: 2.5.4
@@ -3109,6 +3115,19 @@ packages:
       '@types/react':
         optional: true
 
+  '@radix-ui/react-tabs@1.1.1':
+    resolution: {integrity: sha512-3GBUDmP2DvzmtYLMsHmpA1GtR46ZDZ+OreXM/N+kkQJOPIgytFWWTfDQmBQKBvaFS0Vno0FktdbVzN28KGrMdw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-tooltip@1.1.3':
     resolution: {integrity: sha512-Z4w1FIS0BqVFI2c1jZvb/uDVJijJjJ2ZMuPV81oVgTZ7g3BZxobplnMVvXtFWgtozdvYJ+MFWtwkM5S2HnAong==}
     peerDependencies:
@@ -3288,20 +3307,29 @@ packages:
   '@rtsao/scc@1.1.0':
     resolution: {integrity: sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==}
 
-  '@shikijs/core@1.14.1':
-    resolution: {integrity: sha512-KyHIIpKNaT20FtFPFjCQB5WVSTpLR/n+jQXhWHWVUMm9MaOaG9BGOG0MSyt7yA4+Lm+4c9rTc03tt3nYzeYSfw==}
-
   '@shikijs/core@1.22.0':
     resolution: {integrity: sha512-S8sMe4q71TJAW+qG93s5VaiihujRK6rqDFqBnxqvga/3LvqHEnxqBIOPkt//IdXVtHkQWKu4nOQNk0uBGicU7Q==}
+
+  '@shikijs/core@1.22.2':
+    resolution: {integrity: sha512-bvIQcd8BEeR1yFvOYv6HDiyta2FFVePbzeowf5pPS1avczrPK+cjmaxxh0nx5QzbON7+Sv0sQfQVciO7bN72sg==}
 
   '@shikijs/engine-javascript@1.22.0':
     resolution: {integrity: sha512-AeEtF4Gcck2dwBqCFUKYfsCq0s+eEbCEbkUuFou53NZ0sTGnJnJ/05KHQFZxpii5HMXbocV9URYVowOP2wH5kw==}
 
+  '@shikijs/engine-javascript@1.22.2':
+    resolution: {integrity: sha512-iOvql09ql6m+3d1vtvP8fLCVCK7BQD1pJFmHIECsujB0V32BJ0Ab6hxk1ewVSMFA58FI0pR2Had9BKZdyQrxTw==}
+
   '@shikijs/engine-oniguruma@1.22.0':
     resolution: {integrity: sha512-5iBVjhu/DYs1HB0BKsRRFipRrD7rqjxlWTj4F2Pf+nQSPqc3kcyqFFeZXnBMzDf0HdqaFVvhDRAGiYNvyLP+Mw==}
 
+  '@shikijs/engine-oniguruma@1.22.2':
+    resolution: {integrity: sha512-GIZPAGzQOy56mGvWMoZRPggn0dTlBf1gutV5TdceLCZlFNqWmuc7u+CzD0Gd9vQUTgLbrt0KLzz6FNprqYAxlA==}
+
   '@shikijs/types@1.22.0':
     resolution: {integrity: sha512-Fw/Nr7FGFhlQqHfxzZY8Cwtwk5E9nKDUgeLjZgt3UuhcM3yJR9xj3ZGNravZZok8XmEZMiYkSMTPlPkULB8nww==}
+
+  '@shikijs/types@1.22.2':
+    resolution: {integrity: sha512-NCWDa6LGZqTuzjsGfXOBWfjS/fDIbDdmVDug+7ykVe1IKT4c1gakrvlfFYp5NhAXH/lyqLM8wsAPo5wNy73Feg==}
 
   '@shikijs/vscode-textmate@9.3.0':
     resolution: {integrity: sha512-jn7/7ky30idSkd/O5yDBfAnVt+JJpepofP/POZ1iMOxK59cOfqIgg/Dj0eFsjOTMw+4ycJN0uhZH/Eb0bs/EUA==}
@@ -6686,11 +6714,11 @@ packages:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
 
-  shiki@1.14.1:
-    resolution: {integrity: sha512-FujAN40NEejeXdzPt+3sZ3F2dx1U24BY2XTY01+MG8mbxCiA2XukXdcbyMyLAHJ/1AUUnQd1tZlvIjefWWEJeA==}
-
   shiki@1.22.0:
     resolution: {integrity: sha512-/t5LlhNs+UOKQCYBtl5ZsH/Vclz73GIqT2yQsCBygr8L/ppTdmpL4w3kPLoZJbMKVWtoG77Ue1feOjZfDxvMkw==}
+
+  shiki@1.22.2:
+    resolution: {integrity: sha512-3IZau0NdGKXhH2bBlUk4w1IHNxPh6A5B2sUpyY+8utLu2j/h1QpFkAaUA1bAMxOWWGtTWcAh531vnS4NJKS/lA==}
 
   side-channel@1.0.6:
     resolution: {integrity: sha512-fDW/EZ6Q9RiO8eFG8Hj+7u/oW+XrPTIChwCOM2+th2A6OblDtYYIpve9m+KvI9Z4C9qSEXlaGR6bTEYHReuglA==}
@@ -8562,7 +8590,7 @@ snapshots:
   '@expressive-code/plugin-shiki@0.35.6':
     dependencies:
       '@expressive-code/core': 0.35.6
-      shiki: 1.14.1
+      shiki: 1.22.0
 
   '@expressive-code/plugin-text-markers@0.35.6':
     dependencies:
@@ -9142,6 +9170,22 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.11
 
+  '@radix-ui/react-tabs@1.1.1(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.0
+      '@radix-ui/react-context': 1.1.1(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-direction': 1.1.0(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-id': 1.1.0(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-presence': 1.1.1(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-primitive': 2.0.0(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-roving-focus': 1.1.0(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-controllable-state': 1.1.0(@types/react@18.3.11)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.11
+      '@types/react-dom': 18.3.1
+
   '@radix-ui/react-tooltip@1.1.3(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@radix-ui/primitive': 1.1.0
@@ -9276,15 +9320,20 @@ snapshots:
 
   '@rtsao/scc@1.1.0': {}
 
-  '@shikijs/core@1.14.1':
-    dependencies:
-      '@types/hast': 3.0.4
-
   '@shikijs/core@1.22.0':
     dependencies:
       '@shikijs/engine-javascript': 1.22.0
       '@shikijs/engine-oniguruma': 1.22.0
       '@shikijs/types': 1.22.0
+      '@shikijs/vscode-textmate': 9.3.0
+      '@types/hast': 3.0.4
+      hast-util-to-html: 9.0.3
+
+  '@shikijs/core@1.22.2':
+    dependencies:
+      '@shikijs/engine-javascript': 1.22.2
+      '@shikijs/engine-oniguruma': 1.22.2
+      '@shikijs/types': 1.22.2
       '@shikijs/vscode-textmate': 9.3.0
       '@types/hast': 3.0.4
       hast-util-to-html: 9.0.3
@@ -9295,12 +9344,28 @@ snapshots:
       '@shikijs/vscode-textmate': 9.3.0
       oniguruma-to-js: 0.4.3
 
+  '@shikijs/engine-javascript@1.22.2':
+    dependencies:
+      '@shikijs/types': 1.22.2
+      '@shikijs/vscode-textmate': 9.3.0
+      oniguruma-to-js: 0.4.3
+
   '@shikijs/engine-oniguruma@1.22.0':
     dependencies:
       '@shikijs/types': 1.22.0
       '@shikijs/vscode-textmate': 9.3.0
 
+  '@shikijs/engine-oniguruma@1.22.2':
+    dependencies:
+      '@shikijs/types': 1.22.2
+      '@shikijs/vscode-textmate': 9.3.0
+
   '@shikijs/types@1.22.0':
+    dependencies:
+      '@shikijs/vscode-textmate': 9.3.0
+      '@types/hast': 3.0.4
+
+  '@shikijs/types@1.22.2':
     dependencies:
       '@shikijs/vscode-textmate': 9.3.0
       '@types/hast': 3.0.4
@@ -13703,17 +13768,21 @@ snapshots:
 
   shebang-regex@3.0.0: {}
 
-  shiki@1.14.1:
-    dependencies:
-      '@shikijs/core': 1.14.1
-      '@types/hast': 3.0.4
-
   shiki@1.22.0:
     dependencies:
       '@shikijs/core': 1.22.0
       '@shikijs/engine-javascript': 1.22.0
       '@shikijs/engine-oniguruma': 1.22.0
       '@shikijs/types': 1.22.0
+      '@shikijs/vscode-textmate': 9.3.0
+      '@types/hast': 3.0.4
+
+  shiki@1.22.2:
+    dependencies:
+      '@shikijs/core': 1.22.2
+      '@shikijs/engine-javascript': 1.22.2
+      '@shikijs/engine-oniguruma': 1.22.2
+      '@shikijs/types': 1.22.2
       '@shikijs/vscode-textmate': 9.3.0
       '@types/hast': 3.0.4
 

--- a/src/gui/package.json
+++ b/src/gui/package.json
@@ -6,6 +6,7 @@
   "dependencies": {
     "@radix-ui/react-dropdown-menu": "^2.1.2",
     "@radix-ui/react-slot": "catalog:",
+    "@radix-ui/react-tabs": "^1.1.1",
     "@vltpkg/dep-id": "workspace:*",
     "@vltpkg/fast-split": "workspace:*",
     "@vltpkg/graph": "workspace:*",
@@ -18,6 +19,7 @@
     "lucide-react": "catalog:",
     "react": "catalog:",
     "react-dom": "catalog:",
+    "shiki": "^1.22.2",
     "tailwind-merge": "catalog:",
     "tailwindcss-animate": "catalog:",
     "zustand": "^4.5.4"

--- a/src/gui/src/components/dashboard-grid/index.tsx
+++ b/src/gui/src/components/dashboard-grid/index.tsx
@@ -113,12 +113,9 @@ export const DashboardGrid = () => {
 
   return (
     <div className="flex flex-wrap justify-center width-full mt-6">
-      {dashboard?.projects.map(
-        (item, index) => (
-          console.error(item),
-          (<DashboardItem key={index} item={item} />)
-        ),
-      )}
+      {dashboard?.projects.map((item, index) => (
+        <DashboardItem key={index} item={item} />
+      ))}
     </div>
   )
 }

--- a/src/gui/src/components/explorer-grid/selected-item.tsx
+++ b/src/gui/src/components/explorer-grid/selected-item.tsx
@@ -8,6 +8,14 @@ import {
 } from '@/components/ui/card.jsx'
 import { useGraphStore } from '@/state/index.js'
 import { type GridItemData, type GridItemOptions } from './types.js'
+import {
+  Tabs,
+  TabsContent,
+  TabsList,
+  TabsTrigger,
+} from '@/components/ui/tabs.jsx'
+import { CodeBlock } from '../ui/shiki.jsx'
+import { FileSearch2 } from 'lucide-react'
 
 const getItemOrigin = ({
   item,
@@ -68,12 +76,28 @@ export const SelectedItem = ({ item }: GridItemOptions) => {
             )}
           </CardTitle>
         </CardHeader>
-        <div className="flex flex-row pl-4 pr-3">
+        <div className="p-4">
           {item.to?.manifest?.description ?
             <CardDescription className="grow content-center py-2">
               {item.to.manifest.description}
             </CardDescription>
           : ''}
+        </div>
+        <div className="px-4 pb-4 w-full">
+          <Tabs defaultValue="package.json">
+            <TabsList className="grid w-full grid-cols-2">
+              <TabsTrigger value="package.json" className="w-36">
+                <FileSearch2 size={16} className="mr-2" />
+                package.json
+              </TabsTrigger>
+            </TabsList>
+            <TabsContent value="package.json">
+              <CodeBlock
+                code={JSON.stringify(item.to?.manifest, null, 2)}
+                lang="json"
+              />
+            </TabsContent>
+          </Tabs>
         </div>
       </Card>
       {

--- a/src/gui/src/components/explorer-grid/side-item.tsx
+++ b/src/gui/src/components/explorer-grid/side-item.tsx
@@ -26,7 +26,7 @@ export const SideItem = ({
   useEffect(() => {
     if (idx === 1) {
       const rect = divRef.current?.getBoundingClientRect()
-      if (rect && lineRef.current && rect.height > 85.5) {
+      if (rect && lineRef.current && rect.height > 86) {
         lineRef.current.style.height = '124px'
       }
     }

--- a/src/gui/src/components/ui/shiki.tsx
+++ b/src/gui/src/components/ui/shiki.tsx
@@ -1,0 +1,37 @@
+import { useGraphStore } from '@/state/index.js'
+import { useLayoutEffect, useState } from 'react'
+import { codeToHtml } from 'shiki/bundle/web'
+
+export function CodeBlock({
+  code,
+  lang,
+}: {
+  code: string
+  lang: string
+}) {
+  const [out, setOut] = useState<string | null>(null)
+  const theme = useGraphStore(state => state.theme)
+  useLayoutEffect(() => {
+    async function startCodeBlock() {
+      const out = await codeToHtml(code, {
+        lang,
+        theme: theme === 'light' ? 'github-light' : 'poimandres',
+      })
+      if (out) {
+        setOut(out)
+      }
+    }
+    startCodeBlock().catch((err: unknown) => console.error(err))
+  }, [code, lang, theme])
+
+  return (
+    <>
+      {out ?
+        <div
+          className={`text-xs rounded-md overflow-x-scroll border border-solid border-neutral-600 snap-x ${theme === 'light' ? 'bg-white' : 'bg-[#1b1e28]'} p-4`}>
+          <div dangerouslySetInnerHTML={{ __html: out }} />
+        </div>
+      : ''}
+    </>
+  )
+}

--- a/src/gui/src/components/ui/tabs.tsx
+++ b/src/gui/src/components/ui/tabs.tsx
@@ -1,0 +1,55 @@
+'use client'
+
+import * as React from 'react'
+import * as TabsPrimitive from '@radix-ui/react-tabs'
+
+import { cn } from '@/lib/utils.js'
+
+const Tabs = TabsPrimitive.Root
+
+const TabsList = React.forwardRef<
+  React.ElementRef<typeof TabsPrimitive.List>,
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.List>
+>(({ className, ...props }, ref) => (
+  <TabsPrimitive.List
+    ref={ref}
+    className={cn(
+      'inline-flex h-10 items-center justify-center rounded-md bg-muted p-1 text-muted-foreground',
+      className,
+    )}
+    {...props}
+  />
+))
+TabsList.displayName = TabsPrimitive.List.displayName
+
+const TabsTrigger = React.forwardRef<
+  React.ElementRef<typeof TabsPrimitive.Trigger>,
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.Trigger>
+>(({ className, ...props }, ref) => (
+  <TabsPrimitive.Trigger
+    ref={ref}
+    className={cn(
+      'inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow-sm',
+      className,
+    )}
+    {...props}
+  />
+))
+TabsTrigger.displayName = TabsPrimitive.Trigger.displayName
+
+const TabsContent = React.forwardRef<
+  React.ElementRef<typeof TabsPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.Content>
+>(({ className, ...props }, ref) => (
+  <TabsPrimitive.Content
+    ref={ref}
+    className={cn(
+      'mt-2 ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
+      className,
+    )}
+    {...props}
+  />
+))
+TabsContent.displayName = TabsPrimitive.Content.displayName
+
+export { Tabs, TabsList, TabsTrigger, TabsContent }

--- a/src/gui/src/components/ui/theme-provider.tsx
+++ b/src/gui/src/components/ui/theme-provider.tsx
@@ -1,3 +1,5 @@
+import { useGraphStore } from '@/state/index.js'
+import { type State } from '@/state/types.js'
 import { createContext, useContext, useEffect, useState } from 'react'
 
 export type Theme = 'dark' | 'light' | 'system'
@@ -31,6 +33,7 @@ export function ThemeProvider({
     // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
     () => (localStorage.getItem(storageKey) as Theme) || defaultTheme,
   )
+  const updateTheme = useGraphStore(state => state.updateTheme)
 
   useEffect(() => {
     const root = window.document.documentElement
@@ -55,6 +58,7 @@ export function ThemeProvider({
     setTheme: (theme: Theme) => {
       localStorage.setItem(storageKey, theme)
       setTheme(theme)
+      updateTheme(theme as State['theme'])
     },
   }
 

--- a/src/gui/src/state/index.ts
+++ b/src/gui/src/state/index.ts
@@ -19,6 +19,7 @@ const initialState: State = {
   selectedNode: undefined,
   specOptions: undefined,
   stamp: String(Math.random()).slice(2),
+  theme: localStorage.getItem('vite-ui-theme') as State['theme'],
 }
 
 /**
@@ -50,6 +51,7 @@ export const useGraphStore = create<Action & State>(set => {
     updateSpecOptions: (specOptions: State['specOptions']) =>
       set(() => ({ specOptions })),
     updateStamp: (stamp: string) => set(() => ({ stamp })),
+    updateTheme: (theme: State['theme']) => set(() => ({ theme })),
     reset: () => set(initialState),
   }
 

--- a/src/gui/src/state/types.ts
+++ b/src/gui/src/state/types.ts
@@ -21,6 +21,7 @@ export type Action = {
   updateSelectedNode: (node: State['selectedNode']) => void
   updateSpecOptions: (specOptions: State['specOptions']) => void
   updateStamp: (stamp: string) => void
+  updateTheme: (theme: State['theme']) => void
   reset: () => void
 }
 
@@ -98,6 +99,10 @@ export type State = {
    * A random string to control when graph data should be reloaded.
    */
   stamp: string
+  /**
+   * Store the current theme value.
+   */
+  theme: 'light' | 'dark'
 }
 
 export type DashboardTools =

--- a/src/gui/test/components/explorer-grid/__snapshots__/index.tsx.snap
+++ b/src/gui/test/components/explorer-grid/__snapshots__/index.tsx.snap
@@ -153,7 +153,73 @@ exports[`explorer-grid renders workspace with edges in 1`] = `
               </div>
             </h3>
           </div>
-          <div class="flex flex-row pl-4 pr-3">
+          <div class="p-4">
+          </div>
+          <div class="px-4 pb-4 w-full">
+            <div
+              dir="ltr"
+              data-orientation="horizontal"
+            >
+              <div
+                role="tablist"
+                aria-orientation="horizontal"
+                class="h-10 items-center justify-center rounded-md bg-muted p-1 text-muted-foreground grid w-full grid-cols-2"
+                tabindex="0"
+                data-orientation="horizontal"
+                style="outline: none;"
+              >
+                <button
+                  type="button"
+                  role="tab"
+                  aria-selected="true"
+                  aria-controls="radix-:r0:-content-package.json"
+                  data-state="active"
+                  id="radix-:r0:-trigger-package.json"
+                  class="inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow-sm w-36"
+                  tabindex="-1"
+                  data-orientation="horizontal"
+                  data-radix-collection-item
+                >
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    width="16"
+                    height="16"
+                    viewbox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    stroke-width="2"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    class="lucide lucide-file-search2 mr-2"
+                  >
+                    <path d="M15 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7Z">
+                    </path>
+                    <path d="M14 2v4a2 2 0 0 0 2 2h4">
+                    </path>
+                    <circle
+                      cx="11.5"
+                      cy="14.5"
+                      r="2.5"
+                    >
+                    </circle>
+                    <path d="M13.3 16.3 15 18">
+                    </path>
+                  </svg>
+                  package.json
+                </button>
+              </div>
+              <div
+                data-state="active"
+                data-orientation="horizontal"
+                role="tabpanel"
+                aria-labelledby="radix-:r0:-trigger-package.json"
+                id="radix-:r0:-content-package.json"
+                tabindex="0"
+                class="mt-2 ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+                style="animation-duration: 0s;"
+              >
+              </div>
+            </div>
           </div>
         </div>
       </div>

--- a/src/gui/test/components/explorer-grid/__snapshots__/selected-item.tsx.snap
+++ b/src/gui/test/components/explorer-grid/__snapshots__/selected-item.tsx.snap
@@ -20,7 +20,46 @@ exports[`SelectedItem render connection lines 1`] = `
           </div>
         </gui-card-title>
       </gui-card-header>
-      <div class="flex flex-row pl-4 pr-3">
+      <div class="p-4">
+      </div>
+      <div class="px-4 pb-4 w-full">
+        <gui-tabs>
+          <gui-tabs-list classname="grid w-full grid-cols-2">
+            <gui-tabs-trigger
+              value="package.json"
+              classname="w-36"
+            >
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                width="16"
+                height="16"
+                viewbox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                class="lucide lucide-file-search2 mr-2"
+              >
+                <path d="M15 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7Z">
+                </path>
+                <path d="M14 2v4a2 2 0 0 0 2 2h4">
+                </path>
+                <circle
+                  cx="11.5"
+                  cy="14.5"
+                  r="2.5"
+                >
+                </circle>
+                <path d="M13.3 16.3 15 18">
+                </path>
+              </svg>
+              package.json
+            </gui-tabs-trigger>
+          </gui-tabs-list>
+          <gui-tabs-content value="package.json">
+          </gui-tabs-content>
+        </gui-tabs>
       </div>
     </gui-card>
     <div class="absolute border-t border-solid border-neutral-300 dark:border-neutral-600 rounded-tr-sm w-4 top-7 -right-4">
@@ -53,7 +92,46 @@ exports[`SelectedItem render with custom registry 1`] = `
           </div>
         </gui-card-title>
       </gui-card-header>
-      <div class="flex flex-row pl-4 pr-3">
+      <div class="p-4">
+      </div>
+      <div class="px-4 pb-4 w-full">
+        <gui-tabs>
+          <gui-tabs-list classname="grid w-full grid-cols-2">
+            <gui-tabs-trigger
+              value="package.json"
+              classname="w-36"
+            >
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                width="16"
+                height="16"
+                viewbox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                class="lucide lucide-file-search2 mr-2"
+              >
+                <path d="M15 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7Z">
+                </path>
+                <path d="M14 2v4a2 2 0 0 0 2 2h4">
+                </path>
+                <circle
+                  cx="11.5"
+                  cy="14.5"
+                  r="2.5"
+                >
+                </circle>
+                <path d="M13.3 16.3 15 18">
+                </path>
+              </svg>
+              package.json
+            </gui-tabs-trigger>
+          </gui-tabs-list>
+          <gui-tabs-content value="package.json">
+          </gui-tabs-content>
+        </gui-tabs>
       </div>
     </gui-card>
   </div>
@@ -84,7 +162,46 @@ exports[`SelectedItem render with default git host 1`] = `
           </div>
         </gui-card-title>
       </gui-card-header>
-      <div class="flex flex-row pl-4 pr-3">
+      <div class="p-4">
+      </div>
+      <div class="px-4 pb-4 w-full">
+        <gui-tabs>
+          <gui-tabs-list classname="grid w-full grid-cols-2">
+            <gui-tabs-trigger
+              value="package.json"
+              classname="w-36"
+            >
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                width="16"
+                height="16"
+                viewbox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                class="lucide lucide-file-search2 mr-2"
+              >
+                <path d="M15 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7Z">
+                </path>
+                <path d="M14 2v4a2 2 0 0 0 2 2h4">
+                </path>
+                <circle
+                  cx="11.5"
+                  cy="14.5"
+                  r="2.5"
+                >
+                </circle>
+                <path d="M13.3 16.3 15 18">
+                </path>
+              </svg>
+              package.json
+            </gui-tabs-trigger>
+          </gui-tabs-list>
+          <gui-tabs-content value="package.json">
+          </gui-tabs-content>
+        </gui-tabs>
       </div>
     </gui-card>
   </div>
@@ -112,7 +229,46 @@ exports[`SelectedItem render with item 1`] = `
           </div>
         </gui-card-title>
       </gui-card-header>
-      <div class="flex flex-row pl-4 pr-3">
+      <div class="p-4">
+      </div>
+      <div class="px-4 pb-4 w-full">
+        <gui-tabs>
+          <gui-tabs-list classname="grid w-full grid-cols-2">
+            <gui-tabs-trigger
+              value="package.json"
+              classname="w-36"
+            >
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                width="16"
+                height="16"
+                viewbox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                class="lucide lucide-file-search2 mr-2"
+              >
+                <path d="M15 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7Z">
+                </path>
+                <path d="M14 2v4a2 2 0 0 0 2 2h4">
+                </path>
+                <circle
+                  cx="11.5"
+                  cy="14.5"
+                  r="2.5"
+                >
+                </circle>
+                <path d="M13.3 16.3 15 18">
+                </path>
+              </svg>
+              package.json
+            </gui-tabs-trigger>
+          </gui-tabs-list>
+          <gui-tabs-content value="package.json">
+          </gui-tabs-content>
+        </gui-tabs>
       </div>
     </gui-card>
   </div>
@@ -143,7 +299,46 @@ exports[`SelectedItem render with scoped registry 1`] = `
           </div>
         </gui-card-title>
       </gui-card-header>
-      <div class="flex flex-row pl-4 pr-3">
+      <div class="p-4">
+      </div>
+      <div class="px-4 pb-4 w-full">
+        <gui-tabs>
+          <gui-tabs-list classname="grid w-full grid-cols-2">
+            <gui-tabs-trigger
+              value="package.json"
+              classname="w-36"
+            >
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                width="16"
+                height="16"
+                viewbox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                class="lucide lucide-file-search2 mr-2"
+              >
+                <path d="M15 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7Z">
+                </path>
+                <path d="M14 2v4a2 2 0 0 0 2 2h4">
+                </path>
+                <circle
+                  cx="11.5"
+                  cy="14.5"
+                  r="2.5"
+                >
+                </circle>
+                <path d="M13.3 16.3 15 18">
+                </path>
+              </svg>
+              package.json
+            </gui-tabs-trigger>
+          </gui-tabs-list>
+          <gui-tabs-content value="package.json">
+          </gui-tabs-content>
+        </gui-tabs>
       </div>
     </gui-card>
   </div>

--- a/src/gui/test/components/explorer-grid/selected-item.tsx
+++ b/src/gui/test/components/explorer-grid/selected-item.tsx
@@ -11,11 +11,20 @@ import { SelectedItem } from '@/components/explorer-grid/selected-item.jsx'
 vi.mock('@/components/ui/badge.jsx', () => ({
   Badge: 'gui-badge',
 }))
+vi.mock('lucid-react', () => ({
+  FileSearch2: 'gui-lucid-file-search2',
+}))
 vi.mock('@/components/ui/card.jsx', () => ({
   Card: 'gui-card',
   CardDescription: 'gui-card-description',
   CardHeader: 'gui-card-header',
   CardTitle: 'gui-card-title',
+}))
+vi.mock('@/components/ui/tabs.jsx', () => ({
+  Tabs: 'gui-tabs',
+  TabsContent: 'gui-tabs-content',
+  TabsList: 'gui-tabs-list',
+  TabsTrigger: 'gui-tabs-trigger',
 }))
 
 const specOptions = getOptions({


### PR DESCRIPTION
Adds a tab navigation to the selected item view of the explorer, in which it renders the contents of the manifest using https://shiki.style

### Preview

<img width="1556" alt="Screenshot 2024-11-03 at 11 56 31 PM" src="https://github.com/user-attachments/assets/cecc7594-70ba-468e-82b5-7a08b498132f">
<img width="1556" alt="Screenshot 2024-11-03 at 11 56 27 PM" src="https://github.com/user-attachments/assets/f109c92b-befc-4d94-b43f-7f2a9abe21a9">
