### PR TITLE
package-json: sort dependencies by name

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -913,6 +913,9 @@ importers:
       '@vltpkg/error-cause':
         specifier: workspace:*
         version: link:../error-cause
+      '@vltpkg/graph':
+        specifier: workspace:*
+        version: link:../graph
       '@vltpkg/types':
         specifier: workspace:*
         version: link:../types

--- a/src/package-json/package.json
+++ b/src/package-json/package.json
@@ -17,6 +17,7 @@
   },
   "dependencies": {
     "@vltpkg/error-cause": "workspace:*",
+    "@vltpkg/graph": "workspace:*",
     "@vltpkg/types": "workspace:*",
     "polite-json": "catalog:"
   },

--- a/src/package-json/src/index.ts
+++ b/src/package-json/src/index.ts
@@ -1,5 +1,6 @@
 import { error, type ErrorCauseObject } from '@vltpkg/error-cause'
 import { asManifest, type Manifest } from '@vltpkg/types'
+import { longDependencyTypes } from '@vltpkg/graph/browser'
 import { readFileSync, writeFileSync } from 'node:fs'
 import { resolve } from 'node:path'
 import { parse, stringify } from 'polite-json'
@@ -59,6 +60,7 @@ export class PackageJson {
 
   write(dir: string, manifest: Manifest): void {
     const filename = resolve(dir, 'package.json')
+    this.fix(manifest)
 
     try {
       // This assumes kIndent and kNewline are already present on the manifest because we would
@@ -94,5 +96,19 @@ export class PackageJson {
       )
     }
     this.write(dir, manifest)
+  }
+
+  fix(manifest: Manifest): void {
+    for (const depType of longDependencyTypes) {
+      const deps = manifest[depType]
+      if (deps) {
+        // should sort dependencies by name
+        manifest[depType] = Object.fromEntries(
+          Object.entries(deps).sort(([a], [b]) =>
+            a.localeCompare(b, 'en'),
+          ),
+        )
+      }
+    }
   }
 }

--- a/src/package-json/tap-snapshots/test/index.ts.test.cjs
+++ b/src/package-json/tap-snapshots/test/index.ts.test.cjs
@@ -5,6 +5,29 @@
  * Make sure to inspect the output below.  Do not ignore changes!
  */
 'use strict'
+exports[`test/index.ts > TAP > should sort dependencies by name in memory manifest > dependencies should be sorted by name 1`] = `
+Object {
+  "a": "1.0.0",
+  "b": "1.0.0",
+  "c": "1.0.0",
+  "d": "1.0.0",
+}
+`
+
+exports[`test/index.ts > TAP > should sort dependencies by name when saving > saved manifest dependencies should be sorted by name 1`] = `
+{
+        "name": "my-project",
+        "version": "1.0.0",
+        "dependencies": {
+                "a": "1.0.0",
+                "b": "1.0.0",
+                "c": "1.0.0",
+                "d": "1.0.0"
+        }
+}
+
+`
+
 exports[`test/index.ts > TAP > successfully saves a manifest > manifest should be read with original indent 1`] = `
 {
         "name": "my-project",

--- a/src/package-json/test/index.ts
+++ b/src/package-json/test/index.ts
@@ -199,3 +199,58 @@ t.test(
     })
   },
 )
+
+t.test(
+  'should sort dependencies by name in memory manifest',
+  async t => {
+    const dir = t.testdir({
+      'package.json': JSON.stringify(
+        {
+          name: 'my-project',
+          version: '1.0.0',
+          dependencies: {
+            c: '1.0.0',
+            d: '1.0.0',
+            b: '1.0.0',
+            a: '1.0.0',
+          },
+        },
+        null,
+        8,
+      ),
+    })
+    const pj = new PackageJson()
+    const mani = pj.read(dir)
+    pj.fix(mani)
+    t.matchSnapshot(
+      mani.dependencies,
+      'dependencies should be sorted by name',
+    )
+  },
+)
+
+t.test('should sort dependencies by name when saving', async t => {
+  const dir = t.testdir({
+    'package.json': JSON.stringify(
+      {
+        name: 'my-project',
+        version: '1.0.0',
+        dependencies: {
+          c: '1.0.0',
+          a: '1.0.0',
+          d: '1.0.0',
+          b: '1.0.0',
+        },
+      },
+      null,
+      8,
+    ),
+  })
+  const pj = new PackageJson()
+  const mani = pj.read(dir)
+  pj.save(mani)
+  t.matchSnapshot(
+    readFileSync(join(dir, 'package.json'), 'utf8'),
+    'saved manifest dependencies should be sorted by name',
+  )
+})


### PR DESCRIPTION
Dependencies should be automatically sorted by name when saving a `package.json` file.

Fixes: https://github.com/vltpkg/vltpkg/issues/238