### PR TITLE
gui: fix ResultItem text overflow

### DIFF
--- a/src/gui/src/components/explorer-grid/result-item.tsx
+++ b/src/gui/src/components/explorer-grid/result-item.tsx
@@ -100,33 +100,26 @@ export const ResultItem = ({ item }: GridItemOptions) => {
         </CardHeader>
 
         {/* Card Bottom */}
-        <div className="flex flex-row px-3 py-2 items-center justify-between">
+        <div className="w-full h-12 flex items-center gap-4 justify-between border-t-[1px] px-4 py-3">
           {item.version ?
             <TooltipProvider>
-              <div className="flex items-center justify-center rounded-sm border-[1px] px-2 py-1">
-                <Tooltip>
-                  <TooltipTrigger>
-                    <p className="text-[0.65rem] text-muted-foreground font-mono font-medium truncate w-full m-0 p-0 align-baseline">
-                      {item.version}
-                    </p>
-                  </TooltipTrigger>
-                  <TooltipContent>
-                    <p>{item.version}</p>
-                  </TooltipContent>
-                </Tooltip>
-              </div>
+              <Tooltip>
+                <TooltipTrigger className="rounded-sm border-[1px] px-2 py-1 text-[0.65rem] text-muted-foreground font-mono m-0 align-baseline truncate">
+                  {item.version}
+                </TooltipTrigger>
+                <TooltipContent>
+                  <p>{item.version}</p>
+                </TooltipContent>
+              </Tooltip>
             </TooltipProvider>
           : ''}
-          <div className="flex gap-2 overflow-x-scroll">
+          <div className="flex gap-2">
             {item.labels?.length ?
               item.labels.map(i => (
                 <div key={i}>
-                  {
-                    <Badge
-                      className={labelClassNamesMap.get(i) || ''}>
-                      {i}
-                    </Badge>
-                  }
+                  <Badge className={labelClassNamesMap.get(i) || ''}>
+                    {i}
+                  </Badge>
                 </div>
               ))
             : ''}

--- a/src/gui/test/components/explorer-grid/__snapshots__/index.tsx.snap
+++ b/src/gui/test/components/explorer-grid/__snapshots__/index.tsx.snap
@@ -340,15 +340,14 @@ exports[`explorer-grid with results 1`] = `
                 </p>
               </div>
             </div>
-            <div class="flex flex-row px-3 py-2 items-center justify-between">
-              <div class="flex items-center justify-center rounded-sm border-[1px] px-2 py-1">
-                <button data-state="closed">
-                  <p class="text-[0.65rem] text-muted-foreground font-mono font-medium truncate w-full m-0 p-0 align-baseline">
-                    npm:a@1.0.0
-                  </p>
-                </button>
-              </div>
-              <div class="flex gap-2 overflow-x-scroll">
+            <div class="w-full h-12 flex items-center gap-4 justify-between border-t-[1px] px-4 py-3">
+              <button
+                data-state="closed"
+                class="rounded-sm border-[1px] px-2 py-1 text-[0.65rem] text-muted-foreground font-mono m-0 align-baseline truncate"
+              >
+                npm:a@1.0.0
+              </button>
+              <div class="flex gap-2">
               </div>
             </div>
           </a>
@@ -381,15 +380,14 @@ exports[`explorer-grid with results 1`] = `
                 </p>
               </div>
             </div>
-            <div class="flex flex-row px-3 py-2 items-center justify-between">
-              <div class="flex items-center justify-center rounded-sm border-[1px] px-2 py-1">
-                <button data-state="closed">
-                  <p class="text-[0.65rem] text-muted-foreground font-mono font-medium truncate w-full m-0 p-0 align-baseline">
-                    npm:b@1.0.0
-                  </p>
-                </button>
-              </div>
-              <div class="flex gap-2 overflow-x-scroll">
+            <div class="w-full h-12 flex items-center gap-4 justify-between border-t-[1px] px-4 py-3">
+              <button
+                data-state="closed"
+                class="rounded-sm border-[1px] px-2 py-1 text-[0.65rem] text-muted-foreground font-mono m-0 align-baseline truncate"
+              >
+                npm:b@1.0.0
+              </button>
+              <div class="flex gap-2">
               </div>
             </div>
           </a>
@@ -442,15 +440,14 @@ exports[`explorer-grid with stack 1`] = `
                 </p>
               </div>
             </div>
-            <div class="flex flex-row px-3 py-2 items-center justify-between">
-              <div class="flex items-center justify-center rounded-sm border-[1px] px-2 py-1">
-                <button data-state="closed">
-                  <p class="text-[0.65rem] text-muted-foreground font-mono font-medium truncate w-full m-0 p-0 align-baseline">
-                    npm:a@1.0.0
-                  </p>
-                </button>
-              </div>
-              <div class="flex gap-2 overflow-x-scroll">
+            <div class="w-full h-12 flex items-center gap-4 justify-between border-t-[1px] px-4 py-3">
+              <button
+                data-state="closed"
+                class="rounded-sm border-[1px] px-2 py-1 text-[0.65rem] text-muted-foreground font-mono m-0 align-baseline truncate"
+              >
+                npm:a@1.0.0
+              </button>
+              <div class="flex gap-2">
               </div>
             </div>
           </a>
@@ -482,15 +479,14 @@ exports[`explorer-grid with stack 1`] = `
                 </p>
               </div>
             </div>
-            <div class="flex flex-row px-3 py-2 items-center justify-between">
-              <div class="flex items-center justify-center rounded-sm border-[1px] px-2 py-1">
-                <button data-state="closed">
-                  <p class="text-[0.65rem] text-muted-foreground font-mono font-medium truncate w-full m-0 p-0 align-baseline">
-                    npm:b@1.0.0
-                  </p>
-                </button>
-              </div>
-              <div class="flex gap-2 overflow-x-scroll">
+            <div class="w-full h-12 flex items-center gap-4 justify-between border-t-[1px] px-4 py-3">
+              <button
+                data-state="closed"
+                class="rounded-sm border-[1px] px-2 py-1 text-[0.65rem] text-muted-foreground font-mono m-0 align-baseline truncate"
+              >
+                npm:b@1.0.0
+              </button>
+              <div class="flex gap-2">
               </div>
             </div>
           </a>

--- a/src/gui/test/components/explorer-grid/__snapshots__/result-item.tsx.snap
+++ b/src/gui/test/components/explorer-grid/__snapshots__/result-item.tsx.snap
@@ -18,8 +18,8 @@ exports[`ResultItem render missing version and labels 1`] = `
           </h3>
         </button>
       </div>
-      <div class="flex flex-row px-3 py-2 items-center justify-between">
-        <div class="flex gap-2 overflow-x-scroll">
+      <div class="w-full h-12 flex items-center gap-4 justify-between border-t-[1px] px-4 py-3">
+        <div class="flex gap-2">
         </div>
       </div>
     </a>
@@ -50,15 +50,14 @@ exports[`ResultItem render stacked many 1`] = `
           </h3>
         </button>
       </div>
-      <div class="flex flex-row px-3 py-2 items-center justify-between">
-        <div class="flex items-center justify-center rounded-sm border-[1px] px-2 py-1">
-          <button data-state="closed">
-            <p class="text-[0.65rem] text-muted-foreground font-mono font-medium truncate w-full m-0 p-0 align-baseline">
-              1.1.1
-            </p>
-          </button>
-        </div>
-        <div class="flex gap-2 overflow-x-scroll">
+      <div class="w-full h-12 flex items-center gap-4 justify-between border-t-[1px] px-4 py-3">
+        <button
+          data-state="closed"
+          class="rounded-sm border-[1px] px-2 py-1 text-[0.65rem] text-muted-foreground font-mono m-0 align-baseline truncate"
+        >
+          1.1.1
+        </button>
+        <div class="flex gap-2">
           <div>
             <div class="inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 border-transparent bg-lime-100 text-neutral-900 hover:bg-lime-100/80">
               peer
@@ -92,15 +91,14 @@ exports[`ResultItem render stacked two 1`] = `
           </h3>
         </button>
       </div>
-      <div class="flex flex-row px-3 py-2 items-center justify-between">
-        <div class="flex items-center justify-center rounded-sm border-[1px] px-2 py-1">
-          <button data-state="closed">
-            <p class="text-[0.65rem] text-muted-foreground font-mono font-medium truncate w-full m-0 p-0 align-baseline">
-              1.0.0
-            </p>
-          </button>
-        </div>
-        <div class="flex gap-2 overflow-x-scroll">
+      <div class="w-full h-12 flex items-center gap-4 justify-between border-t-[1px] px-4 py-3">
+        <button
+          data-state="closed"
+          class="rounded-sm border-[1px] px-2 py-1 text-[0.65rem] text-muted-foreground font-mono m-0 align-baseline truncate"
+        >
+          1.0.0
+        </button>
+        <div class="flex gap-2">
           <div>
             <div class="inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 border-transparent bg-fuchsia-100 text-neutral-900 hover:bg-fuchsia-100/80">
               dev
@@ -132,15 +130,14 @@ exports[`ResultItem render with item 1`] = `
           </h3>
         </button>
       </div>
-      <div class="flex flex-row px-3 py-2 items-center justify-between">
-        <div class="flex items-center justify-center rounded-sm border-[1px] px-2 py-1">
-          <button data-state="closed">
-            <p class="text-[0.65rem] text-muted-foreground font-mono font-medium truncate w-full m-0 p-0 align-baseline">
-              1.0.0
-            </p>
-          </button>
-        </div>
-        <div class="flex gap-2 overflow-x-scroll">
+      <div class="w-full h-12 flex items-center gap-4 justify-between border-t-[1px] px-4 py-3">
+        <button
+          data-state="closed"
+          class="rounded-sm border-[1px] px-2 py-1 text-[0.65rem] text-muted-foreground font-mono m-0 align-baseline truncate"
+        >
+          1.0.0
+        </button>
+        <div class="flex gap-2">
           <div>
             <div class="inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 border-transparent bg-cyan-100 text-neutral-900 hover:bg-cyan-100/80">
               prod
@@ -185,15 +182,14 @@ exports[`ResultItem render with type 1`] = `
           </p>
         </div>
       </div>
-      <div class="flex flex-row px-3 py-2 items-center justify-between">
-        <div class="flex items-center justify-center rounded-sm border-[1px] px-2 py-1">
-          <button data-state="closed">
-            <p class="text-[0.65rem] text-muted-foreground font-mono font-medium truncate w-full m-0 p-0 align-baseline">
-              1.0.0
-            </p>
-          </button>
-        </div>
-        <div class="flex gap-2 overflow-x-scroll">
+      <div class="w-full h-12 flex items-center gap-4 justify-between border-t-[1px] px-4 py-3">
+        <button
+          data-state="closed"
+          class="rounded-sm border-[1px] px-2 py-1 text-[0.65rem] text-muted-foreground font-mono m-0 align-baseline truncate"
+        >
+          1.0.0
+        </button>
+        <div class="flex gap-2">
           <div>
             <div class="inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 border-transparent bg-cyan-100 text-neutral-900 hover:bg-cyan-100/80">
               prod


### PR DESCRIPTION
Copy/pasted the same code from #337

**Before**
<img width="356" alt="Screenshot 2025-01-28 at 7 44 47 PM" src="https://github.com/user-attachments/assets/cee534f8-e66c-4beb-b266-8dfb87b5cac2" />

**After**
<img width="287" alt="Screenshot 2025-01-28 at 7 43 53 PM" src="https://github.com/user-attachments/assets/9488a6aa-bb3d-4cd6-a7a8-422c3af91769" />
