### PR TITLE
publish: compiled binaries to a separate tag

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -25,9 +25,9 @@ jobs:
         with:
           bun-version: latest
 
-      - uses: denoland/setup-deno@v1
+      - uses: denoland/setup-deno@v2
         with:
-          deno-version: v1.x
+          deno-version: v2.x
 
       - uses: pnpm/action-setup@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,9 +139,9 @@ jobs:
         with:
           bun-version: latest
 
-      - uses: denoland/setup-deno@v1
+      - uses: denoland/setup-deno@v2
         with:
-          deno-version: v1.x
+          deno-version: v2.x
 
       - uses: pnpm/action-setup@v4
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,9 +31,9 @@ jobs:
           version: 9
           run_install: false
 
-      - uses: denoland/setup-deno@v1
+      - uses: denoland/setup-deno@v2
         with:
-          deno-version: v1.x
+          deno-version: v2.x
 
       - name: Setup Nodejs
         uses: actions/setup-node@v4

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,6 +6,9 @@ on:
       ref:
         description: 'the GitHub ref to checkout and publish'
         type: string
+      dryRun:
+        description: 'run the publish script in dry-run mode'
+        type: boolean
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -28,6 +31,10 @@ jobs:
           version: 9
           run_install: false
 
+      - uses: denoland/setup-deno@v1
+        with:
+          deno-version: v1.x
+
       - name: Setup Nodejs
         uses: actions/setup-node@v4
         with:
@@ -37,7 +44,12 @@ jobs:
       - name: Install dependencies
         run: pnpm install
 
