### PR TITLE
query view directory tooltip

### DIFF
--- a/src/gui/src/components/queries/saved-item.tsx
+++ b/src/gui/src/components/queries/saved-item.tsx
@@ -181,8 +181,8 @@ const SavedQueryItem = ({
         <div className="flex col-span-2 items-center gap-2 w-full">
           <TooltipProvider>
             <Tooltip>
-              <TooltipTrigger className="w-full text-left">
-                <p className="text-sm truncate">{item.context}</p>
+              <TooltipTrigger className="text-sm truncate w-full text-left">
+                {item.context}
               </TooltipTrigger>
               <TooltipContent>{item.context}</TooltipContent>
             </Tooltip>

--- a/src/gui/src/components/queries/saved-item.tsx
+++ b/src/gui/src/components/queries/saved-item.tsx
@@ -18,6 +18,12 @@ import {
   PopoverTrigger,
   PopoverContent,
 } from '@/components/ui/popover.jsx'
+import {
+  Tooltip,
+  TooltipProvider,
+  TooltipTrigger,
+  TooltipContent,
+} from '@/components/ui/tooltip.jsx'
 
 type SelectQueryOptions = {
   updateActiveRoute: Action['updateActiveRoute']
@@ -172,8 +178,15 @@ const SavedQueryItem = ({
             <p className="text-sm w-[500px] truncate">{editQuery}</p>
           )}
         </div>
-        <div className="flex col-span-2 items-center gap-2">
-          <p className="text-sm truncate">{item.context}</p>
+        <div className="flex col-span-2 items-center gap-2 w-full">
+          <TooltipProvider>
+            <Tooltip>
+              <TooltipTrigger className="w-full text-left">
+                <p className="text-sm truncate">{item.context}</p>
+              </TooltipTrigger>
+              <TooltipContent>{item.context}</TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
         </div>
         <div className="flex col-span-2 items-center gap-2">
           {selectedLabels.map((label, idx) => (

--- a/src/gui/test/components/queries/__snapshots__/saved-item.tsx.snap
+++ b/src/gui/test/components/queries/__snapshots__/saved-item.tsx.snap
@@ -22,10 +22,8 @@ exports[`labels view > labels render default 1`] = `
     <div class="flex col-span-2 items-center gap-2 w-full">
       <gui-tooltip-provider>
         <gui-tooltip>
-          <gui-tooltip-trigger classname="w-full text-left">
-            <p class="text-sm truncate">
-              /mock/context/query
-            </p>
+          <gui-tooltip-trigger classname="text-sm truncate w-full text-left">
+            /mock/context/query
           </gui-tooltip-trigger>
           <gui-tooltip-content>
             /mock/context/query

--- a/src/gui/test/components/queries/__snapshots__/saved-item.tsx.snap
+++ b/src/gui/test/components/queries/__snapshots__/saved-item.tsx.snap
@@ -19,10 +19,19 @@ exports[`labels view > labels render default 1`] = `
         mock-query
       </p>
     </div>
-    <div class="flex col-span-2 items-center gap-2">
-      <p class="text-sm truncate">
-        /mock/context/query
-      </p>
+    <div class="flex col-span-2 items-center gap-2 w-full">
+      <gui-tooltip-provider>
+        <gui-tooltip>
+          <gui-tooltip-trigger classname="w-full text-left">
+            <p class="text-sm truncate">
+              /mock/context/query
+            </p>
+          </gui-tooltip-trigger>
+          <gui-tooltip-content>
+            /mock/context/query
+          </gui-tooltip-content>
+        </gui-tooltip>
+      </gui-tooltip-provider>
     </div>
     <div class="flex col-span-2 items-center gap-2">
     </div>

--- a/src/gui/test/components/queries/saved-item.tsx
+++ b/src/gui/test/components/queries/saved-item.tsx
@@ -40,6 +40,13 @@ vi.mock('@/components/ui/popover.jsx', () => ({
   PopoverContent: 'gui-popover-content',
 }))
 
+vi.mock('@/components/ui/tooltip.jsx', () => ({
+  Tooltip: 'gui-tooltip',
+  TooltipProvider: 'gui-tooltip-provider',
+  TooltipTrigger: 'gui-tooltip-trigger',
+  TooltipContent: 'gui-tooltip-content',
+}))
+
 expect.addSnapshotSerializer({
   serialize: v => html(v),
   test: () => true,


### PR DESCRIPTION
Adds tooltip for the directory/context of the query to view untruncated text

<img width="552" alt="Screenshot 2025-01-28 at 16 17 13" src="https://github.com/user-attachments/assets/fcfb349c-0143-43e1-bcbc-77c9ec9c8bc3" />

Fixes #350