### PR TITLE
gui: add dependency management

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -636,12 +636,24 @@ importers:
       '@radix-ui/react-dropdown-menu':
         specifier: ^2.1.2
         version: 2.1.2(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-label':
+        specifier: ^2.1.0
+        version: 2.1.0(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-popover':
+        specifier: ^1.1.2
+        version: 1.1.2(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-select':
+        specifier: ^2.1.2
+        version: 2.1.2(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-slot':
         specifier: ^1.1.0
         version: 1.1.0(@types/react@18.3.11)(react@18.3.1)
       '@radix-ui/react-tabs':
         specifier: ^1.1.1
         version: 1.1.1(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-toast':
+        specifier: ^1.2.2
+        version: 1.2.2(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-tooltip':
         specifier: ^1.1.3
         version: 1.1.3(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -2857,6 +2869,9 @@ packages:
     resolution: {integrity: sha512-cq8o4cWH0ibXh9VGi5P20Tu9XF/0fFXl9EUinr9QfTM7a7p0oTA4iJRCQWppXR1Pg8dSM0UCItCkPwsk9qWWYA==}
     engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
 
+  '@radix-ui/number@1.1.0':
+    resolution: {integrity: sha512-V3gRzhVNU1ldS5XhAPTom1fOIo4ccrjjJgmE+LI2h/WaFpHmx0MQApT+KZHnx8abG6Avtfcz4WoEciMnpFT3HQ==}
+
   '@radix-ui/primitive@1.1.0':
     resolution: {integrity: sha512-4Z8dn6Upk0qk4P74xBhZ6Hd/w0mPEzOOLxy4xiPXOXqjF7jZS0VAKk7/x/H6FyY2zCkYJqePf1G5KmkmNJ4RBA==}
 
@@ -2997,8 +3012,34 @@ packages:
       '@types/react':
         optional: true
 
+  '@radix-ui/react-label@2.1.0':
+    resolution: {integrity: sha512-peLblDlFw/ngk3UWq0VnYaOLy6agTZZ+MUO/WhVfm14vJGML+xH4FAl2XQGLqdefjNb7ApRg6Yn7U42ZhmYXdw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-menu@2.1.2':
     resolution: {integrity: sha512-lZ0R4qR2Al6fZ4yCCZzu/ReTFrylHFxIqy7OezIpWF4bL0o9biKo0pFIvkaew3TyZ9Fy5gYVrR5zCGZBVbO1zg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-popover@1.1.2':
+    resolution: {integrity: sha512-u2HRUyWW+lOiA2g0Le0tMmT55FGOEWHwPFt1EPfbLly7uXQExFo5duNKqG2DzmFXIdqOeNd+TpE8baHWJCyP9w==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -3075,6 +3116,19 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-select@2.1.2':
+    resolution: {integrity: sha512-rZJtWmorC7dFRi0owDmoijm6nSJH1tVw64QGiNIZ9PNLyBDtG+iAq+XGsya052At4BfarzY/Dhv9wrrUr6IMZA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-separator@1.1.0':
     resolution: {integrity: sha512-3uBAs+egzvJBDZAzvb/n4NxxOYpnspmWxO2u5NbZ8Y6FM/NdrGSF9bop3Cf6F6C71z1rTSn8KV0Fo2ZVd79lGA==}
     peerDependencies:
@@ -3099,6 +3153,19 @@ packages:
 
   '@radix-ui/react-tabs@1.1.1':
     resolution: {integrity: sha512-3GBUDmP2DvzmtYLMsHmpA1GtR46ZDZ+OreXM/N+kkQJOPIgytFWWTfDQmBQKBvaFS0Vno0FktdbVzN28KGrMdw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-toast@1.2.2':
+    resolution: {integrity: sha512-Z6pqSzmAP/bFJoqMAston4eSNa+ud44NSZTiZUmUen+IOZ5nBY8kzuU5WDBVyFXPtcW6yUalOHsxM/BP6Sv8ww==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -3152,6 +3219,15 @@ packages:
 
   '@radix-ui/react-use-layout-effect@1.1.0':
     resolution: {integrity: sha512-+FPE0rOdziWSrH9athwI1R0HDVbWlEhd+FR+aSDk4uWGmSJ9Z54sdZVDQPZAinJhJXwfT+qnj969mCsT2gfm5w==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-previous@1.1.0':
+    resolution: {integrity: sha512-Z/e78qg2YFnnXcW88A4JmTtm4ADckLno6F7OXotmkQfeuCVaKuYzqAATPhVzl3delXE7CxIV8shofPn3jPc5Og==}
     peerDependencies:
       '@types/react': '*'
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
@@ -8938,6 +9014,8 @@ snapshots:
 
   '@pkgr/core@0.1.1': {}
 
+  '@radix-ui/number@1.1.0': {}
+
   '@radix-ui/primitive@1.1.0': {}
 
   '@radix-ui/react-arrow@1.1.0(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
@@ -9063,6 +9141,15 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.11
 
+  '@radix-ui/react-label@2.1.0(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.0.0(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.11
+      '@types/react-dom': 18.3.1
+
   '@radix-ui/react-menu@2.1.2(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@radix-ui/primitive': 1.1.0
@@ -9081,6 +9168,29 @@ snapshots:
       '@radix-ui/react-roving-focus': 1.1.0(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-slot': 1.1.0(@types/react@18.3.11)(react@18.3.1)
       '@radix-ui/react-use-callback-ref': 1.1.0(@types/react@18.3.11)(react@18.3.1)
+      aria-hidden: 1.2.4
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      react-remove-scroll: 2.6.0(@types/react@18.3.11)(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.11
+      '@types/react-dom': 18.3.1
+
+  '@radix-ui/react-popover@1.1.2(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.0
+      '@radix-ui/react-compose-refs': 1.1.0(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-context': 1.1.1(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-dismissable-layer': 1.1.1(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-focus-guards': 1.1.1(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-focus-scope': 1.1.0(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-id': 1.1.0(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-popper': 1.2.0(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-portal': 1.1.2(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-presence': 1.1.1(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-primitive': 2.0.0(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-slot': 1.1.0(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-use-controllable-state': 1.1.0(@types/react@18.3.11)(react@18.3.1)
       aria-hidden: 1.2.4
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
@@ -9153,6 +9263,35 @@ snapshots:
       '@types/react': 18.3.11
       '@types/react-dom': 18.3.1
 
+  '@radix-ui/react-select@2.1.2(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/number': 1.1.0
+      '@radix-ui/primitive': 1.1.0
+      '@radix-ui/react-collection': 1.1.0(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-compose-refs': 1.1.0(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-context': 1.1.1(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-direction': 1.1.0(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-dismissable-layer': 1.1.1(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-focus-guards': 1.1.1(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-focus-scope': 1.1.0(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-id': 1.1.0(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-popper': 1.2.0(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-portal': 1.1.2(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-primitive': 2.0.0(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-slot': 1.1.0(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-use-callback-ref': 1.1.0(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-use-controllable-state': 1.1.0(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-use-layout-effect': 1.1.0(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-use-previous': 1.1.0(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-visually-hidden': 1.1.0(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      aria-hidden: 1.2.4
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      react-remove-scroll: 2.6.0(@types/react@18.3.11)(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.11
+      '@types/react-dom': 18.3.1
+
   '@radix-ui/react-separator@1.1.0(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@radix-ui/react-primitive': 2.0.0(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -9179,6 +9318,26 @@ snapshots:
       '@radix-ui/react-primitive': 2.0.0(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-roving-focus': 1.1.0(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-use-controllable-state': 1.1.0(@types/react@18.3.11)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.11
+      '@types/react-dom': 18.3.1
+
+  '@radix-ui/react-toast@1.2.2(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.0
+      '@radix-ui/react-collection': 1.1.0(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-compose-refs': 1.1.0(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-context': 1.1.1(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-dismissable-layer': 1.1.1(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-portal': 1.1.2(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-presence': 1.1.1(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-primitive': 2.0.0(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-callback-ref': 1.1.0(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-use-controllable-state': 1.1.0(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-use-layout-effect': 1.1.0(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-visually-hidden': 1.1.0(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
     optionalDependencies:
@@ -9226,6 +9385,12 @@ snapshots:
       '@types/react': 18.3.11
 
   '@radix-ui/react-use-layout-effect@1.1.0(@types/react@18.3.11)(react@18.3.1)':
+    dependencies:
+      react: 18.3.1
+    optionalDependencies:
+      '@types/react': 18.3.11
+
+  '@radix-ui/react-use-previous@1.1.0(@types/react@18.3.11)(react@18.3.1)':
     dependencies:
       react: 18.3.1
     optionalDependencies:
@@ -11042,7 +11207,7 @@ snapshots:
       debug: 4.3.7
       enhanced-resolve: 5.17.1
       eslint: 9.9.0(jiti@1.21.6)
-      eslint-module-utils: 2.12.0(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@9.9.0(jiti@1.21.6))
+      eslint-module-utils: 2.12.0(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(eslint-plugin-import@2.31.0)(eslint@9.9.0(jiti@1.21.6)))(eslint@9.9.0(jiti@1.21.6))
       fast-glob: 3.3.2
       get-tsconfig: 4.8.1
       is-bun-module: 1.2.1
@@ -11055,7 +11220,7 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-module-utils@2.12.0(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@9.9.0(jiti@1.21.6)):
+  eslint-module-utils@2.12.0(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(eslint-plugin-import@2.31.0)(eslint@9.9.0(jiti@1.21.6)))(eslint@9.9.0(jiti@1.21.6)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
@@ -11076,7 +11241,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.9.0(jiti@1.21.6)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.0(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@9.9.0(jiti@1.21.6))
+      eslint-module-utils: 2.12.0(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(eslint-plugin-import@2.31.0)(eslint@9.9.0(jiti@1.21.6)))(eslint@9.9.0(jiti@1.21.6))
       hasown: 2.0.2
       is-core-module: 2.15.1
       is-glob: 4.0.3

--- a/src/graph/src/reify/add-edge.ts
+++ b/src/graph/src/reify/add-edge.ts
@@ -39,12 +39,18 @@ export const addEdge = async (
   remover: RollbackRemove,
 ) => {
   if (!edge.to) return
-  const binRoot = scurry.resolve(edge.from.nodeModules, '.bin')
-  const path = scurry.resolve(edge.from.nodeModules, edge.spec.name)
+  const binRoot = scurry.resolve(
+    edge.from.nodeModules(scurry),
+    '.bin',
+  )
+  const path = scurry.resolve(
+    edge.from.nodeModules(scurry),
+    edge.spec.name,
+  )
   const promises: Promise<unknown>[] = []
   const target = relative(
     dirname(path),
-    scurry.resolve(edge.to.location),
+    edge.to.resolvedLocation(scurry),
   )
   promises.push(clobberSymlink(target, path, remover, 'dir'))
   const bp = binPaths(manifest)

--- a/src/graph/src/reify/add-edges.ts
+++ b/src/graph/src/reify/add-edges.ts
@@ -14,7 +14,8 @@ export const addEdges = (
   for (const edge of diff.edges.add) {
     const { to } = edge
     if (!to) continue
-    const mani = to.manifest ?? packageJson.read(to.location)
+    const mani =
+      to.manifest ?? packageJson.read(to.resolvedLocation(scurry))
     actions.push(addEdge(edge, mani, scurry, remover))
   }
   return actions

--- a/src/graph/src/reify/add-nodes.ts
+++ b/src/graph/src/reify/add-nodes.ts
@@ -23,7 +23,7 @@ export const addNodes = (
     // we're just linking to a location that already exists.
     if (!node.inVltStore()) continue
     // remove anything already there
-    const target = scurry.resolve(node.location)
+    const target = node.resolvedLocation(scurry)
     const from = scurry.resolve('')
     const spec = hydrate(node.id, manifest.name, options)
     const onErr = optionalFail(diff, node)

--- a/src/graph/src/reify/build.ts
+++ b/src/graph/src/reify/build.ts
@@ -59,7 +59,7 @@ const visit = async (
   signal: AbortSignal,
   _path: Node[],
 ): Promise<void> => {
-  node.manifest ??= packageJson.read(scurry.resolve(node.location))
+  node.manifest ??= packageJson.read(node.resolvedLocation(scurry))
   const { manifest } = node
   const { scripts = {} } = manifest
 
@@ -80,7 +80,7 @@ const visit = async (
       arg0: 'install',
       ignoreMissing: true,
       packageJson,
-      cwd: node.location,
+      cwd: node.resolvedLocation(scurry),
       projectRoot: node.projectRoot,
       manifest,
     })
@@ -98,7 +98,7 @@ const visit = async (
       arg0: 'prepare',
       ignoreMissing: true,
       packageJson,
-      cwd: node.location,
+      cwd: node.resolvedLocation(scurry),
       projectRoot: node.projectRoot,
       manifest,
     })
@@ -106,7 +106,9 @@ const visit = async (
 
   const chmods: Promise<unknown>[] = []
   for (const bin of Object.values(binPaths(manifest))) {
-    const path = scurry.resolve(node.location, bin)
+    const path = scurry.resolve(
+      `${node.resolvedLocation(scurry)}/${bin}`,
+    )
     chmods.push(makeExecutable(path))
   }
   await Promise.all(chmods)

--- a/src/graph/src/reify/delete-edge.ts
+++ b/src/graph/src/reify/delete-edge.ts
@@ -26,7 +26,7 @@ export const deleteEdge = async (
     spec: { name },
     to,
   } = edge
-  const nm = edge.from.nodeModules
+  const nm = edge.from.nodeModules(scurry)
   const path = scurry.resolve(nm, name)
   const binRoot = scurry.cwd.resolve(`${nm}/.bin`)
   const promises: Promise<unknown>[] = []

--- a/src/graph/test/node.ts
+++ b/src/graph/test/node.ts
@@ -5,6 +5,7 @@ import t from 'tap'
 import { Edge } from '../src/edge.js'
 import { Node } from '../src/node.js'
 import { type GraphLike } from '../src/types.js'
+import { PathScurry } from 'path-scurry'
 
 t.cleanSnapshot = s =>
   s
@@ -292,8 +293,12 @@ t.test('nodeModules path and inVltStore flag', t => {
   }
   const rootMani = { name: 'root' }
   const root = new Node(opts, joinDepIDTuple(['file', '.']), rootMani)
+  const scurry = new PathScurry(opts.projectRoot)
   root.location = '.'
-  t.equal(root.nodeModules, './node_modules')
+  t.equal(
+    root.nodeModules(scurry),
+    scurry.resolve(opts.projectRoot, 'node_modules'),
+  )
   const foo = new Node(
     opts,
     joinDepIDTuple(['registry', '', 'foo@1.2.3']),
@@ -308,10 +313,13 @@ t.test('nodeModules path and inVltStore flag', t => {
   t.equal(foo.inVltStore(), true)
   t.equal(foo.inVltStore(), true, 'test twice for caching')
   t.equal(
-    foo.nodeModules,
-    './node_modules/.vlt/' +
-      joinDepIDTuple(['registry', '', 'foo@1.2.3']) +
-      '/node_modules',
+    foo.nodeModules(scurry),
+    scurry.resolve(
+      opts.projectRoot,
+      './node_modules/.vlt/' +
+        joinDepIDTuple(['registry', '', 'foo@1.2.3']) +
+        '/node_modules',
+    ),
   )
   const bar = new Node(
     opts,
@@ -327,10 +335,13 @@ t.test('nodeModules path and inVltStore flag', t => {
       '/node_modules/@bar/bloo',
   )
   t.equal(
-    bar.nodeModules,
-    './node_modules/.vlt/' +
-      joinDepIDTuple(['registry', '', '@bar/bloo@1.2.3']) +
-      '/node_modules',
+    bar.nodeModules(scurry),
+    scurry.resolve(
+      opts.projectRoot,
+      './node_modules/.vlt/' +
+        joinDepIDTuple(['registry', '', '@bar/bloo@1.2.3']) +
+        '/node_modules',
+    ),
   )
   const outside = new Node(
     opts,
@@ -343,7 +354,10 @@ t.test('nodeModules path and inVltStore flag', t => {
   outside.optional = false
   t.equal(outside.isOptional(), false)
   outside.location = './some/path'
-  t.equal(outside.nodeModules, './some/path/node_modules')
+  t.equal(
+    outside.nodeModules(scurry),
+    scurry.resolve(opts.projectRoot, './some/path/node_modules'),
+  )
   t.end()
 })
 

--- a/src/graph/test/reify/add-edges.ts
+++ b/src/graph/test/reify/add-edges.ts
@@ -24,21 +24,25 @@ t.test('add some edges', async t => {
     },
   })
 
+  const a = {
+    to: {
+      // no manifest
+      resolvedLocation() {
+        return 'some/path'
+      },
+    },
+  }
+  const b = {
+    to: { manifest: {} },
+  }
   const diff = {
     edges: {
       add: new Set([
         // no target, nothing to reify
         {},
-        // this one gets reified
-        {
-          to: {
-            // no manifest
-            location: 'some/path',
-          },
-        },
-        {
-          to: { manifest: {} },
-        },
+        // these one gets reified
+        a,
+        b,
       ]),
     },
   } as unknown as Diff
@@ -51,18 +55,5 @@ t.test('add some edges', async t => {
       {} as unknown as RollbackRemove,
     ),
   )
-  t.strictSame(
-    new Set(reified),
-    new Set([
-      {
-        to: {
-          // no manifest
-          location: 'some/path',
-        },
-      },
-      {
-        to: { manifest: {} },
-      },
-    ]),
-  )
+  t.strictSame(new Set(reified), new Set([a, b]))
 })

--- a/src/graph/test/reify/add-nodes.ts
+++ b/src/graph/test/reify/add-nodes.ts
@@ -30,6 +30,12 @@ const inVltStoreTrue = () => true
 const isOptionalFalse = () => false
 const isOptionalTrue = () => true
 
+const node = (props: Record<string, any>) => ({
+  ...props,
+  resolvedLocation: (scurry: PathScurry) =>
+    scurry.cwd.resolve(props.location).fullpath(),
+})
+
 const diff = {
   to: {
     removeNode: () => {},
@@ -44,7 +50,7 @@ const diff = {
         isOptional: isOptionalFalse,
       },
       // this one gets added
-      {
+      node({
         id: joinDepIDTuple(['registry', '', 'foo@1.2.3']),
         inVltStore: inVltStoreTrue,
         location:
@@ -53,9 +59,9 @@ const diff = {
           '/node_modules/foo',
         name: 'foo',
         isOptional: isOptionalFalse,
-      },
+      }),
       // this one too, but has a manifest
-      {
+      node({
         id: joinDepIDTuple(['registry', '', 'bar@1.2.3']),
         inVltStore: inVltStoreTrue,
         location:
@@ -65,9 +71,9 @@ const diff = {
         name: 'bar',
         manifest: { name: 'bar', version: '1.2.3' },
         isOptional: isOptionalFalse,
-      },
+      }),
       // this one fails, but it's optional, so it's fine
-      {
+      node({
         id: joinDepIDTuple(['registry', '', 'failer@1.2.3']),
         inVltStore: inVltStoreTrue,
         location:
@@ -78,9 +84,9 @@ const diff = {
         manifest: { name: 'failer', version: '1.2.3' },
         isOptional: isOptionalTrue,
         edgesIn: new Set(),
-      },
+      }),
       // this one is incompatible and it's optional, so skip it
-      {
+      node({
         id: joinDepIDTuple([
           'registry',
           '',
@@ -103,9 +109,9 @@ const diff = {
         },
         isOptional: isOptionalTrue,
         edgesIn: new Set(),
-      },
+      }),
       // this one is deprecated and it's optional, so skip it
-      {
+      node({
         id: joinDepIDTuple([
           'registry',
           '',
@@ -128,7 +134,7 @@ const diff = {
         },
         isOptional: isOptionalTrue,
         edgesIn: new Set(),
-      },
+      }),
     ]),
   },
 } as unknown as Diff

--- a/src/graph/test/reify/build.ts
+++ b/src/graph/test/reify/build.ts
@@ -162,9 +162,12 @@ t.test(
       new Set([
         {
           arg0: 'install',
-          cwd: `./node_modules/.vlt/${yid}/node_modules/y`,
+          cwd: resolve(
+            projectRoot,
+            `./node_modules/.vlt/${yid}/node_modules/y`,
+          ),
         },
-        { arg0: 'prepare', cwd: `./src/app` },
+        { arg0: 'prepare', cwd: resolve(projectRoot, `./src/app`) },
       ]),
     )
     t.match(

--- a/src/gui/package.json
+++ b/src/gui/package.json
@@ -5,8 +5,12 @@
   "private": true,
   "dependencies": {
     "@radix-ui/react-dropdown-menu": "^2.1.2",
+    "@radix-ui/react-label": "^2.1.0",
+    "@radix-ui/react-popover": "^1.1.2",
+    "@radix-ui/react-select": "^2.1.2",
     "@radix-ui/react-slot": "^1.1.0",
     "@radix-ui/react-tabs": "^1.1.1",
+    "@radix-ui/react-toast": "^1.2.2",
     "@radix-ui/react-tooltip": "^1.1.3",
     "@vltpkg/dep-id": "workspace:*",
     "@vltpkg/fast-split": "workspace:*",

--- a/src/gui/src/app/dashboard.tsx
+++ b/src/gui/src/app/dashboard.tsx
@@ -45,7 +45,8 @@ export const Dashboard = () => {
         '',
         '/dashboard',
       )
-      window.scrollTo(0, 0)
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+      window.scrollTo?.(0, 0)
     }
 
     startDashboard().catch((err: unknown) => {

--- a/src/gui/src/components/dashboard-grid/index.tsx
+++ b/src/gui/src/components/dashboard-grid/index.tsx
@@ -83,7 +83,7 @@ const selectDashboardItem = async ({
     window.scrollTo(0, 0)
     updateQuery(DEFAULT_QUERY)
     updateActiveRoute('/explore')
-    updateStamp(String(Math.random()).slice(2))
+    updateStamp()
   } else {
     updateActiveRoute('/error')
     updateErrorCause('Failed to select project.')

--- a/src/gui/src/components/explorer-grid/dependency-side-bar.tsx
+++ b/src/gui/src/components/explorer-grid/dependency-side-bar.tsx
@@ -1,0 +1,106 @@
+import { useState } from 'react'
+import { GitFork, PlusIcon, X } from 'lucide-react'
+import { type DepID } from '@vltpkg/dep-id/browser'
+import { Button } from '@/components/ui/button.jsx'
+import { GridHeader } from '@/components/explorer-grid/header.jsx'
+import { SideItem } from '@/components/explorer-grid/side-item.jsx'
+import { type GridItemData } from '@/components/explorer-grid/types.js'
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@/components/ui/tooltip.jsx'
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from '@/components/ui/popover.jsx'
+import { ManageDependencies } from '@/components/explorer-grid/manage-dependencies.jsx'
+
+export type DependencySideBarProps = {
+  dependencies: GridItemData[]
+  importerId?: DepID
+  onDependencyClick: (item: GridItemData) => () => undefined
+}
+
+export const DependencySideBar = ({
+  dependencies,
+  importerId,
+  onDependencyClick,
+}: DependencySideBarProps) => {
+  const [showAddDepPopover, setShowAddDepPopover] = useState(false)
+  const [addedDependencies, setAddedDependencies] = useState<
+    string[]
+  >([])
+  const toggleShowAddDepPopover = () => {
+    setShowAddDepPopover(!showAddDepPopover)
+  }
+  const onDependencyInstall = (name: string) => {
+    toggleShowAddDepPopover()
+    setAddedDependencies([name, ...addedDependencies])
+  }
+  return (
+    <>
+      <GridHeader>
+        <GitFork size={22} className="mr-3 rotate-180" />
+        Dependencies
+        {importerId ?
+          <div className="grow flex justify-end">
+            <Popover
+              open={showAddDepPopover}
+              onOpenChange={toggleShowAddDepPopover}>
+              <PopoverTrigger>
+                <TooltipProvider>
+                  <Tooltip>
+                    <TooltipTrigger>
+                      <Button
+                        role="button"
+                        variant="outline"
+                        size="xs">
+                        {showAddDepPopover ?
+                          <X size={16} />
+                        : <PlusIcon size={16} />}
+                      </Button>
+                    </TooltipTrigger>
+                    <TooltipContent>
+                      <p>Add a new dependency</p>
+                    </TooltipContent>
+                  </Tooltip>
+                </TooltipProvider>
+              </PopoverTrigger>
+              <PopoverContent
+                align="end"
+                className="p-0 w-96 top-0 right-0">
+                <ManageDependencies
+                  importerId={importerId}
+                  onSuccessfulInstall={onDependencyInstall}
+                />
+              </PopoverContent>
+            </Popover>
+          </div>
+        : ''}
+      </GridHeader>
+      {[
+        ...dependencies
+          .filter(item => addedDependencies.includes(item.name))
+          .sort(
+            (a, b) =>
+              addedDependencies.indexOf(a.name) -
+              addedDependencies.indexOf(b.name),
+          ),
+        ...dependencies
+          .filter(item => !addedDependencies.includes(item.name))
+          .sort((a, b) => a.name.localeCompare(b.name, 'en')),
+      ].map((item, idx) => (
+        <SideItem
+          item={item}
+          idx={idx}
+          key={item.id}
+          dependencies={true}
+          onClick={onDependencyClick(item)}
+        />
+      ))}
+    </>
+  )
+}

--- a/src/gui/src/components/explorer-grid/header.tsx
+++ b/src/gui/src/components/explorer-grid/header.tsx
@@ -1,0 +1,20 @@
+import { type ReactNode } from 'react'
+import { cn } from '@/lib/utils.js'
+
+export const GridHeader = ({
+  children,
+  className,
+  ...props
+}: {
+  className?: string
+  children: ReactNode
+}) => (
+  <div
+    className={cn(
+      'pt-6 text-md flex flex-row items-center font-medium',
+      className,
+    )}
+    {...props}>
+    {children}
+  </div>
+)

--- a/src/gui/src/components/explorer-grid/index.tsx
+++ b/src/gui/src/components/explorer-grid/index.tsx
@@ -3,7 +3,6 @@ import {
   GalleryVertical,
   GalleryVerticalEnd,
   GalleryThumbnails,
-  GitFork,
 } from 'lucide-react'
 import { type EdgeLike, type NodeLike } from '@vltpkg/graph'
 import { stringifyNode } from '@vltpkg/graph/browser'
@@ -16,22 +15,9 @@ import { SelectedItem } from '@/components/explorer-grid/selected-item.jsx'
 import {
   type EdgeLoose,
   type GridItemData,
-} from '@/components/explorer-grid//types.js'
-
-const GridHeader = ({
-  children,
-  className,
-  ...props
-}: {
-  className?: string
-  children: React.ReactNode
-}) => (
-  <div
-    className={`pt-6 text-md flex flex-row items-center font-medium ${className}`}
-    {...props}>
-    {children}
-  </div>
-)
+} from '@/components/explorer-grid/types.js'
+import { GridHeader } from '@/components/explorer-grid/header.jsx'
+import { DependencySideBar } from '@/components/explorer-grid/dependency-side-bar.jsx'
 
 const getItemsData = (edges: EdgeLike[], nodes: NodeLike[]) => {
   const items: GridItemData[] = []
@@ -211,6 +197,10 @@ export const ExplorerGrid = () => {
   const items = getItemsData(edges, nodes)
   const selected = items.length === 1
   const [selectedItem] = items
+  const importerId =
+    selected && selectedItem?.to?.importer ?
+      selectedItem.to.id
+    : undefined
   const parent = selected ? selectedItem?.from : undefined
   const parentItem = getParent(selectedItem, parent)
   const dependents =
@@ -308,21 +298,11 @@ export const ExplorerGrid = () => {
       </div>
       <div className="col-span-2">
         {dependencies && dependencies.length > 0 ?
-          <>
-            <GridHeader>
-              <GitFork size={22} className="mr-3 rotate-180" />
-              Dependencies
-            </GridHeader>
-            {dependencies.map((item, idx) => (
-              <SideItem
-                item={item}
-                idx={idx}
-                key={item.id}
-                dependencies={true}
-                onClick={dependencyClick(item)}
-              />
-            ))}
-          </>
+          <DependencySideBar
+            dependencies={dependencies}
+            importerId={importerId}
+            onDependencyClick={dependencyClick}
+          />
         : ''}
       </div>
     </div>

--- a/src/gui/src/components/explorer-grid/manage-dependencies.tsx
+++ b/src/gui/src/components/explorer-grid/manage-dependencies.tsx
@@ -1,0 +1,258 @@
+import { type ChangeEvent, useState } from 'react'
+import { BatteryLow, PackageCheck, PackagePlus } from 'lucide-react'
+import { Button } from '@/components/ui/button.jsx'
+import { CardHeader, CardTitle } from '@/components/ui/card.jsx'
+import { Input } from '@/components/ui/input.jsx'
+import { Label } from '@/components/ui/form-label.jsx'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select.jsx'
+import { PopoverClose } from '@/components/ui/popover.jsx'
+import { LoadingSpinner } from '@/components/ui/loading-spinner.jsx'
+import { type Action } from '@/state/types.js'
+import { useGraphStore } from '@/state/index.js'
+import { useToast } from '@/components/hooks/use-toast.js'
+
+type ManageDependenciesProps = {
+  importerId: string
+  onSuccessfulInstall: (str: string) => void
+}
+
+type InstallPackageOptions = {
+  setError: (str: string) => void
+  setInProgress: (bool: boolean) => void
+  updateStamp: Action['updateStamp']
+  toast: ReturnType<typeof useToast>['toast']
+  name: string
+  version: string
+  type: string
+  importerId: string
+  onSuccessfulInstall: ManageDependenciesProps['onSuccessfulInstall']
+}
+
+const installPackage = async ({
+  setError,
+  setInProgress,
+  updateStamp,
+  toast,
+  importerId,
+  name,
+  version,
+  type,
+  onSuccessfulInstall,
+}: InstallPackageOptions) => {
+  let req
+  try {
+    setInProgress(true)
+    req = await fetch('/install', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        add: {
+          [importerId]: {
+            [name]: {
+              version,
+              type,
+            },
+          },
+        },
+      }),
+    })
+  } catch (err) {
+    console.error(err)
+    setError(String(err))
+    return
+  } finally {
+    setInProgress(false)
+  }
+
+  let installed = false
+  try {
+    installed = (await req.json()) === 'ok'
+  } catch (err) {
+    console.error(err)
+  }
+
+  if (installed) {
+    toast({
+      description: `Successfully installed: ${name}`,
+    })
+    onSuccessfulInstall(name)
+    updateStamp()
+  } else {
+    setError('Failed to install dependency.')
+  }
+}
+
+export const ManageDependencies = ({
+  importerId,
+  onSuccessfulInstall,
+}: ManageDependenciesProps) => {
+  const { toast } = useToast()
+  const updateStamp = useGraphStore(state => state.updateStamp)
+  const updateActiveRoute = useGraphStore(
+    state => state.updateActiveRoute,
+  )
+  const updateErrorCause = useGraphStore(
+    state => state.updateErrorCause,
+  )
+  const [error, setError] = useState<string>('')
+  const [inProgress, setInProgress] = useState<boolean>(false)
+  const [packageName, setPackageName] = useState<string>('')
+  const [packageVersion, setPackageVersion] =
+    useState<string>('latest')
+  const [packageType, setPackageType] = useState<string>('prod')
+  const onInstall = () => {
+    installPackage({
+      setError,
+      setInProgress,
+      updateStamp,
+      toast,
+      importerId,
+      name: packageName,
+      version: packageVersion,
+      type: packageType,
+      onSuccessfulInstall,
+    }).catch((err: unknown) => {
+      console.error(err)
+      updateActiveRoute('/error')
+      updateErrorCause(
+        'Unexpected error trying to install dependency.',
+      )
+    })
+  }
+
+  if (inProgress) {
+    return (
+      <>
+        <CardHeader className="rounded-t-lg relative flex flex-col w-full p-0">
+          <div className="flex items-center justify-between px-6 py-4">
+            <CardTitle className="text-lg font-medium flex items-center">
+              <PackagePlus size={18} className="mr-2" />
+              Add new dependency
+            </CardTitle>
+          </div>
+        </CardHeader>
+        <div className="flex justify-center items-center h-48">
+          <LoadingSpinner />
+        </div>
+      </>
+    )
+  }
+
+  if (error) {
+    return (
+      <>
+        <CardHeader className="rounded-t-lg relative flex flex-col w-full p-0">
+          <div className="flex items-center justify-between px-6 py-4">
+            <CardTitle className="text-lg font-medium flex items-center">
+              <BatteryLow size={18} className="mr-2" />
+              Error
+            </CardTitle>
+          </div>
+        </CardHeader>
+        <div className="flex items-center flex-row justify-between gap-2 flex-wrap p-6 border-muted-foreground/20 border-t-[1px]">
+          <p className="text-sm">{error}</p>
+        </div>
+        <div className="flex justify-end w-full">
+          <PopoverClose>
+            <Button
+              className="m-2"
+              role="cancel"
+              variant="secondary"
+              tabIndex={4}>
+              Close
+            </Button>
+          </PopoverClose>
+        </div>
+      </>
+    )
+  }
+
+  return (
+    <>
+      <CardHeader className="rounded-t-lg relative flex flex-col w-full p-0">
+        <div className="flex items-center justify-between px-6 py-4">
+          <CardTitle className="text-lg font-medium flex items-center">
+            <PackagePlus size={18} className="mr-2" />
+            Add new dependency
+          </CardTitle>
+        </div>
+      </CardHeader>
+      <div className="flex items-center flex-row justify-between gap-2 flex-wrap p-6 border-muted-foreground/20 border-t-[1px]">
+        <Label htmlFor="package-name" className="ml-1">
+          Package Name
+        </Label>
+        <Input
+          id="package-name"
+          tabIndex={1}
+          type="text"
+          role="input"
+          placeholder="Package name"
+          value={packageName}
+          onChange={(e: ChangeEvent) => {
+            const value = (e.currentTarget as HTMLInputElement).value
+            setPackageName(value)
+          }}
+        />
+        <Label htmlFor="package-version" className="ml-1 mt-2">
+          Version | Spec
+        </Label>
+        <Input
+          id="package-version"
+          tabIndex={2}
+          type="text"
+          role="input"
+          value={packageVersion}
+          onChange={(e: ChangeEvent) => {
+            const value = (e.currentTarget as HTMLInputElement).value
+            setPackageVersion(value)
+          }}
+        />
+        <Label htmlFor="package-type" className="ml-1 mt-2">
+          Type
+        </Label>
+        <Select
+          defaultValue={packageType}
+          onValueChange={setPackageType}>
+          <SelectTrigger>
+            <SelectValue tabIndex={3} />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="prod">dependencies</SelectItem>
+            <SelectItem value="dev">devDependencies</SelectItem>
+            <SelectItem value="optional">
+              optionalDependencies
+            </SelectItem>
+            <SelectItem value="peer">peerDependencies</SelectItem>
+          </SelectContent>
+        </Select>
+        <div className="flex justify-end w-full">
+          <PopoverClose>
+            <Button
+              className="mt-2 mr-2"
+              role="cancel"
+              variant="secondary"
+              tabIndex={4}>
+              Cancel
+            </Button>
+          </PopoverClose>
+          <Button
+            className="mt-2"
+            role="submit"
+            tabIndex={5}
+            onClick={onInstall}>
+            <PackageCheck size={16} />
+            Install package
+          </Button>
+        </div>
+      </div>
+    </>
+  )
+}

--- a/src/gui/src/components/hooks/use-toast.ts
+++ b/src/gui/src/components/hooks/use-toast.ts
@@ -1,0 +1,194 @@
+'use client'
+
+// Inspired by react-hot-toast library
+import * as React from 'react'
+
+import {
+  type ToastActionElement,
+  type ToastProps,
+} from '@/components/ui/toast.jsx'
+
+const TOAST_LIMIT = 1
+const TOAST_REMOVE_DELAY = 1000000
+
+type ToasterToast = ToastProps & {
+  id: string
+  title?: React.ReactNode
+  description?: React.ReactNode
+  action?: ToastActionElement
+}
+
+export const actionTypes = {
+  ADD_TOAST: 'ADD_TOAST',
+  UPDATE_TOAST: 'UPDATE_TOAST',
+  DISMISS_TOAST: 'DISMISS_TOAST',
+  REMOVE_TOAST: 'REMOVE_TOAST',
+} as const
+
+let count = 0
+
+function genId() {
+  count = (count + 1) % Number.MAX_SAFE_INTEGER
+  return count.toString()
+}
+
+type ActionType = typeof actionTypes
+
+type Action =
+  | {
+      type: ActionType['ADD_TOAST']
+      toast: ToasterToast
+    }
+  | {
+      type: ActionType['UPDATE_TOAST']
+      toast: Partial<ToasterToast>
+    }
+  | {
+      type: ActionType['DISMISS_TOAST']
+      toastId?: ToasterToast['id']
+    }
+  | {
+      type: ActionType['REMOVE_TOAST']
+      toastId?: ToasterToast['id']
+    }
+
+interface State {
+  toasts: ToasterToast[]
+}
+
+const toastTimeouts = new Map<string, ReturnType<typeof setTimeout>>()
+
+const addToRemoveQueue = (toastId: string) => {
+  if (toastTimeouts.has(toastId)) {
+    return
+  }
+
+  const timeout = setTimeout(() => {
+    toastTimeouts.delete(toastId)
+    dispatch({
+      type: 'REMOVE_TOAST',
+      toastId: toastId,
+    })
+  }, TOAST_REMOVE_DELAY)
+
+  toastTimeouts.set(toastId, timeout)
+}
+
+export const reducer = (state: State, action: Action): State => {
+  switch (action.type) {
+    case 'ADD_TOAST':
+      return {
+        ...state,
+        toasts: [action.toast, ...state.toasts].slice(0, TOAST_LIMIT),
+      }
+
+    case 'UPDATE_TOAST':
+      return {
+        ...state,
+        toasts: state.toasts.map(t =>
+          t.id === action.toast.id ? { ...t, ...action.toast } : t,
+        ),
+      }
+
+    case 'DISMISS_TOAST': {
+      const { toastId } = action
+
+      if (toastId) {
+        addToRemoveQueue(toastId)
+      } else {
+        state.toasts.forEach(toast => {
+          addToRemoveQueue(toast.id)
+        })
+      }
+
+      return {
+        ...state,
+        toasts: state.toasts.map(t =>
+          t.id === toastId || toastId === undefined ?
+            {
+              ...t,
+              open: false,
+            }
+          : t,
+        ),
+      }
+    }
+    case 'REMOVE_TOAST':
+      if (action.toastId === undefined) {
+        return {
+          ...state,
+          toasts: [],
+        }
+      }
+      return {
+        ...state,
+        toasts: state.toasts.filter(t => t.id !== action.toastId),
+      }
+  }
+}
+
+const listeners: ((state: State) => void)[] = []
+
+let memoryState: State = { toasts: [] }
+
+function dispatch(action: Action) {
+  memoryState = reducer(memoryState, action)
+  listeners.forEach(listener => {
+    listener(memoryState)
+  })
+}
+
+type Toast = Omit<ToasterToast, 'id'>
+
+function toast({ ...props }: Toast) {
+  const id = genId()
+
+  const update = (props: ToasterToast) =>
+    dispatch({
+      type: 'UPDATE_TOAST',
+      toast: { ...props, id },
+    })
+  const dismiss = () =>
+    dispatch({ type: 'DISMISS_TOAST', toastId: id })
+
+  dispatch({
+    type: 'ADD_TOAST',
+    toast: {
+      ...props,
+      id,
+      open: true,
+      onOpenChange: open => {
+        if (!open) dismiss()
+      },
+    },
+  })
+
+  return {
+    id: id,
+    dismiss,
+    update,
+  }
+}
+
+function useToast() {
+  const [state, setState] = React.useState<State>(memoryState)
+
+  React.useEffect(() => {
+    listeners.push(setState)
+    return () => {
+      const index = listeners.indexOf(setState)
+      if (index > -1) {
+        listeners.splice(index, 1)
+      }
+    }
+  }, [state])
+
+  return {
+    ...state,
+    toast,
+    dismiss: (toastId?: string) =>
+      dispatch({ type: 'DISMISS_TOAST', toastId }),
+  }
+}
+
+export { useToast, toast }

--- a/src/gui/src/components/navigation/sidebar.tsx
+++ b/src/gui/src/components/navigation/sidebar.tsx
@@ -781,7 +781,7 @@ const selectProjectItem = async ({
     window.scrollTo(0, 0)
     updateQuery(DEFAULT_QUERY)
     updateActiveRoute('/explore')
-    updateStamp(String(Math.random()).slice(2))
+    updateStamp()
   } else {
     updateActiveRoute('/error')
     updateErrorCause('Failed to select project.')

--- a/src/gui/src/components/ui/button.tsx
+++ b/src/gui/src/components/ui/button.tsx
@@ -22,6 +22,7 @@ const buttonVariants = cva(
       },
       size: {
         default: 'h-10 px-4 py-2',
+        xs: 'h-6 rounded-sm px-1',
         sm: 'h-9 rounded-md px-3',
         lg: 'h-11 rounded-md px-8',
         icon: 'h-10 w-10',

--- a/src/gui/src/components/ui/form-label.tsx
+++ b/src/gui/src/components/ui/form-label.tsx
@@ -1,0 +1,24 @@
+import * as React from 'react'
+import * as LabelPrimitive from '@radix-ui/react-label'
+import { cva, type VariantProps } from 'class-variance-authority'
+
+import { cn } from '@/lib/utils.js'
+
+const labelVariants = cva(
+  'text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70',
+)
+
+const Label = React.forwardRef<
+  React.ElementRef<typeof LabelPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof LabelPrimitive.Root> &
+    VariantProps<typeof labelVariants>
+>(({ className, ...props }, ref) => (
+  <LabelPrimitive.Root
+    ref={ref}
+    className={cn(labelVariants(), className)}
+    {...props}
+  />
+))
+Label.displayName = LabelPrimitive.Root.displayName
+
+export { Label }

--- a/src/gui/src/components/ui/loading-spinner.tsx
+++ b/src/gui/src/components/ui/loading-spinner.tsx
@@ -1,0 +1,28 @@
+import * as React from 'react'
+import { LoaderIcon } from 'lucide-react'
+import { cn } from '@/lib/utils.js'
+
+const spinnerVariants = 'w-6 h-6 rounded-full animate-spin'
+
+interface LoadingSpinnerProps
+  extends React.HTMLAttributes<SVGSVGElement> {
+  className?: string
+}
+
+const LoadingSpinner = React.forwardRef<
+  SVGSVGElement,
+  LoadingSpinnerProps
+>((props, ref) => {
+  const { className, ...rest } = props
+  return (
+    <LoaderIcon
+      ref={ref}
+      className={cn(spinnerVariants, className)}
+      {...rest}
+    />
+  )
+})
+
+LoadingSpinner.displayName = 'LoadingSpinner'
+
+export { LoadingSpinner }

--- a/src/gui/src/components/ui/popover.tsx
+++ b/src/gui/src/components/ui/popover.tsx
@@ -1,0 +1,36 @@
+import * as React from 'react'
+import * as PopoverPrimitive from '@radix-ui/react-popover'
+
+import { cn } from '@/lib/utils.js'
+
+const Popover = PopoverPrimitive.Root
+
+const PopoverTrigger = PopoverPrimitive.Trigger
+
+const PopoverClose = PopoverPrimitive.Close
+
+const PopoverContent = React.forwardRef<
+  React.ElementRef<typeof PopoverPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof PopoverPrimitive.Content>
+>(
+  (
+    { className, align = 'center', sideOffset = 4, ...props },
+    ref,
+  ) => (
+    <PopoverPrimitive.Portal>
+      <PopoverPrimitive.Content
+        ref={ref}
+        align={align}
+        sideOffset={sideOffset}
+        className={cn(
+          'z-50 w-72 rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
+          className,
+        )}
+        {...props}
+      />
+    </PopoverPrimitive.Portal>
+  ),
+)
+PopoverContent.displayName = PopoverPrimitive.Content.displayName
+
+export { Popover, PopoverClose, PopoverTrigger, PopoverContent }

--- a/src/gui/src/components/ui/select.tsx
+++ b/src/gui/src/components/ui/select.tsx
@@ -1,0 +1,160 @@
+import * as React from 'react'
+import * as SelectPrimitive from '@radix-ui/react-select'
+import { Check, ChevronDown, ChevronUp } from 'lucide-react'
+
+import { cn } from '@/lib/utils.js'
+
+const Select = SelectPrimitive.Root
+
+const SelectGroup = SelectPrimitive.Group
+
+const SelectValue = SelectPrimitive.Value
+
+const SelectTrigger = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.Trigger>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Trigger>
+>(({ className, children, ...props }, ref) => (
+  <SelectPrimitive.Trigger
+    ref={ref}
+    className={cn(
+      'flex h-10 w-full items-center justify-between rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1',
+      className,
+    )}
+    {...props}>
+    {children}
+    <SelectPrimitive.Icon asChild>
+      <ChevronDown className="h-4 w-4 opacity-50" />
+    </SelectPrimitive.Icon>
+  </SelectPrimitive.Trigger>
+))
+SelectTrigger.displayName = SelectPrimitive.Trigger.displayName
+
+const SelectScrollUpButton = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.ScrollUpButton>,
+  React.ComponentPropsWithoutRef<
+    typeof SelectPrimitive.ScrollUpButton
+  >
+>(({ className, ...props }, ref) => (
+  <SelectPrimitive.ScrollUpButton
+    ref={ref}
+    className={cn(
+      'flex cursor-default items-center justify-center py-1',
+      className,
+    )}
+    {...props}>
+    <ChevronUp className="h-4 w-4" />
+  </SelectPrimitive.ScrollUpButton>
+))
+SelectScrollUpButton.displayName =
+  SelectPrimitive.ScrollUpButton.displayName
+
+const SelectScrollDownButton = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.ScrollDownButton>,
+  React.ComponentPropsWithoutRef<
+    typeof SelectPrimitive.ScrollDownButton
+  >
+>(({ className, ...props }, ref) => (
+  <SelectPrimitive.ScrollDownButton
+    ref={ref}
+    className={cn(
+      'flex cursor-default items-center justify-center py-1',
+      className,
+    )}
+    {...props}>
+    <ChevronDown className="h-4 w-4" />
+  </SelectPrimitive.ScrollDownButton>
+))
+SelectScrollDownButton.displayName =
+  SelectPrimitive.ScrollDownButton.displayName
+
+const SelectContent = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Content>
+>(({ className, children, position = 'popper', ...props }, ref) => (
+  <SelectPrimitive.Portal>
+    <SelectPrimitive.Content
+      ref={ref}
+      className={cn(
+        'relative z-50 max-h-96 min-w-[8rem] overflow-hidden rounded-md border bg-popover text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
+        position === 'popper' &&
+          'data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1',
+        className,
+      )}
+      position={position}
+      {...props}>
+      <SelectScrollUpButton />
+      <SelectPrimitive.Viewport
+        className={cn(
+          'p-1',
+          position === 'popper' &&
+            'h-[var(--radix-select-trigger-height)] w-full min-w-[var(--radix-select-trigger-width)]',
+        )}>
+        {children}
+      </SelectPrimitive.Viewport>
+      <SelectScrollDownButton />
+    </SelectPrimitive.Content>
+  </SelectPrimitive.Portal>
+))
+SelectContent.displayName = SelectPrimitive.Content.displayName
+
+const SelectLabel = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.Label>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Label>
+>(({ className, ...props }, ref) => (
+  <SelectPrimitive.Label
+    ref={ref}
+    className={cn(
+      'py-1.5 pl-8 pr-2 text-sm font-semibold',
+      className,
+    )}
+    {...props}
+  />
+))
+SelectLabel.displayName = SelectPrimitive.Label.displayName
+
+const SelectItem = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.Item>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Item>
+>(({ className, children, ...props }, ref) => (
+  <SelectPrimitive.Item
+    ref={ref}
+    className={cn(
+      'relative flex w-full cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
+      className,
+    )}
+    {...props}>
+    <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
+      <SelectPrimitive.ItemIndicator>
+        <Check className="h-4 w-4" />
+      </SelectPrimitive.ItemIndicator>
+    </span>
+
+    <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
+  </SelectPrimitive.Item>
+))
+SelectItem.displayName = SelectPrimitive.Item.displayName
+
+const SelectSeparator = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.Separator>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Separator>
+>(({ className, ...props }, ref) => (
+  <SelectPrimitive.Separator
+    ref={ref}
+    className={cn('-mx-1 my-1 h-px bg-muted', className)}
+    {...props}
+  />
+))
+SelectSeparator.displayName = SelectPrimitive.Separator.displayName
+
+export {
+  Select,
+  SelectGroup,
+  SelectValue,
+  SelectTrigger,
+  SelectContent,
+  SelectLabel,
+  SelectItem,
+  SelectSeparator,
+  SelectScrollUpButton,
+  SelectScrollDownButton,
+}

--- a/src/gui/src/components/ui/toast.tsx
+++ b/src/gui/src/components/ui/toast.tsx
@@ -1,0 +1,128 @@
+'use client'
+
+import * as React from 'react'
+import * as ToastPrimitives from '@radix-ui/react-toast'
+import { cva, type VariantProps } from 'class-variance-authority'
+import { X } from 'lucide-react'
+
+import { cn } from '@/lib/utils.js'
+
+const ToastProvider = ToastPrimitives.Provider
+
+const ToastViewport = React.forwardRef<
+  React.ElementRef<typeof ToastPrimitives.Viewport>,
+  React.ComponentPropsWithoutRef<typeof ToastPrimitives.Viewport>
+>(({ className, ...props }, ref) => (
+  <ToastPrimitives.Viewport
+    ref={ref}
+    className={cn(
+      'fixed top-0 z-[100] flex max-h-screen w-full flex-col-reverse p-4 sm:bottom-0 sm:right-0 sm:top-auto sm:flex-col md:max-w-[420px]',
+      className,
+    )}
+    {...props}
+  />
+))
+ToastViewport.displayName = ToastPrimitives.Viewport.displayName
+
+const toastVariants = cva(
+  'group pointer-events-auto relative flex w-full items-center justify-between space-x-4 overflow-hidden rounded-md border p-6 pr-8 shadow-lg transition-all data-[swipe=cancel]:translate-x-0 data-[swipe=end]:translate-x-[var(--radix-toast-swipe-end-x)] data-[swipe=move]:translate-x-[var(--radix-toast-swipe-move-x)] data-[swipe=move]:transition-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[swipe=end]:animate-out data-[state=closed]:fade-out-80 data-[state=closed]:slide-out-to-right-full data-[state=open]:slide-in-from-top-full data-[state=open]:sm:slide-in-from-bottom-full',
+  {
+    variants: {
+      variant: {
+        default: 'border bg-background text-foreground',
+        destructive:
+          'destructive group border-destructive bg-destructive text-destructive-foreground',
+      },
+    },
+    defaultVariants: {
+      variant: 'default',
+    },
+  },
+)
+
+const Toast = React.forwardRef<
+  React.ElementRef<typeof ToastPrimitives.Root>,
+  React.ComponentPropsWithoutRef<typeof ToastPrimitives.Root> &
+    VariantProps<typeof toastVariants>
+>(({ className, variant, ...props }, ref) => {
+  return (
+    <ToastPrimitives.Root
+      ref={ref}
+      className={cn(toastVariants({ variant }), className)}
+      {...props}
+    />
+  )
+})
+Toast.displayName = ToastPrimitives.Root.displayName
+
+const ToastAction = React.forwardRef<
+  React.ElementRef<typeof ToastPrimitives.Action>,
+  React.ComponentPropsWithoutRef<typeof ToastPrimitives.Action>
+>(({ className, ...props }, ref) => (
+  <ToastPrimitives.Action
+    ref={ref}
+    className={cn(
+      'inline-flex h-8 shrink-0 items-center justify-center rounded-md border bg-transparent px-3 text-sm font-medium ring-offset-background transition-colors hover:bg-secondary focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 group-[.destructive]:border-muted/40 group-[.destructive]:hover:border-destructive/30 group-[.destructive]:hover:bg-destructive group-[.destructive]:hover:text-destructive-foreground group-[.destructive]:focus:ring-destructive',
+      className,
+    )}
+    {...props}
+  />
+))
+ToastAction.displayName = ToastPrimitives.Action.displayName
+
+const ToastClose = React.forwardRef<
+  React.ElementRef<typeof ToastPrimitives.Close>,
+  React.ComponentPropsWithoutRef<typeof ToastPrimitives.Close>
+>(({ className, ...props }, ref) => (
+  <ToastPrimitives.Close
+    ref={ref}
+    className={cn(
+      'absolute right-2 top-2 rounded-md p-1 text-foreground/50 opacity-0 transition-opacity hover:text-foreground focus:opacity-100 focus:outline-none focus:ring-2 group-hover:opacity-100 group-[.destructive]:text-red-300 group-[.destructive]:hover:text-red-50 group-[.destructive]:focus:ring-red-400 group-[.destructive]:focus:ring-offset-red-600',
+      className,
+    )}
+    toast-close=""
+    {...props}>
+    <X className="h-4 w-4" />
+  </ToastPrimitives.Close>
+))
+ToastClose.displayName = ToastPrimitives.Close.displayName
+
+const ToastTitle = React.forwardRef<
+  React.ElementRef<typeof ToastPrimitives.Title>,
+  React.ComponentPropsWithoutRef<typeof ToastPrimitives.Title>
+>(({ className, ...props }, ref) => (
+  <ToastPrimitives.Title
+    ref={ref}
+    className={cn('text-sm font-semibold', className)}
+    {...props}
+  />
+))
+ToastTitle.displayName = ToastPrimitives.Title.displayName
+
+const ToastDescription = React.forwardRef<
+  React.ElementRef<typeof ToastPrimitives.Description>,
+  React.ComponentPropsWithoutRef<typeof ToastPrimitives.Description>
+>(({ className, ...props }, ref) => (
+  <ToastPrimitives.Description
+    ref={ref}
+    className={cn('text-sm opacity-90', className)}
+    {...props}
+  />
+))
+ToastDescription.displayName = ToastPrimitives.Description.displayName
+
+type ToastProps = React.ComponentPropsWithoutRef<typeof Toast>
+
+type ToastActionElement = React.ReactElement<typeof ToastAction>
+
+export {
+  type ToastProps,
+  type ToastActionElement,
+  ToastProvider,
+  ToastViewport,
+  Toast,
+  ToastTitle,
+  ToastDescription,
+  ToastClose,
+  ToastAction,
+}

--- a/src/gui/src/components/ui/toaster.tsx
+++ b/src/gui/src/components/ui/toaster.tsx
@@ -1,0 +1,41 @@
+'use client'
+
+import { useToast } from '@/components/hooks/use-toast.js'
+import {
+  Toast,
+  ToastClose,
+  ToastDescription,
+  ToastProvider,
+  ToastTitle,
+  ToastViewport,
+} from '@/components/ui/toast.jsx'
+
+export function Toaster() {
+  const { toasts } = useToast()
+
+  return (
+    <ToastProvider>
+      {toasts.map(function ({
+        id,
+        title,
+        description,
+        action,
+        ...props
+      }) {
+        return (
+          <Toast key={id} {...props}>
+            <div className="grid gap-1">
+              {title && <ToastTitle>{title}</ToastTitle>}
+              {description && (
+                <ToastDescription>{description}</ToastDescription>
+              )}
+            </div>
+            {action}
+            <ToastClose />
+          </Toast>
+        )
+      })}
+      <ToastViewport />
+    </ToastProvider>
+  )
+}

--- a/src/gui/src/layout.tsx
+++ b/src/gui/src/layout.tsx
@@ -9,6 +9,7 @@ import { ErrorFound } from './app/error-found.jsx'
 import { Dashboard } from './app/dashboard.jsx'
 
 import { useGraphStore } from './state/index.js'
+import { Toaster } from '@/components/ui/toaster.jsx'
 
 interface LayoutProps {
   children: React.ReactNode
@@ -31,6 +32,7 @@ const Layout = () => {
           <Footer />
         </Layout.Content>
       </Layout.Body>
+      <Toaster />
     </Layout.Wrapper>
   )
 }

--- a/src/gui/src/state/index.ts
+++ b/src/gui/src/state/index.ts
@@ -7,6 +7,8 @@ import {
 
 export const DEFAULT_QUERY = ':project > *'
 
+const newStamp = () => String(Math.random()).slice(2)
+
 const initialState: State = {
   activeRoute: location.pathname,
   dashboard: undefined,
@@ -22,7 +24,7 @@ const initialState: State = {
   q: undefined,
   selectedNode: undefined,
   specOptions: undefined,
-  stamp: String(Math.random()).slice(2),
+  stamp: newStamp(),
   theme: localStorage.getItem('vite-ui-theme') as State['theme'],
   savedProjects: JSON.parse(
     localStorage.getItem('saved-projects') || '[]',
@@ -60,7 +62,7 @@ export const useGraphStore = create<Action & State>((set, get) => {
       set(() => ({ selectedNode })),
     updateSpecOptions: (specOptions: State['specOptions']) =>
       set(() => ({ specOptions })),
-    updateStamp: (stamp: string) => set(() => ({ stamp })),
+    updateStamp: () => set(() => ({ stamp: newStamp() })),
     updateTheme: (theme: State['theme']) => set(() => ({ theme })),
     reset: () => set(initialState),
     updateSavedProjects: (savedProjects: State['savedProjects']) =>

--- a/src/gui/src/state/types.ts
+++ b/src/gui/src/state/types.ts
@@ -20,7 +20,7 @@ export type Action = {
   updateNodes: (nodes: State['nodes']) => void
   updateSelectedNode: (node: State['selectedNode']) => void
   updateSpecOptions: (specOptions: State['specOptions']) => void
-  updateStamp: (stamp: string) => void
+  updateStamp: () => void
   updateTheme: (theme: State['theme']) => void
   reset: () => void
   saveProject: (item: DashboardDataProject) => void
@@ -90,6 +90,7 @@ export type State = {
    * The query string typed by the user in the interface.
    */
   query: string
+  // TODO: remove selectedNode as it's unused
   /**
    * Reference to a currently selected node.
    */

--- a/src/gui/test/components/explorer-grid/__snapshots__/dependency-side-bar.tsx.snap
+++ b/src/gui/test/components/explorer-grid/__snapshots__/dependency-side-bar.tsx.snap
@@ -1,0 +1,49 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`dependency-side-bar 1`] = `
+
+<div>
+  <div class="pt-6 text-md flex flex-row items-center font-medium">
+    <gui-git-fork-icon
+      size="22"
+      classname="mr-3 rotate-180"
+    >
+    </gui-git-fork-icon>
+    Dependencies
+  </div>
+  <gui-side-item
+    item="[object Object]"
+    idx="0"
+    dependencies="true"
+  >
+  </gui-side-item>
+  <gui-side-item
+    item="[object Object]"
+    idx="1"
+    dependencies="true"
+  >
+  </gui-side-item>
+  <gui-side-item
+    item="[object Object]"
+    idx="2"
+    dependencies="true"
+  >
+  </gui-side-item>
+</div>
+
+`;
+
+exports[`dependency-side-bar no items 1`] = `
+
+<div>
+  <div class="pt-6 text-md flex flex-row items-center font-medium">
+    <gui-git-fork-icon
+      size="22"
+      classname="mr-3 rotate-180"
+    >
+    </gui-git-fork-icon>
+    Dependencies
+  </div>
+</div>
+
+`;

--- a/src/gui/test/components/explorer-grid/__snapshots__/header.tsx.snap
+++ b/src/gui/test/components/explorer-grid/__snapshots__/header.tsx.snap
@@ -1,0 +1,21 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`grid header render custom class 1`] = `
+
+<div>
+  <div class="pt-6 text-md flex flex-row items-center font-medium custom-class">
+    With a custom class
+  </div>
+</div>
+
+`;
+
+exports[`grid header render default 1`] = `
+
+<div>
+  <div class="pt-6 text-md flex flex-row items-center font-medium">
+    Some text content
+  </div>
+</div>
+
+`;

--- a/src/gui/test/components/explorer-grid/__snapshots__/index.tsx.snap
+++ b/src/gui/test/components/explorer-grid/__snapshots__/index.tsx.snap
@@ -7,7 +7,7 @@ exports[`explorer-grid render default 1`] = `
     <div class="col-span-2">
     </div>
     <div class="col-span-3">
-      <div class="pt-6 text-md flex flex-row items-center font-medium undefined">
+      <div class="pt-6 text-md flex flex-row items-center font-medium">
         <svg
           xmlns="http://www.w3.org/2000/svg"
           width="22"
@@ -46,7 +46,7 @@ exports[`explorer-grid renders workspace with edges in 1`] = `
 <div>
   <div class="grow grid grid-cols-7 gap-4 px-8 bg-secondary dark:bg-black">
     <div class="col-span-2">
-      <div class="pt-6 text-md flex flex-row items-center font-medium undefined">
+      <div class="pt-6 text-md flex flex-row items-center font-medium">
         <svg
           xmlns="http://www.w3.org/2000/svg"
           width="22"
@@ -110,7 +110,7 @@ exports[`explorer-grid renders workspace with edges in 1`] = `
       </div>
     </div>
     <div class="col-span-3">
-      <div class="pt-6 text-md flex flex-row items-center font-medium undefined">
+      <div class="pt-6 text-md flex flex-row items-center font-medium">
         <svg
           xmlns="http://www.w3.org/2000/svg"
           width="22"

--- a/src/gui/test/components/explorer-grid/__snapshots__/manage-dependencies.tsx.snap
+++ b/src/gui/test/components/explorer-grid/__snapshots__/manage-dependencies.tsx.snap
@@ -1,0 +1,98 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`manage-dependencies render default 1`] = `
+
+<div>
+  <gui-card-header classname="rounded-t-lg relative flex flex-col w-full p-0">
+    <div class="flex items-center justify-between px-6 py-4">
+      <gui-card-title classname="text-lg font-medium flex items-center">
+        <gui-package-plus-icon
+          size="18"
+          classname="mr-2"
+        >
+        </gui-package-plus-icon>
+        Add new dependency
+      </gui-card-title>
+    </div>
+  </gui-card-header>
+  <div class="flex items-center flex-row justify-between gap-2 flex-wrap p-6 border-muted-foreground/20 border-t-[1px]">
+    <gui-label
+      htmlfor="package-name"
+      classname="ml-1"
+    >
+      Package Name
+    </gui-label>
+    <gui-input
+      id="package-name"
+      tabindex="1"
+      type="text"
+      role="input"
+      placeholder="Package name"
+      value
+    >
+    </gui-input>
+    <gui-label
+      htmlfor="package-version"
+      classname="ml-1 mt-2"
+    >
+      Version | Spec
+    </gui-label>
+    <gui-input
+      id="package-version"
+      tabindex="2"
+      type="text"
+      role="input"
+      value="latest"
+    >
+    </gui-input>
+    <gui-label
+      htmlfor="package-type"
+      classname="ml-1 mt-2"
+    >
+      Type
+    </gui-label>
+    <gui-select>
+      <gui-select-trigger>
+        <gui-select-value tabindex="3">
+        </gui-select-value>
+      </gui-select-trigger>
+      <gui-select-content>
+        <gui-select-item value="prod">
+          dependencies
+        </gui-select-item>
+        <gui-select-item value="dev">
+          devDependencies
+        </gui-select-item>
+        <gui-select-item value="optional">
+          optionalDependencies
+        </gui-select-item>
+        <gui-select-item value="peer">
+          peerDependencies
+        </gui-select-item>
+      </gui-select-content>
+    </gui-select>
+    <div class="flex justify-end w-full">
+      <gui-popover-close>
+        <gui-button
+          classname="mt-2 mr-2"
+          role="cancel"
+          variant="secondary"
+          tabindex="4"
+        >
+          Cancel
+        </gui-button>
+      </gui-popover-close>
+      <gui-button
+        classname="mt-2"
+        role="submit"
+        tabindex="5"
+      >
+        <gui-package-check-icon size="16">
+        </gui-package-check-icon>
+        Install package
+      </gui-button>
+    </div>
+  </div>
+</div>
+
+`;

--- a/src/gui/test/components/explorer-grid/dependency-side-bar.tsx
+++ b/src/gui/test/components/explorer-grid/dependency-side-bar.tsx
@@ -1,0 +1,82 @@
+import { vi, test, expect, afterEach } from 'vitest'
+import { cleanup, render } from '@testing-library/react'
+import html from 'diffable-html'
+import { useGraphStore as useStore } from '@/state/index.js'
+import { DependencySideBar } from '@/components/explorer-grid/dependency-side-bar.jsx'
+import { type GridItemData } from '@/components/explorer-grid/types.js'
+
+vi.mock('lucide-react', () => ({
+  GitFork: 'gui-git-fork-icon',
+  PlusIcon: 'gui-plus-icon',
+  X: 'gui-x-icon',
+}))
+
+vi.mock('@/components/ui/button.jsx', () => ({
+  Button: 'gui-button',
+}))
+
+vi.mock('@/components/explore-grid/header.jsx', () => ({
+  Header: 'gui-header',
+}))
+
+vi.mock('@/components/explorer-grid/side-item.jsx', () => ({
+  SideItem: 'gui-side-item',
+}))
+
+vi.mock('@/components/explorer-grid/types.js', () => ({
+  GridItemData: 'gui-grid-item-data',
+}))
+
+vi.mock('@/components/ui/tooltip.jsx', () => ({
+  Tooltip: 'gui-tooltip',
+  TooltipContent: 'gui-tooltip-content',
+  TooltipProvider: 'gui-tooltip-provider',
+  TooltipTrigger: 'gui-tooltip-trigger',
+}))
+
+vi.mock('@/components/ui/popover.jsx', () => ({
+  Popover: 'gui-popover',
+  PopoverContent: 'gui-popover-content',
+  PopoverTrigger: 'gui-popover-trigger',
+}))
+
+vi.mock('@/components/explorer-grid/manage-dependencies.jsx', () => ({
+  ManageDependencies: 'gui-manage-dependencies',
+}))
+
+expect.addSnapshotSerializer({
+  serialize: v => html(v),
+  test: () => true,
+})
+
+afterEach(() => {
+  const CleanUp = () => (useStore(state => state.reset)(), '')
+  render(<CleanUp />)
+  cleanup()
+})
+
+test('dependency-side-bar', async () => {
+  const dependencies = [
+    { name: 'simple-output', id: '1' } as GridItemData,
+    { name: 'abbrev', id: '2' } as GridItemData,
+    { name: '@vltpkg/semver', id: '3' } as GridItemData,
+  ]
+  render(
+    <DependencySideBar
+      dependencies={dependencies}
+      onDependencyClick={() => () => {}}
+    />,
+  )
+  expect(window.document.body.innerHTML).toMatchSnapshot()
+})
+
+test('dependency-side-bar no items', async () => {
+  const dependencies: GridItemData[] = []
+  render(
+    <DependencySideBar
+      dependencies={dependencies}
+      onDependencyClick={() => () => {}}
+    />,
+  )
+  expect(window.document.body.innerHTML).toMatchSnapshot()
+})

--- a/src/gui/test/components/explorer-grid/header.tsx
+++ b/src/gui/test/components/explorer-grid/header.tsx
@@ -1,0 +1,27 @@
+import { test, expect, afterEach } from 'vitest'
+import { cleanup, render } from '@testing-library/react'
+import html from 'diffable-html'
+import { GridHeader } from '@/components/explorer-grid/header.jsx'
+
+expect.addSnapshotSerializer({
+  serialize: v => html(v),
+  test: () => true,
+})
+
+afterEach(() => {
+  cleanup()
+})
+
+test('grid header render default', async () => {
+  render(<GridHeader>Some text content</GridHeader>)
+  expect(window.document.body.innerHTML).toMatchSnapshot()
+})
+
+test('grid header render custom class', async () => {
+  render(
+    <GridHeader className="custom-class">
+      With a custom class
+    </GridHeader>,
+  )
+  expect(window.document.body.innerHTML).toMatchSnapshot()
+})

--- a/src/gui/test/components/explorer-grid/manage-dependencies.tsx
+++ b/src/gui/test/components/explorer-grid/manage-dependencies.tsx
@@ -1,0 +1,65 @@
+import { vi, test, expect, afterEach } from 'vitest'
+import { cleanup, render } from '@testing-library/react'
+import html from 'diffable-html'
+import { useGraphStore as useStore } from '@/state/index.js'
+import { ManageDependencies } from '@/components/explorer-grid/manage-dependencies.jsx'
+
+vi.mock('lucide-react', () => ({
+  BatteryLow: 'gui-battery-low-icon',
+  PackageCheck: 'gui-package-check-icon',
+  PackagePlus: 'gui-package-plus-icon',
+}))
+
+vi.mock('@/components/ui/button.jsx', () => ({
+  Button: 'gui-button',
+}))
+
+vi.mock('@/components/ui/card.jsx', () => ({
+  CardHeader: 'gui-card-header',
+  CardTitle: 'gui-card-title',
+}))
+
+vi.mock('@/components/ui/input.jsx', () => ({
+  Input: 'gui-input',
+}))
+
+vi.mock('@/components/ui/form-label.jsx', () => ({
+  Label: 'gui-label',
+}))
+
+vi.mock('@/components/ui/select.jsx', () => ({
+  Select: 'gui-select',
+  SelectContent: 'gui-select-content',
+  SelectItem: 'gui-select-item',
+  SelectTrigger: 'gui-select-trigger',
+  SelectValue: 'gui-select-value',
+}))
+
+vi.mock('@/components/ui/popover.jsx', () => ({
+  PopoverClose: 'gui-popover-close',
+}))
+
+vi.mock('@/components/ui/loading-spinner.jsx', () => ({
+  LoadingSpinner: 'gui-loading-spinner',
+}))
+
+expect.addSnapshotSerializer({
+  serialize: v => html(v),
+  test: () => true,
+})
+
+afterEach(() => {
+  const CleanUp = () => (useStore(state => state.reset)(), '')
+  render(<CleanUp />)
+  cleanup()
+})
+
+test('manage-dependencies render default', async () => {
+  render(
+    <ManageDependencies
+      importerId="file:."
+      onSuccessfulInstall={() => {}}
+    />,
+  )
+  expect(window.document.body.innerHTML).toMatchSnapshot()
+})

--- a/src/gui/test/components/ui/__snapshots__/loading-spinner.tsx.snap
+++ b/src/gui/test/components/ui/__snapshots__/loading-spinner.tsx.snap
@@ -1,0 +1,37 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`loading-spinner render default 1`] = `
+
+<div>
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width="24"
+    height="24"
+    viewbox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    stroke-width="2"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+    class="lucide lucide-loader w-6 h-6 rounded-full animate-spin"
+  >
+    <path d="M12 2v4">
+    </path>
+    <path d="m16.2 7.8 2.9-2.9">
+    </path>
+    <path d="M18 12h4">
+    </path>
+    <path d="m16.2 16.2 2.9 2.9">
+    </path>
+    <path d="M12 18v4">
+    </path>
+    <path d="m4.9 19.1 2.9-2.9">
+    </path>
+    <path d="M2 12h4">
+    </path>
+    <path d="m4.9 4.9 2.9 2.9">
+    </path>
+  </svg>
+</div>
+
+`;

--- a/src/gui/test/components/ui/__snapshots__/popover.tsx.snap
+++ b/src/gui/test/components/ui/__snapshots__/popover.tsx.snap
@@ -1,0 +1,62 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`popover render default 1`] = `
+
+<div>
+  <button
+    type="button"
+    aria-haspopup="dialog"
+    aria-expanded="false"
+    aria-controls="radix-:r0:"
+    data-state="closed"
+  >
+    Trigger Element
+  </button>
+</div>
+
+`;
+
+exports[`popover render open 1`] = `
+
+<span
+  data-radix-focus-guard
+  tabindex="0"
+  style="outline: none; opacity: 0; position: fixed; pointer-events: none;"
+>
+</span>
+<div>
+  <button
+    type="button"
+    aria-haspopup="dialog"
+    aria-expanded="true"
+    aria-controls="radix-:r1:"
+    data-state="open"
+  >
+    Trigger Element
+  </button>
+</div>
+<div
+  data-radix-popper-content-wrapper
+  style="position: fixed; left: 0px; top: 0px; transform: translate(0, -200%); min-width: max-content;"
+>
+  <div
+    data-side="bottom"
+    data-align="center"
+    data-state="open"
+    role="dialog"
+    id="radix-:r1:"
+    class="z-50 w-72 rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2"
+    style="--radix-popover-content-transform-origin: var(--radix-popper-transform-origin); --radix-popover-content-available-width: var(--radix-popper-available-width); --radix-popover-content-available-height: var(--radix-popper-available-height); --radix-popover-trigger-width: var(--radix-popper-anchor-width); --radix-popover-trigger-height: var(--radix-popper-anchor-height); animation: none;"
+    tabindex="-1"
+  >
+    Content
+  </div>
+</div>
+<span
+  data-radix-focus-guard
+  tabindex="0"
+  style="outline: none; opacity: 0; position: fixed; pointer-events: none;"
+>
+</span>
+
+`;

--- a/src/gui/test/components/ui/__snapshots__/select.tsx.snap
+++ b/src/gui/test/components/ui/__snapshots__/select.tsx.snap
@@ -1,0 +1,205 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`select render default 1`] = `
+
+<div>
+  <button
+    type="button"
+    role="combobox"
+    aria-controls="radix-:r0:"
+    aria-expanded="false"
+    aria-autocomplete="none"
+    dir="ltr"
+    data-state="closed"
+    class="flex h-10 w-full items-center justify-between rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 [&amp;>span]:line-clamp-1"
+  >
+    <span
+      tabindex="3"
+      style="pointer-events: none;"
+    >
+      dependencies
+    </span>
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="24"
+      height="24"
+      viewbox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      stroke-width="2"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      class="lucide lucide-chevron-down h-4 w-4 opacity-50"
+      aria-hidden="true"
+    >
+      <path d="m6 9 6 6 6-6">
+      </path>
+    </svg>
+  </button>
+</div>
+
+`;
+
+exports[`select render open 1`] = `
+
+<span
+  data-radix-focus-guard
+  tabindex="0"
+  style="outline: none; opacity: 0; position: fixed; pointer-events: none;"
+  data-aria-hidden="true"
+  aria-hidden="true"
+>
+</span>
+<div
+  data-aria-hidden="true"
+  aria-hidden="true"
+>
+  <button
+    type="button"
+    role="combobox"
+    aria-controls="radix-:r5:"
+    aria-expanded="true"
+    aria-autocomplete="none"
+    dir="ltr"
+    data-state="open"
+    class="flex h-10 w-full items-center justify-between rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 [&amp;>span]:line-clamp-1"
+  >
+    <span
+      tabindex="3"
+      style="pointer-events: none;"
+    >
+      dependencies
+    </span>
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="24"
+      height="24"
+      viewbox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      stroke-width="2"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      class="lucide lucide-chevron-down h-4 w-4 opacity-50"
+      aria-hidden="true"
+    >
+      <path d="m6 9 6 6 6-6">
+      </path>
+    </svg>
+  </button>
+</div>
+<div
+  data-radix-popper-content-wrapper
+  style="position: fixed; left: 0px; top: 0px; transform: translate(0, -200%); min-width: max-content;"
+  dir="ltr"
+>
+  <div
+    data-side="bottom"
+    data-align="start"
+    role="listbox"
+    id="radix-:r5:"
+    data-state="open"
+    dir="ltr"
+    class="relative z-50 max-h-96 min-w-[8rem] overflow-hidden rounded-md border bg-popover text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1"
+    style="box-sizing: border-box; display: flex; flex-direction: column; outline: none; --radix-select-content-transform-origin: var(--radix-popper-transform-origin); --radix-select-content-available-width: var(--radix-popper-available-width); --radix-select-content-available-height: var(--radix-popper-available-height); --radix-select-trigger-width: var(--radix-popper-anchor-width); --radix-select-trigger-height: var(--radix-popper-anchor-height); animation: none; pointer-events: auto;"
+    tabindex="-1"
+  >
+    <style>
+      [data-radix-select-viewport]{scrollbar-width:none;-ms-overflow-style:none;-webkit-overflow-scrolling:touch;}[data-radix-select-viewport]::-webkit-scrollbar{display:none}
+    </style>
+    <div
+      data-radix-select-viewport
+      role="presentation"
+      class="p-1 h-[var(--radix-select-trigger-height)] w-full min-w-[var(--radix-select-trigger-width)]"
+      style="position: relative; flex: 1; overflow: hidden auto;"
+    >
+      <div
+        role="option"
+        aria-labelledby="radix-:r6:"
+        aria-selected="false"
+        data-state="checked"
+        tabindex="-1"
+        class="relative flex w-full cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50"
+        data-radix-collection-item
+      >
+        <span class="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
+          <span aria-hidden="true">
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              width="24"
+              height="24"
+              viewbox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              class="lucide lucide-check h-4 w-4"
+            >
+              <path d="M20 6 9 17l-5-5">
+              </path>
+            </svg>
+          </span>
+        </span>
+        <span id="radix-:r6:">
+          dependencies
+        </span>
+      </div>
+      <div
+        role="option"
+        aria-labelledby="radix-:r7:"
+        aria-selected="false"
+        data-state="unchecked"
+        tabindex="-1"
+        class="relative flex w-full cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50"
+        data-radix-collection-item
+      >
+        <span class="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
+        </span>
+        <span id="radix-:r7:">
+          devDependencies
+        </span>
+      </div>
+      <div
+        role="option"
+        aria-labelledby="radix-:r8:"
+        aria-selected="false"
+        data-state="unchecked"
+        tabindex="-1"
+        class="relative flex w-full cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50"
+        data-radix-collection-item
+      >
+        <span class="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
+        </span>
+        <span id="radix-:r8:">
+          optionalDependencies
+        </span>
+      </div>
+      <div
+        role="option"
+        aria-labelledby="radix-:r9:"
+        aria-selected="false"
+        data-state="unchecked"
+        tabindex="-1"
+        class="relative flex w-full cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50"
+        data-radix-collection-item
+      >
+        <span class="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
+        </span>
+        <span id="radix-:r9:">
+          peerDependencies
+        </span>
+      </div>
+    </div>
+  </div>
+</div>
+<span
+  data-radix-focus-guard
+  tabindex="0"
+  style="outline: none; opacity: 0; position: fixed; pointer-events: none;"
+  data-aria-hidden="true"
+  aria-hidden="true"
+>
+</span>
+
+`;

--- a/src/gui/test/components/ui/__snapshots__/toast.tsx.snap
+++ b/src/gui/test/components/ui/__snapshots__/toast.tsx.snap
@@ -1,0 +1,57 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`toaster render default 1`] = `
+
+<div>
+  <div
+    role="region"
+    aria-label="Notifications (F8)"
+    tabindex="-1"
+    style
+  >
+    <span
+      aria-hidden="true"
+      tabindex="0"
+      style="position: fixed; border: 0px; width: 1px; height: 1px; padding: 0px; margin: -1px; overflow: hidden; clip: rect(0px, 0px, 0px, 0px); white-space: nowrap; word-wrap: normal;"
+    >
+    </span>
+    <ol
+      tabindex="-1"
+      class="fixed top-0 z-[100] flex max-h-screen w-full flex-col-reverse p-4 sm:bottom-0 sm:right-0 sm:top-auto sm:flex-col md:max-w-[420px]"
+    >
+      <li
+        role="status"
+        aria-live="off"
+        aria-atomic="true"
+        tabindex="0"
+        data-state="open"
+        data-swipe-direction="right"
+        class="group pointer-events-auto relative flex w-full items-center justify-between space-x-4 overflow-hidden rounded-md p-6 pr-8 shadow-lg transition-all data-[swipe=cancel]:translate-x-0 data-[swipe=end]:translate-x-[var(--radix-toast-swipe-end-x)] data-[swipe=move]:translate-x-[var(--radix-toast-swipe-move-x)] data-[swipe=move]:transition-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[swipe=end]:animate-out data-[state=closed]:fade-out-80 data-[state=closed]:slide-out-to-right-full data-[state=open]:slide-in-from-top-full data-[state=open]:sm:slide-in-from-bottom-full border bg-background text-foreground"
+        style="user-select: none;"
+        data-radix-collection-item
+      >
+        <div class="text-sm font-semibold">
+          Title
+        </div>
+        <div class="text-sm opacity-90">
+          Description
+        </div>
+      </li>
+    </ol>
+    <span
+      aria-hidden="true"
+      tabindex="0"
+      style="position: fixed; border: 0px; width: 1px; height: 1px; padding: 0px; margin: -1px; overflow: hidden; clip: rect(0px, 0px, 0px, 0px); white-space: nowrap; word-wrap: normal;"
+    >
+    </span>
+  </div>
+</div>
+<span
+  role="status"
+  aria-live="assertive"
+  aria-atomic="true"
+  style="position: absolute; border: 0px; width: 1px; height: 1px; padding: 0px; margin: -1px; overflow: hidden; clip: rect(0px, 0px, 0px, 0px); white-space: nowrap; word-wrap: normal;"
+>
+</span>
+
+`;

--- a/src/gui/test/components/ui/__snapshots__/toaster.tsx.snap
+++ b/src/gui/test/components/ui/__snapshots__/toaster.tsx.snap
@@ -1,0 +1,20 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`toaster render default 1`] = `
+
+<div>
+  <div
+    role="region"
+    aria-label="Notifications (F8)"
+    tabindex="-1"
+    style="pointer-events: none;"
+  >
+    <ol
+      tabindex="-1"
+      class="fixed top-0 z-[100] flex max-h-screen w-full flex-col-reverse p-4 sm:bottom-0 sm:right-0 sm:top-auto sm:flex-col md:max-w-[420px]"
+    >
+    </ol>
+  </div>
+</div>
+
+`;

--- a/src/gui/test/components/ui/loading-spinner.tsx
+++ b/src/gui/test/components/ui/loading-spinner.tsx
@@ -1,0 +1,19 @@
+import { test, expect, afterEach } from 'vitest'
+import { cleanup, render } from '@testing-library/react'
+import html from 'diffable-html'
+import { LoadingSpinner } from '@/components/ui/loading-spinner.jsx'
+
+expect.addSnapshotSerializer({
+  serialize: v => html(v),
+  test: () => true,
+})
+
+afterEach(() => {
+  cleanup()
+})
+
+test('loading-spinner render default', async () => {
+  const Container = () => <LoadingSpinner />
+  render(<Container />)
+  expect(window.document.body.innerHTML).toMatchSnapshot()
+})

--- a/src/gui/test/components/ui/popover.tsx
+++ b/src/gui/test/components/ui/popover.tsx
@@ -1,0 +1,39 @@
+import { test, expect, afterEach } from 'vitest'
+import { cleanup, render } from '@testing-library/react'
+import html from 'diffable-html'
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from '@/components/ui/popover.jsx'
+
+expect.addSnapshotSerializer({
+  serialize: v => html(v),
+  test: () => true,
+})
+
+afterEach(() => {
+  cleanup()
+})
+
+test('popover render default', async () => {
+  const Container = () => (
+    <Popover>
+      <PopoverTrigger>Trigger Element</PopoverTrigger>
+      <PopoverContent>Content</PopoverContent>
+    </Popover>
+  )
+  render(<Container />)
+  expect(window.document.body.innerHTML).toMatchSnapshot()
+})
+
+test('popover render open', async () => {
+  const Container = () => (
+    <Popover open={true}>
+      <PopoverTrigger>Trigger Element</PopoverTrigger>
+      <PopoverContent>Content</PopoverContent>
+    </Popover>
+  )
+  render(<Container />)
+  expect(window.document.body.innerHTML).toMatchSnapshot()
+})

--- a/src/gui/test/components/ui/select.tsx
+++ b/src/gui/test/components/ui/select.tsx
@@ -1,0 +1,55 @@
+import { test, expect, afterEach } from 'vitest'
+import { cleanup, render } from '@testing-library/react'
+import html from 'diffable-html'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select.jsx'
+
+expect.addSnapshotSerializer({
+  serialize: v => html(v),
+  test: () => true,
+})
+
+afterEach(() => {
+  cleanup()
+})
+
+test('select render default', async () => {
+  const Container = () => (
+    <Select defaultValue="prod">
+      <SelectTrigger>
+        <SelectValue tabIndex={3} />
+      </SelectTrigger>
+      <SelectContent>
+        <SelectItem value="prod">dependencies</SelectItem>
+        <SelectItem value="dev">devDependencies</SelectItem>
+        <SelectItem value="optional">optionalDependencies</SelectItem>
+        <SelectItem value="peer">peerDependencies</SelectItem>
+      </SelectContent>
+    </Select>
+  )
+  render(<Container />)
+  expect(window.document.body.innerHTML).toMatchSnapshot()
+})
+
+test('select render open', async () => {
+  const Container = () => (
+    <Select defaultValue="prod" open={true}>
+      <SelectTrigger>
+        <SelectValue tabIndex={3} />
+      </SelectTrigger>
+      <SelectContent>
+        <SelectItem value="prod">dependencies</SelectItem>
+        <SelectItem value="dev">devDependencies</SelectItem>
+        <SelectItem value="optional">optionalDependencies</SelectItem>
+        <SelectItem value="peer">peerDependencies</SelectItem>
+      </SelectContent>
+    </Select>
+  )
+  render(<Container />)
+  expect(window.document.body.innerHTML).toMatchSnapshot()
+})

--- a/src/gui/test/components/ui/toast.tsx
+++ b/src/gui/test/components/ui/toast.tsx
@@ -1,0 +1,33 @@
+import { test, expect, afterEach } from 'vitest'
+import { cleanup, render } from '@testing-library/react'
+import html from 'diffable-html'
+import {
+  Toast,
+  ToastProvider,
+  ToastViewport,
+  ToastTitle,
+  ToastDescription,
+} from '@/components/ui/toast.jsx'
+
+expect.addSnapshotSerializer({
+  serialize: v => html(v),
+  test: () => true,
+})
+
+afterEach(() => {
+  cleanup()
+})
+
+test('toaster render default', async () => {
+  const Container = () => (
+    <ToastProvider>
+      <Toast>
+        <ToastTitle>Title</ToastTitle>
+        <ToastDescription>Description</ToastDescription>
+      </Toast>
+      <ToastViewport />
+    </ToastProvider>
+  )
+  render(<Container />)
+  expect(window.document.body.innerHTML).toMatchSnapshot()
+})

--- a/src/gui/test/components/ui/toaster.tsx
+++ b/src/gui/test/components/ui/toaster.tsx
@@ -1,0 +1,19 @@
+import { test, expect, afterEach } from 'vitest'
+import { cleanup, render } from '@testing-library/react'
+import html from 'diffable-html'
+import { Toaster } from '@/components/ui/toaster.jsx'
+
+expect.addSnapshotSerializer({
+  serialize: v => html(v),
+  test: () => true,
+})
+
+afterEach(() => {
+  cleanup()
+})
+
+test('toaster render default', async () => {
+  const Container = () => <Toaster />
+  render(<Container />)
+  expect(window.document.body.innerHTML).toMatchSnapshot()
+})

--- a/src/vlt/src/commands/install.ts
+++ b/src/vlt/src/commands/install.ts
@@ -1,8 +1,7 @@
-import { actual, ideal, reify } from '@vltpkg/graph'
-import { PackageInfoClient } from '@vltpkg/package-info'
 import { parseAddArgs } from '../parse-add-remove-args.js'
 import { type CliCommandUsage, type CliCommandFn } from '../types.js'
 import { commandUsage } from '../config/usage.js'
+import { install } from '../install.js'
 
 export const usage: CliCommandUsage = () =>
   commandUsage({
@@ -15,31 +14,5 @@ export const usage: CliCommandUsage = () =>
 export const command: CliCommandFn = async conf => {
   const monorepo = conf.options.monorepo
   const { add } = parseAddArgs(conf, monorepo)
-  const mainManifest = conf.options.packageJson.read(
-    conf.options.projectRoot,
-  )
-
-  const graph = await ideal.build({
-    ...conf.options,
-    add,
-    mainManifest,
-    monorepo,
-    loadManifests: true,
-    packageInfo: new PackageInfoClient(conf.options),
-  })
-  const act = actual.load({
-    ...conf.options,
-    mainManifest,
-    monorepo,
-    loadManifests: true,
-  })
-  await reify({
-    ...conf.options,
-    packageInfo: new PackageInfoClient(conf.options),
-    add,
-    actual: act,
-    monorepo,
-    graph,
-    loadManifests: true,
-  })
+  await install({ add, conf })
 }

--- a/src/vlt/src/install.ts
+++ b/src/vlt/src/install.ts
@@ -1,0 +1,46 @@
+import {
+  type AddImportersDependenciesMap,
+  type RemoveImportersDependenciesMap,
+  actual,
+  ideal,
+  reify,
+} from '@vltpkg/graph'
+import { PackageInfoClient } from '@vltpkg/package-info'
+import { type LoadedConfig } from './types.js'
+
+export type InstallOptions = {
+  conf: LoadedConfig
+  add?: AddImportersDependenciesMap
+  remove?: RemoveImportersDependenciesMap
+}
+
+export const install = async ({ add, conf }: InstallOptions) => {
+  const monorepo = conf.options.monorepo
+  const mainManifest = conf.options.packageJson.read(
+    conf.options.projectRoot,
+  )
+
+  const graph = await ideal.build({
+    ...conf.options,
+    add,
+    mainManifest,
+    monorepo,
+    loadManifests: true,
+    packageInfo: new PackageInfoClient(conf.options),
+  })
+  const act = actual.load({
+    ...conf.options,
+    mainManifest,
+    monorepo,
+    loadManifests: true,
+  })
+  await reify({
+    ...conf.options,
+    packageInfo: new PackageInfoClient(conf.options),
+    add,
+    actual: act,
+    monorepo,
+    graph,
+    loadManifests: true,
+  })
+}

--- a/src/vlt/tap-snapshots/test/commands/install.ts.test.cjs
+++ b/src/vlt/tap-snapshots/test/commands/install.ts.test.cjs
@@ -5,146 +5,16 @@
  * Make sure to inspect the output below.  Do not ignore changes!
  */
 'use strict'
-exports[`test/commands/install.ts > TAP > should call reify with expected options 1`] = `
-Object {
-  "actual": "actual.load result",
-  "add": Map {
-    "file·." => Map {},
-  },
-  "graph": "buildideal result adds 0 new package(s)",
-  "loadManifests": true,
-  "monorepo": undefined,
-  "packageInfo": PackageInfoClient {
-    "monorepo": undefined,
-    "options": Object {
-      "packageJson": PackageJson {},
-      projectRoot: #
-      "scurry": PathScurry {},
-    },
-    "packageJson": PackageJson {},
-  },
-  "packageJson": PackageJson {},
-  projectRoot: #
-  "scurry": PathScurry {},
-}
+exports[`test/commands/install.ts > TAP > should call install with expected options 1`] = `
+parse add args 
+install
+
 `
 
-exports[`test/commands/install.ts > TAP > should reify installing a new dependency 1`] = `
-Object {
-  "actual": "actual.load result",
-  "add": Map {
-    "file·." => Map {
-      "abbrev" => Object {
-        "spec": Spec {
-          "bareSpec": "2",
-          "conventionalRegistryTarball": undefined,
-          "distTag": undefined,
-          "file": undefined,
-          "gitCommittish": undefined,
-          "gitRemote": undefined,
-          "gitSelector": undefined,
-          "gitSelectorParsed": undefined,
-          "name": "abbrev",
-          "namedGitHost": undefined,
-          "namedGitHostPath": undefined,
-          "namedRegistry": undefined,
-          "options": Object {
-            "git-host-archives": Object {
-              "bitbucket": "https://bitbucket.org/$1/$2/get/$committish.tar.gz",
-              "gist": "https://codeload.github.com/gist/$1/tar.gz/$committish",
-              "github": "https://codeload.github.com/$1/$2/tar.gz/$committish",
-              "gitlab": "https://gitlab.com/$1/$2/repository/archive.tar.gz?ref=$committish",
-            },
-            "git-hosts": Object {
-              "bitbucket": "git+ssh://git@bitbucket.org:$1/$2.git",
-              "gist": "git+ssh://git@gist.github.com/$1.git",
-              "github": "git+ssh://git@github.com:$1/$2.git",
-              "gitlab": "git+ssh://git@gitlab.com:$1/$2.git",
-            },
-            "packageJson": PackageJson {},
-            projectRoot: #
-            "registries": Object {
-              "npm": "https://registry.npmjs.org/",
-            },
-            "registry": "https://registry.npmjs.org/",
-            "scope-registries": Object {},
-            "scurry": PathScurry {},
-          },
-          "range": Range {
-            "includePrerelease": false,
-            "isAny": false,
-            "isSingle": false,
-            "raw": "2",
-            "set": Array [
-              Comparator {
-                "includePrerelease": false,
-                "isAny": false,
-                "isNone": false,
-                "raw": "2",
-                "tokens": Array [
-                  "2",
-                ],
-                "tuples": Array [
-                  Array [
-                    ">=",
-                    Version {
-                      "build": undefined,
-                      "major": 2,
-                      "minor": 0,
-                      "patch": 0,
-                      "prerelease": undefined,
-                      "raw": "2",
-                    },
-                  ],
-                  Array [
-                    "<",
-                    Version {
-                      "build": undefined,
-                      "major": 3,
-                      "minor": 0,
-                      "patch": 0,
-                      "prerelease": Array [
-                        0,
-                      ],
-                      "raw": "2",
-                    },
-                  ],
-                ],
-              },
-            ],
-          },
-          "registry": "https://registry.npmjs.org/",
-          "registrySpec": "2",
-          "remoteURL": undefined,
-          "scope": undefined,
-          "scopeRegistry": undefined,
-          "semver": "2",
-          "spec": "abbrev@2",
-          "subspec": undefined,
-          "type": "registry",
-          "workspace": undefined,
-          "workspaceSpec": undefined,
-        },
-        "type": "dev",
-      },
-    },
-  },
-  "graph": "buildideal result adds 1 new package(s)",
-  "loadManifests": true,
-  "monorepo": undefined,
-  "packageInfo": PackageInfoClient {
-    "monorepo": undefined,
-    "options": Object {
-      "packageJson": PackageJson {},
-      projectRoot: #
-      "scurry": PathScurry {},
-    },
-    "packageJson": PackageJson {},
-  },
-  "packageJson": PackageJson {},
-  projectRoot: #
-  "scurry": PathScurry {},
-}
+exports[`test/commands/install.ts > TAP > should install adding a new dependency 1`] = `
+parse add args from abbrev@2, with values save-dev,true
+install
+
 `
 
 exports[`test/commands/install.ts > TAP > usage 1`] = `

--- a/src/vlt/tap-snapshots/test/install.ts.test.cjs
+++ b/src/vlt/tap-snapshots/test/install.ts.test.cjs
@@ -1,0 +1,20 @@
+/* IMPORTANT
+ * This snapshot file is auto-generated, but designed for humans.
+ * It should be checked into source control and tracked carefully.
+ * Re-generate by setting TAP_SNAPSHOT=1 and running tests.
+ * Make sure to inspect the output below.  Do not ignore changes!
+ */
+'use strict'
+exports[`test/install.ts > TAP > install > should call build -> actual.load -> reify 1`] = `
+buildideal result adds 0 new package(s) 
+actual.load
+reify
+
+`
+
+exports[`test/install.ts > TAP > install > should call build adding new dependency 1`] = `
+buildideal result adds 1 new package(s) 
+actual.load
+reify
+
+`

--- a/src/vlt/tap-snapshots/test/start-gui.ts.test.cjs
+++ b/src/vlt/tap-snapshots/test/start-gui.ts.test.cjs
@@ -5,7 +5,12 @@
  * Make sure to inspect the output below.  Do not ignore changes!
  */
 'use strict'
-exports[`test/start-gui.ts > TAP > e2e server test > should copy all files to tmp directory 1`] = `
+exports[`test/start-gui.ts > TAP > e2e server test > /install > should install dependencies 1`] = `
+install
+
+`
+
+exports[`test/start-gui.ts > TAP > e2e server test > /select-project > should copy all files to tmp directory 1`] = `
 Array [
   "dashboard.json",
   "favicon.ico",
@@ -18,13 +23,13 @@ Array [
 ]
 `
 
-exports[`test/start-gui.ts > TAP > e2e server test > should log the server start message 1`] = `
+exports[`test/start-gui.ts > TAP > e2e server test > /select-project > should log the server start message 1`] = `
 Array [
   "⚡️ vlt GUI running at http://localhost:8017",
 ]
 `
 
-exports[`test/start-gui.ts > TAP > e2e server test > should update graph.json with new data 1`] = `
+exports[`test/start-gui.ts > TAP > e2e server test > /select-project > should update graph.json with new data 1`] = `
 {
   "hasDashboard": true,
   "importers": [
@@ -49,7 +54,7 @@ exports[`test/start-gui.ts > TAP > e2e server test > should update graph.json wi
 }
 `
 
-exports[`test/start-gui.ts > TAP > e2e server test > should write graph.json with data from the current project 1`] = `
+exports[`test/start-gui.ts > TAP > e2e server test > /select-project > should write graph.json with data from the current project 1`] = `
 {
   "hasDashboard": true,
   "importers": [
@@ -110,6 +115,287 @@ Array [
   "index.js.map",
   "main.css",
 ]
+`
+
+exports[`test/start-gui.ts > TAP > parseInstallArgs > multiple item added to root and workspace 1`] = `
+Object {
+  "add": Map {
+    "file·." => Map {
+      "abbrev" => Object {
+        "spec": Spec {
+          "bareSpec": "latest",
+          "conventionalRegistryTarball": undefined,
+          "distTag": "latest",
+          "file": undefined,
+          "gitCommittish": undefined,
+          "gitRemote": undefined,
+          "gitSelector": undefined,
+          "gitSelectorParsed": undefined,
+          "name": "abbrev",
+          "namedGitHost": undefined,
+          "namedGitHostPath": undefined,
+          "namedRegistry": undefined,
+          "options": Object {
+            "git-host-archives": Object {
+              "bitbucket": "https://bitbucket.org/$1/$2/get/$committish.tar.gz",
+              "gist": "https://codeload.github.com/gist/$1/tar.gz/$committish",
+              "github": "https://codeload.github.com/$1/$2/tar.gz/$committish",
+              "gitlab": "https://gitlab.com/$1/$2/repository/archive.tar.gz?ref=$committish",
+            },
+            "git-hosts": Object {
+              "bitbucket": "git+ssh://git@bitbucket.org:$1/$2.git",
+              "gist": "git+ssh://git@gist.github.com/$1.git",
+              "github": "git+ssh://git@github.com:$1/$2.git",
+              "gitlab": "git+ssh://git@gitlab.com:$1/$2.git",
+            },
+            "registries": Object {
+              "npm": "https://registry.npmjs.org/",
+            },
+            "registry": "https://registry.npmjs.org/",
+            "scope-registries": Object {},
+          },
+          "range": undefined,
+          "registry": "https://registry.npmjs.org/",
+          "registrySpec": "latest",
+          "remoteURL": undefined,
+          "scope": undefined,
+          "scopeRegistry": undefined,
+          "semver": undefined,
+          "spec": "abbrev@latest",
+          "subspec": undefined,
+          "type": "registry",
+          "workspace": undefined,
+          "workspaceSpec": undefined,
+        },
+        "type": "dev",
+      },
+    },
+    "workspace·packages§a" => Map {
+      "english-days" => Object {
+        "spec": Spec {
+          "bareSpec": "latest",
+          "conventionalRegistryTarball": undefined,
+          "distTag": "latest",
+          "file": undefined,
+          "gitCommittish": undefined,
+          "gitRemote": undefined,
+          "gitSelector": undefined,
+          "gitSelectorParsed": undefined,
+          "name": "english-days",
+          "namedGitHost": undefined,
+          "namedGitHostPath": undefined,
+          "namedRegistry": undefined,
+          "options": Object {
+            "git-host-archives": Object {
+              "bitbucket": "https://bitbucket.org/$1/$2/get/$committish.tar.gz",
+              "gist": "https://codeload.github.com/gist/$1/tar.gz/$committish",
+              "github": "https://codeload.github.com/$1/$2/tar.gz/$committish",
+              "gitlab": "https://gitlab.com/$1/$2/repository/archive.tar.gz?ref=$committish",
+            },
+            "git-hosts": Object {
+              "bitbucket": "git+ssh://git@bitbucket.org:$1/$2.git",
+              "gist": "git+ssh://git@gist.github.com/$1.git",
+              "github": "git+ssh://git@github.com:$1/$2.git",
+              "gitlab": "git+ssh://git@gitlab.com:$1/$2.git",
+            },
+            "registries": Object {
+              "npm": "https://registry.npmjs.org/",
+            },
+            "registry": "https://registry.npmjs.org/",
+            "scope-registries": Object {},
+          },
+          "range": undefined,
+          "registry": "https://registry.npmjs.org/",
+          "registrySpec": "latest",
+          "remoteURL": undefined,
+          "scope": undefined,
+          "scopeRegistry": undefined,
+          "semver": undefined,
+          "spec": "english-days@latest",
+          "subspec": undefined,
+          "type": "registry",
+          "workspace": undefined,
+          "workspaceSpec": undefined,
+        },
+        "type": "prod",
+      },
+      "simple-output" => Object {
+        "spec": Spec {
+          "bareSpec": "latest",
+          "conventionalRegistryTarball": undefined,
+          "distTag": "latest",
+          "file": undefined,
+          "gitCommittish": undefined,
+          "gitRemote": undefined,
+          "gitSelector": undefined,
+          "gitSelectorParsed": undefined,
+          "name": "simple-output",
+          "namedGitHost": undefined,
+          "namedGitHostPath": undefined,
+          "namedRegistry": undefined,
+          "options": Object {
+            "git-host-archives": Object {
+              "bitbucket": "https://bitbucket.org/$1/$2/get/$committish.tar.gz",
+              "gist": "https://codeload.github.com/gist/$1/tar.gz/$committish",
+              "github": "https://codeload.github.com/$1/$2/tar.gz/$committish",
+              "gitlab": "https://gitlab.com/$1/$2/repository/archive.tar.gz?ref=$committish",
+            },
+            "git-hosts": Object {
+              "bitbucket": "git+ssh://git@bitbucket.org:$1/$2.git",
+              "gist": "git+ssh://git@gist.github.com/$1.git",
+              "github": "git+ssh://git@github.com:$1/$2.git",
+              "gitlab": "git+ssh://git@gitlab.com:$1/$2.git",
+            },
+            "registries": Object {
+              "npm": "https://registry.npmjs.org/",
+            },
+            "registry": "https://registry.npmjs.org/",
+            "scope-registries": Object {},
+          },
+          "range": undefined,
+          "registry": "https://registry.npmjs.org/",
+          "registrySpec": "latest",
+          "remoteURL": undefined,
+          "scope": undefined,
+          "scopeRegistry": undefined,
+          "semver": undefined,
+          "spec": "simple-output@latest",
+          "subspec": undefined,
+          "type": "registry",
+          "workspace": undefined,
+          "workspaceSpec": undefined,
+        },
+        "type": "prod",
+      },
+    },
+  },
+  "conf": Object {},
+}
+`
+
+exports[`test/start-gui.ts > TAP > parseInstallArgs > no item added to root 1`] = `
+Object {
+  "add": Map {
+    "file·." => Map {},
+  },
+  "conf": Object {},
+}
+`
+
+exports[`test/start-gui.ts > TAP > parseInstallArgs > single item added to root 1`] = `
+Object {
+  "add": Map {
+    "file·." => Map {
+      "abbrev" => Object {
+        "spec": Spec {
+          "bareSpec": "latest",
+          "conventionalRegistryTarball": undefined,
+          "distTag": "latest",
+          "file": undefined,
+          "gitCommittish": undefined,
+          "gitRemote": undefined,
+          "gitSelector": undefined,
+          "gitSelectorParsed": undefined,
+          "name": "abbrev",
+          "namedGitHost": undefined,
+          "namedGitHostPath": undefined,
+          "namedRegistry": undefined,
+          "options": Object {
+            "git-host-archives": Object {
+              "bitbucket": "https://bitbucket.org/$1/$2/get/$committish.tar.gz",
+              "gist": "https://codeload.github.com/gist/$1/tar.gz/$committish",
+              "github": "https://codeload.github.com/$1/$2/tar.gz/$committish",
+              "gitlab": "https://gitlab.com/$1/$2/repository/archive.tar.gz?ref=$committish",
+            },
+            "git-hosts": Object {
+              "bitbucket": "git+ssh://git@bitbucket.org:$1/$2.git",
+              "gist": "git+ssh://git@gist.github.com/$1.git",
+              "github": "git+ssh://git@github.com:$1/$2.git",
+              "gitlab": "git+ssh://git@gitlab.com:$1/$2.git",
+            },
+            "registries": Object {
+              "npm": "https://registry.npmjs.org/",
+            },
+            "registry": "https://registry.npmjs.org/",
+            "scope-registries": Object {},
+          },
+          "range": undefined,
+          "registry": "https://registry.npmjs.org/",
+          "registrySpec": "latest",
+          "remoteURL": undefined,
+          "scope": undefined,
+          "scopeRegistry": undefined,
+          "semver": undefined,
+          "spec": "abbrev@latest",
+          "subspec": undefined,
+          "type": "registry",
+          "workspace": undefined,
+          "workspaceSpec": undefined,
+        },
+        "type": "dev",
+      },
+    },
+  },
+  "conf": Object {},
+}
+`
+
+exports[`test/start-gui.ts > TAP > parseInstallArgs > single item added to workspace 1`] = `
+Object {
+  "add": Map {
+    "workspace·packages§a" => Map {
+      "abbrev" => Object {
+        "spec": Spec {
+          "bareSpec": "latest",
+          "conventionalRegistryTarball": undefined,
+          "distTag": "latest",
+          "file": undefined,
+          "gitCommittish": undefined,
+          "gitRemote": undefined,
+          "gitSelector": undefined,
+          "gitSelectorParsed": undefined,
+          "name": "abbrev",
+          "namedGitHost": undefined,
+          "namedGitHostPath": undefined,
+          "namedRegistry": undefined,
+          "options": Object {
+            "git-host-archives": Object {
+              "bitbucket": "https://bitbucket.org/$1/$2/get/$committish.tar.gz",
+              "gist": "https://codeload.github.com/gist/$1/tar.gz/$committish",
+              "github": "https://codeload.github.com/$1/$2/tar.gz/$committish",
+              "gitlab": "https://gitlab.com/$1/$2/repository/archive.tar.gz?ref=$committish",
+            },
+            "git-hosts": Object {
+              "bitbucket": "git+ssh://git@bitbucket.org:$1/$2.git",
+              "gist": "git+ssh://git@gist.github.com/$1.git",
+              "github": "git+ssh://git@github.com:$1/$2.git",
+              "gitlab": "git+ssh://git@gitlab.com:$1/$2.git",
+            },
+            "registries": Object {
+              "npm": "https://registry.npmjs.org/",
+            },
+            "registry": "https://registry.npmjs.org/",
+            "scope-registries": Object {},
+          },
+          "range": undefined,
+          "registry": "https://registry.npmjs.org/",
+          "registrySpec": "latest",
+          "remoteURL": undefined,
+          "scope": undefined,
+          "scopeRegistry": undefined,
+          "semver": undefined,
+          "spec": "abbrev@latest",
+          "subspec": undefined,
+          "type": "registry",
+          "workspace": undefined,
+          "workspaceSpec": undefined,
+        },
+        "type": "optional",
+      },
+    },
+  },
+  "conf": Object {},
+}
 `
 
 exports[`test/start-gui.ts > TAP > starts gui data and server > should copy all files to tmp directory 1`] = `

--- a/src/vlt/test/commands/install.ts
+++ b/src/vlt/test/commands/install.ts
@@ -1,53 +1,30 @@
 import t from 'tap'
-import { joinDepIDTuple } from '@vltpkg/dep-id'
-import { type BuildIdealOptions } from '@vltpkg/graph'
 import { type LoadedConfig } from '../../src/config/index.js'
 
-t.cleanSnapshot = s =>
-  s.replace(/^(\s+)"?projectRoot"?: .*$/gm, '$1projectRoot: #')
-
-class PackageJson {
-  read() {
-    return { name: 'my-project', version: '1.0.0' }
-  }
-}
-
-// eslint-disable-next-line @typescript-eslint/no-extraneous-class
-class PathScurry {}
-
-const options = {
-  projectRoot: t.testdirName,
-  scurry: new PathScurry(),
-  packageJson: new PackageJson(),
-}
-let reifyOpts: any
-
-const rootDepID = joinDepIDTuple(['file', '.'])
+const options = {}
+let log = ''
 
 const { usage, command } = await t.mockImport<
   typeof import('../../src/commands/install.js')
 >('../../src/commands/install.js', {
-  '@vltpkg/graph': {
-    ideal: {
-      build: async ({ add }: BuildIdealOptions) =>
-        `buildideal result adds ${add?.get(rootDepID)?.size || 0} new package(s)`,
-    },
-    actual: {
-      load: () => 'actual.load result',
-    },
-    reify: async (reifyOptions: any) => {
-      reifyOpts = reifyOptions
+  '../../src/install.js': {
+    async install() {
+      log += 'install\n'
     },
   },
-  '@vltpkg/package-json': {
-    PackageJson,
-  },
-  'path-scurry': {
-    PathScurry,
-    PathScurryDarwin: PathScurry,
-    PathScurryLinux: PathScurry,
-    PathScurryPosix: PathScurry,
-    PathScurryWin32: PathScurry,
+  '../../src/parse-add-remove-args.js': {
+    parseAddArgs: (conf: LoadedConfig) => {
+      const items =
+        conf.positionals.length > 0 ?
+          `from ${conf.positionals.join(',')}`
+        : ''
+      const values =
+        Object.keys(conf.values).length > 0 ?
+          `, with values ${Object.entries(conf.values).join('=')}`
+        : ''
+      log += `parse add args ${items}${values}\n`
+      return { add: new Map() }
+    },
   },
 })
 t.matchSnapshot(usage().usage(), 'usage')
@@ -56,12 +33,13 @@ await command({
   values: {},
   options,
 } as unknown as LoadedConfig)
-t.matchSnapshot(reifyOpts, 'should call reify with expected options')
+t.matchSnapshot(log, 'should call install with expected options')
 
 // adds a new package
+log = ''
 await command({
   positionals: ['abbrev@2'],
   values: { 'save-dev': true },
   options,
 } as unknown as LoadedConfig)
-t.matchSnapshot(reifyOpts, 'should reify installing a new dependency')
+t.matchSnapshot(log, 'should install adding a new dependency')

--- a/src/vlt/test/install.ts
+++ b/src/vlt/test/install.ts
@@ -1,0 +1,95 @@
+import t from 'tap'
+import { joinDepIDTuple } from '@vltpkg/dep-id'
+import {
+  type Dependency,
+  asDependency,
+  type BuildIdealOptions,
+} from '@vltpkg/graph'
+import { type LoadedConfig } from '../src/config/index.js'
+import { Spec } from '@vltpkg/spec'
+
+t.cleanSnapshot = s =>
+  s.replace(/^(\s+)"?projectRoot"?: .*$/gm, '$1projectRoot: #')
+
+class PackageJson {
+  read() {
+    return { name: 'my-project', version: '1.0.0' }
+  }
+}
+
+// eslint-disable-next-line @typescript-eslint/no-extraneous-class
+class PathScurry {}
+
+t.test('install', async t => {
+  const options = {
+    projectRoot: t.testdirName,
+    scurry: new PathScurry(),
+    packageJson: new PackageJson(),
+  }
+  let log = ''
+
+  const rootDepID = joinDepIDTuple(['file', '.'])
+
+  const { install } = await t.mockImport<
+    typeof import('../src/install.js')
+  >('../src/install.js', {
+    '@vltpkg/graph': {
+      ideal: {
+        build: async ({ add }: BuildIdealOptions) => {
+          log += `buildideal result adds ${add?.get(rootDepID)?.size || 0} new package(s) \n`
+        },
+      },
+      actual: {
+        load: () => {
+          log += 'actual.load\n'
+        },
+      },
+      reify: async () => {
+        log += 'reify\n'
+      },
+    },
+    '@vltpkg/package-json': {
+      PackageJson,
+    },
+    'path-scurry': {
+      PathScurry,
+      PathScurryDarwin: PathScurry,
+      PathScurryLinux: PathScurry,
+      PathScurryPosix: PathScurry,
+      PathScurryWin32: PathScurry,
+    },
+  })
+
+  await install({
+    add: new Map(),
+    conf: {
+      options,
+    } as unknown as LoadedConfig,
+  })
+
+  t.matchSnapshot(log, 'should call build -> actual.load -> reify')
+
+  // adding a new dependency
+  log = ''
+  await install({
+    add: new Map([
+      [
+        rootDepID,
+        new Map<string, Dependency>([
+          [
+            'abbrev',
+            asDependency({
+              spec: Spec.parse('abbrev', 'latest'),
+              type: 'dev',
+            }),
+          ],
+        ]),
+      ],
+    ]),
+    conf: {
+      options,
+    } as unknown as LoadedConfig,
+  })
+
+  t.matchSnapshot(log, 'should call build adding new dependency')
+})


### PR DESCRIPTION
Add the ability to add dependencies to an importer node from the GUI.

Includes a fix for reifying from a current working directory that is different from `projectRoot`.

![Screenshot 2024-12-06 at 9 57 42 PM](https://github.com/user-attachments/assets/4487c262-b16d-4e76-8eb0-001101babb11)