-      - name: Run Publish
-        run: pnpm -F infra-build exec node dist/esm/bin/publish.js --forReal
+      - name: Publish
+        run: pnpm -F infra-build exec node dist/esm/bin/publish.js ${{ !inputs.dryRun && '--forReal' || '' }}
+        env:
+          VLT_CLI_PUBLISH_TOKEN: ${{ secrets.VLT_CLI_PUBLISH_TOKEN }}
+
+      - name: Publish Deno
+        run: pnpm -F infra-build exec node dist/esm/bin/publish.js --compile=true --runtime=deno --platform=all --arch=all ${{ !inputs.dryRun && '--forReal' || '' }}
         env:
           VLT_CLI_PUBLISH_TOKEN: ${{ secrets.VLT_CLI_PUBLISH_TOKEN }}

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -196,7 +196,11 @@ export default tseslint.config(
      * but anywhere else is beneficial. Goal is to at least not
      * have any src/ files in here.
      */
-    files: ['**/test/**/*.{ts,tsx}', '**/infra/**/*.ts'],
+    files: [
+      '**/test/**/*.{ts,tsx}',
+      '**/infra/**/*.ts',
+      '!**/infra/build/src/bin/publish.ts',
+    ],
     rules: {
       '@typescript-eslint/no-unsafe-argument': 'off',
       '@typescript-eslint/no-unsafe-assignment': 'off',

--- a/infra/build/src/bin/benchmark.ts
+++ b/infra/build/src/bin/benchmark.ts
@@ -57,7 +57,10 @@ const main = async () => {
   const { hyperfine, args, ...o } = parseArgs()
   rmSync(o.outdir, { recursive: true, force: true })
 
-  const { bundles, compilations } = await generateMatrix(o)
+  const { bundles, compilations } = await generateMatrix({
+    ...o,
+    bin: [o.bin],
+  })
 
   const benchmarks = new Set<string>()
   if (o.matrix.bundle) {

--- a/infra/build/src/bin/publish.ts
+++ b/infra/build/src/bin/publish.ts
@@ -1,33 +1,109 @@
 import { join, resolve } from 'node:path'
 import assert from 'node:assert'
-import { spawnSync, type SpawnSyncOptions } from 'node:child_process'
+import { spawnSync } from 'node:child_process'
 import { parseArgs as nodeParseArgs } from 'node:util'
-import {
-  copyFileSync,
-  readdirSync,
-  readFileSync,
-  rmSync,
-  writeFileSync,
-} from 'node:fs'
+import fs from 'node:fs'
 import generateMatrix, {
   getMatrix,
   matrixConfig,
-  type BundleDir,
   type CompilationDir,
 } from '../matrix.js'
 import { Paths } from '../index.js'
 import * as types from '../types.js'
 
-const PUBLISH_TOKEN = 'NPM_PUBLISH_TOKEN'
-const DATE_ID = `${Date.now()}`
+type PackageJsonBase = {
+  name: string
+  version: string
+  description: string
+  license: string
+  keywords: string[]
+  repository: Record<string, string>
+}
 
-type Package = BundleDir | CompilationDir
+type PackageJsonBundle = PackageJsonBase & {
+  engines: Record<string, string>
+}
+
+type PackageJsonCompiled = PackageJsonBase & {
+  engines: undefined
+}
+
+type PackageJsonCompiledRoot = PackageJsonCompiled & {
+  scripts: { postinstall: string }
+  optionalDependencies: Record<string, string>
+}
+
+type PackageJsonCompiledPlatform = PackageJsonCompiled & {
+  bin: undefined
+  os: types.Platform[]
+  cpu: types.Arch[]
+}
+
+type PackageJson =
+  | PackageJsonBundle
+  | PackageJsonCompiled
+  | PackageJsonCompiledRoot
+  | PackageJsonCompiledPlatform
+
+type PublishOptions<T extends PackageJson = PackageJson> = {
+  dryRun: boolean
+  tag: string
+  files: {
+    LICENSE: string
+    'README.md': string
+    'package.json': T
+    '.npmrc': string
+  } & (T extends PackageJsonCompiledRoot ?
+    {
+      [bin in types.Bin]?: string
+    } & {
+      'postinstall.js': string
+    }
+  : unknown)
+}
+
+const readFile = (path: string) => fs.readFileSync(path, 'utf8')
+
+// eslint-disable-next-line @typescript-eslint/no-unnecessary-type-parameters
+const readPackageJson = <T>(path: string): T =>
+  JSON.parse(readFile(path)) as T
+
+const TOKEN = process.env.VLT_CLI_PUBLISH_TOKEN
+const PRERELEASE_ID = `.${Date.now()}`
+const FILES = {
+  README: readFile(join(Paths.CLI, 'README.md')),
+  LICENSE: readFile(join(Paths.CLI, 'LICENSE')),
+  PACKAGE_JSON: readPackageJson<PackageJsonBundle>(
+    join(Paths.CLI, 'package.json'),
+  ),
+  POST_INSTALL: readFile(
+    join(Paths.BUILD_ROOT, 'src/postinstall.js'),
+  ),
+  PLACEHOLDER_BIN: readFile(
+    join(Paths.BUILD_ROOT, 'src/placeholder-bin.js'),
+  ),
+}
+
+const createWriteFiles = (dir: string) => {
+  fs.mkdirSync(dir, { recursive: true })
+  return (files: Record<string, string | object>) => {
+    for (const [name, contents] of Object.entries(files)) {
+      fs.writeFileSync(
+        join(dir, name),
+        typeof contents === 'string' ? contents : (
+          JSON.stringify(contents, null, 2) + '\n'
+        ),
+      )
+    }
+  }
+}
 
 const parseArgs = () => {
   const { outdir, forReal, ...matrix } = nodeParseArgs({
     options: {
       outdir: { type: 'string' },
       forReal: { type: 'boolean' },
+      tag: { type: 'string' },
       ...matrixConfig,
     },
   }).values
@@ -36,161 +112,188 @@ const parseArgs = () => {
     /* c8 ignore next */
     outdir: resolve(outdir ?? '.publish'),
     /* c8 ignore next */
-    npmArgs: forReal ? [] : ['--dry-run'],
+    dryRun: !forReal,
     matrix: getMatrix(matrix),
   }
 }
 
-const npm = (
-  pkg: Package,
-  args: string[],
-  options: Omit<SpawnSyncOptions, 'cwd' | 'stdio' | 'shell'> = {},
-) =>
-  spawnSync('npm', args, {
-    cwd: pkg.dir,
-    stdio: 'inherit',
-    shell: true,
-    ...options,
-    env: {
-      ...process.env,
-      ...options.env,
-    },
-  })
-
-const getToken = (bin: types.Bin) => {
-  if (process.env.CI) {
-    return process.env.VLT_CLI_PUBLISH_TOKEN
-  }
-  const { sections, fields } = JSON.parse(
-    spawnSync(
-      'op',
-      [
-        'item',
-        'get',
-        '"npm - Ops Account"',
-        '--format=json',
-        '--account=vltpkg.1password.com',
-      ],
-      { shell: true, encoding: 'utf8' },
-    ).stdout,
-  ) as {
-    sections?: { label?: string; id?: string }[]
-    fields?: {
-      section?: { id?: string }
-      label?: string
-      value?: string
-    }[]
-  }
-  /* c8 ignore start - make sure op CLI response is expected shape  */
-  const section = sections?.find(s => s.label === 'tokens')?.id
-  const token = fields?.find(
-    f => f.section?.id === section && f.label === bin,
-  )?.value
-  /* c8 ignore stop */
-  assert(typeof token === 'string', 'token')
-  return token
-}
-
-const transformJsonFile = <U extends Record<string, any>>(
-  dir: string,
-  f: string,
-  t: (v: U) => U,
+const publish = <T extends PackageJson>(
+  pkg: { dir: string; format: types.Format },
+  options: PublishOptions<T>,
 ) => {
-  const p = join(dir, f)
-  return writeFileSync(
-    p,
-    JSON.stringify(t(JSON.parse(readFileSync(p, 'utf8'))), null, 2),
-  )
-}
+  const writeFiles = createWriteFiles(pkg.dir)
 
-const transformMdFile = (
-  dir: string,
-  f: string,
-  t: (v: string) => string,
-) => {
-  const p = join(dir, f)
-  return writeFileSync(p, t(readFileSync(p, 'utf8')))
-}
+  writeFiles(options.files)
 
-const keysToObj = (arr: string[], t: (k: string) => string) =>
-  arr.reduce<Record<string, string>>((acc, k) => {
-    acc[k] = t(k)
-    return acc
-  }, {})
-
-const writeFiles = (
-  name: string,
-  { dir, format, compileId }: Package,
-  { bins = types.BinNames }: { bins?: types.Bin[] },
-) => {
-  const { dirs, files } = readdirSync(dir, {
-    withFileTypes: true,
-  }).reduce<{ dirs: string[]; files: string[] }>(
-    (acc, f) => {
-      acc[f.isDirectory() ? 'dirs' : 'files'].push(f.name)
+  const binFiles = fs
+    .readdirSync(pkg.dir)
+    .reduce<Partial<Record<types.Bin, string>>>((acc, f) => {
+      const bin = types.BinNames.find(b =>
+        [b, `${b}.js`, `${b}.exe`].includes(f),
+      )
+      if (bin) {
+        acc[bin] = f
+      }
       return acc
+    }, {})
+
+  writeFiles({
+    'package.json': {
+      ...options.files['package.json'],
+      bin:
+        'bin' in options.files['package.json'] ?
+          options.files['package.json'].bin
+        : binFiles,
+      type: pkg.format === types.Formats.Cjs ? 'commonjs' : 'module',
     },
-    { dirs: [], files: [] },
-  )
-  const binPath = (p: string) => `${p}${compileId ? '' : '.js'}`
-  writeFileSync(
-    join(dir, '.npmrc'),
-    `//registry.npmjs.org/:_authToken=\${${PUBLISH_TOKEN}}`,
-  )
-  for (const f of ['README.md', 'LICENSE', 'package.json']) {
-    copyFileSync(join(Paths.CLI, f), join(dir, f))
-  }
-  transformMdFile(dir, 'README.md', p => {
-    return p.replaceAll('# @vltpkg/vlt', '# vlt')
   })
-  transformJsonFile(dir, 'package.json', p => ({
-    name,
-    version: `${p.version}.${DATE_ID}`,
-    type: format === types.Formats.Cjs ? 'commonjs' : 'module',
-    bin: keysToObj(bins, binPath),
-    files: [
-      ...dirs.map(d => `${d}/`),
-      ...files.filter(f => {
-        const base = f.split('.')[0]
-        const bin = types.isBin(base) ? base : null
-        return bin && bins.includes(bin)
-      }),
-    ],
-    ...keysToObj(
-      ['description', 'license', 'engines', 'keywords'],
-      k => p[k],
-    ),
-  }))
+
+  spawnSync(
+    'npm',
+    [
+      'publish',
+      '--access=public',
+      `--tag=${options.tag}`,
+      options.dryRun ? '--dry-run' : null,
+    ].filter(v => v !== null),
+    {
+      cwd: pkg.dir,
+      stdio: 'inherit',
+      shell: true,
+      env: {
+        ...process.env,
+        NPM_PUBLISH_TOKEN: TOKEN,
+      },
+    },
+  )
+
+  return {
+    pkg: readPackageJson<T>(join(pkg.dir, 'package.json')),
+    binFiles: Object.keys(binFiles),
+  }
+}
+
+const publishCompiled = (
+  outdir: string,
+  runtime: types.Runtime,
+  compilations: CompilationDir[],
+  baseOptions: PublishOptions,
+) => {
+  const options: PublishOptions<PackageJsonCompiled> = {
+    ...baseOptions,
+    files: {
+      ...baseOptions.files,
+      'package.json': {
+        ...baseOptions.files['package.json'],
+        // No engines needed for compiled packages
+        engines: undefined,
+      },
+    },
+  }
+
+  const platformPackages = compilations.map(pkg =>
+    publish<PackageJsonCompiledPlatform>(pkg, {
+      ...options,
+      files: {
+        ...options.files,
+        'package.json': {
+          ...options.files['package.json'],
+          name: `@vltpkg/cli-${pkg.platform}-${pkg.arch}`,
+          description: `${FILES.PACKAGE_JSON.description} for ${pkg.platform} ${pkg.arch}`,
+          // platform packaged dont get bins set in package json since those
+          // would conflict with the root package. they get moved in place
+          // by the postinstall script
+          bin: undefined,
+          os: [pkg.platform],
+          cpu: [pkg.arch],
+        },
+      },
+    }),
+  )
+
+  publish<PackageJsonCompiledRoot>(
+    { dir: join(outdir, 'root-compiled'), format: types.Formats.Cjs },
+    {
+      ...options,
+      tag: runtime,
+      files: {
+        ...options.files,
+        // all platform packages should have the same bins
+        ...Object.fromEntries(
+          (platformPackages[0]?.binFiles ?? []).map(
+            b => [b, FILES.PLACEHOLDER_BIN] as const,
+          ),
+        ),
+        'postinstall.js': FILES.POST_INSTALL,
+        'package.json': {
+          ...options.files['package.json'],
+          scripts: { postinstall: 'node postinstall.js' },
+          optionalDependencies: Object.fromEntries(
+            platformPackages.map(({ pkg }) => [
+              pkg.name,
+              pkg.version,
+            ]),
+          ),
+        },
+      },
+    },
+  )
 }
 
 const main = async () => {
-  const { outdir, matrix, npmArgs } = parseArgs()
+  const { outdir, matrix, dryRun } = parseArgs()
 
-  rmSync(outdir, { recursive: true, force: true })
+  assert(
+    dryRun || TOKEN,
+    'expected VLT_CLI_PUBLISH_TOKEN to be set in non-dry-run mode',
+  )
+
+  fs.rmSync(outdir, { recursive: true, force: true })
+
+  const options: PublishOptions<PackageJsonBundle> = {
+    dryRun,
+    tag: 'latest',
+    files: {
+      'README.md': FILES.README.replaceAll('# @vltpkg/vlt', '# vlt'),
+      LICENSE: FILES.LICENSE,
+      '.npmrc': `//registry.npmjs.org/:_authToken=\${NPM_PUBLISH_TOKEN}`,
+      'package.json': {
+        name: 'vlt',
+        version: `${FILES.PACKAGE_JSON.version}${PRERELEASE_ID}`,
+        description: FILES.PACKAGE_JSON.description,
+        license: FILES.PACKAGE_JSON.license,
+        keywords: FILES.PACKAGE_JSON.keywords,
+        repository: FILES.PACKAGE_JSON.repository,
+        engines: FILES.PACKAGE_JSON.engines,
+      },
+    },
+  }
+
   const { bundles, compilations } = await generateMatrix({
     outdir,
     verbose: true,
     matrix,
+    // Only publish the main `vlt` bin if it's a compilation because its probably too
+    // big to publish 5 * 80MB bins.
+    bin: matrix.compilations.length ? types.Bins.vlt : undefined,
   })
-  const pkg = bundles[0] ?? compilations[0]
-  assert(
-    bundles.length + compilations.length === 1,
-    'should only have 1 package to publish',
-  )
-  assert(pkg, 'could not find package to publish')
 
-  const [opts = {}, args = []] =
-    'runtime' in pkg && pkg.runtime === 'deno' ?
-      [{ bins: [types.Bins.vlt] }, ['--tag=deno']]
-    : []
-
-  const registryPackageToPublish = 'vlt'
-  writeFiles(registryPackageToPublish, pkg, opts)
-  npm(pkg, ['publish', ...npmArgs, ...args], {
-    env: {
-      [PUBLISH_TOKEN]: getToken(registryPackageToPublish),
-    },
-  })
+  if (compilations.length) {
+    const runtimes = new Set(matrix.compilations.map(c => c.runtime))
+    const runtime = [...runtimes][0]
+    assert(
+      runtime && runtimes.size === 1,
+      'expected all compilations to have the same runtime',
+    )
+    publishCompiled(outdir, runtime, compilations, options)
+  } else {
+    const [pkg] = bundles
+    assert(
+      pkg && bundles.length === 1,
+      'expected exactly one bundle to publish',
+    )
+    publish(pkg, options)
+  }
 }
 
 await main()

--- a/infra/build/src/bin/publish.ts
+++ b/infra/build/src/bin/publish.ts
@@ -93,7 +93,6 @@ const parseArgs = () => {
     options: {
       outdir: { type: 'string' },
       forReal: { type: 'boolean' },
-      tag: { type: 'string' },
       ...matrixConfig,
     },
   }).values
@@ -175,10 +174,15 @@ const publish = <T extends Package>(
 }
 
 const publishCompiled = (
-  { dir, runtime }: { dir: string; runtime: types.Runtime },
+  { dir }: { dir: string },
   compilations: CompilationDir[],
   baseOptions: Publish,
 ) => {
+  assertOne(
+    uniq(compilations.map(c => c.runtime)),
+    'expected all compilations to have the same runtime',
+  )
+
   const options: Publish<Compiled> = {
     ...baseOptions,
     files: {
@@ -243,7 +247,7 @@ const publishCompiled = (
     },
     {
       ...options,
-      tag: runtime,
+      tag: 'compiled',
       files: {
         ...options.files,
         ...placeholderBinFiles,
@@ -298,13 +302,7 @@ const main = async () => {
 
   if (compilations.length) {
     publishCompiled(
-      {
-        dir: join(outdir, 'compile-root-package'),
-        runtime: assertOne(
-          uniq(matrix.compilations.map(c => c.runtime)),
-          'expected all compilations to have the same runtime',
-        ),
-      },
+      { dir: join(outdir, 'compile-root-package') },
       compilations,
       options,
     )

--- a/infra/build/src/matrix.ts
+++ b/infra/build/src/matrix.ts
@@ -214,7 +214,7 @@ export const getMatrix = (o: ParseArgs['matrix'] = {}) => {
 export default async (o: {
   outdir: string
   verbose?: boolean
-  bin?: types.Bin
+  bin?: types.Bin[]
   save?: boolean
   matrix: ReturnType<typeof getMatrix>
 }) => {
@@ -244,22 +244,13 @@ export default async (o: {
       if (o.verbose) {
         console.log(`compiling - ${dir}`)
       }
-      if (o.bin) {
+      for (const bin of o.bin ?? types.BinNames) {
         compile({
           ...c,
           source,
-          bin: o.bin,
+          bin,
           outdir: dir,
         })
-      } else {
-        for (const bin of types.BinNames) {
-          compile({
-            ...c,
-            source,
-            bin,
-            outdir: dir,
-          })
-        }
       }
       compilations.push({ dir, ...c })
     }

--- a/infra/build/src/placeholder-bin.js
+++ b/infra/build/src/placeholder-bin.js
@@ -1,7 +1,27 @@
 #!/usr/bin/env node
 
-console.log(`The correct platform specific binary was not found.
-This could be due to --no-optional or --ignore-scripts being used.
-Try again without either of those flags.`)
+/* eslint-disable @typescript-eslint/no-require-imports */
+
+const { readFileSync } = require('fs')
+const { resolve } = require('path')
+const os = require('os')
+
+const validPlatforms = Object.keys(
+  JSON.parse(readFileSync(resolve(__dirname, 'package.json'), 'utf8'))
+    .optionalDependencies,
+).map(name => name.replace('@vltpkg/cli-', ''))
+
+const currentPlatform = `${os.platform()}-${os.arch()}`
+
+console.error(
+  validPlatforms.includes(currentPlatform) ?
+    `This is a supported platform but the matching binary was not found.
+This could be due to --no-optional or --ignore-scripts being used when installing.
+Try again without either of those flags.
+Otherwise check for error logs from the postinstall script.`
+  : `The current platform is not supported by this package.`,
+)
+console.error(`Valid platforms: ${JSON.stringify(validPlatforms)}`)
+console.error(`Current platform: ${JSON.stringify(currentPlatform)}`)
 
 process.exit(1)

--- a/infra/build/src/placeholder-bin.js
+++ b/infra/build/src/placeholder-bin.js
@@ -1,0 +1,7 @@
+#!/usr/bin/env node
+
+console.log(`The correct platform specific binary was not found.
+This could be due to --no-optional or --ignore-scripts being used.
+Try again without either of those flags.`)
+
+process.exit(1)

--- a/infra/build/src/postinstall.js
+++ b/infra/build/src/postinstall.js
@@ -1,0 +1,51 @@
+/* eslint-disable @typescript-eslint/no-require-imports */
+
+const os = require('os')
+const { join, dirname, basename } = require('path')
+const fs = require('fs')
+
+const platform = os.platform()
+const arch = os.arch()
+const rootPackage = __dirname
+const bins = Object.values(
+  require(join(rootPackage, 'package.json')).bin,
+)
+
+const platformPkg = (() => {
+  try {
+    return dirname(
+      require.resolve(`@vltpkg/cli-${platform}-${arch}/package.json`),
+    )
+  } catch (e) {
+    throw new Error(
+      `Could not find platform package for ${platform}-${arch}`,
+      {
+        cause: e,
+      },
+    )
+  }
+})()
+
+const atomicCopySync = (source, target) => {
+  const tmp = join(dirname(target), `${basename(target)}.tmp`)
+  try {
+    fs.copyFileSync(source, tmp)
+    fs.renameSync(tmp, target)
+  } catch (err) {
+    try {
+      fs.unlinkSync(tmp)
+    } catch (err2) {
+      throw new Error(`Could not unlink tmp platform bin`, {
+        cause: err2,
+      })
+    }
+    throw new Error(`Could not copy platform bin`, { cause: err })
+  }
+}
+
+for (const binPath of bins) {
+  atomicCopySync(
+    join(platformPkg, binPath + `${os === 'win32' ? '.exe' : ''}`),
+    join(rootPackage, binPath),
+  )
+}

--- a/infra/build/test/matrix.ts
+++ b/infra/build/test/matrix.ts
@@ -4,7 +4,7 @@ import { type Bin, Bins } from '../src/types.js'
 
 const testGenerateMatrix = async (
   t: Test,
-  { bin, ...o }: ParseArgs['matrix'] & { bin?: Bin } = {},
+  { bin, ...o }: ParseArgs['matrix'] & { bin?: Bin[] } = {},
 ) => {
   const dir = t.testdir()
   t.capture(console, 'log')
@@ -82,7 +82,7 @@ t.test('compile matrix', async t => {
 
 t.test('single bin', async t => {
   const { compiles } = await testGenerateMatrix(t, {
-    bin: Bins.vlt,
+    bin: [Bins.vlt],
     platform: ['linux'],
     arch: ['arm64'],
     compile: [true],


### PR DESCRIPTION
This adds a separate step to the `publish.yml` workflow that will publish the Deno compiled binary to `vlt@compiled`.

It also publishes the 5 platform/arch combinations supported by Deno to `@vltpkg/cli-{PLATFORM}-{ARCH}` which are set as optional dependencies with the correct picked by a postinstall script.

Currently if a correct optional dep is not found there is a placeholder bin that will just error with a message saying it's probably because `--ignore-scripts` or `--no-optional` was used and to try again. This is a tradeoff for now because I'd rather this special `compiled` tag not fallback to running the bundled JS version so we can ensure the compiled version is always being run for perf testing.

Also the `compiled` tag currently only contains the main `vlt` bin and not any of the others like `vlr`, etc. This can be revisted in the future, but for now it's easier and faster not to publish all 5 compiled bins which ends up around ~500mb per platform package.

Closes #318