### PR TITLE
gui: fix dashboard item selection

### DIFF
--- a/src/gui/src/components/dashboard-grid/index.tsx
+++ b/src/gui/src/components/dashboard-grid/index.tsx
@@ -119,9 +119,9 @@ export const DashboardItem = ({
         <TooltipProvider>
           <Tooltip>
             <TooltipTrigger className="rounded-sm border-[1px] px-2 py-1 text-[0.65rem] text-muted-foreground font-mono m-0 align-baseline truncate">
-              {item.path}
+              {item.readablePath}
             </TooltipTrigger>
-            <TooltipContent>{item.path}</TooltipContent>
+            <TooltipContent>{item.readablePath}</TooltipContent>
           </Tooltip>
         </TooltipProvider>
 

--- a/src/gui/src/state/types.ts
+++ b/src/gui/src/state/types.ts
@@ -165,6 +165,7 @@ export type SavedQuery = {
 
 export type DashboardDataProject = {
   name: string
+  readablePath: string
   path: string
   manifest: Manifest
   tools: DashboardTools[]

--- a/src/gui/test/components/dashboard-grid/__snapshots__/index.tsx.snap
+++ b/src/gui/test/components/dashboard-grid/__snapshots__/index.tsx.snap
@@ -72,10 +72,10 @@ exports[`dashboard-grid with results 1`] = `
             <gui-tooltip-provider>
               <gui-tooltip>
                 <gui-tooltip-trigger classname="rounded-sm border-[1px] px-2 py-1 text-[0.65rem] text-muted-foreground font-mono m-0 align-baseline truncate">
-                  /home/user/project-bar
+                  ~/project-foo
                 </gui-tooltip-trigger>
                 <gui-tooltip-content>
-                  /home/user/project-bar
+                  ~/project-foo
                 </gui-tooltip-content>
               </gui-tooltip>
             </gui-tooltip-provider>
@@ -108,10 +108,10 @@ exports[`dashboard-grid with results 1`] = `
             <gui-tooltip-provider>
               <gui-tooltip>
                 <gui-tooltip-trigger classname="rounded-sm border-[1px] px-2 py-1 text-[0.65rem] text-muted-foreground font-mono m-0 align-baseline truncate">
-                  /home/user/project-foo
+                  ~/project-foo
                 </gui-tooltip-trigger>
                 <gui-tooltip-content>
-                  /home/user/project-foo
+                  ~/project-foo
                 </gui-tooltip-content>
               </gui-tooltip>
             </gui-tooltip-provider>

--- a/src/gui/test/components/dashboard-grid/index.tsx
+++ b/src/gui/test/components/dashboard-grid/index.tsx
@@ -52,6 +52,7 @@ test('dashboard-grid with results', async () => {
       projects: [
         {
           name: 'project-foo',
+          readablePath: '~/project-foo',
           path: '/home/user/project-foo',
           manifest: { name: 'project-foo', version: '1.0.0' },
           tools: ['node', 'vlt'],
@@ -59,6 +60,7 @@ test('dashboard-grid with results', async () => {
         },
         {
           name: 'project-bar',
+          readablePath: '~/project-foo',
           path: '/home/user/project-bar',
           manifest: { name: 'project-bar', version: '1.0.0' },
           tools: ['pnpm'],

--- a/src/vlt/src/start-gui.ts
+++ b/src/vlt/src/start-gui.ts
@@ -78,6 +78,7 @@ export type DashboardData = {
 
 export type DashboardDataProject = {
   name: string
+  readablePath: string
   path: string
   manifest: Manifest
   tools: DashboardTools[]
@@ -206,10 +207,12 @@ export const formatDashboardJson = (
     } catch {
       continue
     }
+    const path = folder.fullpath()
     result.projects.push({
       /* c8 ignore next */
       name: manifest.name || folder.name,
-      path: folder.fullpath().replace(homedir(), '~'),
+      readablePath: path.replace(homedir(), '~'),
+      path,
       manifest,
       tools: inferTools(manifest, folder, options.scurry),
       mtime: folder.lstatSync()?.mtimeMs,


### PR DESCRIPTION
- Set a separate property for the shortened readable path value.
- Use the `readablePath` for the rendered path in the dashboard
while using `path` for navigating to different projects.