### PR TITLE
fix(gui): text-overflow on dashboard item paths

### DIFF
--- a/src/gui/src/components/dashboard-grid/index.tsx
+++ b/src/gui/src/components/dashboard-grid/index.tsx
@@ -117,19 +117,15 @@ export const DashboardItem = ({
 
       <div className="w-full h-12 flex items-center gap-4 justify-between border-t-[1px] px-4 py-3">
         <TooltipProvider>
-          <div className="flex items-center justify-center rounded-sm border-[1px] px-2 py-1">
-            <Tooltip>
-              <TooltipTrigger>
-                <p className="text-[0.65rem] text-muted-foreground font-mono truncate w-full m-0 p-0 align-baseline">
-                  {item.path}
-                </p>
-              </TooltipTrigger>
-              <TooltipContent>{item.path}</TooltipContent>
-            </Tooltip>
-          </div>
+          <Tooltip>
+            <TooltipTrigger className="rounded-sm border-[1px] px-2 py-1 text-[0.65rem] text-muted-foreground font-mono m-0 align-baseline truncate">
+              {item.path}
+            </TooltipTrigger>
+            <TooltipContent>{item.path}</TooltipContent>
+          </Tooltip>
         </TooltipProvider>
 
-        <div className="flex gap-2 overflow-x-scroll">
+        <div className="flex gap-2">
           {item.tools.map((tool, index) => (
             <div
               key={index}

--- a/src/gui/test/components/dashboard-grid/__snapshots__/index.tsx.snap
+++ b/src/gui/test/components/dashboard-grid/__snapshots__/index.tsx.snap
@@ -70,20 +70,16 @@ exports[`dashboard-grid with results 1`] = `
           </div>
           <div class="w-full h-12 flex items-center gap-4 justify-between border-t-[1px] px-4 py-3">
             <gui-tooltip-provider>
-              <div class="flex items-center justify-center rounded-sm border-[1px] px-2 py-1">
-                <gui-tooltip>
-                  <gui-tooltip-trigger>
-                    <p class="text-[0.65rem] text-muted-foreground font-mono truncate w-full m-0 p-0 align-baseline">
-                      /home/user/project-bar
-                    </p>
-                  </gui-tooltip-trigger>
-                  <gui-tooltip-content>
-                    /home/user/project-bar
-                  </gui-tooltip-content>
-                </gui-tooltip>
-              </div>
+              <gui-tooltip>
+                <gui-tooltip-trigger classname="rounded-sm border-[1px] px-2 py-1 text-[0.65rem] text-muted-foreground font-mono m-0 align-baseline truncate">
+                  /home/user/project-bar
+                </gui-tooltip-trigger>
+                <gui-tooltip-content>
+                  /home/user/project-bar
+                </gui-tooltip-content>
+              </gui-tooltip>
             </gui-tooltip-provider>
-            <div class="flex gap-2 overflow-x-scroll">
+            <div class="flex gap-2">
               <div class="flex-none bg-secondary rounded-xl px-2 py-1">
                 <p class="text-[0.7rem] font-medium text-primary ">
                   pnpm
@@ -110,20 +106,16 @@ exports[`dashboard-grid with results 1`] = `
           </div>
           <div class="w-full h-12 flex items-center gap-4 justify-between border-t-[1px] px-4 py-3">
             <gui-tooltip-provider>
-              <div class="flex items-center justify-center rounded-sm border-[1px] px-2 py-1">
-                <gui-tooltip>
-                  <gui-tooltip-trigger>
-                    <p class="text-[0.65rem] text-muted-foreground font-mono truncate w-full m-0 p-0 align-baseline">
-                      /home/user/project-foo
-                    </p>
-                  </gui-tooltip-trigger>
-                  <gui-tooltip-content>
-                    /home/user/project-foo
-                  </gui-tooltip-content>
-                </gui-tooltip>
-              </div>
+              <gui-tooltip>
+                <gui-tooltip-trigger classname="rounded-sm border-[1px] px-2 py-1 text-[0.65rem] text-muted-foreground font-mono m-0 align-baseline truncate">
+                  /home/user/project-foo
+                </gui-tooltip-trigger>
+                <gui-tooltip-content>
+                  /home/user/project-foo
+                </gui-tooltip-content>
+              </gui-tooltip>
             </gui-tooltip-provider>
-            <div class="flex gap-2 overflow-x-scroll">
+            <div class="flex gap-2">
               <div class="flex-none bg-secondary rounded-xl px-2 py-1">
                 <p class="text-[0.7rem] font-medium text-primary ">
                   node


### PR DESCRIPTION
## Before
<img width="1342" alt="Screenshot 2025-01-26 at 10 38 52 AM" src="https://github.com/user-attachments/assets/863f8a10-1834-4ef9-8996-00b6d710ebd3" />

## After
<img width="1269" alt="Screenshot 2025-01-26 at 1 15 39 PM" src="https://github.com/user-attachments/assets/77931fab-d274-4dd3-afc9-d8bdca6cb8c8" />

