### PR TITLE
gui: fix react render warnings

### DIFF
--- a/src/gui/src/components/explorer-grid/dependency-side-bar.tsx
+++ b/src/gui/src/components/explorer-grid/dependency-side-bar.tsx
@@ -231,6 +231,7 @@ export const DependencySideBar = ({
                   <Tooltip>
                     <TooltipTrigger asChild>
                       <Button
+                        asChild
                         role="button"
                         variant="outline"
                         size="xs"

--- a/src/gui/src/components/explorer-grid/save-query.tsx
+++ b/src/gui/src/components/explorer-grid/save-query.tsx
@@ -72,6 +72,7 @@ const SaveQueryButton = () => {
               asChild
               className="flex rounded-sm items-center justify-center h-[1.5rem] w-[1.5rem] bg-muted border border-muted-foreground/20">
               <Button
+                asChild
                 role="button"
                 variant="outline"
                 size="icon"

--- a/src/gui/test/components/explorer-grid/__snapshots__/index.tsx.snap
+++ b/src/gui/test/components/explorer-grid/__snapshots__/index.tsx.snap
@@ -273,12 +273,6 @@ exports[`explorer-grid renders workspace with edges in 1`] = `
             aria-controls="radix-:ra:"
             data-state="closed"
           >
-          </button>
-          <button
-            class="inline-flex items-center justify-center gap-2 whitespace-nowrap text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&amp;_svg]:pointer-events-none [&amp;_svg]:size-4 [&amp;_svg]:shrink-0 border border-input bg-background hover:bg-accent hover:text-accent-foreground h-6 rounded-sm px-1"
-            role="button"
-            data-state="closed"
-          >
             <svg
               xmlns="http://www.w3.org/2000/svg"
               width="24"
@@ -289,7 +283,9 @@ exports[`explorer-grid renders workspace with edges in 1`] = `
               stroke-width="2"
               stroke-linecap="round"
               stroke-linejoin="round"
-              class="lucide lucide-plus"
+              class="lucide lucide-plus inline-flex items-center justify-center gap-2 whitespace-nowrap text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&amp;_svg]:pointer-events-none [&amp;_svg]:size-4 [&amp;_svg]:shrink-0 border border-input bg-background hover:bg-accent hover:text-accent-foreground h-6 rounded-sm px-1"
+              role="button"
+              data-state="closed"
             >
               <path d="M5 12h14">
               </path>

--- a/src/gui/test/components/explorer-grid/__snapshots__/save-query.tsx.snap
+++ b/src/gui/test/components/explorer-grid/__snapshots__/save-query.tsx.snap
@@ -11,6 +11,7 @@ exports[`save-query > should render correctly 1`] = `
           classname="flex rounded-sm items-center justify-center h-[1.5rem] w-[1.5rem] bg-muted border border-muted-foreground/20"
         >
           <gui-button
+            aschild="true"
             role="button"
             variant="outline"
             size="icon"


### PR DESCRIPTION
React development mode was complaining about nested buttons, setting `asChild` props fixes the warnings.