### PR TITLE
gui: fix explorer connecting line issues

### DIFF
--- a/src/gui/src/components/explorer-grid/dependency-side-bar.tsx
+++ b/src/gui/src/components/explorer-grid/dependency-side-bar.tsx
@@ -270,10 +270,9 @@ export const DependencySideBar = ({
         ...dependencies
           .filter(item => !addedDependencies.includes(item.name))
           .sort((a, b) => a.name.localeCompare(b.name, 'en')),
-      ].map((item, idx) => (
+      ].map(item => (
         <SideItem
           item={item}
-          idx={idx}
           key={item.id}
           dependencies={true}
           onSelect={onDependencyClick(item)}

--- a/src/gui/src/components/explorer-grid/selected-item.tsx
+++ b/src/gui/src/components/explorer-grid/selected-item.tsx
@@ -16,6 +16,7 @@ import {
 } from '@/components/ui/tabs.jsx'
 import { CodeBlock } from '../ui/shiki.jsx'
 import { FileSearch2 } from 'lucide-react'
+import { useEffect, useRef } from 'react'
 
 const getItemOrigin = ({
   item,
@@ -52,7 +53,23 @@ const getItemOrigin = ({
 
 export const SelectedItem = ({ item }: GridItemOptions) => {
   const specOptions = useGraphStore(state => state.specOptions)
+  const updateLinePositionReference = useGraphStore(
+    state => state.updateLinePositionReference,
+  )
   const origin = specOptions && getItemOrigin({ item, specOptions })
+  const linePositionRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    const handleResize = () => {
+      const rect = linePositionRef.current?.getBoundingClientRect()
+      if (rect?.top) {
+        updateLinePositionReference(rect.top)
+      }
+    }
+    handleResize()
+    window.addEventListener('resize', handleResize)
+    return () => window.removeEventListener('resize', handleResize)
+  })
 
   return (
     <div className="relative">
@@ -104,8 +121,9 @@ export const SelectedItem = ({ item }: GridItemOptions) => {
         // Draw the connection line between dependencies and the selected item
         item.to?.edgesOut && item.to.edgesOut.size > 0 ?
           <div
+            ref={linePositionRef}
             className={
-              'absolute border-t border-solid border-neutral-300 dark:border-neutral-600 rounded-tr-sm w-4 top-7 -right-4'
+              'absolute border-t border-solid border-neutral-300 dark:border-neutral-600 rounded-tr-sm w-4 top-[44px] -right-4'
             }></div>
         : ''
       }

--- a/src/gui/src/components/explorer-grid/side-item.tsx
+++ b/src/gui/src/components/explorer-grid/side-item.tsx
@@ -10,11 +10,11 @@ import {
 } from '@/components/ui/dropdown-menu.jsx'
 import { labelClassNamesMap } from './label-helper.js'
 import { type GridItemData, type GridItemOptions } from './types.js'
+import { useGraphStore } from '@/state/index.js'
 
 export type SideItemOptions = GridItemOptions & {
   parent?: boolean
-  idx?: number
-  onSelect: () => undefined
+  onSelect?: () => undefined
   onUninstall?: (item: GridItemData) => void
 }
 
@@ -23,7 +23,6 @@ export const SideItem = ({
   item,
   highlight,
   parent,
-  idx,
   onSelect,
   onUninstall,
 }: SideItemOptions) => {
@@ -32,12 +31,17 @@ export const SideItem = ({
   // a single line, which should be a very rare occasion
   const divRef = useRef<HTMLDivElement>(null)
   const lineRef = useRef<HTMLDivElement>(null)
+  const linePositionReference = useGraphStore(
+    state => state.linePositionReference,
+  )
   useEffect(() => {
-    if (idx === 1) {
-      const rect = divRef.current?.getBoundingClientRect()
-      if (rect && lineRef.current && rect.height > 86) {
-        lineRef.current.style.height = '124px'
-      }
+    const rect = lineRef.current?.getBoundingClientRect()
+    if (rect && lineRef.current) {
+      const height = rect.bottom - linePositionReference
+      lineRef.current.style.height = `${height}px`
+    }
+    if (item.depIndex && divRef.current) {
+      divRef.current.style.zIndex = `${9999 - item.depIndex}`
     }
   })
   const uninstallItem = (e: MouseEvent) => {
@@ -54,14 +58,18 @@ export const SideItem = ({
       {item.stacked ?
         <>
           {item.size > 2 ?
-            <div className="transition-all absolute border top-2 left-2 w-[96%] h-full bg-card rounded-lg group-hover:border-neutral-400 dark:group-hover:border-neutral-600" />
+            <div
+              className={`transition-all absolute border top-2 left-2 w-[96%] h-full bg-card rounded-lg ${onSelect ? 'group-hover:border-neutral-400 dark:group-hover:border-neutral-600' : ''}`}
+            />
           : ''}
-          <div className="transition-all absolute border top-1 left-1 w-[98%] h-full bg-card rounded-lg group-hover:border-neutral-400 dark:group-hover:border-neutral-600" />
+          <div
+            className={`transition-all absolute border top-1 left-1 w-[98%] h-full bg-card rounded-lg ${onSelect ? 'group-hover:border-neutral-400 dark:group-hover:border-neutral-600' : ''}`}
+          />
         </>
       : ''}
       <Card
         role="article"
-        className={`transition-all relative my-4 ${highlight ? 'border-foreground' : ''} cursor-pointer group-hover:border-neutral-400 dark:group-hover:border-neutral-600`}
+        className={`transition-all relative my-4 ${highlight ? 'border-foreground' : ''} ${onSelect ? 'cursor-pointer group-hover:border-neutral-400 dark:group-hover:border-neutral-600' : ''}`}
         onClick={onSelect}>
         <CardHeader className="rounded-t-lg relative flex flex-col w-full p-0">
           <div className="flex items-center px-3 py-2">
@@ -115,10 +123,10 @@ export const SideItem = ({
         <div className="absolute border-t border-solid border-muted-foreground w-4 -right-4 top-7" />
       : dependencies ?
         <div
-          className="absolute border-b border-l border-solid border-neutral-300 dark:border-neutral-700 rounded-bl-sm z-0 w-[9px] -left-[9px] h-[13.35rem] bottom-[62px] group-[&:nth-child(2)]:hidden group-[&:nth-child(3)]:h-24"
+          className={`absolute border-b border-l border-solid border-neutral-300 dark:border-neutral-600 rounded-bl-sm z-0 h-[5px] w-[9px] -left-[9px] h-[13.35rem] bottom-[62px] group-[&:nth-child(2)]:hidden group-[&:nth-child(3)]:h-24`}
           ref={lineRef}
         />
-      : null}
+      : ''}
     </div>
   )
 }

--- a/src/gui/src/components/explorer-grid/types.ts
+++ b/src/gui/src/components/explorer-grid/types.ts
@@ -16,6 +16,11 @@ export type EdgeLoose = Pick<EdgeLike, 'name' | 'to'> & {
  */
 export type GridItemData = EdgeLoose & {
   /**
+   * An index value shared between installed and uninstalled dependencies
+   * to keep track of the order they were added to the UI.
+   */
+  depIndex?: number
+  /**
    * A unique identifier for the item. This will not translate to `node.to.id`
    * but rather concatenate names / ids to create a unique id per item.
    * Used as the unique `key` for React components.

--- a/src/gui/src/state/index.ts
+++ b/src/gui/src/state/index.ts
@@ -39,6 +39,7 @@ const initialState: State = {
   edges: [],
   errorCause: '',
   hasDashboard: false,
+  linePositionReference: 258,
   nodes: [],
   query:
     new URL(
@@ -95,6 +96,8 @@ export const useGraphStore = create<Action & State>((set, get) => {
       set(() => ({ errorCause })),
     updateHasDashboard: (hasDashboard: State['hasDashboard']) =>
       set(() => ({ hasDashboard })),
+    updateLinePositionReference: (position: number) =>
+      set(() => ({ linePositionReference: position })),
     updateNodes: (nodes: State['nodes']) => set(() => ({ nodes })),
     updateSelectedNode: (selectedNode: State['selectedNode']) =>
       set(() => ({ selectedNode })),

--- a/src/gui/src/state/types.ts
+++ b/src/gui/src/state/types.ts
@@ -18,6 +18,7 @@ export type Action = {
   updateEdges: (edges: State['edges']) => void
   updateErrorCause: (errorCause: State['errorCause']) => void
   updateHasDashboard: (hasDashboard: State['hasDashboard']) => void
+  updateLinePositionReference: (position: number) => void
   updateNodes: (nodes: State['nodes']) => void
   updateSelectedNode: (node: State['selectedNode']) => void
   updateSpecOptions: (specOptions: State['specOptions']) => void
@@ -86,6 +87,10 @@ export type State = {
    * Whether the dashboard is enabled or not.
    */
   hasDashboard: boolean
+  /**
+   * A reference value to properly draw connections between nodes in the graph.
+   */
+  linePositionReference: number
   /**
    * List of selected nodes returned after querying the graph.
    */

--- a/src/gui/test/components/explorer-grid/__snapshots__/dependency-side-bar.tsx.snap
+++ b/src/gui/test/components/explorer-grid/__snapshots__/dependency-side-bar.tsx.snap
@@ -13,19 +13,16 @@ exports[`dependency-side-bar 1`] = `
   </div>
   <gui-side-item
     item="[object Object]"
-    idx="0"
     dependencies="true"
   >
   </gui-side-item>
   <gui-side-item
     item="[object Object]"
-    idx="1"
     dependencies="true"
   >
   </gui-side-item>
   <gui-side-item
     item="[object Object]"
-    idx="2"
     dependencies="true"
   >
   </gui-side-item>

--- a/src/gui/test/components/explorer-grid/__snapshots__/selected-item.tsx.snap
+++ b/src/gui/test/components/explorer-grid/__snapshots__/selected-item.tsx.snap
@@ -62,7 +62,7 @@ exports[`SelectedItem render connection lines 1`] = `
         </gui-tabs>
       </div>
     </gui-card>
-    <div class="absolute border-t border-solid border-neutral-300 dark:border-neutral-600 rounded-tr-sm w-4 top-7 -right-4">
+    <div class="absolute border-t border-solid border-neutral-300 dark:border-neutral-600 rounded-tr-sm w-4 top-[44px] -right-4">
     </div>
   </div>
 </div>

--- a/src/gui/test/components/explorer-grid/__snapshots__/side-item.tsx.snap
+++ b/src/gui/test/components/explorer-grid/__snapshots__/side-item.tsx.snap
@@ -31,7 +31,10 @@ exports[`SideItem render as dependency 1`] = `
         </div>
       </gui-card-header>
     </gui-card>
-    <div class="absolute border-b border-l border-solid border-neutral-300 dark:border-neutral-700 rounded-bl-sm z-0 w-[9px] -left-[9px] h-[13.35rem] bottom-[62px] group-[&amp;:nth-child(2)]:hidden group-[&amp;:nth-child(3)]:h-24">
+    <div
+      class="absolute border-b border-l border-solid border-neutral-300 dark:border-neutral-600 rounded-bl-sm z-0 h-[5px] w-[9px] -left-[9px] h-[13.35rem] bottom-[62px] group-[&amp;:nth-child(2)]:hidden group-[&amp;:nth-child(3)]:h-24"
+      style="height: -258px;"
+    >
     </div>
   </div>
 </div>
@@ -69,7 +72,10 @@ exports[`SideItem render as dependency with long name 1`] = `
         </div>
       </gui-card-header>
     </gui-card>
-    <div class="absolute border-b border-l border-solid border-neutral-300 dark:border-neutral-700 rounded-bl-sm z-0 w-[9px] -left-[9px] h-[13.35rem] bottom-[62px] group-[&amp;:nth-child(2)]:hidden group-[&amp;:nth-child(3)]:h-24">
+    <div
+      class="absolute border-b border-l border-solid border-neutral-300 dark:border-neutral-600 rounded-bl-sm z-0 h-[5px] w-[9px] -left-[9px] h-[13.35rem] bottom-[62px] group-[&amp;:nth-child(2)]:hidden group-[&amp;:nth-child(3)]:h-24"
+      style="height: -258px;"
+    >
     </div>
   </div>
 </div>


### PR DESCRIPTION
Rewrites a good part of the logic drawing connection lines between a selected items and its dependencies. The new system now dynamically retrieves the top-most value and calculate the height of each connection line based on that.

### Before

<img width="442" alt="Screenshot 2025-01-24 at 3 25 16 PM" src="https://github.com/user-attachments/assets/991eb326-904f-47b1-a9dd-1407dd653115" />


### After

<img width="443" alt="Screenshot 2025-01-24 at 3 25 24 PM" src="https://github.com/user-attachments/assets/f92e0c28-552c-4f9b-ba4f-a6ba9275a0eb" />

