### PR TITLE
cache: increase in-memory cache size

### DIFF
--- a/src/cache/src/index.ts
+++ b/src/cache/src/index.ts
@@ -89,7 +89,7 @@ export class Cache extends LRUCache<
    * Disk cache is unbounded.
    */
   static get defaultMax() {
-    return 1000
+    return 10_000
   }
 
   constructor(options: CacheOptions) {


### PR DESCRIPTION
Increasing the in-memory cache size improves performance when installing average-sized projects from a cold cache, since reify loads information from disk rather than the in-memory cache once items start to be evicted from our LRU cache.

Bumping its value by 10x helps average size install but also particularly really large ones.

### Benchmarks

```
$ hyperfine --warmup=1 --prepare="rm -rf node_modules; rm -rf $HOME/Library/Caches/vlt || true" -r=4 --cleanup="sleep 1" "vlt install" "vlt-main install"
Benchmark 1: vlt install
  Time (mean ± σ):     17.275 s ± 12.380 s    [User: 7.584 s, System: 4.426 s]
  Range (min … max):    6.039 s … 28.580 s    4 runs

Benchmark 2: vlt-main install
  Time (mean ± σ):     19.276 s ± 12.882 s    [User: 7.916 s, System: 4.791 s]
  Range (min … max):    6.488 s … 31.055 s    4 runs

Summary
  vlt install ran
    1.12 ± 1.09 times faster than vlt-main install
```

<img src="https://github.com/user-attachments/assets/b896241b-05bf-4a45-a259-935e0b8c2f10" width="80%"/>

---

```
$ hyperfine --warmup=1 --prepare="rm -rf node_modules; rm -rf $HOME/Library/Caches/vlt || true" -r=3 --cleanup="sleep 1" "vlt install" "vlt-main install"
Benchmark 1: vlt install
  Time (mean ± σ):     80.739 s ±  5.006 s    [User: 35.344 s, System: 18.185 s]
  Range (min … max):   77.736 s … 86.518 s    3 runs

  Warning: Statistical outliers were detected. Consider re-running this benchmark on a quiet system without any interferences from other programs.

Benchmark 2: vlt-main install
  Time (mean ± σ):     98.832 s ±  2.704 s    [User: 39.143 s, System: 20.770 s]
  Range (min … max):   97.158 s … 101.951 s    3 runs

  Warning: Statistical outliers were detected. Consider re-running this benchmark on a quiet system without any interferences from other programs.

Summary
  vlt install ran
    1.22 ± 0.08 times faster than vlt-main install
```

<img src="https://github.com/user-attachments/assets/14f5d45d-5685-425d-83d6-90cd174fb332" width="80%"/>