### PR TITLE
add custom export dialect for typescript source

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -5,6 +5,7 @@ import { readFileSync } from 'fs'
 import { resolve } from 'path'
 import jsdoc from 'eslint-plugin-jsdoc'
 import importPlugin from 'eslint-plugin-import'
+import { defaultConditionNames } from 'eslint-import-resolver-typescript'
 
 // 'error' to fix, or 'warn' to see
 const BE_EXTRA = process.env.LINT_SUPER_CONSISTENT ?? 'off'
@@ -39,7 +40,12 @@ export default tseslint.config(
     },
     settings: {
       'import/resolver': {
-        typescript: true,
+        typescript: {
+          conditionNames: [
+            '@vltpkg/source',
+            ...defaultConditionNames,
+          ],
+        },
         node: true,
       },
     },

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -41,9 +41,15 @@ export default tseslint.config(
     settings: {
       'import/resolver': {
         typescript: {
+          alwaysTryTypes: true,
           conditionNames: [
             '@vltpkg/source',
             ...defaultConditionNames,
+          ],
+          project: [
+            'src/*/tsconfig.json',
+            'infra/*/tsconfig.json',
+            'www/*/tsconfig.json',
           ],
         },
         node: true,
@@ -232,14 +238,25 @@ export default tseslint.config(
   },
   {
     /**
-     * Front end code
+     * shadcn-ui specific patterns
      */
-    files: ['{src/gui,www/docs}/{src,test}/**/*.{tsx,ts}'],
+    files: ['{src/gui,www/docs}/src/components/ui/*.{tsx,ts}'],
     rules: {
-      // TODO: get eslint import resolver working with workspace tsconfig paths
-      'import/no-unresolved': 'off',
-      // shadcn-ui specific patterns
       '@typescript-eslint/no-empty-object-type': 'off',
+    },
+  },
+  {
+    /**
+     * Astro
+     */
+    files: ['www/docs/**/*.{ts,tsx}'],
+    rules: {
+      'import/no-unresolved': [
+        2,
+        {
+          ignore: ['astro:content'], // https://github.com/import-js/eslint-import-resolver-typescript/issues/261
+        },
+      ],
     },
   },
   {

--- a/infra/benchmark/package.json
+++ b/infra/benchmark/package.json
@@ -8,6 +8,9 @@
     "dialects": [
       "esm"
     ],
+    "sourceDialects": [
+      "@vltpkg/source"
+    ],
     "exports": {
       "./package.json": "./package.json",
       ".": "./src/index.ts"
@@ -56,6 +59,7 @@
     "./package.json": "./package.json",
     ".": {
       "import": {
+        "@vltpkg/source": "./src/index.ts",
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
       }

--- a/infra/build/package.json
+++ b/infra/build/package.json
@@ -8,6 +8,9 @@
     "dialects": [
       "esm"
     ],
+    "sourceDialects": [
+      "@vltpkg/source"
+    ],
     "exports": {
       "./package.json": "./package.json",
       ".": "./src/index.ts"
@@ -61,6 +64,7 @@
     "./package.json": "./package.json",
     ".": {
       "import": {
+        "@vltpkg/source": "./src/index.ts",
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
       }

--- a/scripts/consistent-package-json.js
+++ b/scripts/consistent-package-json.js
@@ -280,6 +280,7 @@ const fixTools = async ws => {
         ...ws.pj.tshy,
         selfLink: false,
         dialects: ['esm'],
+        sourceDialects: ['@vltpkg/source'],
         exports: sortObject(
           {
             ...ws.pj.tshy.exports,
@@ -289,7 +290,7 @@ const fixTools = async ws => {
           ['./package.json', '.'],
         ),
       },
-      ['selfLink', 'dialects'],
+      ['selfLink', 'dialects', 'sourceDialects'],
     )
     mergeJson(resolve(ws.dir, 'tsconfig.json'), d =>
       sortObject({

--- a/src/cache-unzip/package.json
+++ b/src/cache-unzip/package.json
@@ -7,6 +7,9 @@
     "dialects": [
       "esm"
     ],
+    "sourceDialects": [
+      "@vltpkg/source"
+    ],
     "exports": {
       "./package.json": "./package.json",
       ".": "./src/index.ts"
@@ -55,6 +58,7 @@
     "./package.json": "./package.json",
     ".": {
       "import": {
+        "@vltpkg/source": "./src/index.ts",
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
       }

--- a/src/cache/package.json
+++ b/src/cache/package.json
@@ -7,6 +7,9 @@
     "dialects": [
       "esm"
     ],
+    "sourceDialects": [
+      "@vltpkg/source"
+    ],
     "exports": {
       "./package.json": "./package.json",
       ".": "./src/index.ts"
@@ -55,6 +58,7 @@
     "./package.json": "./package.json",
     ".": {
       "import": {
+        "@vltpkg/source": "./src/index.ts",
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
       }

--- a/src/dep-id/package.json
+++ b/src/dep-id/package.json
@@ -7,6 +7,9 @@
     "dialects": [
       "esm"
     ],
+    "sourceDialects": [
+      "@vltpkg/source"
+    ],
     "exports": {
       "./package.json": "./package.json",
       ".": "./src/index.ts",
@@ -54,12 +57,14 @@
     "./package.json": "./package.json",
     ".": {
       "import": {
+        "@vltpkg/source": "./src/index.ts",
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
       }
     },
     "./browser": {
       "import": {
+        "@vltpkg/source": "./src/browser.ts",
         "types": "./dist/esm/browser.d.ts",
         "default": "./dist/esm/browser.js"
       }

--- a/src/dot-prop/package.json
+++ b/src/dot-prop/package.json
@@ -7,6 +7,9 @@
     "dialects": [
       "esm"
     ],
+    "sourceDialects": [
+      "@vltpkg/source"
+    ],
     "exports": {
       "./package.json": "./package.json",
       ".": "./src/index.ts"
@@ -49,6 +52,7 @@
     "./package.json": "./package.json",
     ".": {
       "import": {
+        "@vltpkg/source": "./src/index.ts",
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
       }

--- a/src/error-cause/package.json
+++ b/src/error-cause/package.json
@@ -7,6 +7,9 @@
     "dialects": [
       "esm"
     ],
+    "sourceDialects": [
+      "@vltpkg/source"
+    ],
     "exports": {
       "./package.json": "./package.json",
       ".": "./src/index.ts"
@@ -48,6 +51,7 @@
     "./package.json": "./package.json",
     ".": {
       "import": {
+        "@vltpkg/source": "./src/index.ts",
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
       }

--- a/src/fast-split/package.json
+++ b/src/fast-split/package.json
@@ -7,6 +7,9 @@
     "dialects": [
       "esm"
     ],
+    "sourceDialects": [
+      "@vltpkg/source"
+    ],
     "exports": {
       "./package.json": "./package.json",
       ".": "./src/index.ts"
@@ -49,6 +52,7 @@
     "./package.json": "./package.json",
     ".": {
       "import": {
+        "@vltpkg/source": "./src/index.ts",
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
       }

--- a/src/git-scp-url/package.json
+++ b/src/git-scp-url/package.json
@@ -7,6 +7,9 @@
     "dialects": [
       "esm"
     ],
+    "sourceDialects": [
+      "@vltpkg/source"
+    ],
     "exports": {
       "./package.json": "./package.json",
       ".": "./src/index.ts"
@@ -48,6 +51,7 @@
     "./package.json": "./package.json",
     ".": {
       "import": {
+        "@vltpkg/source": "./src/index.ts",
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
       }

--- a/src/git/package.json
+++ b/src/git/package.json
@@ -7,6 +7,9 @@
     "dialects": [
       "esm"
     ],
+    "sourceDialects": [
+      "@vltpkg/source"
+    ],
     "exports": {
       "./package.json": "./package.json",
       ".": "./src/index.ts"
@@ -63,6 +66,7 @@
     "./package.json": "./package.json",
     ".": {
       "import": {
+        "@vltpkg/source": "./src/index.ts",
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
       }

--- a/src/graph/package.json
+++ b/src/graph/package.json
@@ -7,6 +7,9 @@
     "dialects": [
       "esm"
     ],
+    "sourceDialects": [
+      "@vltpkg/source"
+    ],
     "exports": {
       "./package.json": "./package.json",
       ".": "./src/index.ts",
@@ -70,12 +73,14 @@
     "./package.json": "./package.json",
     ".": {
       "import": {
+        "@vltpkg/source": "./src/index.ts",
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
       }
     },
     "./browser": {
       "import": {
+        "@vltpkg/source": "./src/browser.ts",
         "types": "./dist/esm/browser.d.ts",
         "default": "./dist/esm/browser.js"
       }

--- a/src/gui/tsconfig.json
+++ b/src/gui/tsconfig.json
@@ -3,10 +3,9 @@
   "compilerOptions": {
     "incremental": false,
     "outDir": "dist",
-    "target": "esnext",
-    "lib": ["es6", "dom"],
+    "target": "ES2022",
+    "lib": ["ES2022", "dom"],
     "jsx": "preserve",
-    "noImplicitReturns": true,
     "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"]

--- a/src/package-info/package.json
+++ b/src/package-info/package.json
@@ -7,6 +7,9 @@
     "dialects": [
       "esm"
     ],
+    "sourceDialects": [
+      "@vltpkg/source"
+    ],
     "exports": {
       "./package.json": "./package.json",
       ".": "./src/index.ts"
@@ -65,6 +68,7 @@
     "./package.json": "./package.json",
     ".": {
       "import": {
+        "@vltpkg/source": "./src/index.ts",
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
       }

--- a/src/package-json/package.json
+++ b/src/package-json/package.json
@@ -7,6 +7,9 @@
     "dialects": [
       "esm"
     ],
+    "sourceDialects": [
+      "@vltpkg/source"
+    ],
     "exports": {
       "./package.json": "./package.json",
       ".": "./src/index.ts"
@@ -53,6 +56,7 @@
     "./package.json": "./package.json",
     ".": {
       "import": {
+        "@vltpkg/source": "./src/index.ts",
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
       }

--- a/src/pick-manifest/package.json
+++ b/src/pick-manifest/package.json
@@ -7,6 +7,9 @@
     "dialects": [
       "esm"
     ],
+    "sourceDialects": [
+      "@vltpkg/source"
+    ],
     "exports": {
       "./package.json": "./package.json",
       ".": "./src/index.ts"
@@ -58,6 +61,7 @@
     "./package.json": "./package.json",
     ".": {
       "import": {
+        "@vltpkg/source": "./src/index.ts",
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
       }

--- a/src/promise-spawn/package.json
+++ b/src/promise-spawn/package.json
@@ -7,6 +7,9 @@
     "dialects": [
       "esm"
     ],
+    "sourceDialects": [
+      "@vltpkg/source"
+    ],
     "exports": {
       "./package.json": "./package.json",
       ".": "./src/index.ts"
@@ -52,6 +55,7 @@
     "./package.json": "./package.json",
     ".": {
       "import": {
+        "@vltpkg/source": "./src/index.ts",
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
       }

--- a/src/query/package.json
+++ b/src/query/package.json
@@ -7,6 +7,9 @@
     "dialects": [
       "esm"
     ],
+    "sourceDialects": [
+      "@vltpkg/source"
+    ],
     "exports": {
       "./package.json": "./package.json",
       ".": "./src/index.ts"
@@ -56,6 +59,7 @@
     "./package.json": "./package.json",
     ".": {
       "import": {
+        "@vltpkg/source": "./src/index.ts",
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
       }

--- a/src/registry-client/package.json
+++ b/src/registry-client/package.json
@@ -7,6 +7,9 @@
     "dialects": [
       "esm"
     ],
+    "sourceDialects": [
+      "@vltpkg/source"
+    ],
     "exports": {
       "./package.json": "./package.json",
       ".": "./src/index.ts",
@@ -59,12 +62,14 @@
     "./package.json": "./package.json",
     ".": {
       "import": {
+        "@vltpkg/source": "./src/index.ts",
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
       }
     },
     "./cache-entry": {
       "import": {
+        "@vltpkg/source": "./src/cache-entry.ts",
         "types": "./dist/esm/cache-entry.d.ts",
         "default": "./dist/esm/cache-entry.js"
       }

--- a/src/rollback-remove/package.json
+++ b/src/rollback-remove/package.json
@@ -7,6 +7,9 @@
     "dialects": [
       "esm"
     ],
+    "sourceDialects": [
+      "@vltpkg/source"
+    ],
     "exports": {
       "./package.json": "./package.json",
       ".": "./src/index.ts"
@@ -45,6 +48,7 @@
     "./package.json": "./package.json",
     ".": {
       "import": {
+        "@vltpkg/source": "./src/index.ts",
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
       }

--- a/src/run/package.json
+++ b/src/run/package.json
@@ -7,6 +7,9 @@
     "dialects": [
       "esm"
     ],
+    "sourceDialects": [
+      "@vltpkg/source"
+    ],
     "exports": {
       "./package.json": "./package.json",
       ".": "./src/index.ts"
@@ -56,6 +59,7 @@
     "./package.json": "./package.json",
     ".": {
       "import": {
+        "@vltpkg/source": "./src/index.ts",
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
       }

--- a/src/satisfies/package.json
+++ b/src/satisfies/package.json
@@ -7,6 +7,9 @@
     "dialects": [
       "esm"
     ],
+    "sourceDialects": [
+      "@vltpkg/source"
+    ],
     "exports": {
       "./package.json": "./package.json",
       ".": "./src/index.ts"
@@ -55,6 +58,7 @@
     "./package.json": "./package.json",
     ".": {
       "import": {
+        "@vltpkg/source": "./src/index.ts",
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
       }

--- a/src/semver/package.json
+++ b/src/semver/package.json
@@ -7,6 +7,9 @@
     "dialects": [
       "esm"
     ],
+    "sourceDialects": [
+      "@vltpkg/source"
+    ],
     "exports": {
       "./package.json": "./package.json",
       ".": "./src/index.ts"
@@ -58,6 +61,7 @@
     "./package.json": "./package.json",
     ".": {
       "import": {
+        "@vltpkg/source": "./src/index.ts",
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
       }

--- a/src/spec/package.json
+++ b/src/spec/package.json
@@ -7,6 +7,9 @@
     "dialects": [
       "esm"
     ],
+    "sourceDialects": [
+      "@vltpkg/source"
+    ],
     "exports": {
       "./package.json": "./package.json",
       ".": "./src/index.ts",
@@ -56,12 +59,14 @@
     "./package.json": "./package.json",
     ".": {
       "import": {
+        "@vltpkg/source": "./src/index.ts",
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
       }
     },
     "./browser": {
       "import": {
+        "@vltpkg/source": "./src/browser.ts",
         "types": "./dist/esm/browser.d.ts",
         "default": "./dist/esm/browser.js"
       }

--- a/src/tar/package.json
+++ b/src/tar/package.json
@@ -7,6 +7,9 @@
     "dialects": [
       "esm"
     ],
+    "sourceDialects": [
+      "@vltpkg/source"
+    ],
     "exports": {
       "./package.json": "./package.json",
       ".": "./src/index.ts",
@@ -62,24 +65,28 @@
     "./package.json": "./package.json",
     ".": {
       "import": {
+        "@vltpkg/source": "./src/index.ts",
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
       }
     },
     "./pool": {
       "import": {
+        "@vltpkg/source": "./src/pool.ts",
         "types": "./dist/esm/pool.d.ts",
         "default": "./dist/esm/pool.js"
       }
     },
     "./unpack": {
       "import": {
+        "@vltpkg/source": "./src/unpack.ts",
         "types": "./dist/esm/unpack.d.ts",
         "default": "./dist/esm/unpack.js"
       }
     },
     "./unpack-request": {
       "import": {
+        "@vltpkg/source": "./src/unpack-request.ts",
         "types": "./dist/esm/unpack-request.d.ts",
         "default": "./dist/esm/unpack-request.js"
       }

--- a/src/types/package.json
+++ b/src/types/package.json
@@ -7,6 +7,9 @@
     "dialects": [
       "esm"
     ],
+    "sourceDialects": [
+      "@vltpkg/source"
+    ],
     "exports": {
       "./package.json": "./package.json",
       ".": "./src/index.ts"
@@ -51,6 +54,7 @@
     "./package.json": "./package.json",
     ".": {
       "import": {
+        "@vltpkg/source": "./src/index.ts",
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
       }

--- a/src/vlt/package.json
+++ b/src/vlt/package.json
@@ -8,6 +8,9 @@
     "dialects": [
       "esm"
     ],
+    "sourceDialects": [
+      "@vltpkg/source"
+    ],
     "exports": {
       "./package.json": "./package.json",
       ".": "./src/index.ts",
@@ -88,36 +91,42 @@
     "./package.json": "./package.json",
     ".": {
       "import": {
+        "@vltpkg/source": "./src/index.ts",
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
       }
     },
     "./commands": {
       "import": {
+        "@vltpkg/source": "./src/commands",
         "types": "./dist/esm/commands",
         "default": "./dist/esm/commands"
       }
     },
     "./commands/*": {
       "import": {
+        "@vltpkg/source": "./src/commands/*.ts",
         "types": "./dist/esm/commands/*.d.ts",
         "default": "./dist/esm/commands/*.js"
       }
     },
     "./config": {
       "import": {
+        "@vltpkg/source": "./src/config/index.ts",
         "types": "./dist/esm/config/index.d.ts",
         "default": "./dist/esm/config/index.js"
       }
     },
     "./config/definition": {
       "import": {
+        "@vltpkg/source": "./src/config/definition.ts",
         "types": "./dist/esm/config/definition.d.ts",
         "default": "./dist/esm/config/definition.js"
       }
     },
     "./types": {
       "import": {
+        "@vltpkg/source": "./src/types.ts",
         "types": "./dist/esm/types.d.ts",
         "default": "./dist/esm/types.js"
       }

--- a/src/which/package.json
+++ b/src/which/package.json
@@ -7,6 +7,9 @@
     "dialects": [
       "esm"
     ],
+    "sourceDialects": [
+      "@vltpkg/source"
+    ],
     "exports": {
       "./package.json": "./package.json",
       ".": "./src/index.ts"
@@ -51,6 +54,7 @@
     "./package.json": "./package.json",
     ".": {
       "import": {
+        "@vltpkg/source": "./src/index.ts",
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
       }

--- a/src/workspaces/package.json
+++ b/src/workspaces/package.json
@@ -7,6 +7,9 @@
     "dialects": [
       "esm"
     ],
+    "sourceDialects": [
+      "@vltpkg/source"
+    ],
     "exports": {
       "./package.json": "./package.json",
       ".": "./src/index.ts"
@@ -60,6 +63,7 @@
     "./package.json": "./package.json",
     ".": {
       "import": {
+        "@vltpkg/source": "./src/index.ts",
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
       }

--- a/src/xdg/package.json
+++ b/src/xdg/package.json
@@ -7,6 +7,9 @@
     "dialects": [
       "esm"
     ],
+    "sourceDialects": [
+      "@vltpkg/source"
+    ],
     "exports": {
       "./package.json": "./package.json",
       ".": "./src/index.ts"
@@ -48,6 +51,7 @@
     "./package.json": "./package.json",
     ".": {
       "import": {
+        "@vltpkg/source": "./src/index.ts",
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
       }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,6 +15,7 @@
     "skipLibCheck": true,
     "sourceMap": true,
     "strict": true,
-    "target": "es2022"
+    "target": "es2022",
+    "customConditions": ["@vltpkg/source"]
   }
 }

--- a/www/docs/tsconfig.json
+++ b/www/docs/tsconfig.json
@@ -6,6 +6,7 @@
     "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"]
-    }
+    },
+    "customConditions": ["@vltpkg/source"]
   }
 }


### PR DESCRIPTION
This PR adds a custom export dialect to all our workspaces that points to the TypeScript files. This dialect is then used by `customConditions` within the tsconfig.json files.

This also required getting eslint to recognize this dialect. While fixing that in our linting config, I also fixed an old todo to get the eslint import plugin to check the imports in files that were doing custom tsconfig pathing.