### PR TITLE
Bugfix: Docs content width

### DIFF
--- a/www/docs/src/components/page-sidebar/page-sidebar.tsx
+++ b/www/docs/src/components/page-sidebar/page-sidebar.tsx
@@ -66,7 +66,7 @@ const PageSidebar = ({ toc }: Props) => {
     ))
 
   return (
-    <div className="hidden md:flex flex-col items-start sticky top-0 pt-8 h-fit md:w-[300px]">
+    <div className="hidden md:flex flex-col items-start sticky top-0 pt-8 pb-8 h-fit md:w-[300px]">
       <h3 className="flex items-center gap-2 text-sm font-bold mb-3">
         <AlignLeft size={16} />
         On this page

--- a/www/docs/src/components/two-column-layout/astro-two-column-layout.astro
+++ b/www/docs/src/components/two-column-layout/astro-two-column-layout.astro
@@ -25,7 +25,7 @@ const isHero = Astro.url.pathname === '/'
       </>
     )
   }
-  <div class={`${!isHero ? 'max-w-[75ch]' : 'w-full'} order-1`}>
+  <div class={`w-full ${!isHero ? 'max-w-[75ch]' : ''} order-1`}>
     <slot />
   </div>
 </div>


### PR DESCRIPTION
# Fixes small layout sizes

Sets max width as 75ch, content width as full.

Applies bottom padding to the page sidebar (pagination) for longer elements.

## Before
<img width="1675" alt="Screenshot 2024-12-16 at 12 36 07" src="https://github.com/user-attachments/assets/80420474-6967-440b-885f-6123bf73870d" />

## After
<img width="1675" alt="Screenshot 2024-12-16 at 12 36 00" src="https://github.com/user-attachments/assets/4feab151-2565-424e-990d-ab798a495727" />
