### PR TITLE
error-cause: allow cause to be unknown

### DIFF
--- a/src/error-cause/src/index.ts
+++ b/src/error-cause/src/index.ts
@@ -177,10 +177,11 @@ export type DuckTypeManifest = Record<string, any> & {
 
 export type ErrorCause = Error | ErrorCauseObject
 
-const unknownToCause = (er: unknown): ErrorCause =>
+export const asErrorCause = (er: unknown): ErrorCause =>
   er instanceof Error ? er
     // if it is any sort of truthy object, assume its an error cause
   : !!er && typeof er === 'object' ? er
+    // otherwise, make an error of the stringified message
   : new Error(String(er) || 'Unknown error')
 
 /**
@@ -219,24 +220,16 @@ export const error = (
   message: string,
   cause?: ErrorCause,
   from?: ((...a: any[]) => any) | (new (...a: any[]) => any),
-) => create(Error, error, message, unknownToCause(cause), from)
+) => create(Error, error, message, cause, from)
 
 export const typeError = (
   message: string,
   cause?: ErrorCause,
   from?: ((...a: any[]) => any) | (new (...a: any[]) => any),
-) =>
-  create(TypeError, typeError, message, unknownToCause(cause), from)
+) => create(TypeError, typeError, message, cause, from)
 
 export const syntaxError = (
   message: string,
   cause?: ErrorCause,
   from?: ((...a: any[]) => any) | (new (...a: any[]) => any),
-) =>
-  create(
-    SyntaxError,
-    syntaxError,
-    message,
-    unknownToCause(cause),
-    from,
-  )
+) => create(SyntaxError, syntaxError, message, cause, from)

--- a/src/error-cause/src/index.ts
+++ b/src/error-cause/src/index.ts
@@ -179,10 +179,13 @@ export type ErrorCause = Error | ErrorCauseObject
 
 export const asErrorCause = (er: unknown): ErrorCause =>
   er instanceof Error ? er
-    // if it is any sort of truthy object, assume its an error cause
-  : !!er && typeof er === 'object' ? er
+    // if it is any sort of plain-ish object, assume its an error cause
+  : !!er && typeof er === 'object' && !Array.isArray(er) ? er
     // otherwise, make an error of the stringified message
-  : new Error(String(er) || 'Unknown error')
+  : new Error(
+      // eslint-disable-next-line @typescript-eslint/no-base-to-string
+      er == null ? 'Unknown error' : String(er) || 'Unknown error',
+    )
 
 /**
  * Valid properties for the 'code' field in an Error cause.

--- a/src/error-cause/src/index.ts
+++ b/src/error-cause/src/index.ts
@@ -14,9 +14,11 @@ export type ErrorCauseObject = {
    * always be an `Error` object that was previously thrown. Note
    * that the `cause` on an Error itself might _also_ be a
    * previously thrown error, if no additional information could be
-   * usefully added beyond improving the message.
+   * usefully added beyond improving the message. It is typed as `unknown`
+   * because we use `useUnknownInCatchVariables` so this makes it easier
+   * to rethrow a caught error without recasting it.
    */
-  cause?: unknown
+  cause?: ErrorCause | unknown // eslint-disable-line @typescript-eslint/no-redundant-type-constituents
 
   /** the name of something */
   name?: string
@@ -215,20 +217,20 @@ const create = (
 
 export const error = (
   message: string,
-  cause?: unknown,
+  cause?: ErrorCause,
   from?: ((...a: any[]) => any) | (new (...a: any[]) => any),
 ) => create(Error, error, message, unknownToCause(cause), from)
 
 export const typeError = (
   message: string,
-  cause?: unknown,
+  cause?: ErrorCause,
   from?: ((...a: any[]) => any) | (new (...a: any[]) => any),
 ) =>
   create(TypeError, typeError, message, unknownToCause(cause), from)
 
 export const syntaxError = (
   message: string,
-  cause?: unknown,
+  cause?: ErrorCause,
   from?: ((...a: any[]) => any) | (new (...a: any[]) => any),
 ) =>
   create(

--- a/src/error-cause/src/index.ts
+++ b/src/error-cause/src/index.ts
@@ -177,10 +177,32 @@ export type DuckTypeManifest = Record<string, any> & {
 
 export type ErrorCause = Error | ErrorCauseObject
 
+/**
+ * An error with a cause that is a direct error cause object and not another
+ * nested error.
+ */
+export type ErrorWithCauseObject = Error & { cause: ErrorCauseObject }
+
+/**
+ * If it is any sort of plain-ish object, assume its an error cause
+ * because all properties of the cause are optional.
+ */
+export const isErrorCauseObject = (
+  v: unknown,
+): v is ErrorCauseObject =>
+  !!v && typeof v === 'object' && !Array.isArray(v)
+
+/**
+ * Type guard for {@link ErrorWithCauseObject} type
+ */
+export const isErrorRoot = (
+  er: unknown,
+): er is ErrorWithCauseObject =>
+  er instanceof Error && isErrorCauseObject(er.cause)
+
 export const asErrorCause = (er: unknown): ErrorCause =>
   er instanceof Error ? er
-    // if it is any sort of plain-ish object, assume its an error cause
-  : !!er && typeof er === 'object' && !Array.isArray(er) ? er
+  : isErrorCauseObject(er) ? er
     // otherwise, make an error of the stringified message
   : new Error(
       // eslint-disable-next-line @typescript-eslint/no-base-to-string

--- a/src/error-cause/test/index.ts
+++ b/src/error-cause/test/index.ts
@@ -3,6 +3,7 @@ import {
   syntaxError,
   typeError,
   asErrorCause,
+  isErrorRoot,
 } from '../src/index.js'
 import t from 'tap'
 
@@ -63,5 +64,12 @@ t.test('asErrorCause', t => {
   t.match(asErrorCause(null), unknownErr)
   t.match(asErrorCause(undefined), unknownErr)
   t.match(asErrorCause([]), unknownErr)
+  t.end()
+})
+
+t.test('isErrorRoot', t => {
+  t.equal(isErrorRoot(new Error('', { cause: {} })), true)
+  t.equal(isErrorRoot(new Error('')), false)
+  t.equal(isErrorRoot(new Error('', { cause: null })), false)
   t.end()
 })

--- a/src/error-cause/test/index.ts
+++ b/src/error-cause/test/index.ts
@@ -15,25 +15,6 @@ t.test('setting cause about syntax', t => {
   t.end()
 })
 
-t.test('invalid causes cause TS errors', t => {
-  //@ts-expect-error
-  error('x', 'y')
-  //@ts-expect-error
-  error('x', { code: 1 })
-  //@ts-expect-error
-  typeError('x', { code: 123 })
-  //@ts-expect-error
-  typeError('x', { code: 'E_I_AM_SO_CREATIVE' })
-  //@ts-expect-error
-  syntaxError('x', { status: true })
-  //@ts-expect-error
-  error('x', { version: true })
-  //@ts-expect-error
-  error('x', { range: true })
-  t.pass('typechecks passed')
-  t.end()
-})
-
 t.test('stack pruning', t => {
   const foo = () => bar()
   const bar = () => baz()

--- a/src/error-cause/test/index.ts
+++ b/src/error-cause/test/index.ts
@@ -1,4 +1,9 @@
-import { error, syntaxError, typeError } from '../src/index.js'
+import {
+  error,
+  syntaxError,
+  typeError,
+  asErrorCause,
+} from '../src/index.js'
 import t from 'tap'
 
 t.test('setting cause', t => {
@@ -42,5 +47,21 @@ t.test('stack pruning', t => {
     return error('x', undefined, bar)
   }
   t.match(foo().stack, /Error: x\n {4}at foo/)
+  t.end()
+})
+
+t.test('asErrorCause', t => {
+  const err = new Error('an error')
+  t.strictSame(asErrorCause(err), err)
+  const errCause = { code: 'ok' }
+  t.strictSame(asErrorCause(errCause), errCause)
+  t.match(asErrorCause(0), new Error('0'))
+  t.match(asErrorCause(false), new Error('false'))
+  t.match(asErrorCause(true), new Error('true'))
+  const unknownErr = new Error('Unknown error')
+  t.match(asErrorCause(''), unknownErr)
+  t.match(asErrorCause(null), unknownErr)
+  t.match(asErrorCause(undefined), unknownErr)
+  t.match(asErrorCause([]), unknownErr)
   t.end()
 })

--- a/src/error-cause/test/index.ts
+++ b/src/error-cause/test/index.ts
@@ -15,6 +15,25 @@ t.test('setting cause about syntax', t => {
   t.end()
 })
 
+t.test('invalid causes cause TS errors', t => {
+  //@ts-expect-error
+  error('x', 'y')
+  //@ts-expect-error
+  error('x', { code: 1 })
+  //@ts-expect-error
+  typeError('x', { code: 123 })
+  //@ts-expect-error
+  typeError('x', { code: 'E_I_AM_SO_CREATIVE' })
+  //@ts-expect-error
+  syntaxError('x', { status: true })
+  //@ts-expect-error
+  error('x', { version: true })
+  //@ts-expect-error
+  error('x', { range: true })
+  t.pass('typechecks passed')
+  t.end()
+})
+
 t.test('stack pruning', t => {
   const foo = () => bar()
   const bar = () => baz()

--- a/src/git/src/which.ts
+++ b/src/git/src/which.ts
@@ -8,13 +8,13 @@ export const which = (opts: GitOptions = {}) => {
   if (opts.git) {
     return opts.git
   }
-  let whichError: Error | undefined = undefined
+  let whichError: unknown = undefined
   if (opts.git !== false) {
     if (!gitPath) {
       try {
         gitPath = whichSync('git')
       } catch (er) {
-        whichError = er as Error
+        whichError = er
       }
     }
   }

--- a/src/package-info/src/index.ts
+++ b/src/package-info/src/index.ts
@@ -222,7 +222,7 @@ export class PackageInfoClient {
             spec,
             options,
             'tar unpack failed',
-            { cause: er as Error },
+            { cause: er },
           )
         }
         return r
@@ -247,7 +247,7 @@ export class PackageInfoClient {
               spec,
               options,
               'tar unpack failed',
-              { cause: er as Error },
+              { cause: er },
             )
           }
         } else if (st.isDirectory()) {
@@ -480,7 +480,7 @@ export class PackageInfoClient {
               s,
               options,
               'tar unpack failed',
-              { cause: er as Error },
+              { cause: er },
             )
           }
           return this.packageJson.read(dir)
@@ -504,7 +504,7 @@ export class PackageInfoClient {
               s,
               options,
               'tar unpack failed',
-              { cause: er as Error },
+              { cause: er },
             )
           }
           return this.packageJson.read(dir)

--- a/src/package-json/src/index.ts
+++ b/src/package-json/src/index.ts
@@ -50,7 +50,7 @@ export class PackageJson {
     } catch (err) {
       const ec: ErrorCauseObject = {
         path: filename,
-        cause: err as Error,
+        cause: err,
       }
       this.#errCache.set(dir, ec)
       throw fail(ec)
@@ -75,7 +75,7 @@ export class PackageJson {
         'Could not write package.json file',
         {
           path: filename,
-          cause: err as Error,
+          cause: err,
         },
         this.write,
       )

--- a/src/query/src/pseudo.ts
+++ b/src/query/src/pseudo.ts
@@ -80,7 +80,7 @@ const attr = async (state: ParserState) => {
     )
   } catch (err) {
     throw error('Failed to parse :attr selector', {
-      cause: err as Error,
+      cause: err,
     })
   }
 

--- a/src/registry-client/src/index.ts
+++ b/src/registry-client/src/index.ts
@@ -216,19 +216,11 @@ export class RegistryClient {
 
       if (isRedirect(result)) {
         resp.body.resume()
-        try {
-          const [nextURL, nextOptions] = redirect(options, result, u)
-          if (nextOptions && nextURL) {
-            return this.request(nextURL, nextOptions)
-          }
-          return result
-        } catch (er) {
-          /* c8 ignore start */
-          throw er instanceof Error ? er : (
-              new Error(typeof er === 'string' ? er : 'Unknown error')
-            )
-          /* c8 ignore stop */
+        const [nextURL, nextOptions] = redirect(options, result, u)
+        if (nextOptions && nextURL) {
+          return this.request(nextURL, nextOptions)
         }
+        return result
       }
 
       resp.body.on('data', (chunk: Buffer) => result.addBody(chunk))

--- a/src/spec/src/browser.ts
+++ b/src/spec/src/browser.ts
@@ -803,7 +803,7 @@ export const getNormalizeFile =
         // invalid URI for other reasons, eg file://x\u0000y/z
         throw error('invalid file:// specifier', {
           spec,
-          cause: er as Error,
+          cause: er,
         })
       }
     }

--- a/src/tar/src/pool.ts
+++ b/src/tar/src/pool.ts
@@ -51,11 +51,14 @@ export class Pool {
       ur.resolve()
       /* c8 ignore start - nearly impossible in normal circumstances */
     } else {
-      const er =
+      const message =
         m.error instanceof Error ? m.error.message : String(m.error)
-      const cause: ErrorCauseObject = { found: m }
-      if (m.error instanceof Error) cause.cause = m.error
-      ur.reject(error(er || 'failed without error message', cause))
+      ur.reject(
+        error(message || 'failed without error message', {
+          found: m,
+          cause: m.error,
+        }),
+      )
     }
     /* c8 ignore stop */
     const next = this.queue.shift()

--- a/src/tar/src/pool.ts
+++ b/src/tar/src/pool.ts
@@ -1,4 +1,4 @@
-import { error, type ErrorCauseObject } from '@vltpkg/error-cause'
+import { error } from '@vltpkg/error-cause'
 import os from 'os'
 import { UnpackRequest } from './unpack-request.js'
 import {

--- a/src/vlt/src/config/index.ts
+++ b/src/vlt/src/config/index.ts
@@ -430,7 +430,7 @@ export class Config {
       } catch (er) {
         throw error('failed to load config values from file', {
           path: file,
-          cause: er as Error,
+          cause: er,
         })
       }
     }
@@ -454,7 +454,7 @@ export class Config {
     } catch (er) {
       throw error('failed to parse vlt config file', {
         path: file,
-        cause: er as Error,
+        cause: er,
       })
     }
     this.configFiles[file] = result as ConfigFileData

--- a/src/vlt/src/exec-command.ts
+++ b/src/vlt/src/exec-command.ts
@@ -2,7 +2,7 @@
  * Implementation shared between `vlt run`, `vlt run-exec`, and `vlt exec`
  */
 
-import { error } from '@vltpkg/error-cause'
+import { error, isErrorRoot } from '@vltpkg/error-cause'
 import {
   type exec,
   type execFG,
@@ -90,11 +90,7 @@ export class ExecCommand<B extends RunnerBG, F extends RunnerFG> {
       if (!failed) stderr(`${ws.path} ${arg0}`)
       const result = await this.bg(this.bgArg(ws)).catch(
         (er: unknown) => {
-          if (
-            er instanceof Error &&
-            er.cause &&
-            isRunResult(er.cause)
-          ) {
+          if (isErrorRoot(er) && isRunResult(er.cause)) {
             this.printResult(ws, er.cause)
           }
           failed = true

--- a/src/vlt/src/index.ts
+++ b/src/vlt/src/index.ts
@@ -21,7 +21,7 @@ const loadCommand = async (
   } catch (e) {
     throw error('Command not implemented', {
       found: command,
-      cause: e as Error,
+      cause: e,
     })
   }
   /* c8 ignore stop */

--- a/src/vlt/src/output.ts
+++ b/src/vlt/src/output.ts
@@ -4,6 +4,7 @@ import {
   type CliCommandResult,
   type LoadedConfig,
 } from './types.js'
+import { isErrorRoot } from '@vltpkg/error-cause'
 
 // TODO: make these have log levels etc
 // eslint-disable-next-line no-console
@@ -53,18 +54,16 @@ export const outputError = (
   { usage }: { usage: string },
 ) => {
   process.exitCode ||= 1
-  if (
-    e instanceof Error &&
-    e.cause &&
-    typeof e.cause === 'object' &&
-    'code' in e.cause
-  ) {
-    if (e.cause.code === 'EUSAGE') {
-      stderr(usage)
-      stderr(`Error: ${e.message}`)
-      return
+  if (isErrorRoot(e)) {
+    switch (e.cause.code) {
+      case 'EUSAGE': {
+        stderr(usage)
+        stderr(`Error: ${e.message}`)
+        return
+      }
     }
   }
+
   // TODO: handle more error codes and causes
   stderr(e)
 }

--- a/src/workspaces/src/index.ts
+++ b/src/workspaces/src/index.ts
@@ -191,7 +191,7 @@ export class Monorepo {
     } catch (er) {
       throw error('Not in a monorepo, no vlt-workspaces.json found', {
         path: this.projectRoot,
-        cause: er as Error,
+        cause: er,
       })
     }
     let parsed: unknown
@@ -200,7 +200,7 @@ export class Monorepo {
     } catch (er) {
       throw error('Invalid vlt-workspaces.json file', {
         path: this.projectRoot,
-        cause: er as Error,
+        cause: er,
       })
     }
     this.#config = asWSConfig(parsed, file)


### PR DESCRIPTION
We turned on `useUnknownInCatchVariables` in our tsconfig when we started linting 9cc25431b5567aa5c094c4557b7626df75a74d41. So I think it makes sense for the `cause` property on `ErrorCauseObject` to be `unknown` as well. This removes the need down to do `{ cause: er as Error }` every time we want to throw a previously caught error.

I originally set the `cause: ErrorCause` argument for all the exported `error|typeError|syntaxError()` functions to also be `unknown` but this gets rid of some of the type safety. So you still have to pass an actual `Error | ErrorCauseObject` to the functions, but the cause object can now have `{ cause: unknown }`.

This also adds some type guard utility functions to `error-cause` which I used to clean up some `er instanceof Error` checks.

