### PR TITLE
fix: project root resolution

### DIFF
--- a/src/vlt/src/config/index.ts
+++ b/src/vlt/src/config/index.ts
@@ -582,25 +582,29 @@ export class Config {
     // indicators that this *may* be the root, if no .git or workspaces
     // file is found higher up in the search.
     let lastKnownRoot = this.projectRoot
-    for (const dir of walkUp(this.projectRoot)) {      
+    for (const dir of walkUp(this.projectRoot)) {
       // don't look in ~
       if (dir === home) break
 
       // finding a project config file stops the search
       const projectConfig = resolve(dir, 'vlt.json')
       if (projectConfig === userConfig) break
-      if (await exists(projectConfig) && await this.#maybeLoadConfigFile(projectConfig)) {
+      if (
+        (await exists(projectConfig)) &&
+        (await this.#maybeLoadConfigFile(projectConfig))
+      ) {
         lastKnownRoot = dir
         break
       }
 
       // stat existence of these files
-      const [hasPackage, hasModules, hasWorkspaces, hasGit] = await Promise.all([
-        exists(resolve(dir, 'package.json')),
-        exists(resolve(dir, 'node_modules')),
-        exists(resolve(dir, 'vlt-workspaces.json')),
-        exists(resolve(dir, '.git'))
-      ])
+      const [hasPackage, hasModules, hasWorkspaces, hasGit] =
+        await Promise.all([
+          exists(resolve(dir, 'package.json')),
+          exists(resolve(dir, 'node_modules')),
+          exists(resolve(dir, 'vlt-workspaces.json')),
+          exists(resolve(dir, '.git')),
+        ])
 
       // treat these as potential roots
       if (hasPackage || hasModules || hasWorkspaces) {

--- a/src/vlt/src/config/index.ts
+++ b/src/vlt/src/config/index.ts
@@ -581,7 +581,7 @@ export class Config {
 
     // indicators that this *may* be the root, if no .git or workspaces
     // file is found higher up in the search.
-    let lastKnownRoot = this.projectRoot
+    let lastKnownRoot = resolve(this.projectRoot)
     for (const dir of walkUp(this.projectRoot)) {
       // don't look in ~
       if (dir === home) break

--- a/src/vlt/src/config/index.ts
+++ b/src/vlt/src/config/index.ts
@@ -579,41 +579,40 @@ export class Config {
     const userConfig = xdg.config('vlt.json')
     await this.#maybeLoadConfigFile(userConfig)
 
-    // don't walk up past a folder containing any of these
-    const stops = ['vlt-workspaces.json', '.git']
     // indicators that this *may* be the root, if no .git or workspaces
     // file is found higher up in the search.
-    let foundLikelyRoot = false
-    const likelies = ['package.json', 'node_modules']
-    for (const dir of walkUp(this.projectRoot)) {
+    let lastKnownRoot = this.projectRoot
+    for (const dir of walkUp(this.projectRoot)) {      
       // don't look in ~
       if (dir === home) break
+
+      // finding a project config file stops the search
       const projectConfig = resolve(dir, 'vlt.json')
       if (projectConfig === userConfig) break
-      if (await this.#maybeLoadConfigFile(resolve(dir, 'vlt.json'))) {
-        this.projectRoot = dir
+      if (await exists(projectConfig) && await this.#maybeLoadConfigFile(projectConfig)) {
+        lastKnownRoot = dir
         break
       }
-      if (
-        !foundLikelyRoot &&
-        (
-          await Promise.all(
-            likelies.map(s => exists(resolve(dir, s))),
-          )
-        ).find(x => x)
-      ) {
-        foundLikelyRoot = true
-        this.projectRoot = dir
+
+      // stat existence of these files
+      const [hasPackage, hasModules, hasWorkspaces, hasGit] = await Promise.all([
+        exists(resolve(dir, 'package.json')),
+        exists(resolve(dir, 'node_modules')),
+        exists(resolve(dir, 'vlt-workspaces.json')),
+        exists(resolve(dir, '.git'))
+      ])
+
+      // treat these as potential roots
+      if (hasPackage || hasModules || hasWorkspaces) {
+        lastKnownRoot = dir
       }
-      if (
-        (
-          await Promise.all(stops.map(s => exists(resolve(dir, s))))
-        ).find(x => x)
-      ) {
-        this.projectRoot = dir
+
+      // define backstops
+      if (hasWorkspaces || hasGit) {
         break
       }
     }
+    this.projectRoot = lastKnownRoot
     return this
   }
 

--- a/src/vlt/src/config/index.ts
+++ b/src/vlt/src/config/index.ts
@@ -579,7 +579,6 @@ export class Config {
     const userConfig = xdg.config('vlt.json')
     await this.#maybeLoadConfigFile(userConfig)
 
-    // file is found higher up in the search.
     let lastKnownRoot = resolve(this.projectRoot)
     for (const dir of walkUp(this.projectRoot)) {
       // don't look in ~

--- a/src/vlt/src/config/index.ts
+++ b/src/vlt/src/config/index.ts
@@ -579,7 +579,6 @@ export class Config {
     const userConfig = xdg.config('vlt.json')
     await this.#maybeLoadConfigFile(userConfig)
 
-    // indicators that this *may* be the root, if no .git or workspaces
     // file is found higher up in the search.
     let lastKnownRoot = resolve(this.projectRoot)
     for (const dir of walkUp(this.projectRoot)) {

--- a/src/vlt/test/config/index.ts
+++ b/src/vlt/test/config/index.ts
@@ -509,6 +509,27 @@ t.test('kv string[] stored as Record<string, string>', async t => {
   })
 })
 
+t.test('.git is treated as a backstop', async t => {
+  const dir = t.testdir({
+    '.git': {},
+    a: {}
+  })
+  const c = await Config.load(dir + '/a', undefined, true)
+  t.equal(c.projectRoot, resolve(dir, 'a/'))
+})
+
+t.test('root resolution finds last known good location', async t => {
+  const dir = t.testdir({
+    '.git': {},
+    a: {
+      b: {},
+      'package.json': {}
+    }
+  })
+  const c = await Config.load(dir + '/a/b', undefined, true)
+  t.equal(c.projectRoot, resolve(dir, 'a/'))
+})
+
 t.test('do not walk to home dir', async t => {
   const dir = t.testdir({
     // take the first likely root, not this one, because it's ~

--- a/src/vlt/test/config/index.ts
+++ b/src/vlt/test/config/index.ts
@@ -512,7 +512,7 @@ t.test('kv string[] stored as Record<string, string>', async t => {
 t.test('.git is treated as a backstop', async t => {
   const dir = t.testdir({
     '.git': {},
-    a: {}
+    a: {},
   })
   const c = await Config.load(dir + '/a', undefined, true)
   t.equal(c.projectRoot, resolve(dir, 'a/'))
@@ -523,8 +523,8 @@ t.test('root resolution finds last known good location', async t => {
     '.git': {},
     a: {
       b: {},
-      'package.json': {}
-    }
+      'package.json': {},
+    },
   })
   const c = await Config.load(dir + '/a/b', undefined, true)
   t.equal(c.projectRoot, resolve(dir, 'a/'))

--- a/src/vlt/test/config/index.ts
+++ b/src/vlt/test/config/index.ts
@@ -515,7 +515,7 @@ t.test('.git is treated as a backstop', async t => {
     a: {},
   })
   const c = await Config.load(dir + '/a', undefined, true)
-  t.equal(c.projectRoot, resolve(dir, 'a/'))
+  t.equal(c.projectRoot, resolve(dir, 'a'))
 })
 
 t.test('root resolution finds last known good location', async t => {
@@ -527,7 +527,7 @@ t.test('root resolution finds last known good location', async t => {
     },
   })
   const c = await Config.load(dir + '/a/b', undefined, true)
-  t.equal(c.projectRoot, resolve(dir, 'a/'))
+  t.equal(c.projectRoot, resolve(dir, 'a'))
 })
 
 t.test('do not walk to home dir', async t => {


### PR DESCRIPTION
### Description
- fixes root resolution which was causing errors to occur when trying to run `vlt` inside a nested dir of any git project
- the root-cause was incorrectly treating the existence of `.git` as both a backstop & a root identifier
- this change also... 
   - resolves issues where a previously found/known-good root existed while walking up the path but was ignored
   - treats the cwd as the preferred default root instead of the `.git` backstop (which is less confusing for end-users if no known root is found while walking up the path)
- the existence of `vlt-workspaces.json` continues to be treated as both a backstop & a well-known root location

### Minimum Reproduction
- since I'm not opening a separate issue for the resolution error/backstop, here's a minimum reproduction to see the issue with the previous algorithm

```bash
mkdir test && cd test # make a test dir
git init # initial git repo
mkdir foo && cd foo # make a subdir
npm init -y # create a package.json
vlt install express # try to install & get errors as vlt uses an incorrect root location
```

![Screenshot 2024-12-03 at 11 35 08 AM](https://github.com/user-attachments/assets/777584c8-e822-47cf-9a04-2687e27553a3)