### PR TITLE
dev(gui): add live reload

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -89,6 +89,13 @@ export default tseslint.config(
           ignoreArrowShorthand: true,
         },
       ],
+      // allow for async functions when return type is void
+      '@typescript-eslint/no-misused-promises': [
+        'error',
+        {
+          checksVoidReturn: false,
+        },
+      ],
       // while (true) is ok
       '@typescript-eslint/no-unnecessary-condition': [
         'error',

--- a/infra/build/src/bundle.ts
+++ b/infra/build/src/bundle.ts
@@ -448,15 +448,18 @@ const bundle = async (o: {
     banner: {
       [EXT.slice(1)]: globals.toString(),
     },
-    // The import.meta shims are then globally replaced with our newly defined values
-    define: Object.values(IMPORT_META).reduce(
-      (acc, k) => {
-        acc[k] = globals.get(k)
-        return acc
-      },
-      // eslint-disable-next-line @typescript-eslint/prefer-reduce-type-parameter
-      {} as Record<`import.meta.${keyof ImportMeta}`, string>,
-    ),
+    define: {
+      'process.env._VLT_DEV_LIVE_RELOAD': 'false',
+      // The import.meta shims are then globally replaced with our newly defined values
+      ...Object.values(IMPORT_META).reduce(
+        (acc, k) => {
+          acc[k] = globals.get(k)
+          return acc
+        },
+        // eslint-disable-next-line @typescript-eslint/prefer-reduce-type-parameter
+        {} as Record<`import.meta.${keyof ImportMeta}`, string>,
+      ),
+    },
   })
 
   assert(

--- a/src/gui/package.json
+++ b/src/gui/package.json
@@ -70,7 +70,6 @@
     "lint": "eslint . --fix",
     "lint:check": "eslint .",
     "prepare": "node scripts/prepare.js --production",
-    "serve": "node scripts/prepare.js --watch --serve",
     "snap": "vitest --no-watch -u",
     "test": "vitest",
     "posttest": "tsc --noEmit",

--- a/src/gui/src/index.tsx
+++ b/src/gui/src/index.tsx
@@ -16,3 +16,14 @@ if (rootElement) {
     </StrictMode>,
   )
 }
+
+if (process.env.NODE_ENV === 'development') {
+  const sse = new EventSource('/esbuild')
+  sse.addEventListener('change', () => location.reload())
+  sse.addEventListener('error', () => {
+    console.log(
+      'Live reload is not enabled. Start the GUI dev server to enable it.',
+    )
+    sse.close()
+  })
+}

--- a/src/vlt/test/start-gui.ts
+++ b/src/vlt/test/start-gui.ts
@@ -3,6 +3,7 @@ import { type Dependency } from '@vltpkg/graph'
 import { PackageJson } from '@vltpkg/package-json'
 import { type Manifest } from '@vltpkg/types'
 import { readdirSync, readFileSync } from 'node:fs'
+import http from 'node:http'
 import { resolve } from 'node:path'
 import { PathScurry, type PathBase } from 'path-scurry'
 import t from 'tap'
@@ -46,6 +47,7 @@ t.test('starts gui data and server', async t => {
     typeof import('../src/start-gui.js')
   >('../src/start-gui.js', {
     'node:http': {
+      ...http,
       createServer() {
         return {
           listen(port: number, host: string, cb: () => void) {


### PR DESCRIPTION
This PR adds live reload to the GUI during local development by setting the environment variable `_VLT_DEV_LIVE_RELOAD`.

### How to run it
- Run the GUI watch script the same way that you currently do: `pnpm -F gui watch`
- When running the GUI locally set `_VLT_DEV_LIVE_RELOAD=1`
- Changes to `src/gui` will cause open browsers to `reload()`

### How it works
When `_VLT_DEV_LIVE_RELOAD` is set, requests for gui assets will be proxied to the esbuild dev server instead of the static asset. In the browser an `EventSource` connection is opened which uses esbuild's builtin [live reload](https://esbuild.github.io/api/#live-reload) feature.

If the esbuild dev server is not running, then requests will fallback to the static asset like normal and message will be logged in the browser.

`_VLT_DEV_LIVE_RELOAD` has no effect on production builds and the code is stripped by esbuild from both the GUI and the CLI.

### Caveats
All the caveats from [esbuild's docs](https://esbuild.github.io/api/#live-reload-caveats) apply with the most notable being the 6 connection limit. If you run `vlt gui` repeatedly it will open a new tab each time and eventually the persistent SSE connections will hit this limit and new GUIs won't load anymore. Best workaround is to close old tabs.

### Other notes
- I went with the underscore prefixed `_VLT_*` naming so that it cant be confused with the other `VLT_*`.
- Refactors the GUI request handler to clean it up a bit
- I created an [`.envrc`](https://direnv.net) file in a testing directory, so all `vlt` commands run in there will use the local version with live reload enabled:
  ```sh
  PATH_add $HOME/projects/vltpkg/vltpkg/node_modules/.bin
  export _VLT_DEV_LIVE_RELOAD=1
  ```

### Demo:
https://github.com/user-attachments/assets/b3679976-c60c-4aa1-b843-aff6dd439cb0