### PR TITLE
test(start-gui): pass in values obj to match types

### DIFF
--- a/src/vlt/src/start-gui.ts
+++ b/src/vlt/src/start-gui.ts
@@ -244,9 +244,7 @@ const updateDashboardData = async (
   tmp: string,
   conf: LoadedConfig,
 ) => {
-  const userDefinedProjectPaths =
-    // eslint-disable-next-line
-    conf.values?.['dashboard-root'] || []
+  const userDefinedProjectPaths = conf.values['dashboard-root'] ?? []
   const dashboard = formatDashboardJson(
     readProjectFolders({
       ...conf.options,

--- a/src/vlt/test/start-gui.ts
+++ b/src/vlt/test/start-gui.ts
@@ -102,7 +102,7 @@ t.test('starts gui data and server', async t => {
   const log = t.capture(console, 'log').args
 
   await startGUI({
-    conf: { options } as unknown as LoadedConfig,
+    conf: { options, values: {} } as unknown as LoadedConfig,
     assetsDir,
     tmpDir: dir,
   })
@@ -279,6 +279,7 @@ t.test('e2e server test', async t => {
         resetOptions(newProjectRoot: string) {
           options.projectRoot = newProjectRoot
         },
+        values: {},
       } as LoadedConfig,
       assetsDir,
       port,


### PR DESCRIPTION
Ref https://github.com/vltpkg/vltpkg/pull/319#discussion_r1920876696

A not-great but ok-for-now way to remove an `eslint-disable-next-line`. The issue stems from unsafe code in the tests where we currently have a lot of lint rules disabled:

https://github.com/vltpkg/vltpkg/blob/a83e2d4cacbfc0a27ace040429522d42f9a8eced/eslint.config.mjs#L194-L199

Still don't think it's worth the effort to turn them on but something to keep in mind.