### PR TITLE
gui: add uninstalled dependencies

### DIFF
--- a/src/graph/src/browser.ts
+++ b/src/graph/src/browser.ts
@@ -1,8 +1,13 @@
-import { asDependencyTypeShort } from './dependencies.js'
+import {
+  asDependencyTypeShort,
+  longDependencyTypes,
+  shorten,
+} from './dependencies.js'
 import { getBooleanFlagsFromNum } from './lockfile/types.js'
 import { stringifyNode } from './stringify-node.js'
 import { loadEdges } from './lockfile/load-edges.js'
 import { loadNodes } from './lockfile/load-nodes.js'
+export * from './types.js'
 
 const lockfile = {
   loadEdges,
@@ -13,5 +18,7 @@ export {
   asDependencyTypeShort,
   getBooleanFlagsFromNum,
   lockfile,
+  longDependencyTypes,
+  shorten,
   stringifyNode,
 }

--- a/src/gui/src/components/explorer-grid/dependency-side-bar.tsx
+++ b/src/gui/src/components/explorer-grid/dependency-side-bar.tsx
@@ -114,12 +114,14 @@ export type DependencySideBarProps = {
   dependencies: GridItemData[]
   importerId?: DepID
   onDependencyClick: (item: GridItemData) => () => undefined
+  uninstalledDependencies: GridItemData[]
 }
 
 export const DependencySideBar = ({
   dependencies,
   importerId,
   onDependencyClick,
+  uninstalledDependencies,
 }: DependencySideBarProps) => {
   const [scope, animate] = useAnimate()
   const { toast } = useToast()
@@ -260,13 +262,11 @@ export const DependencySideBar = ({
         : ''}
       </GridHeader>
       {[
+        // added dependencies should come first
         ...dependencies
           .filter(item => addedDependencies.includes(item.name))
-          .sort(
-            (a, b) =>
-              addedDependencies.indexOf(a.name) -
-              addedDependencies.indexOf(b.name),
-          ),
+          .sort((a, b) => a.name.localeCompare(b.name, 'en')),
+        // then we display the rest of dependencies, sorted by name
         ...dependencies
           .filter(item => !addedDependencies.includes(item.name))
           .sort((a, b) => a.name.localeCompare(b.name, 'en')),
@@ -279,6 +279,21 @@ export const DependencySideBar = ({
           onUninstall={onUninstall}
         />
       ))}
+      {uninstalledDependencies.length ?
+        <>
+          <GridHeader>
+            <GitFork size={22} className="mr-3 rotate-180" />
+            Uninstalled Dependencies
+          </GridHeader>
+          {[
+            ...uninstalledDependencies.sort((a, b) =>
+              a.name.localeCompare(b.name, 'en'),
+            ),
+          ].map(item => (
+            <SideItem item={item} key={item.id} dependencies={true} />
+          ))}
+        </>
+      : ''}
     </>
   )
 }

--- a/src/gui/test/components/explorer-grid/__snapshots__/dependency-side-bar.tsx.snap
+++ b/src/gui/test/components/explorer-grid/__snapshots__/dependency-side-bar.tsx.snap
@@ -12,17 +12,103 @@ exports[`dependency-side-bar 1`] = `
     Dependencies
   </div>
   <gui-side-item
-    item="[object Object]"
+    item="GridItemData { @vltpkg/semver }"
     dependencies="true"
   >
   </gui-side-item>
   <gui-side-item
-    item="[object Object]"
+    item="GridItemData { abbrev }"
     dependencies="true"
   >
   </gui-side-item>
   <gui-side-item
-    item="[object Object]"
+    item="GridItemData { simple-output }"
+    dependencies="true"
+  >
+  </gui-side-item>
+</div>
+
+`;
+
+exports[`dependency-side-bar has both installed and uninstalled deps 1`] = `
+
+<div>
+  <div class="pt-6 text-md flex flex-row items-center font-medium">
+    <gui-git-fork-icon
+      size="22"
+      classname="mr-3 rotate-180"
+    >
+    </gui-git-fork-icon>
+    Dependencies
+  </div>
+  <gui-side-item
+    item="GridItemData { @vltpkg/semver }"
+    dependencies="true"
+  >
+  </gui-side-item>
+  <gui-side-item
+    item="GridItemData { abbrev }"
+    dependencies="true"
+  >
+  </gui-side-item>
+  <gui-side-item
+    item="GridItemData { simple-output }"
+    dependencies="true"
+  >
+  </gui-side-item>
+  <div class="pt-6 text-md flex flex-row items-center font-medium">
+    <gui-git-fork-icon
+      size="22"
+      classname="mr-3 rotate-180"
+    >
+    </gui-git-fork-icon>
+    Uninstalled Dependencies
+  </div>
+  <gui-side-item
+    item="GridItemData { @ruyadorno/redact }"
+    dependencies="true"
+  >
+  </gui-side-item>
+  <gui-side-item
+    item="GridItemData { ntl }"
+    dependencies="true"
+  >
+  </gui-side-item>
+</div>
+
+`;
+
+exports[`dependency-side-bar has uninstalled deps only 1`] = `
+
+<div>
+  <div class="pt-6 text-md flex flex-row items-center font-medium">
+    <gui-git-fork-icon
+      size="22"
+      classname="mr-3 rotate-180"
+    >
+    </gui-git-fork-icon>
+    Dependencies
+  </div>
+  <div class="pt-6 text-md flex flex-row items-center font-medium">
+    <gui-git-fork-icon
+      size="22"
+      classname="mr-3 rotate-180"
+    >
+    </gui-git-fork-icon>
+    Uninstalled Dependencies
+  </div>
+  <gui-side-item
+    item="GridItemData { @vltpkg/semver }"
+    dependencies="true"
+  >
+  </gui-side-item>
+  <gui-side-item
+    item="GridItemData { abbrev }"
+    dependencies="true"
+  >
+  </gui-side-item>
+  <gui-side-item
+    item="GridItemData { simple-output }"
     dependencies="true"
   >
   </gui-side-item>

--- a/src/gui/test/components/explorer-grid/dependency-side-bar.tsx
+++ b/src/gui/test/components/explorer-grid/dependency-side-bar.tsx
@@ -54,15 +54,28 @@ afterEach(() => {
   cleanup()
 })
 
+const getGridItemData = (
+  name: string,
+  id: string,
+  depIndex: number,
+) =>
+  ({
+    name,
+    id,
+    depIndex,
+    toString: () => `GridItemData { ${name} }`,
+  }) as GridItemData
+
 test('dependency-side-bar', async () => {
   const dependencies = [
-    { name: 'simple-output', id: '1' } as GridItemData,
-    { name: 'abbrev', id: '2' } as GridItemData,
-    { name: '@vltpkg/semver', id: '3' } as GridItemData,
+    getGridItemData('simple-output', '1', 0),
+    getGridItemData('abbrev', '2', 1),
+    getGridItemData('@vltpkg/semver', '3', 2),
   ]
   render(
     <DependencySideBar
       dependencies={dependencies}
+      uninstalledDependencies={[]}
       onDependencyClick={() => () => {}}
     />,
   )
@@ -74,6 +87,43 @@ test('dependency-side-bar no items', async () => {
   render(
     <DependencySideBar
       dependencies={dependencies}
+      uninstalledDependencies={[]}
+      onDependencyClick={() => () => {}}
+    />,
+  )
+  expect(window.document.body.innerHTML).toMatchSnapshot()
+})
+
+test('dependency-side-bar has uninstalled deps only', async () => {
+  const dependencies = [
+    getGridItemData('simple-output', '1', 0),
+    getGridItemData('abbrev', '2', 1),
+    getGridItemData('@vltpkg/semver', '3', 2),
+  ]
+  render(
+    <DependencySideBar
+      dependencies={[]}
+      uninstalledDependencies={dependencies}
+      onDependencyClick={() => () => {}}
+    />,
+  )
+  expect(window.document.body.innerHTML).toMatchSnapshot()
+})
+
+test('dependency-side-bar has both installed and uninstalled deps', async () => {
+  const dependencies = [
+    getGridItemData('simple-output', '1', 0),
+    getGridItemData('abbrev', '2', 1),
+    getGridItemData('@vltpkg/semver', '3', 2),
+  ]
+  const uninstalledDependencies = [
+    getGridItemData('@ruyadorno/redact', '4', 3),
+    getGridItemData('ntl', '1', 4),
+  ]
+  render(
+    <DependencySideBar
+      dependencies={dependencies}
+      uninstalledDependencies={uninstalledDependencies}
       onDependencyClick={() => () => {}}
     />,
   )


### PR DESCRIPTION
Now the GUI Explorer also display uninstalled dependencies for a given selected item.

### Before

<img width="1487" alt="Screenshot 2025-01-24 at 3 34 15 PM" src="https://github.com/user-attachments/assets/43769129-a0bf-44bf-b78a-6bc591b4beab" />

### After

<img width="1487" alt="Screenshot 2025-01-24 at 3 33 59 PM" src="https://github.com/user-attachments/assets/d2eada56-55e9-4ad3-b981-ca5bd631022e" />
