### PR TITLE
vlt: add new dashboard root path logic

### DIFF
--- a/src/vlt/src/config/definition.ts
+++ b/src/vlt/src/config/definition.ts
@@ -428,6 +428,14 @@ export const definition = j
     },
   })
 
+  .optList({
+    'dashboard-root': {
+      hint: 'path',
+      description: `The root directory to use for the dashboard GUI.
+                    If not set, the user home directory is used.`,
+    },
+  })
+
   .flag({
     'save-dev': {
       short: 'D',

--- a/src/vlt/src/ignored-homedir-folder-names.ts
+++ b/src/vlt/src/ignored-homedir-folder-names.ts
@@ -1,0 +1,23 @@
+/**
+ * A list of folder names that are ignored when reading the user's home dir.
+ */
+export const ignoredHomedirFolderNames = [
+  'Desktop',
+  'Downloads',
+  'Movies',
+  'Music',
+  'Pictures',
+].concat(
+  process.platform === 'darwin' ? ['Library', 'Public']
+  : process.platform === 'win32' ?
+    [
+      'AppData',
+      'Application Data',
+      'Favorites',
+      'Links',
+      'Videos',
+      'Contacts',
+      'Searches',
+    ]
+  : ['Videos', 'Public'],
+)

--- a/src/vlt/src/start-gui.ts
+++ b/src/vlt/src/start-gui.ts
@@ -242,11 +242,17 @@ const updateGraphData = (
 
 const updateDashboardData = async (
   tmp: string,
-  options: ConfigOptions,
+  conf: LoadedConfig,
 ) => {
+  const userDefinedProjectPaths =
+    // eslint-disable-next-line
+    conf.values?.['dashboard-root'] || []
   const dashboard = formatDashboardJson(
-    readProjectFolders(process.cwd(), options),
-    options,
+    readProjectFolders({
+      ...conf.options,
+      userDefinedProjectPaths,
+    }),
+    conf.options,
   )
   const dashboardJson = JSON.stringify(dashboard, null, 2)
   writeFileSync(resolve(tmp, 'dashboard.json'), dashboardJson)
@@ -260,7 +266,6 @@ export const startGUI = async ({
   startingRoute = '/dashboard',
   tmpDir = tmpdir(),
 }: StartGUIOptions) => {
-  const { options } = conf
   const tmp = resolve(tmpDir, 'vltgui')
   rmSync(tmp, { recursive: true, force: true })
   mkdirSync(tmp, { recursive: true })
@@ -274,7 +279,7 @@ export const startGUI = async ({
   // project in order to just explore its graph data
   let hasDashboard = false
   try {
-    hasDashboard = await updateDashboardData(tmp, options)
+    hasDashboard = await updateDashboardData(tmp, conf)
     /* c8 ignore next */
   } catch (_err) {}
   if (!hasDashboard) {

--- a/src/vlt/tap-snapshots/test/commands/help.ts.test.cjs
+++ b/src/vlt/tap-snapshots/test/commands/help.ts.test.cjs
@@ -228,6 +228,12 @@ More documentation available at <https://docs.vlt.sh>
   --view=<output>      Configures the output format for ls & query commands.
                        Valid options: "human", "json", "mermaid", "gui"
 
+  --dashboard-root=<path>
+                       The root directory to use for the dashboard GUI. If not
+                       set, the user home directory is used.
+
+                       Can be set multiple times
+
   -D --save-dev        Save installed packages to a package.json file as
                        devDependencies
 

--- a/src/vlt/tap-snapshots/test/config/definition.ts.test.cjs
+++ b/src/vlt/tap-snapshots/test/config/definition.ts.test.cjs
@@ -70,6 +70,12 @@ Object {
       "project",
     ],
   },
+  "dashboard-root": Object {
+    "description": "The root directory to use for the dashboard GUI. If not set, the user home directory is used.",
+    "hint": "path",
+    "multiple": true,
+    "type": "string",
+  },
   "editor": Object {
     "description": String(
       The blocking editor to use for \`vlt config edit\` and any other cases where a file should be opened for editing.

--- a/src/vlt/test/read-project-folders.ts
+++ b/src/vlt/test/read-project-folders.ts
@@ -38,111 +38,18 @@ t.test('run from folder with project folders on it', async t => {
       },
     },
   })
-  const cwd = resolve(dir, 'projects')
-  t.chdir(cwd)
-  const projectRoot = cwd
+  const userDefinedPath = resolve(dir, 'projects')
+  const projectRoot = userDefinedPath
   const scurry = new PathScurry(projectRoot)
-  const projectFolders = readProjectFolders(cwd, {
-    projectRoot,
+  const projectFolders = readProjectFolders({
     scurry,
+    userDefinedProjectPaths: [userDefinedPath],
   })
   t.matchSnapshot(
     projectFolders.map(i => i.name),
     'should return project folders',
   )
 })
-
-t.test('run from a given project root', async t => {
-  const dir = t.testdir({
-    projects: {
-      a: {
-        'package.json': JSON.stringify({
-          name: 'a',
-          version: '1.0.0',
-        }),
-      },
-      b: {
-        'package.json': JSON.stringify({
-          name: 'b',
-          version: '1.0.0',
-        }),
-      },
-      c: {
-        'package.json': JSON.stringify({
-          name: 'c',
-          version: '1.0.0',
-        }),
-      },
-      d: {},
-      e: {
-        'README.md': 'File content',
-      },
-      'README.md': 'File content',
-      'linked-folder': t.fixture('symlink', '../a'),
-      node_modules: {
-        'package.json': JSON.stringify({
-          name: 'wat',
-          version: '1.0.0',
-        }),
-      },
-    },
-  })
-  const cwd = resolve(dir, 'projects/a')
-  t.chdir(cwd)
-  const projectRoot = cwd
-  const scurry = new PathScurry(projectRoot)
-  const projectFolders = readProjectFolders(cwd, {
-    projectRoot,
-    scurry,
-  })
-  t.matchSnapshot(
-    projectFolders.map(i => i.name),
-    'should return sibling folders',
-  )
-})
-
-t.test(
-  'read siblings when dir is a nested in projectRoot',
-  async t => {
-    const dir = t.testdir({
-      a: {
-        'package.json': JSON.stringify({
-          name: 'a',
-          version: '1.0.0',
-        }),
-        lib: {
-          utils: {
-            'index.js': 'console.log("hello")',
-          },
-        },
-      },
-      b: {
-        'package.json': JSON.stringify({
-          name: 'b',
-          version: '1.0.0',
-        }),
-      },
-      c: {
-        'package.json': JSON.stringify({
-          name: 'c',
-          version: '1.0.0',
-        }),
-      },
-    })
-    const cwd = resolve(dir, 'a/lib/utils')
-    t.chdir(cwd)
-    const projectRoot = resolve(dir, 'a')
-    const scurry = new PathScurry(projectRoot)
-    const projectFolders = readProjectFolders(cwd, {
-      projectRoot,
-      scurry,
-    })
-    t.matchSnapshot(
-      projectFolders.map(i => i.name),
-      'should return sibling folders to project root',
-    )
-  },
-)
 
 t.test(
   'read nested dirs if nothing is found at first level',
@@ -213,13 +120,12 @@ t.test(
         },
       },
     })
-    const cwd = resolve(dir, 'home')
-    t.chdir(cwd)
-    const projectRoot = cwd
-    const scurry = new PathScurry(projectRoot)
-    const projectFolders = readProjectFolders(cwd, {
-      projectRoot,
+    const homedir = resolve(dir, 'home')
+    const scurry = new PathScurry(homedir)
+    const projectFolders = readProjectFolders({
+      path: homedir,
       scurry,
+      userDefinedProjectPaths: [],
     })
     t.matchSnapshot(
       projectFolders.map(i => i.name),
@@ -274,13 +180,11 @@ t.test(
         'README.md': 'File content',
       },
     })
-    const cwd = resolve(dir, 'projects')
-    t.chdir(cwd)
-    const projectRoot = cwd
-    const scurry = new PathScurry(projectRoot)
-    const projectFolders = readProjectFolders(cwd, {
-      projectRoot,
+    const userDefinedPath = resolve(dir, 'projects')
+    const scurry = new PathScurry(userDefinedPath)
+    const projectFolders = readProjectFolders({
       scurry,
+      userDefinedProjectPaths: [userDefinedPath],
     })
     t.matchSnapshot(
       projectFolders.map(i => i.name),
@@ -288,57 +192,3 @@ t.test(
     )
   },
 )
-
-t.test('run from a workspace dir', async t => {
-  const dir = t.testdir({
-    'project-foo': {
-      'package.json': JSON.stringify({
-        name: 'project-foo',
-        version: '1.0.0',
-      }),
-      'vlt-workspaces.json': JSON.stringify({ packages: ['a', 'b'] }),
-      a: {
-        'package.json': JSON.stringify({
-          name: 'a',
-          version: '1.0.0',
-        }),
-      },
-      b: {
-        'package.json': JSON.stringify({
-          name: 'b',
-          version: '1.0.0',
-        }),
-      },
-    },
-    'project-bar': {
-      'package.json': JSON.stringify({
-        name: 'project-bar',
-        version: '1.0.0',
-      }),
-      'vlt-workspaces.json': JSON.stringify({ packages: ['c'] }),
-      c: {
-        'package.json': JSON.stringify({
-          name: 'c',
-          version: '1.0.0',
-        }),
-      },
-      d: {},
-      e: {
-        'README.md': 'File content',
-      },
-    },
-    'README.md': 'File content',
-  })
-  const cwd = resolve(dir, 'project-foo/a')
-  t.chdir(cwd)
-  const projectRoot = resolve(dir, 'project-foo')
-  const scurry = new PathScurry(projectRoot)
-  const projectFolders = readProjectFolders(cwd, {
-    projectRoot,
-    scurry,
-  })
-  t.matchSnapshot(
-    projectFolders.map(i => i.name),
-    'should return project folders',
-  )
-})

--- a/src/vlt/test/start-gui.ts
+++ b/src/vlt/test/start-gui.ts
@@ -591,6 +591,9 @@ t.test('no data to be found', async t => {
       resetOptions(newProjectRoot: string) {
         options.projectRoot = newProjectRoot
       },
+      values: {
+        'dashboard-root': [resolve(dir, 'emtpy-dir')],
+      },
     } as LoadedConfig,
     assetsDir,
     port,


### PR DESCRIPTION
This changeset introduces a new system for finding out projects to be displayed in the GUI dashboard.

It's now configurable via a `dashboard-root` config option and otherwise defaults to reading all projects available starting from the user home directory.

Fixes: https://github.com/vltpkg/vltpkg/issues/271