### PR TITLE
graph: store user-defined prefix

### DIFF
--- a/src/graph/src/reify/update-importers-package-json.ts
+++ b/src/graph/src/reify/update-importers-package-json.ts
@@ -108,7 +108,7 @@ const addOrRemoveDeps = (
       dependencies[name] =
         (
           nodeType === 'registry' &&
-          (!dep.spec.semver || dep.spec.range?.isSingle)
+          (!dep.spec.semver || !dep.spec.range)
         ) ?
           `${SAVE_PREFIX}${node.version}`
         : dep.spec.bareSpec

--- a/src/graph/tap-snapshots/test/reify/update-importers-package-json.ts.test.cjs
+++ b/src/graph/tap-snapshots/test/reify/update-importers-package-json.ts.test.cjs
@@ -9,7 +9,7 @@ exports[`test/reify/update-importers-package-json.ts > TAP > updatePackageJson >
 Array [
   Object {
     "dependencies": Object {
-      "foo": "^1.0.0",
+      "foo": "1.0.0",
       "git": "github:a/b",
     },
     "devDependencies": Object {
@@ -26,8 +26,25 @@ exports[`test/reify/update-importers-package-json.ts > TAP > updatePackageJson >
 Array [
   Object {
     "dependencies": Object {
-      "foo": "^1.0.0",
+      "foo": "1.0.0",
       "git": "github:a/b",
+    },
+    "name": "root",
+    "version": "1.0.0",
+  },
+]
+`
+
+exports[`test/reify/update-importers-package-json.ts > TAP > updatePackageJson > registry gt range dep > should use provided range in package json save 1`] = `
+Array [
+  Object {
+    "dependencies": Object {
+      "git": "github:a/b",
+    },
+    "devDependencies": Object {
+      "def": "^1.0.0",
+      "gtor": ">=1.1.0 || 2",
+      "range": "~1.1.0",
     },
     "name": "root",
     "version": "1.0.0",
@@ -39,7 +56,7 @@ exports[`test/reify/update-importers-package-json.ts > TAP > updatePackageJson >
 Array [
   Object {
     "dependencies": Object {
-      "foo": "^1.0.0",
+      "foo": "1.0.0",
       "git": "github:a/b",
     },
     "devDependencies": Object {
@@ -71,7 +88,7 @@ exports[`test/reify/update-importers-package-json.ts > TAP > updatePackageJson >
 Array [
   Object {
     "dependencies": Object {
-      "foo": "^1.0.0",
+      "foo": "1.0.0",
     },
     "name": "root",
     "version": "1.0.0",

--- a/src/graph/test/reify/update-importers-package-json.ts
+++ b/src/graph/test/reify/update-importers-package-json.ts
@@ -291,4 +291,44 @@ t.test('updatePackageJson', async t => {
     const res = retrieveManifestResult()
     t.strictSame(res.length, 0, 'should have not been called')
   })
+
+  await t.test('registry gt range dep', async t => {
+    const gtMani = { name: 'gtor', version: '1.0.0' }
+    const gtSpec = Spec.parse('gtor@>=1.1.0 || 2')
+    const gt = graph.addNode(
+      undefined,
+      gtMani,
+      gtSpec,
+      gtMani.name,
+      gtMani.version,
+    )
+    graph.addEdge('prod', gtSpec, root, gt)
+
+    updatePackageJson({
+      packageJson,
+      graph,
+      add: new Map([
+        [
+          rootID,
+          new Map([
+            [
+              'gtor',
+              asDependency({
+                spec: gtSpec,
+                type: 'dev',
+              }),
+            ],
+          ]),
+        ],
+      ]),
+    })()
+
+    const res = retrieveManifestResult()
+    const [mani] = res
+    t.strictSame(res.length, 1, 'should have been called once')
+    t.matchSnapshot(
+      mani,
+      'should use provided range in package json save',
+    )
+  })
 })


### PR DESCRIPTION
If the user provides a specific range in order to add a package using `vlt install` then we should preserve that used prefix when saving to the `package.json` file.

e.g (installing a package named `foo`, assuming a dist-tag of `latest` pointing to version `1.1.2`):

`vlt install foo` -> `"foo": "^1.1.2"`
`vlt install foo@latest` -> `"foo": "^1.1.2"`
`vlt install foo@1.1.2` -> `"foo": "1.1.2"`
`vlt install foo@1 || 2` -> `"foo": "1 || 2"`
`vlt install foo@~1.1.0` -> `"foo": "~1.1.0"`

Relates to: https://github.com/vltpkg/vltpkg/issues/266