### PR TITLE
graph: fix adding nameless specs 

### DIFF
--- a/src/graph/src/graph.ts
+++ b/src/graph/src/graph.ts
@@ -393,7 +393,7 @@ export class Graph implements GraphLike {
       ) {
         edge.to = replacement
       } else {
-        edge.to = undefined
+        edge.from.edgesOut.delete(edge.spec.name)
       }
     }
   }

--- a/src/graph/src/ideal/add-nodes.ts
+++ b/src/graph/src/ideal/add-nodes.ts
@@ -53,6 +53,7 @@ export const addNodes = async ({
     // Add new nodes for packages defined in the dependencies list fetching
     // metadata from the registry manifests and updating the graph
     await appendNodes(
+      dependencies,
       packageInfo,
       graph,
       importer,

--- a/src/graph/src/lockfile/load.ts
+++ b/src/graph/src/lockfile/load.ts
@@ -71,7 +71,8 @@ export const loadObject = (
     registries,
     'git-hosts': gitHosts,
     'git-host-archives': gitHostArchives,
-  } = lockfileData.options
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+  } = lockfileData.options || {}
   const mergedOptions = {
     ...options,
     'scope-registries': {

--- a/src/graph/tap-snapshots/test/graph.ts.test.cjs
+++ b/src/graph/tap-snapshots/test/graph.ts.test.cjs
@@ -27,7 +27,7 @@ exports[`test/graph.ts > TAP > using placePackage > should find and fix nameless
     'file·. bar': 'prod ^1.0.0 ··bar@1.0.0',
     'file·. foo': 'prod ^1.0.0 ··foo@1.0.0',
     'file·. a': 'prod file:./a file·a',
-    '··bar@1.0.0 baz': 'prod ^1.0.0 MISSING'
+    '··bar@1.0.0 baz': 'prod ^1.0.0 ··baz@1.0.0'
   }
 }
 `
@@ -48,7 +48,7 @@ exports[`test/graph.ts > TAP > using placePackage > should have removed baz from
     'file·. missing': 'prod ^1.0.0 MISSING',
     'file·. bar': 'prod ^1.0.0 ··bar@1.0.0',
     'file·. foo': 'prod ^1.0.0 ··foo@1.0.0',
-    '··bar@1.0.0 baz': 'prod ^1.0.0 MISSING'
+    '··bar@1.0.0 baz': 'prod ^1.0.0 ··baz@1.0.0'
   }
 }
 `

--- a/src/graph/tap-snapshots/test/ideal/append-nodes.ts.test.cjs
+++ b/src/graph/tap-snapshots/test/ideal/append-nodes.ts.test.cjs
@@ -5,6 +5,39 @@
  * Make sure to inspect the output below.  Do not ignore changes!
  */
 'use strict'
+exports[`test/ideal/append-nodes.ts > TAP > append a new node to a graph from a registry > should have fixed the spec name for the nameless git dep 1`] = `
+Array [
+  Array [
+    "foo",
+    Object {
+      "spec": "foo@^1.0.0",
+      "type": "prod",
+    },
+  ],
+  Array [
+    "bar",
+    Object {
+      "spec": "bar@",
+      "type": "prod",
+    },
+  ],
+  Array [
+    "borked",
+    Object {
+      "spec": "borked@",
+      "type": "prod",
+    },
+  ],
+  Array [
+    "ipsum",
+    Object {
+      "spec": "ipsum@github:lorem/ipsum",
+      "type": "prod",
+    },
+  ],
+]
+`
+
 exports[`test/ideal/append-nodes.ts > TAP > append different type of dependencies > should install different type of deps on different conditions 1`] = `
 @vltpkg/graph.Graph {
   options: { registries: {} },

--- a/src/graph/tap-snapshots/test/ideal/build-ideal-from-starting-graph.ts.test.cjs
+++ b/src/graph/tap-snapshots/test/ideal/build-ideal-from-starting-graph.ts.test.cjs
@@ -5,6 +5,23 @@
  * Make sure to inspect the output below.  Do not ignore changes!
  */
 'use strict'
+exports[`test/ideal/build-ideal-from-starting-graph.ts > TAP > add from manifest file only > must match snapshot 1`] = `
+[
+  Node {
+    id: 'file·.',
+    location: '.',
+    importer: true,
+    edgesOut: [
+      Edge spec(baz@^1.0.0) -prod-> to: Node {
+        id: '··baz@1.0.0',
+        location: './node_modules/.vlt/··baz@1.0.0/node_modules/baz',
+        resolved: 'https://registry.npmjs.org/baz/-/baz-1.0.0.tgz'
+      }
+    ]
+  }
+]
+`
+
 exports[`test/ideal/build-ideal-from-starting-graph.ts > TAP > build from a virtual graph > must match snapshot 1`] = `
 [
   Node {
@@ -21,7 +38,6 @@ exports[`test/ideal/build-ideal-from-starting-graph.ts > TAP > build from a virt
         location: './node_modules/.vlt/··foo@1.0.0/node_modules/foo',
         integrity: 'sha512-6/mh1E2u2YgEsCHdY0Yx5oW+61gZU+1vXaoiHHrpKeuRNNgFvS+/jrwHiQhB5apAf5oB7UB7E19ol2R2LKH8hQ=='
       },
-      Edge spec(bar@^1.0.0) -prod-> to: [missing package]: <bar@^1.0.0>,
       Edge spec(missing@^1.0.0) -prod-> to: Node {
         id: '··missing@1.0.0',
         location: './node_modules/.vlt/··missing@1.0.0/node_modules/missing',
@@ -34,6 +50,11 @@ exports[`test/ideal/build-ideal-from-starting-graph.ts > TAP > build from a virt
       Edge spec(baz@^1.0.0) -prod-> to: Node {
         id: '··baz@1.0.0',
         location: './node_modules/.vlt/··baz@1.0.0/node_modules/baz'
+      },
+      Edge spec(ipsum@github:lorem/ipsum) -prod-> to: Node {
+        id: 'git·github%3Alorem§ipsum·',
+        location: './node_modules/.vlt/git·github%3Alorem§ipsum·/node_modules/ipsum',
+        resolved: 'github:lorem/ipsum'
       }
     ]
   }
@@ -52,11 +73,6 @@ exports[`test/ideal/build-ideal-from-starting-graph.ts > TAP > build from an act
         id: '··foo@1.0.0',
         location: './node_modules/.vlt/··foo@1.0.0/node_modules/foo'
       },
-      Edge spec(extraneous@*) -prod-> to: Node {
-        id: '··extraneous@1.0.0',
-        location: './node_modules/.vlt/··extraneous@1.0.0/node_modules/extraneous'
-      },
-      Edge spec(bar@^1.0.0) -prod-> to: [missing package]: <bar@^1.0.0>,
       Edge spec(aliased@custom:foo@^1.0.0) -dev-> to: Node {
         id: '·custom·foo@1.0.0',
         location: './node_modules/.vlt/·custom·foo@1.0.0/node_modules/foo',
@@ -109,4 +125,8 @@ exports[`test/ideal/build-ideal-from-starting-graph.ts > TAP > build from an act
     ]
   }
 ]
+`
+
+exports[`test/ideal/build-ideal-from-starting-graph.ts > TAP > remove from manifest file only > must match snapshot 1`] = `
+[ Node { id: 'file·.', location: '.', importer: true } ]
 `

--- a/src/graph/tap-snapshots/test/ideal/build.ts.test.cjs
+++ b/src/graph/tap-snapshots/test/ideal/build.ts.test.cjs
@@ -31,8 +31,7 @@ exports[`test/ideal/build.ts > TAP > build from lockfile > should build an ideal
       Edge spec(foo@^1.0.0) -prod-> to: Node {
         id: '··foo@1.0.0',
         location: './node_modules/.vlt/··foo@1.0.0/node_modules/foo',
-        resolved: 'https://registry.npmjs.org/foo/-/foo-1.0.0.tgz',
-        integrity: 'sha512-URO90jLnKPqX+P7OLnJkiIQfMX4I6gEdGZ1T84drQLtRPw6uNKYLZfB6K3hjWIrj0VZB1kh2cTFdeq01i6XIYQ=='
+        integrity: 'sha512-6/mh1E2u2YgEsCHdY0Yx5oW+61gZU+1vXaoiHHrpKeuRNNgFvS+/jrwHiQhB5apAf5oB7UB7E19ol2R2LKH8hQ=='
       }
     ]
   }

--- a/src/graph/tap-snapshots/test/lockfile/load.ts.test.cjs
+++ b/src/graph/tap-snapshots/test/lockfile/load.ts.test.cjs
@@ -259,6 +259,18 @@ exports[`test/lockfile/load.ts > TAP > loadHidden > must match snapshot 1`] = `
 ]
 `
 
+exports[`test/lockfile/load.ts > TAP > missing options object > should be able to parse lockfile without options object 1`] = `
+{
+  "options": {
+    "registries": {
+      "example": "http://foo"
+    }
+  },
+  "nodes": {},
+  "edges": {}
+}
+`
+
 exports[`test/lockfile/load.ts > TAP > option-defined values should overwrite lockfile values > should overwrite lockfile values with option-defined values 1`] = `
 {
   "options": {

--- a/src/graph/tap-snapshots/test/reify/optional-fail.ts.test.cjs
+++ b/src/graph/tap-snapshots/test/reify/optional-fail.ts.test.cjs
@@ -8,7 +8,8 @@
 exports[`test/reify/optional-fail.ts > TAP > register and optional node failure > must match snapshot 1`] = `
 Object {
   "edges": Object {
-    "··foo@1.2.3 bar": "prod * MISSING",
+    "··bar@1.2.3 baz": "prod * ··baz@1.2.3",
+    "··foo@1.2.3 bar": "prod * ··bar@1.2.3",
     "file·. foo": "optional * ··foo@1.2.3",
   },
   "nodes": Object {

--- a/src/graph/test/ideal/build.ts
+++ b/src/graph/test/ideal/build.ts
@@ -1,4 +1,4 @@
-import { joinDepIDTuple } from '@vltpkg/dep-id'
+import { type DepIDTuple, joinDepIDTuple } from '@vltpkg/dep-id'
 import { PackageInfoClient } from '@vltpkg/package-info'
 import { PackageJson } from '@vltpkg/package-json'
 import { Monorepo } from '@vltpkg/workspaces'
@@ -6,6 +6,10 @@ import { PathScurry } from 'path-scurry'
 import t from 'tap'
 import { build } from '../../src/ideal/build.js'
 import { objectLikeOutput } from '../../src/visualization/object-like-output.js'
+import { type LockfileEdgeKey } from '../../src/index.js'
+
+const edgeKey = (from: DepIDTuple, to: string): LockfileEdgeKey =>
+  `${joinDepIDTuple(from)} ${to}`
 
 t.test('build from lockfile', async t => {
   const projectRoot = t.testdir({
@@ -17,24 +21,19 @@ t.test('build from lockfile', async t => {
       },
     }),
     'vlt-lock.json': JSON.stringify({
-      registries: {
-        npm: 'https://registry.npmjs.org/',
-      },
+      options: {},
       nodes: {
-        [joinDepIDTuple(['file', '.'])]: ['my-project'],
         [joinDepIDTuple(['registry', '', 'foo@1.0.0'])]: [
+          0,
           'foo',
           'sha512-6/mh1E2u2YgEsCHdY0Yx5oW+61gZU+1vXaoiHHrpKeuRNNgFvS+/jrwHiQhB5apAf5oB7UB7E19ol2R2LKH8hQ==',
         ],
       },
-      edges: [
-        [
-          joinDepIDTuple(['file', '.']),
-          'prod',
-          'foo@^1.0.0',
+      edges: {
+        [edgeKey(['file', '.'], 'foo')]:
+          'prod ^1.0.0 ' +
           joinDepIDTuple(['registry', '', 'foo@1.0.0']),
-        ],
-      ],
+      },
     }),
   })
 

--- a/src/graph/test/lockfile/load.ts
+++ b/src/graph/test/lockfile/load.ts
@@ -434,3 +434,23 @@ t.test(
     )
   },
 )
+
+t.test('missing options object', async t => {
+  const projectRoot = t.testdir()
+  const mainManifest = { name: 'my-project', version: '1.0.0' }
+  const loadOptions = {
+    registries: {
+      example: 'http://foo',
+    },
+    mainManifest,
+    projectRoot,
+  }
+  const lockfileData = {
+    nodes: {},
+    edges: {},
+  } as LockfileData
+  t.matchSnapshot(
+    JSON.stringify(loadObject(loadOptions, lockfileData), null, 2),
+    'should be able to parse lockfile without options object',
+  )
+})


### PR DESCRIPTION
This PR fixes adding nameless dependency specs when using the cli
e.g: `vlt install github:foo/bar` along with fixing inconsistencies
when merging cli-defined dependencies with manifest-defined values.

A few connected changes found when turning many stones related to this
problem that are worthy of mention:

- `Graph.removeNode` removes the edge from its `from` node instead of
  just unsetting the `to` value of that edge.
- `append-nodes` will fix up and update entries in the user-provided
  `add` values, so that we can add a proper dependency name when writing
  to that importer `package.json` at the end of reify.
- cleaned up the logic between `ideal.build` and its
  `get-importer-specs` module so values should be properly merged when
  adding / removing new dependencies.
- Make lockfile load a little more resilient by making sure it does not
  throw when trying to deconstruct values from a missing `options`
  property.
- updated a few tests and snapshots that had either wrong assumptions
  and / or bad fixture data