### PR TITLE
vlt: refactor uninstall command

### DIFF
--- a/src/vlt/src/commands/uninstall.ts
+++ b/src/vlt/src/commands/uninstall.ts
@@ -1,8 +1,7 @@
-import { actual, ideal, reify } from '@vltpkg/graph'
-import { PackageInfoClient } from '@vltpkg/package-info'
 import { parseRemoveArgs } from '../parse-add-remove-args.js'
 import { type CliCommandFn, type CliCommandUsage } from '../types.js'
 import { commandUsage } from '../config/usage.js'
+import { uninstall } from '../uninstall.js'
 
 export const usage: CliCommandUsage = () =>
   commandUsage({
@@ -15,31 +14,5 @@ export const usage: CliCommandUsage = () =>
 export const command: CliCommandFn = async conf => {
   const monorepo = conf.options.monorepo
   const { remove } = parseRemoveArgs(conf, monorepo)
-  const mainManifest = conf.options.packageJson.read(
-    conf.options.projectRoot,
-  )
-
-  const graph = await ideal.build({
-    ...conf.options,
-    packageInfo: new PackageInfoClient(conf.options),
-    remove,
-    mainManifest,
-    monorepo,
-    loadManifests: true,
-  })
-  const act = actual.load({
-    ...conf.options,
-    mainManifest,
-    monorepo,
-    loadManifests: true,
-  })
-  await reify({
-    ...conf.options,
-    packageInfo: new PackageInfoClient(conf.options),
-    remove,
-    actual: act,
-    monorepo,
-    graph,
-    loadManifests: true,
-  })
+  await uninstall({ remove, conf })
 }

--- a/src/vlt/tap-snapshots/test/commands/uninstall.ts.test.cjs
+++ b/src/vlt/tap-snapshots/test/commands/uninstall.ts.test.cjs
@@ -5,28 +5,10 @@
  * Make sure to inspect the output below.  Do not ignore changes!
  */
 'use strict'
-exports[`test/commands/uninstall.ts > TAP > should reify uninstalling a new dependency 1`] = `
-Object {
-  "actual": "actual.load result",
-  "graph": "buildideal result removes 0 new package(s)",
-  "loadManifests": true,
-  "monorepo": undefined,
-  "packageInfo": PackageInfoClient {
-    "monorepo": undefined,
-    "options": Object {
-      "packageJson": PackageJson {},
-      projectRoot: #
-      "scurry": PathScurry {},
-    },
-    "packageJson": PackageJson {},
-  },
-  "packageJson": PackageJson {},
-  projectRoot: #
-  "remove": Map {
-    "file·." => Set {},
-  },
-  "scurry": PathScurry {},
-}
+exports[`test/commands/uninstall.ts > TAP > should uninstall a dependency 1`] = `
+parse remove args from abbrev@2
+uninstall
+
 `
 
 exports[`test/commands/uninstall.ts > TAP > usage 1`] = `


### PR DESCRIPTION
Following up from 08488add800b3db1488cf5f0910406d9c0384edd the uninstall command should now reuse `src/uninstall.ts`.