### PR TITLE
gui: fix cycle manual navigation

### DIFF
--- a/src/gui/src/components/explorer-grid/index.tsx
+++ b/src/gui/src/components/explorer-grid/index.tsx
@@ -191,6 +191,14 @@ const getDependencyItems = (node?: NodeLike) => {
   return items
 }
 
+const getItemQuery = (item: GridItemData) => {
+  if (!item.to) return ''
+  const name = item.to.name ? `[name="${item.to.name}"]` : ''
+  const version =
+    item.to.version ? `[version="${item.to.version}"]` : ''
+  return `${name}${version}`
+}
+
 export const ExplorerGrid = () => {
   const updateQuery = useGraphStore(state => state.updateQuery)
   const query = useGraphStore(state => state.query)
@@ -235,14 +243,20 @@ export const ExplorerGrid = () => {
       return undefined
     }
   const dependencyClick = (item: GridItemData) => () => {
-    console.error('dependencyClick')
-    if (!item.to) return
-    let newQuery = ''
-    const name = item.to.name ? `[name="${item.to.name}"]` : ''
-    const version =
-      item.to.version ? `[version="${item.to.version}"]` : ''
-    newQuery = `${query} > ${name}${version}`
-    updateQuery(newQuery)
+    const itemQuery = getItemQuery(item)
+    if (itemQuery) {
+      if (query.includes(itemQuery)) {
+        const newQuery = query
+          .split(itemQuery)
+          .slice(0, -1)
+          .concat([''])
+          .join(itemQuery)
+        updateQuery(newQuery)
+      } else {
+        const newQuery = `${query} > ${itemQuery}`
+        updateQuery(newQuery)
+      }
+    }
     return undefined
   }
   return (


### PR DESCRIPTION
When using mouse clicks to navigate the Explore graph GUI we should avoid repeating entries in the query when it's possible to subtract from the current query instead.

### Before


https://github.com/user-attachments/assets/52b7526b-3444-44c2-bd9f-7bd1d058bfc6



### After


https://github.com/user-attachments/assets/55e340f5-e7a7-4674-b5b0-bc817c3291a4



Fixes: https://github.com/vltpkg/vltpkg/issues/289