### PR TITLE
build: move source rewriting to single esbuild plugin

### DIFF
--- a/infra/build/src/bundle.ts
+++ b/infra/build/src/bundle.ts
@@ -1,6 +1,5 @@
 import {
   rmSync,
-  readFileSync,
   mkdirSync,
   writeFileSync,
   readdirSync,
@@ -11,293 +10,26 @@ import {
   relative,
   dirname,
   basename,
-  sep,
-  posix,
   extname,
   resolve,
 } from 'node:path'
-import { readFile } from 'node:fs/promises'
 import * as esbuild from 'esbuild'
-import j from 'jscodeshift'
 import { findPackageJson } from 'package-json-from-dist'
 import { builtinModules, createRequire } from 'node:module'
 import assert from 'node:assert'
 import { Bins, Paths } from './index.js'
-import { randomBytes } from 'node:crypto'
 import * as types from './types.js'
+import {
+  transformSourcePlugin,
+  Globals,
+  IMPORT_META,
+  ident,
+  readJson,
+  readPkg,
+  getSrcPath,
+} from './transform-source.js'
 
 const EXT = '.js'
-
-export const IMPORT_META: Record<
-  Capitalize<keyof ImportMeta>,
-  `import.meta.${keyof ImportMeta}`
-> = {
-  Dirname: 'import.meta.dirname',
-  Filename: 'import.meta.filename',
-  Url: 'import.meta.url',
-  Resolve: 'import.meta.resolve',
-}
-
-const ident = (pre = '') =>
-  [...pre.split(/[.:]/g), randomBytes(3).toString('hex')].join('_')
-
-export type OnLoadPlugin = {
-  paths: () => string[]
-  plugin: esbuild.Plugin
-}
-
-const readJson = (p: string) => JSON.parse(readFileSync(p, 'utf8'))
-
-const readPkg = (p: string) => readJson(join(p, 'package.json'))
-
-const getSrcPath = (p: string) =>
-  relative(Paths.SRC, p).replace(join('/dist/esm/'), sep)
-
-const filePluginFilter = (r: string) => ({
-  filter: new RegExp(
-    join(r).replaceAll(sep, `\\${sep}`).replaceAll('.', '\\.'),
-  ),
-  namespace: 'file',
-})
-
-const createOnLoad = (
-  includes: (source: string, path: string) => boolean,
-  fn: (path: string, source: string) => string,
-): {
-  paths: OnLoadPlugin['paths']
-  plugin: (
-    o: esbuild.OnLoadArgs,
-  ) => Promise<esbuild.OnLoadResult | undefined>
-} => {
-  const found = new Set<string>()
-  return {
-    paths: () => [...found],
-    plugin: async o => {
-      const source = await readFile(o.path, 'utf8')
-      if (includes(source, o.path)) {
-        found.add(o.path)
-        return { contents: fn(o.path, source) }
-      }
-    },
-  }
-}
-
-// All files that will be code split into external scripts
-// export __CODE_SPLIT_SCRIPT_NAME which we change to a path
-// to that external script instead
-const codeSplitPlugin = (
-  filter: string,
-  transform: (path: string) => string,
-): OnLoadPlugin => {
-  const CODE_SPLIT_SCRIPT = {
-    file: (path: string) =>
-      readFileSync(
-        join(Paths.BUILD_ROOT, './src/bundle-code-split.js'),
-        'utf8',
-      ).replaceAll('{{PATH}}', path),
-    name: '__CODE_SPLIT_SCRIPT_NAME',
-  }
-  const { paths, plugin } = createOnLoad(
-    s => s.includes(`export const ${CODE_SPLIT_SCRIPT.name}`),
-    p =>
-      CODE_SPLIT_SCRIPT.file(transform(p).replaceAll(sep, posix.sep)),
-  )
-  return {
-    paths,
-    plugin: {
-      name: 'code-split-plugin',
-      setup({ onLoad }) {
-        onLoad(filePluginFilter(filter), plugin)
-      },
-    },
-  }
-}
-
-// This package is used to read package json files from the correct
-// directory. When we bundle those package.json files will be in different
-// places so this plugin will rewrite the package and its function calls
-// to read from the correct places.
-const readPackageJsonPlugin = (
-  filter: string,
-  transform: (path: string) => string,
-): OnLoadPlugin => {
-  const READ_PACKAGE_JSON = {
-    file: readFileSync(
-      join(Paths.BUILD_ROOT, './src/bundle-package-json.js'),
-    ),
-    name: 'package-json-from-dist',
-    exports: ['loadPackageJson', 'findPackageJson'],
-  }
-  const { paths, plugin } = createOnLoad(
-    s => s.includes(READ_PACKAGE_JSON.name),
-    (p, s) =>
-      READ_PACKAGE_JSON.exports
-        .reduce(
-          (ast, name) =>
-            ast
-              .find(j.CallExpression, { callee: { name } })
-              .replaceWith(() =>
-                j.callExpression(j.identifier(name), [
-                  j.identifier(
-                    JSON.stringify(
-                      transform(p).replaceAll(sep, posix.sep),
-                    ),
-                  ),
-                ]),
-              ),
-          j(s),
-        )
-        .toSource(),
-  )
-  return {
-    paths,
-    plugin: {
-      name: 'read-package-json',
-      setup({ onLoad }) {
-        onLoad(filePluginFilter(filter), plugin)
-        onLoad(
-          filePluginFilter(
-            `/node_modules/${READ_PACKAGE_JSON.name}/dist/esm/index.js`,
-          ),
-          () => ({ contents: READ_PACKAGE_JSON.file }),
-        )
-      },
-    },
-  }
-}
-
-const metaResolvePlugin = (filter: string): OnLoadPlugin => {
-  const parts = IMPORT_META.Resolve.split('.')
-  const found = new Set<string>()
-  const { plugin } = createOnLoad(
-    s => s.includes(IMPORT_META.Resolve),
-    (_, s) =>
-      j(s)
-        .find(j.CallExpression, {
-          callee: {
-            object: {
-              type: 'MetaProperty',
-              meta: { name: parts[0] },
-              property: { name: parts[1] },
-            },
-            property: { name: parts[2] },
-          },
-        })
-        .find(j.Literal)
-        .forEach(path => {
-          const { value } = path.node
-          assert(
-            typeof value === 'string',
-            `${IMPORT_META.Resolve} must be a string`,
-          )
-          const workspace = readdirSync(Paths.SRC, {
-            withFileTypes: true,
-          })
-            .filter(d => d.isDirectory())
-            .find(d =>
-              value.startsWith(
-                readPkg(join(d.parentPath, d.name)).name,
-              ),
-            )
-          assert(
-            workspace,
-            `${IMPORT_META.Resolve} can only be used with a workspace in src/`,
-          )
-          found.add(join(workspace.parentPath, workspace.name))
-          path.node.value = workspace.name
-        })
-        .toSource(),
-  )
-  return {
-    paths: () => [...found],
-    plugin: {
-      name: 'meta-resolve',
-      setup({ onLoad }) {
-        onLoad(filePluginFilter(filter), plugin)
-      },
-    },
-  }
-}
-
-const loadCommandsPlugin = (
-  filter: string,
-  o: Pick<types.BundleFactors, 'externalCommands' | 'format'>,
-): esbuild.Plugin => {
-  const COMMENT = '/* LOAD COMMANDS '
-  const isCjs = o.format === types.Formats.Cjs
-  const isExt = o.externalCommands
-  const replaceCommand = (line: string) => {
-    const m =
-      /^(?<ws>\s+)(?<ret>return \()(?<load>await import\()(?<path>.*?)(?<end>\)\);?)$/.exec(
-        line,
-      )?.groups
-    assert(m, `load commands code does not match expected: ${line}`)
-    const load = isCjs ? 'require(' : m.load
-    const pathVar = ident('commandPath')
-    const path = isExt ? pathVar : m.path
-    const prefix =
-      isExt ? `${m.ws}const ${pathVar} = ${m.path}\n` : ''
-    return [prefix, m.ws, m.ret, load, path, m.end].join('')
-  }
-  const { plugin } = createOnLoad(
-    s => s.includes(COMMENT),
-    (_, s) => {
-      let insideBlock = false
-      return s
-        .split('\n')
-        .map(l => {
-          const start = new RegExp(`${COMMENT}(START|STOP) `).exec(l)
-          if (start?.[1]) {
-            insideBlock = start[1] === 'START'
-            return null
-          }
-          return insideBlock ? replaceCommand(l) : l
-        })
-        .filter(l => l !== null)
-        .join('\n')
-    },
-  )
-  return {
-    name: 'load-commands-plugin',
-    setup({ onLoad }) {
-      onLoad(filePluginFilter(filter), plugin)
-    },
-  }
-}
-
-const nodeImportsPlugin = (): esbuild.Plugin => ({
-  name: 'node-imports',
-  setup({ onResolve }) {
-    onResolve({ filter: /()/, namespace: 'file' }, args => {
-      if (
-        builtinModules.includes(args.path) &&
-        !args.path.startsWith('node:')
-      ) {
-        return {
-          path: `node:${args.path}`,
-          external: true,
-        }
-      }
-    })
-  },
-})
-
-const rewriteBinPlugin = (
-  o: Pick<types.BundleFactors, 'format'>,
-): esbuild.Plugin => {
-  const isCjs = o.format === types.Formats.Cjs
-  const { plugin } = createOnLoad(
-    s => s.includes('await import('),
-    (_, s) =>
-      isCjs ? s.replaceAll('await import(', 'void import(') : s,
-  )
-  return {
-    name: 'rewrite-bin-plugin',
-    setup({ onLoad }) {
-      onLoad(filePluginFilter(`^${Bins.DIR}`), plugin)
-    },
-  }
-}
 
 const bundle = async (o: {
   plugins: esbuild.BuildOptions['plugins']
@@ -310,84 +42,17 @@ const bundle = async (o: {
 }) => {
   const cjs = o.format === types.Formats.Cjs
 
-  class Globals {
-    #ids = new Map<string, string>()
-    #items = new Map<string, string>()
-
-    static quote = (v: string) => `"${v}"`
-
-    static var = (name: string, value: string) =>
-      `var ${name} = ${value}`
-
-    static import = (name: string | string[], path: string) => {
-      const mod = Globals.quote(`node:${path}`)
-      const imports =
-        Array.isArray(name) ? `{${name.join(', ')}}` : name
-      return cjs ?
-          Globals.var(imports, `require(${mod})`)
-        : `import ${imports} from ${mod}`
-    }
-
-    toString() {
-      return [...this.#items.values()].join('\n')
-    }
-
-    constructor(
-      ...args: (
-        | false
-        | string
-        | ((b: Globals) => string)
-        | Record<string, (id: string, b: Globals) => string>
-      )[]
-    ) {
-      for (const [k, v] of args.flatMap(arg => {
-        if (typeof arg === 'object') {
-          return Object.entries(arg).map(([k, v]) => {
-            const id = this.#id(k)
-            return [id, v(id, this)] as const
-          })
-        }
-        const value =
-          typeof arg === 'string' ? arg
-          : typeof arg === 'function' ? arg(this)
-          : null
-        return value ? [[value, value] as const] : []
-      })) {
-        this.#items.set(k, v)
-      }
-    }
-
-    #id(key: string) {
-      const cached = this.#ids.get(key)
-      if (cached) {
-        return cached
-      }
-      const id = ident(`bundle.${key}`)
-      this.#ids.set(key, id)
-      return id
-    }
-
-    get = (key: string) => {
-      const value = this.#ids.get(key)
-      assert(value)
-      return value
-    }
-
-    fn = (fn: string, args: string[]) => {
-      const id = this.#id(fn)
-      const [mod, name] = fn.split('.')
-      assert(name && mod)
-      this.#items.set(id, Globals.import([`${name} as ${id}`], mod))
-      return `${id}(${args.join(', ')})`
-    }
-  }
-
   const globals = new Globals(
+    { format: o.format },
     // These are globals that are needed to run in all runtimes
     Globals.var('global', 'globalThis'),
-    Globals.import('process', 'process'),
-    Globals.import(['Buffer'], 'buffer'),
-    Globals.import(['setImmediate', 'clearImmediate'], 'timers'),
+    Globals.import(o.format, 'process', 'process'),
+    Globals.import(o.format, ['Buffer'], 'buffer'),
+    Globals.import(
+      o.format,
+      ['setImmediate', 'clearImmediate'],
+      'timers',
+    ),
     // These are to shim import.meta properties
     {
       [IMPORT_META.Dirname]: (id, { fn }) =>
@@ -471,6 +136,13 @@ const bundle = async (o: {
   return metafile
 }
 
+const createWorkspace = (base: string, source: string) => {
+  const pkg = readPkg(source)
+  const dest = join(base, basename(source))
+  mkdirSync(dest, { recursive: true })
+  return { pkg, dest }
+}
+
 export default async ({
   outdir,
   minify,
@@ -483,43 +155,40 @@ export default async ({
   rmSync(outdir, { recursive: true, force: true })
   mkdirSync(outdir, { recursive: true })
 
-  const codeSplit = codeSplitPlugin(`^${Paths.SRC}`, p =>
-    getSrcPath(p),
-  )
-  const readPackageJson = readPackageJsonPlugin(
-    `^${Paths.SRC}`,
-    p => {
-      // Map the vlt package.json to the actual package.json used for publishing
-      // which will be at the root by resolving an empty string instead of the pkg name.
-      const pkg = dirname(getSrcPath(p))
-      return pkg === 'vlt' ? '' : pkg
-    },
-  )
-  const metaResolve = metaResolvePlugin(`^${Paths.SRC}`)
-  const loadCommands = loadCommandsPlugin(`^${Paths.CLI}`, {
+  const transformSource = transformSourcePlugin({
     externalCommands,
     format,
   })
-  const nodeImports = nodeImportsPlugin()
+
+  const nodeImports: esbuild.Plugin = {
+    name: 'node-imports',
+    setup({ onResolve }) {
+      onResolve({ filter: /()/, namespace: 'file' }, args => {
+        if (
+          builtinModules.includes(args.path) &&
+          !args.path.startsWith('node:')
+        ) {
+          return {
+            path: `node:${args.path}`,
+            external: true,
+          }
+        }
+      })
+    },
+  }
 
   const files: esbuild.Metafile[] = []
   const bundleFiles = async (
     bundles: {
       in: string
       out: string
-      plugins?: esbuild.BuildOptions['plugins']
     }[],
   ) => {
     for (const b of bundles) {
       files.push(
         await bundle({
           ...b,
-          plugins: [
-            readPackageJson.plugin,
-            metaResolve.plugin,
-            nodeImports,
-            ...(b.plugins ?? []),
-          ],
+          plugins: [transformSource.plugin, nodeImports],
           sourcemap,
           format,
           minify,
@@ -533,11 +202,6 @@ export default async ({
     Bins.PATHS.map(bin => ({
       in: join(Paths.CLI, bin),
       out: basename(bin, extname(bin)),
-      plugins: [
-        rewriteBinPlugin({ format }),
-        codeSplit.plugin,
-        loadCommands,
-      ],
     })),
   )
 
@@ -550,26 +214,18 @@ export default async ({
         .map(c => ({
           in: join(c.parentPath, c.name),
           out: `commands/${basename(c.name, extname(c.name))}`,
-          plugins: [codeSplit.plugin],
         })),
     )
   }
 
   await bundleFiles(
-    codeSplit.paths().map(p => ({
+    transformSource.paths.codeSplit().map(p => ({
       in: p,
       out: getSrcPath(p).replaceAll(EXT, ''),
     })),
   )
 
-  const createWorkspace = (base: string, source: string) => {
-    const pkg = readPkg(source)
-    const dest = join(base, basename(source))
-    mkdirSync(dest, { recursive: true })
-    return { pkg, dest }
-  }
-
-  for (const file of readPackageJson.paths()) {
+  for (const file of transformSource.paths.readPackageJson()) {
     const { pkg, dest } = createWorkspace(
       outdir,
       dirname(findPackageJson(file)),
@@ -587,7 +243,7 @@ export default async ({
     )
   }
 
-  for (const dir of metaResolve.paths()) {
+  for (const dir of transformSource.paths.metaResolve()) {
     const { pkg, dest } = createWorkspace(outdir, dir)
     const main = pkg.exports['.']
     assert(typeof main === 'string')

--- a/infra/build/src/transform-source.ts
+++ b/infra/build/src/transform-source.ts
@@ -1,0 +1,329 @@
+import { readFileSync, readdirSync } from 'node:fs'
+import { join, relative, dirname, sep, posix } from 'node:path'
+import { readFile } from 'node:fs/promises'
+import type * as esbuild from 'esbuild'
+import j from 'jscodeshift'
+import assert from 'node:assert'
+import { Paths } from './index.js'
+import { randomBytes } from 'node:crypto'
+import * as types from './types.js'
+import { EOL } from 'node:os'
+
+export const ident = (pre = '') =>
+  [...pre.split(/[.:]/g), randomBytes(3).toString('hex')].join('_')
+
+export const readJson = (p: string) =>
+  JSON.parse(readFileSync(p, 'utf8'))
+
+export const readPkg = (p: string) =>
+  readJson(join(p, 'package.json'))
+
+export const getSrcPath = (p: string) =>
+  relative(Paths.SRC, p).replace(join('/dist/esm/'), sep)
+
+const escapeRegExpPath = (r: string) =>
+  new RegExp(
+    join(r).replaceAll(sep, `\\${sep}`).replaceAll('.', '\\.'),
+  )
+
+export const IMPORT_META: Record<
+  Capitalize<keyof ImportMeta>,
+  `import.meta.${keyof ImportMeta}`
+> = {
+  Dirname: 'import.meta.dirname',
+  Filename: 'import.meta.filename',
+  Url: 'import.meta.url',
+  Resolve: 'import.meta.resolve',
+}
+
+const READ_PACKAGE_JSON = {
+  file: readFileSync(
+    join(Paths.BUILD_ROOT, './src/bundle-package-json.js'),
+  ),
+  name: 'package-json-from-dist',
+  exports: ['loadPackageJson', 'findPackageJson'],
+}
+
+const CODE_SPLIT_SCRIPT = {
+  file: (path: string) =>
+    readFileSync(
+      join(Paths.BUILD_ROOT, './src/bundle-code-split.js'),
+      'utf8',
+    ).replaceAll('{{PATH}}', path),
+  name: '__CODE_SPLIT_SCRIPT_NAME',
+}
+
+const EXTERNAL_COMMANDS = {
+  comment: '/* LOAD COMMANDS ',
+  replaceCommand: (
+    line: string,
+    {
+      format,
+      externalCommands,
+    }: Pick<types.BundleFactors, 'externalCommands' | 'format'>,
+  ) => {
+    const m =
+      /^(?<ws>\s+)(?<ret>return \()(?<load>await import\()(?<path>.*?)(?<end>\)\);?)$/.exec(
+        line,
+      )?.groups
+    assert(m, `load commands code does not match expected: ${line}`)
+    const load = format === types.Formats.Cjs ? 'require(' : m.load
+    const pathVar = ident('commandPath')
+    const path = externalCommands ? pathVar : m.path
+    const prefix =
+      externalCommands ? `${m.ws}const ${pathVar} = ${m.path}\n` : ''
+    return [prefix, m.ws, m.ret, load, path, m.end].join('')
+  },
+}
+
+export const transformSourcePlugin = ({
+  format,
+  externalCommands,
+}: Pick<types.BundleFactors, 'externalCommands' | 'format'>): {
+  paths: {
+    codeSplit: () => string[]
+    readPackageJson: () => string[]
+    metaResolve: () => string[]
+  }
+  plugin: esbuild.Plugin
+} => {
+  const found = {
+    codeSplit: new Set<string>(),
+    readPackageJson: new Set<string>(),
+    metaResolve: new Set<string>(),
+  }
+
+  return {
+    paths: {
+      codeSplit: () => [...found.codeSplit],
+      readPackageJson: () => [...found.readPackageJson],
+      metaResolve: () => [...found.metaResolve],
+    },
+    plugin: {
+      name: 'transform-source-plugin',
+      setup({ onLoad }) {
+        onLoad(
+          {
+            filter: escapeRegExpPath(
+              `/node_modules/${READ_PACKAGE_JSON.name}/dist/esm/index.js`,
+            ),
+            namespace: 'file',
+          },
+          () => ({ contents: READ_PACKAGE_JSON.file }),
+        )
+        onLoad(
+          {
+            filter: escapeRegExpPath(`^${Paths.SRC}`),
+            namespace: 'file',
+          },
+          async o => {
+            let source = await readFile(o.path, 'utf8')
+
+            // All files that will be code split into external scripts
+            // export __CODE_SPLIT_SCRIPT_NAME which we change to a path
+            // to that external script instead
+            if (
+              source.includes(
+                `export const ${CODE_SPLIT_SCRIPT.name}`,
+              )
+            ) {
+              found.codeSplit.add(o.path)
+              source = CODE_SPLIT_SCRIPT.file(
+                getSrcPath(o.path).replaceAll(sep, posix.sep),
+              )
+            }
+
+            // This package is used to read package json files from the correct
+            // directory. When we bundle those package.json files will be in different
+            // places so this plugin will rewrite the package and its function calls
+            // to read from the correct places.
+            if (source.includes(READ_PACKAGE_JSON.name)) {
+              found.readPackageJson.add(o.path)
+              const dir = dirname(getSrcPath(o.path)).replaceAll(
+                sep,
+                posix.sep,
+              )
+              source = READ_PACKAGE_JSON.exports
+                .reduce(
+                  (ast, name) =>
+                    ast
+                      .find(j.CallExpression, {
+                        callee: { name },
+                      })
+                      .replaceWith(() =>
+                        j.callExpression(j.identifier(name), [
+                          j.identifier(
+                            // Map the vlt package.json to the actual package.json used for publishing
+                            // which will be at the root by resolving an empty string instead of the pkg name.
+                            JSON.stringify(dir === 'vlt' ? '' : dir),
+                          ),
+                        ]),
+                      ),
+                  j(source),
+                )
+                .toSource()
+            }
+
+            // Calls to import.meta.resolve are rewritten to the workspace directory
+            if (source.includes(IMPORT_META.Resolve)) {
+              source = j(source)
+                .find(j.CallExpression, {
+                  callee: {
+                    object: {
+                      type: 'MetaProperty',
+                      meta: { name: 'import' },
+                      property: { name: 'meta' },
+                    },
+                    property: { name: 'resolve' },
+                  },
+                })
+                .find(j.Literal)
+                .forEach(path => {
+                  const { value } = path.node
+                  assert(
+                    typeof value === 'string',
+                    `${IMPORT_META.Resolve} must be a string`,
+                  )
+                  const workspace = readdirSync(Paths.SRC, {
+                    withFileTypes: true,
+                  })
+                    .filter(d => d.isDirectory())
+                    .find(d =>
+                      value.startsWith(
+                        readPkg(join(d.parentPath, d.name)).name,
+                      ),
+                    )
+                  assert(
+                    workspace,
+                    `${IMPORT_META.Resolve} can only be used with a workspace in src/`,
+                  )
+                  found.metaResolve.add(
+                    join(workspace.parentPath, workspace.name),
+                  )
+                  path.node.value = workspace.name
+                })
+                .toSource()
+            }
+
+            if (source.includes(EXTERNAL_COMMANDS.comment)) {
+              let insideBlock = false
+              source = source
+                .split(EOL)
+                .map(l => {
+                  const start = new RegExp(
+                    `${EXTERNAL_COMMANDS.comment}(START|STOP) `,
+                  ).exec(l)
+                  if (start?.[1]) {
+                    insideBlock = start[1] === 'START'
+                    return null
+                  }
+                  return insideBlock ?
+                      EXTERNAL_COMMANDS.replaceCommand(l, {
+                        format,
+                        externalCommands,
+                      })
+                    : l
+                })
+                .filter(l => l !== null)
+                .join(EOL)
+            }
+
+            if (
+              source.includes('await import(') &&
+              format === types.Formats.Cjs
+            ) {
+              source = source.replaceAll(
+                'await import(',
+                'void import(',
+              )
+            }
+
+            return { contents: source }
+          },
+        )
+      },
+    },
+  }
+}
+
+export class Globals {
+  #ids = new Map<string, string>()
+  #items = new Map<string, string>()
+  #format: types.Format
+
+  static quote = (v: string) => `"${v}"`
+
+  static var = (name: string, value: string) =>
+    `var ${name} = ${value}`
+
+  static import = (
+    f: types.BundleFactors['format'],
+    name: string | string[],
+    path: string,
+  ) => {
+    const mod = Globals.quote(`node:${path}`)
+    const imports =
+      Array.isArray(name) ? `{${name.join(', ')}}` : name
+    return f === types.Formats.Cjs ?
+        Globals.var(imports, `require(${mod})`)
+      : `import ${imports} from ${mod}`
+  }
+
+  toString() {
+    return [...this.#items.values()].join('\n')
+  }
+
+  constructor(
+    { format }: Pick<types.BundleFactors, 'format'>,
+    ...args: (
+      | false
+      | string
+      | ((b: Globals) => string)
+      | Record<string, (id: string, b: Globals) => string>
+    )[]
+  ) {
+    this.#format = format
+    for (const [k, v] of args.flatMap(arg => {
+      if (typeof arg === 'object') {
+        return Object.entries(arg).map(([k, v]) => {
+          const id = this.#id(k)
+          return [id, v(id, this)] as const
+        })
+      }
+      const value =
+        typeof arg === 'string' ? arg
+        : typeof arg === 'function' ? arg(this)
+        : null
+      return value ? [[value, value] as const] : []
+    })) {
+      this.#items.set(k, v)
+    }
+  }
+
+  #id(key: string) {
+    const cached = this.#ids.get(key)
+    if (cached) {
+      return cached
+    }
+    const id = ident(`bundle.${key}`)
+    this.#ids.set(key, id)
+    return id
+  }
+
+  get = (key: string) => {
+    const value = this.#ids.get(key)
+    assert(value)
+    return value
+  }
+
+  fn = (fn: string, args: string[]) => {
+    const id = this.#id(fn)
+    const [mod, name] = fn.split('.')
+    assert(name && mod)
+    this.#items.set(
+      id,
+      Globals.import(this.#format, [`${name} as ${id}`], mod),
+    )
+    return `${id}(${args.join(', ')})`
+  }
+}


### PR DESCRIPTION
Previously source rewriting was split between multiple esbuild
plugins which made it easier to read. However I did not realize
that onLoad esbuild plugins will bail once one plugin has claimed
a file. So if multiple plugins were trying to alter the source of
a single file then the first one registered would win.

This caused a recent refactor to no longer copy the gui assets to
the correct location during build because that file already had a
plugin that would operate on it first.

This is fixed by using a single esbuild onLoad plugin that is
responsible for all the source rewriting.
