### PR TITLE
vlt: `vlt gui` should open explore if project found

### DIFF
--- a/src/vlt/src/start-gui.ts
+++ b/src/vlt/src/start-gui.ts
@@ -259,11 +259,20 @@ const updateDashboardData = async (
   return dashboard.projects.length > 0
 }
 
+const getDefaultStartingRoute = (options: ConfigOptions) => {
+  const { projectRoot, scurry } = options
+  const defaultExplore = `/explore?query=${encodeURIComponent(':root')}`
+  const stat = scurry.lstatSync(`${projectRoot}/package.json`)
+  return stat && stat.isFile() && !stat.isSymbolicLink() ?
+      defaultExplore
+    : '/dashboard'
+}
+
 export const startGUI = async ({
   assetsDir,
   conf,
   port = PORT,
-  startingRoute = '/dashboard',
+  startingRoute = undefined,
   tmpDir = tmpdir(),
 }: StartGUIOptions) => {
   const tmp = resolve(tmpDir, 'vltgui')
@@ -399,9 +408,11 @@ export const startGUI = async ({
   })
 
   return new Promise<Server>(res => {
+    const route =
+      startingRoute || getDefaultStartingRoute(conf.options)
     server.listen(port, 'localhost', () => {
       stdout(`⚡️ vlt GUI running at http://${HOST}:${port}`)
-      opener(`http://${HOST}:${port}${startingRoute}`)
+      opener(`http://${HOST}:${port}${route}`)
       res(server)
     })
   })

--- a/src/vlt/test/start-gui.ts
+++ b/src/vlt/test/start-gui.ts
@@ -594,7 +594,7 @@ t.test('no data to be found', async t => {
       values: {
         'dashboard-root': [resolve(dir, 'emtpy-dir')],
       },
-    } as LoadedConfig,
+    } as unknown as LoadedConfig,
     assetsDir,
     port,
     tmpDir: resolve(dir, 'assets-dir'),


### PR DESCRIPTION
If the current working directory is recognized as being inside a project then the default starting route should be explore, otherwise it should default to opening the dashboard route.

Fixes: https://github.com/vltpkg/vltpkg/issues/262