### PR TITLE
[FEATURE] `vlt pkg init`

### DIFF
--- a/src/vlt/tap-snapshots/test/commands/pkg.ts.test.cjs
+++ b/src/vlt/tap-snapshots/test/commands/pkg.ts.test.cjs
@@ -33,6 +33,11 @@ Get or manipulate package.json values
 
       ​vlt pkg delete <key> [<key> ...]
 
+    init
+      Create a new package.json file
+
+      ​vlt pkg init [-f|--force]
+
   Examples
 
     Set a value on an object inside an array

--- a/src/vlt/test/commands/pkg.ts
+++ b/src/vlt/test/commands/pkg.ts
@@ -35,7 +35,7 @@ t.test('basic', async t => {
     message: 'Unrecognized pkg command',
     cause: {
       found: 'gett',
-      validOptions: ['get', 'set', 'rm'],
+      validOptions: ['get', 'set', 'rm', 'init'],
     },
   })
 })
@@ -151,4 +151,28 @@ t.test('delete', async t => {
   t.rejects(runCommand(), {
     message: 'rm requires arguments',
   })
+})
+
+t.test('init', async t => {
+  const { runCommand, readPackageJson } = await setupPkg(t, 'init')
+  t.strictSame(await runCommand(), {
+    errs: '',
+    logs: '',
+  })
+  t.strictSame(JSON.parse(readPackageJson()), {})
+})
+
+t.test('init with force', async t => {
+  const { runCommand, readPackageJson } = await setupPkg(t, 'init', {
+    name: 'package-name',
+    version: '1.0.0',
+  })
+  t.rejects(runCommand(), {
+    message: 'package.json already exists. Use --force to overwrite.',
+  })
+  t.strictSame(await runCommand(['--force']), {
+    errs: '',
+    logs: '',
+  })
+  t.strictSame(JSON.parse(readPackageJson()), {})
 })


### PR DESCRIPTION
Add `vlt pkg init` subcommand to create a new `package.json` file.

* **Subcommand Implementation:**
  - Add `init` subcommand to `vlt pkg` in `src/vlt/src/commands/pkg.ts`.
  - Implement logic to create `package.json` with `{}` content.
  - Add `-f|--force` flag to overwrite existing `package.json`.

* **Error Handling:**
  - Throw an error if `package.json` already exists and `-f|--force` flag is not used.

* **Testing:**
  - Add tests for `vlt pkg init` subcommand in `src/vlt/test/commands/pkg.ts`.
  - Test creation of new `package.json` file.
  - Test `-f|--force` flag to overwrite existing `package.json`.

