### PR TITLE
gui side item text contrast

### DIFF
--- a/src/gui/src/components/explorer-grid/side-item.tsx
+++ b/src/gui/src/components/explorer-grid/side-item.tsx
@@ -82,7 +82,7 @@ export const SideItem = ({
             </div>
           </div>
           <div className="flex items-center flex-row justify-between gap-2 flex-wrap px-3 py-2 border-muted-foreground/20 border-t-[1px]">
-            <p className="text-sm text-muted-foreground/50">
+            <p className="text-sm text-muted-foreground">
               {item.title}
             </p>
             {item.labels?.map(i => (

--- a/src/gui/test/components/explorer-grid/__snapshots__/index.tsx.snap
+++ b/src/gui/test/components/explorer-grid/__snapshots__/index.tsx.snap
@@ -63,7 +63,7 @@ exports[`explorer-grid renders workspace with edges in 1`] = `
               </div>
             </div>
             <div class="flex items-center flex-row justify-between gap-2 flex-wrap px-3 py-2 border-muted-foreground/20 border-t-[1px]">
-              <p class="text-sm text-muted-foreground/50">
+              <p class="text-sm text-muted-foreground">
                 b@workspace:*
               </p>
               <div class="inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 grow-0 border-transparent bg-cyan-100 text-neutral-900 hover:bg-cyan-100/80">

--- a/src/gui/test/components/explorer-grid/__snapshots__/side-item.tsx.snap
+++ b/src/gui/test/components/explorer-grid/__snapshots__/side-item.tsx.snap
@@ -20,7 +20,7 @@ exports[`SideItem render as dependency 1`] = `
           </div>
         </div>
         <div class="flex items-center flex-row justify-between gap-2 flex-wrap px-3 py-2 border-muted-foreground/20 border-t-[1px]">
-          <p class="text-sm text-muted-foreground/50">
+          <p class="text-sm text-muted-foreground">
             item
           </p>
           <div>
@@ -61,7 +61,7 @@ exports[`SideItem render as dependency with long name 1`] = `
           </div>
         </div>
         <div class="flex items-center flex-row justify-between gap-2 flex-wrap px-3 py-2 border-muted-foreground/20 border-t-[1px]">
-          <p class="text-sm text-muted-foreground/50">
+          <p class="text-sm text-muted-foreground">
             lorem-ipsum-dolor-sit-amet-consectetur-adipiscing-elit-sed-do-eiusmod-tempor-incididunt-ut-labore-et-dolore-magna-aliqua-ut-enim-ad-minim-veniam-quis-nostrud-exercitation
           </p>
           <div>
@@ -102,7 +102,7 @@ exports[`SideItem render as dependent 1`] = `
           </div>
         </div>
         <div class="flex items-center flex-row justify-between gap-2 flex-wrap px-3 py-2 border-muted-foreground/20 border-t-[1px]">
-          <p class="text-sm text-muted-foreground/50">
+          <p class="text-sm text-muted-foreground">
             item
           </p>
           <div>
@@ -142,7 +142,7 @@ exports[`SideItem render as multi-stacked dependent 1`] = `
           </div>
         </div>
         <div class="flex items-center flex-row justify-between gap-2 flex-wrap px-3 py-2 border-muted-foreground/20 border-t-[1px]">
-          <p class="text-sm text-muted-foreground/50">
+          <p class="text-sm text-muted-foreground">
             item
           </p>
           <div>
@@ -178,7 +178,7 @@ exports[`SideItem render as parent 1`] = `
           </div>
         </div>
         <div class="flex items-center flex-row justify-between gap-2 flex-wrap px-3 py-2 border-muted-foreground/20 border-t-[1px]">
-          <p class="text-sm text-muted-foreground/50">
+          <p class="text-sm text-muted-foreground">
             item
           </p>
           <div>
@@ -218,7 +218,7 @@ exports[`SideItem render as two-stacked dependent 1`] = `
           </div>
         </div>
         <div class="flex items-center flex-row justify-between gap-2 flex-wrap px-3 py-2 border-muted-foreground/20 border-t-[1px]">
-          <p class="text-sm text-muted-foreground/50">
+          <p class="text-sm text-muted-foreground">
             item
           </p>
           <div>


### PR DESCRIPTION
updates text contrast for side items

Fixes #351 

### Before
<img width="449" alt="Screenshot 2025-01-28 at 16 02 38" src="https://github.com/user-attachments/assets/da738559-d3a5-4d74-9820-38ad0b8a6e8f" />

### After
<img width="453" alt="Screenshot 2025-01-28 at 16 02 24" src="https://github.com/user-attachments/assets/a23acbd1-d4e4-4cd6-bf13-53c24c27035a" />