### PR TITLE
Reify should use lockfile`resolved` & `integrity` values

### DIFF
--- a/src/graph/src/lockfile/load-nodes.ts
+++ b/src/graph/src/lockfile/load-nodes.ts
@@ -41,6 +41,7 @@ export const loadNodes = (
     node.optional = optional
     node.integrity = integrity ?? undefined
     node.resolved = resolved ?? undefined
+    if (!node.resolved) node.setResolved()
     if (location) node.location = location
   }
 }

--- a/src/graph/src/reify/add-nodes.ts
+++ b/src/graph/src/reify/add-nodes.ts
@@ -27,6 +27,7 @@ export const addNodes = (
     const from = scurry.resolve('')
     const spec = hydrate(node.id, manifest.name, options)
     const onErr = optionalFail(diff, node)
+    const { integrity, resolved } = node
     // if it's optional, and we know it isn't for this platform, or it's
     // deprecated, don't install it. if it's not optional, try our best.
     if (
@@ -43,15 +44,17 @@ export const addNodes = (
       continue
     }
     actions.push(() =>
-      remover
-        .rm(target)
-        .then(() =>
-          onErr ?
-            packageInfo
-              .extract(spec, target, { from })
-              .then(x => x, onErr)
-          : packageInfo.extract(spec, target, { from }),
-        ),
+      remover.rm(target).then(() =>
+        onErr ?
+          packageInfo
+            .extract(spec, target, { from, integrity, resolved })
+            .then(x => x, onErr)
+        : packageInfo.extract(spec, target, {
+            from,
+            integrity,
+            resolved,
+          }),
+      ),
     )
   }
   return actions

--- a/src/graph/src/types.ts
+++ b/src/graph/src/types.ts
@@ -49,4 +49,5 @@ export type NodeLike = {
   dev: boolean
   optional: boolean
   toString(): string
+  setResolved(): void
 }

--- a/src/graph/tap-snapshots/test/ideal/build-ideal-from-starting-graph.ts.test.cjs
+++ b/src/graph/tap-snapshots/test/ideal/build-ideal-from-starting-graph.ts.test.cjs
@@ -31,11 +31,13 @@ exports[`test/ideal/build-ideal-from-starting-graph.ts > TAP > build from a virt
     edgesOut: [
       Edge spec(linked@file:./linked) -prod-> to: Node {
         id: 'file·linked',
-        location: './node_modules/.vlt/file·linked/node_modules/linked'
+        location: './node_modules/.vlt/file·linked/node_modules/linked',
+        resolved: 'linked'
       },
       Edge spec(foo@^1.0.0) -prod-> to: Node {
         id: '··foo@1.0.0',
         location: './node_modules/.vlt/··foo@1.0.0/node_modules/foo',
+        resolved: 'https://registry.npmjs.org/foo/-/foo-1.0.0.tgz',
         integrity: 'sha512-6/mh1E2u2YgEsCHdY0Yx5oW+61gZU+1vXaoiHHrpKeuRNNgFvS+/jrwHiQhB5apAf5oB7UB7E19ol2R2LKH8hQ=='
       },
       Edge spec(missing@^1.0.0) -prod-> to: Node {
@@ -45,11 +47,13 @@ exports[`test/ideal/build-ideal-from-starting-graph.ts > TAP > build from a virt
       },
       Edge spec(pnpmdep@1) -prod-> to: Node {
         id: '··pnpmdep@1.0.0',
-        location: './node_modules/.vlt/··pnpmdep@1.0.0/node_modules/pnpmdep'
+        location: './node_modules/.vlt/··pnpmdep@1.0.0/node_modules/pnpmdep',
+        resolved: 'https://registry.npmjs.org/pnpmdep/-/pnpmdep-1.0.0.tgz'
       },
       Edge spec(baz@^1.0.0) -prod-> to: Node {
         id: '··baz@1.0.0',
-        location: './node_modules/.vlt/··baz@1.0.0/node_modules/baz'
+        location: './node_modules/.vlt/··baz@1.0.0/node_modules/baz',
+        resolved: 'https://registry.npmjs.org/baz/-/baz-1.0.0.tgz'
       },
       Edge spec(ipsum@github:lorem/ipsum) -prod-> to: Node {
         id: 'git·github%3Alorem§ipsum·',

--- a/src/graph/tap-snapshots/test/ideal/build.ts.test.cjs
+++ b/src/graph/tap-snapshots/test/ideal/build.ts.test.cjs
@@ -31,6 +31,7 @@ exports[`test/ideal/build.ts > TAP > build from lockfile > should build an ideal
       Edge spec(foo@^1.0.0) -prod-> to: Node {
         id: '··foo@1.0.0',
         location: './node_modules/.vlt/··foo@1.0.0/node_modules/foo',
+        resolved: 'https://registry.npmjs.org/foo/-/foo-1.0.0.tgz',
         integrity: 'sha512-6/mh1E2u2YgEsCHdY0Yx5oW+61gZU+1vXaoiHHrpKeuRNNgFvS+/jrwHiQhB5apAf5oB7UB7E19ol2R2LKH8hQ=='
       }
     ]

--- a/src/graph/tap-snapshots/test/lockfile/load-nodes.ts.test.cjs
+++ b/src/graph/tap-snapshots/test/lockfile/load-nodes.ts.test.cjs
@@ -49,7 +49,7 @@ Array [
     "name": "linked",
     "optional": false,
     "projectRoot": "{ROOT}",
-    "resolved": undefined,
+    "resolved": "linked",
     "version": undefined,
   },
   Object {
@@ -62,7 +62,7 @@ Array [
     "name": "foo",
     "optional": false,
     "projectRoot": "{ROOT}",
-    "resolved": undefined,
+    "resolved": "https://registry.npmjs.org/foo/-/foo-1.0.0.tgz",
     "version": "1.0.0",
   },
   Object {
@@ -88,7 +88,7 @@ Array [
     "name": "baz",
     "optional": false,
     "projectRoot": "{ROOT}",
-    "resolved": undefined,
+    "resolved": "https://registry.npmjs.org/baz/-/baz-1.0.0.tgz",
     "version": "1.0.0",
   },
 ]
@@ -125,7 +125,7 @@ Array [
     "name": "bar",
     "optional": true,
     "projectRoot": "{ROOT}",
-    "resolved": undefined,
+    "resolved": "https://registry.npmjs.org/bar/-/bar-1.0.0.tgz",
     "version": "1.0.0",
   },
   Object {
@@ -144,7 +144,7 @@ Array [
     "name": "foo",
     "optional": false,
     "projectRoot": "{ROOT}",
-    "resolved": undefined,
+    "resolved": "https://registry.npmjs.org/foo/-/foo-1.0.0.tgz",
     "version": "1.0.0",
   },
   Object {

--- a/src/graph/tap-snapshots/test/lockfile/load.ts.test.cjs
+++ b/src/graph/tap-snapshots/test/lockfile/load.ts.test.cjs
@@ -14,11 +14,13 @@ exports[`test/lockfile/load.ts > TAP > load > must match snapshot 1`] = `
     edgesOut: [
       Edge spec(linked@file:./linked) -prod-> to: Node {
         id: 'file·linked',
-        location: './node_modules/.vlt/file·linked/node_modules/linked'
+        location: './node_modules/.vlt/file·linked/node_modules/linked',
+        resolved: 'linked'
       },
       Edge spec(foo@^1.0.0 || 1.2.3 ||  2.3.4) -prod-> to: Node {
         id: '··foo@1.0.0',
         location: './node_modules/.vlt/··foo@1.0.0/node_modules/foo',
+        resolved: 'https://registry.npmjs.org/foo/-/foo-1.0.0.tgz',
         integrity: 'sha512-6/mh1E2u2YgEsCHdY0Yx5oW+61gZU+1vXaoiHHrpKeuRNNgFvS+/jrwHiQhB5apAf5oB7UB7E19ol2R2LKH8hQ=='
       },
       Edge spec(bar@^1.0.0) -prod-> to: Node {
@@ -29,7 +31,8 @@ exports[`test/lockfile/load.ts > TAP > load > must match snapshot 1`] = `
         edgesOut: [
           Edge spec(baz@^1.0.0) -prod-> to: Node {
             id: '··baz@1.0.0',
-            location: './node_modules/.pnpm/baz@1.0.0/node_modules/baz'
+            location: './node_modules/.pnpm/baz@1.0.0/node_modules/baz',
+            resolved: 'https://registry.npmjs.org/baz/-/baz-1.0.0.tgz'
           }
         ]
       },
@@ -104,7 +107,8 @@ exports[`test/lockfile/load.ts > TAP > load with custom git hosts > should load 
     edgesOut: [
       Edge spec(foo@example:foo/bar) -prod-> to: Node {
         id: 'git·example%3Afoo§bar·',
-        location: './node_modules/.vlt/git·example%3Afoo§bar·/node_modules/foo'
+        location: './node_modules/.vlt/git·example%3Afoo§bar·/node_modules/foo',
+        resolved: 'example:foo/bar'
       }
     ]
   }
@@ -218,7 +222,8 @@ exports[`test/lockfile/load.ts > TAP > load with custom scope registry > should 
     edgesOut: [
       Edge spec(@myscope/foo@^1.0.0) -prod-> to: Node {
         id: '··@myscope§foo@1.0.0',
-        location: './node_modules/.vlt/··@myscope§foo@1.0.0/node_modules/@myscope/foo'
+        location: './node_modules/.vlt/··@myscope§foo@1.0.0/node_modules/@myscope/foo',
+        resolved: 'https://registry.npmjs.org/@myscope/foo/-/foo-1.0.0.tgz'
       }
     ]
   }
@@ -234,11 +239,13 @@ exports[`test/lockfile/load.ts > TAP > loadHidden > must match snapshot 1`] = `
     edgesOut: [
       Edge spec(linked@file:./linked) -prod-> to: Node {
         id: 'file·linked',
-        location: './node_modules/.vlt/file·linked/node_modules/linked'
+        location: './node_modules/.vlt/file·linked/node_modules/linked',
+        resolved: 'linked'
       },
       Edge spec(foo@^1.0.0 || 1.2.3 ||  2.3.4) -prod-> to: Node {
         id: '··foo@1.0.0',
         location: './node_modules/.vlt/··foo@1.0.0/node_modules/foo',
+        resolved: 'https://registry.npmjs.org/foo/-/foo-1.0.0.tgz',
         integrity: 'sha512-6/mh1E2u2YgEsCHdY0Yx5oW+61gZU+1vXaoiHHrpKeuRNNgFvS+/jrwHiQhB5apAf5oB7UB7E19ol2R2LKH8hQ=='
       },
       Edge spec(bar@^1.0.0) -prod-> to: Node {
@@ -249,7 +256,8 @@ exports[`test/lockfile/load.ts > TAP > loadHidden > must match snapshot 1`] = `
         edgesOut: [
           Edge spec(baz@^1.0.0) -prod-> to: Node {
             id: '··baz@1.0.0',
-            location: './node_modules/.pnpm/baz@1.0.0/node_modules/baz'
+            location: './node_modules/.pnpm/baz@1.0.0/node_modules/baz',
+            resolved: 'https://registry.npmjs.org/baz/-/baz-1.0.0.tgz'
           }
         ]
       },
@@ -296,6 +304,7 @@ exports[`test/lockfile/load.ts > TAP > workspaces > must match snapshot 1`] = `
       Edge spec(c@^1.0.0) -prod-> to: Node {
         id: '··c@1.0.0',
         location: './node_modules/.vlt/··c@1.0.0/node_modules/c',
+        resolved: 'https://registry.npmjs.org/c/-/c-1.0.0.tgz',
         integrity: 'sha512-6/mh1E2u2YgEsCHdY0Yx5oW+61gZU+1vXaoiHHrpKeuRNNgFvS+/jrwHiQhB5apAf5oB7UB7E19ol2R2LKH8hQ=='
       }
     ]

--- a/src/gui/src/state/load-graph.ts
+++ b/src/gui/src/state/load-graph.ts
@@ -119,6 +119,7 @@ export const load = (transfered: TransferData): LoadResponse => {
         projectRoot: graph.projectRoot,
         dev: false,
         optional: false,
+        setResolved() {},
       }
       this.nodes.set(node.id, node)
       return node

--- a/src/gui/test/state/__snapshots__/load-graph.ts.snap
+++ b/src/gui/test/state/__snapshots__/load-graph.ts.snap
@@ -17,6 +17,7 @@ exports[`load graph 1`] = `
         projectRoot: '/path/to/project',
         dev: false,
         optional: false,
+        setResolved: [Function: setResolved],
         location: '.',
         integrity: undefined,
         resolved: undefined
@@ -37,6 +38,7 @@ exports[`load graph 1`] = `
           projectRoot: '/path/to/project',
           dev: false,
           optional: false,
+          setResolved: [Function: setResolved],
           location: '.',
           integrity: undefined,
           resolved: undefined
@@ -56,6 +58,7 @@ exports[`load graph 1`] = `
           projectRoot: '/path/to/project',
           dev: true,
           optional: false,
+          setResolved: [Function: setResolved],
           integrity: 'sha512-6/mh1E2u2YgEsCHdY0Yx5oW+61gZU+1vXaoiHHrpKeuRNNgFvS+/jrwHiQhB5apAf5oB7UB7E19ol2R2LKH8hQ==',
           resolved: undefined,
           location: 'node_modules/.pnpm/foo@1.0.0/node_modules/foo'
@@ -76,6 +79,7 @@ exports[`load graph 1`] = `
           projectRoot: '/path/to/project',
           dev: false,
           optional: false,
+          setResolved: [Function: setResolved],
           location: '.',
           integrity: undefined,
           resolved: undefined
@@ -95,6 +99,7 @@ exports[`load graph 1`] = `
           projectRoot: '/path/to/project',
           dev: false,
           optional: true,
+          setResolved: [Function: setResolved],
           integrity: undefined,
           resolved: 'http://example.com/baz.tgz'
         },
@@ -114,6 +119,7 @@ exports[`load graph 1`] = `
           projectRoot: '/path/to/project',
           dev: true,
           optional: false,
+          setResolved: [Function: setResolved],
           integrity: 'sha512-6/mh1E2u2YgEsCHdY0Yx5oW+61gZU+1vXaoiHHrpKeuRNNgFvS+/jrwHiQhB5apAf5oB7UB7E19ol2R2LKH8hQ==',
           resolved: undefined,
           location: 'node_modules/.pnpm/foo@1.0.0/node_modules/foo'
@@ -133,6 +139,7 @@ exports[`load graph 1`] = `
           projectRoot: '/path/to/project',
           dev: true,
           optional: true,
+          setResolved: [Function: setResolved],
           integrity: undefined,
           resolved: undefined
         },
@@ -153,6 +160,7 @@ exports[`load graph 1`] = `
         projectRoot: '/path/to/project',
         dev: false,
         optional: false,
+        setResolved: [Function: setResolved],
         location: '.',
         integrity: undefined,
         resolved: undefined
@@ -170,6 +178,7 @@ exports[`load graph 1`] = `
         projectRoot: '/path/to/project',
         dev: true,
         optional: true,
+        setResolved: [Function: setResolved],
         integrity: undefined,
         resolved: undefined
       },
@@ -186,6 +195,7 @@ exports[`load graph 1`] = `
         projectRoot: '/path/to/project',
         dev: true,
         optional: false,
+        setResolved: [Function: setResolved],
         integrity: 'sha512-6/mh1E2u2YgEsCHdY0Yx5oW+61gZU+1vXaoiHHrpKeuRNNgFvS+/jrwHiQhB5apAf5oB7UB7E19ol2R2LKH8hQ==',
         resolved: undefined,
         location: 'node_modules/.pnpm/foo@1.0.0/node_modules/foo'
@@ -203,6 +213,7 @@ exports[`load graph 1`] = `
         projectRoot: '/path/to/project',
         dev: false,
         optional: true,
+        setResolved: [Function: setResolved],
         integrity: undefined,
         resolved: 'http://example.com/baz.tgz'
       }
@@ -238,6 +249,7 @@ exports[`load graph 1`] = `
       projectRoot: '/path/to/project',
       dev: false,
       optional: false,
+      setResolved: [Function: setResolved],
       location: '.',
       integrity: undefined,
       resolved: undefined

--- a/src/package-info/src/index.ts
+++ b/src/package-info/src/index.ts
@@ -60,8 +60,15 @@ export type PackageInfoClientRequestOptions = PickManifestOptions & {
   from?: string
 }
 
+export type PackageInfoClientExtractOptions =
+  PackageInfoClientRequestOptions & {
+    integrity?: Integrity
+    resolved?: string
+  }
+
 export type PackageInfoClientAllOptions = PackageInfoClientOptions &
-  PackageInfoClientRequestOptions
+  PackageInfoClientRequestOptions &
+  PackageInfoClientExtractOptions
 
 // provide some helper methods at the top level. Re-use the client if
 // the same options are provided.
@@ -151,13 +158,16 @@ export class PackageInfoClient {
   async extract(
     spec: Spec | string,
     target: string,
-    options: PackageInfoClientRequestOptions = {},
+    options: PackageInfoClientExtractOptions = {},
   ): Promise<Resolution> {
     if (typeof spec === 'string')
       spec = Spec.parse(spec, this.options)
+    const { from = this.#projectRoot, integrity, resolved } = options
     const f = spec.final
-    const r = await this.resolve(spec, options)
-    const { from = this.#projectRoot } = options
+    const r =
+      integrity && resolved ?
+        { resolved, integrity, spec }
+      : await this.resolve(spec, options)
     switch (f.type) {
       case 'git': {
         const {

--- a/src/package-info/test/index.ts
+++ b/src/package-info/test/index.ts
@@ -501,6 +501,18 @@ t.test('extract', async t => {
     resolved: `${defaultRegistry}abbrev/-/abbrev-2.0.0.tgz`,
   })
 
+  t.match(
+    await extract('abbrev@2', dir + '/registry', {
+      ...options,
+      resolved: `${defaultRegistry}abbrev/-/abbrev-2.0.0.tgz`,
+      integrity: pakuAbbrev.versions['2.0.0'].dist.integrity,
+    }),
+    {
+      resolved: `${defaultRegistry}abbrev/-/abbrev-2.0.0.tgz`,
+    },
+    'should use resolved & integrity value when provided',
+  )
+
   t.match(await extract(`abbrev@${pkgDir}`, dir + '/dir', options), {
     resolved: fileURLToPath(pkgDir),
   })

--- a/src/query/test/fixtures/graph.ts
+++ b/src/query/test/fixtures/graph.ts
@@ -53,6 +53,7 @@ export const newNode =
     resolved: undefined,
     dev: false,
     optional: false,
+    setResolved() {},
   })
 const newEdge = (
   from: NodeLike,


### PR DESCRIPTION
Tweaked **package-info** to make it possible for it to accept `resolved` & `integrity` values and ensures that **graph** now properly sends these values whenever available. Also fixes lockfile load to make sure that `resolved` values for default registry gets properly inferred and added to nodes.

### Benchmarks


```
$ hyperfine --warmup 2 --prepare="rm -rf node_modules" --setup="rm -rf $HOME/Library/Caches/vlt" -r=16 --cleanup="sleep 1" "vlt install" "vlt-main install"
Benchmark 1: vlt install
  Time (mean ± σ):      1.910 s ±  0.042 s    [User: 3.209 s, System: 2.273 s]
  Range (min … max):    1.820 s …  1.982 s    16 runs

Benchmark 2: vlt-main install
  Time (mean ± σ):      2.443 s ±  0.046 s    [User: 3.905 s, System: 2.396 s]
  Range (min … max):    2.380 s …  2.530 s    16 runs

Summary
  vlt install ran
    1.28 ± 0.04 times faster than vlt-main install
```


<img src="https://github.com/user-attachments/assets/8af3f6d8-7b59-4984-9dbf-61991372233b" width="80%"/>

---

```
$ hyperfine --warmup 2 --prepare="rm -rf node_modules" -r=8 --cleanup="sleep 1" --setup="rm -rf $HOME/Library/Caches/vlt" "vlt install" "vlt-main install"
Benchmark 1: vlt install
  Time (mean ± σ):      6.939 s ±  0.400 s    [User: 9.780 s, System: 8.079 s]
  Range (min … max):    6.459 s …  7.639 s    8 runs

Benchmark 2: vlt-main install
  Time (mean ± σ):      9.032 s ±  0.130 s    [User: 13.557 s, System: 8.891 s]
  Range (min … max):    8.844 s …  9.242 s    8 runs

Summary
  vlt install ran
    1.30 ± 0.08 times faster than vlt-main install
```
<img src="https://github.com/user-attachments/assets/fb3e973d-d1a6-4b28-8256-486073086701" width="80%" />

