### PR TITLE
gui(test): quiet console.error for undefined manifests

### DIFF
--- a/src/gui/src/components/explorer-grid/selected-item.tsx
+++ b/src/gui/src/components/explorer-grid/selected-item.tsx
@@ -110,7 +110,11 @@ export const SelectedItem = ({ item }: GridItemOptions) => {
             </TabsList>
             <TabsContent value="package.json">
               <CodeBlock
-                code={JSON.stringify(item.to?.manifest, null, 2)}
+                code={
+                  item.to?.manifest ?
+                    JSON.stringify(item.to.manifest, null, 2)
+                  : ''
+                }
                 lang="json"
               />
             </TabsContent>


### PR DESCRIPTION
I think this only happens in tests but `JSON.stringify(undefined)` is undefined so when it gets passed to `shiki.codeToHtml` from we get a lot of console.error output saying the `Cannot read properties of undefined (reading 'split')`.

Also TS doesn't help us here because JSON.stringify always returns a string according to it. So the easiest fix is to manually guard this and pass in an empty string instead.

Currently this is the output I get for the tests on `main`:

```
╰❯ pnpm -F gui test

> @vltpkg/gui@0.0.0-0 test /Users/lukekarrys/projects/vltpkg/vltpkg/src/gui
> vitest


 DEV  v2.1.6 /Users/lukekarrys/projects/vltpkg/vltpkg/src/gui

stderr | src/components/ui/shiki.tsx:24:54
TypeError: Cannot read properties of undefined (reading 'split')
    at splitLines (file:///Users/lukekarrys/projects/vltpkg/vltpkg/node_modules/.pnpm/@shikijs+core@1.22.2/node_modules/@shikijs/core/dist/index.mjs:29:22)
    at _tokenizeWithTheme (file:///Users/lukekarrys/projects/vltpkg/vltpkg/node_modules/.pnpm/@shikijs+core@1.22.2/node_modules/@shikijs/core/dist/index.mjs:831:17)
    at tokenizeWithTheme (file:///Users/lukekarrys/projects/vltpkg/vltpkg/node_modules/.pnpm/@shikijs+core@1.22.2/node_modules/@shikijs/core/dist/index.mjs:816:18)
    at codeToTokensBase (file:///Users/lukekarrys/projects/vltpkg/vltpkg/node_modules/.pnpm/@shikijs+core@1.22.2/node_modules/@shikijs/core/dist/index.mjs:792:10)
    at codeToTokens (file:///Users/lukekarrys/projects/vltpkg/vltpkg/node_modules/.pnpm/@shikijs+core@1.22.2/node_modules/@shikijs/core/dist/index.mjs:1103:14)
    at codeToHast (file:///Users/lukekarrys/projects/vltpkg/vltpkg/node_modules/.pnpm/@shikijs+core@1.22.2/node_modules/@shikijs/core/dist/index.mjs:1166:7)
    at codeToHtml (file:///Users/lukekarrys/projects/vltpkg/vltpkg/node_modules/.pnpm/@shikijs+core@1.22.2/node_modules/@shikijs/core/dist/index.mjs:1393:23)
    at Object.codeToHtml (file:///Users/lukekarrys/projects/vltpkg/vltpkg/node_modules/.pnpm/@shikijs+core@1.22.2/node_modules/@shikijs/core/dist/index.mjs:1826:37)
    at codeToHtml (file:///Users/lukekarrys/projects/vltpkg/vltpkg/node_modules/.pnpm/@shikijs+core@1.22.2/node_modules/@shikijs/core/dist/index.mjs:1961:20)
    at startCodeBlock (/Users/lukekarrys/projects/vltpkg/vltpkg/src/gui/src/components/ui/shiki.tsx:16:19)
TypeError: Cannot read properties of undefined (reading 'split')
    at splitLines (file:///Users/lukekarrys/projects/vltpkg/vltpkg/node_modules/.pnpm/@shikijs+core@1.22.2/node_modules/@shikijs/core/dist/index.mjs:29:22)
    at _tokenizeWithTheme (file:///Users/lukekarrys/projects/vltpkg/vltpkg/node_modules/.pnpm/@shikijs+core@1.22.2/node_modules/@shikijs/core/dist/index.mjs:831:17)
    at tokenizeWithTheme (file:///Users/lukekarrys/projects/vltpkg/vltpkg/node_modules/.pnpm/@shikijs+core@1.22.2/node_modules/@shikijs/core/dist/index.mjs:816:18)
    at codeToTokensBase (file:///Users/lukekarrys/projects/vltpkg/vltpkg/node_modules/.pnpm/@shikijs+core@1.22.2/node_modules/@shikijs/core/dist/index.mjs:792:10)
    at codeToTokens (file:///Users/lukekarrys/projects/vltpkg/vltpkg/node_modules/.pnpm/@shikijs+core@1.22.2/node_modules/@shikijs/core/dist/index.mjs:1103:14)
    at codeToHast (file:///Users/lukekarrys/projects/vltpkg/vltpkg/node_modules/.pnpm/@shikijs+core@1.22.2/node_modules/@shikijs/core/dist/index.mjs:1166:7)
    at codeToHtml (file:///Users/lukekarrys/projects/vltpkg/vltpkg/node_modules/.pnpm/@shikijs+core@1.22.2/node_modules/@shikijs/core/dist/index.mjs:1393:23)
    at Object.codeToHtml (file:///Users/lukekarrys/projects/vltpkg/vltpkg/node_modules/.pnpm/@shikijs+core@1.22.2/node_modules/@shikijs/core/dist/index.mjs:1826:37)
    at codeToHtml (file:///Users/lukekarrys/projects/vltpkg/vltpkg/node_modules/.pnpm/@shikijs+core@1.22.2/node_modules/@shikijs/core/dist/index.mjs:1961:20)
    at startCodeBlock (/Users/lukekarrys/projects/vltpkg/vltpkg/src/gui/src/components/ui/shiki.tsx:16:19)
TypeError: Cannot read properties of undefined (reading 'split')
    at splitLines (file:///Users/lukekarrys/projects/vltpkg/vltpkg/node_modules/.pnpm/@shikijs+core@1.22.2/node_modules/@shikijs/core/dist/index.mjs:29:22)
    at _tokenizeWithTheme (file:///Users/lukekarrys/projects/vltpkg/vltpkg/node_modules/.pnpm/@shikijs+core@1.22.2/node_modules/@shikijs/core/dist/index.mjs:831:17)
    at tokenizeWithTheme (file:///Users/lukekarrys/projects/vltpkg/vltpkg/node_modules/.pnpm/@shikijs+core@1.22.2/node_modules/@shikijs/core/dist/index.mjs:816:18)
    at codeToTokensBase (file:///Users/lukekarrys/projects/vltpkg/vltpkg/node_modules/.pnpm/@shikijs+core@1.22.2/node_modules/@shikijs/core/dist/index.mjs:792:10)
    at codeToTokens (file:///Users/lukekarrys/projects/vltpkg/vltpkg/node_modules/.pnpm/@shikijs+core@1.22.2/node_modules/@shikijs/core/dist/index.mjs:1103:14)
    at codeToHast (file:///Users/lukekarrys/projects/vltpkg/vltpkg/node_modules/.pnpm/@shikijs+core@1.22.2/node_modules/@shikijs/core/dist/index.mjs:1166:7)
    at codeToHtml (file:///Users/lukekarrys/projects/vltpkg/vltpkg/node_modules/.pnpm/@shikijs+core@1.22.2/node_modules/@shikijs/core/dist/index.mjs:1393:23)
    at Object.codeToHtml (file:///Users/lukekarrys/projects/vltpkg/vltpkg/node_modules/.pnpm/@shikijs+core@1.22.2/node_modules/@shikijs/core/dist/index.mjs:1826:37)
    at codeToHtml (file:///Users/lukekarrys/projects/vltpkg/vltpkg/node_modules/.pnpm/@shikijs+core@1.22.2/node_modules/@shikijs/core/dist/index.mjs:1961:20)
    at startCodeBlock (/Users/lukekarrys/projects/vltpkg/vltpkg/src/gui/src/components/ui/shiki.tsx:16:19)
TypeError: Cannot read properties of undefined (reading 'split')
    at splitLines (file:///Users/lukekarrys/projects/vltpkg/vltpkg/node_modules/.pnpm/@shikijs+core@1.22.2/node_modules/@shikijs/core/dist/index.mjs:29:22)
    at _tokenizeWithTheme (file:///Users/lukekarrys/projects/vltpkg/vltpkg/node_modules/.pnpm/@shikijs+core@1.22.2/node_modules/@shikijs/core/dist/index.mjs:831:17)
    at tokenizeWithTheme (file:///Users/lukekarrys/projects/vltpkg/vltpkg/node_modules/.pnpm/@shikijs+core@1.22.2/node_modules/@shikijs/core/dist/index.mjs:816:18)
    at codeToTokensBase (file:///Users/lukekarrys/projects/vltpkg/vltpkg/node_modules/.pnpm/@shikijs+core@1.22.2/node_modules/@shikijs/core/dist/index.mjs:792:10)
    at codeToTokens (file:///Users/lukekarrys/projects/vltpkg/vltpkg/node_modules/.pnpm/@shikijs+core@1.22.2/node_modules/@shikijs/core/dist/index.mjs:1103:14)
    at codeToHast (file:///Users/lukekarrys/projects/vltpkg/vltpkg/node_modules/.pnpm/@shikijs+core@1.22.2/node_modules/@shikijs/core/dist/index.mjs:1166:7)
    at codeToHtml (file:///Users/lukekarrys/projects/vltpkg/vltpkg/node_modules/.pnpm/@shikijs+core@1.22.2/node_modules/@shikijs/core/dist/index.mjs:1393:23)
    at Object.codeToHtml (file:///Users/lukekarrys/projects/vltpkg/vltpkg/node_modules/.pnpm/@shikijs+core@1.22.2/node_modules/@shikijs/core/dist/index.mjs:1826:37)
    at codeToHtml (file:///Users/lukekarrys/projects/vltpkg/vltpkg/node_modules/.pnpm/@shikijs+core@1.22.2/node_modules/@shikijs/core/dist/index.mjs:1961:20)
    at startCodeBlock (/Users/lukekarrys/projects/vltpkg/vltpkg/src/gui/src/components/ui/shiki.tsx:16:19)
TypeError: Cannot read properties of undefined (reading 'split')
    at splitLines (file:///Users/lukekarrys/projects/vltpkg/vltpkg/node_modules/.pnpm/@shikijs+core@1.22.2/node_modules/@shikijs/core/dist/index.mjs:29:22)
    at _tokenizeWithTheme (file:///Users/lukekarrys/projects/vltpkg/vltpkg/node_modules/.pnpm/@shikijs+core@1.22.2/node_modules/@shikijs/core/dist/index.mjs:831:17)
    at tokenizeWithTheme (file:///Users/lukekarrys/projects/vltpkg/vltpkg/node_modules/.pnpm/@shikijs+core@1.22.2/node_modules/@shikijs/core/dist/index.mjs:816:18)
    at codeToTokensBase (file:///Users/lukekarrys/projects/vltpkg/vltpkg/node_modules/.pnpm/@shikijs+core@1.22.2/node_modules/@shikijs/core/dist/index.mjs:792:10)
    at codeToTokens (file:///Users/lukekarrys/projects/vltpkg/vltpkg/node_modules/.pnpm/@shikijs+core@1.22.2/node_modules/@shikijs/core/dist/index.mjs:1103:14)
    at codeToHast (file:///Users/lukekarrys/projects/vltpkg/vltpkg/node_modules/.pnpm/@shikijs+core@1.22.2/node_modules/@shikijs/core/dist/index.mjs:1166:7)
    at codeToHtml (file:///Users/lukekarrys/projects/vltpkg/vltpkg/node_modules/.pnpm/@shikijs+core@1.22.2/node_modules/@shikijs/core/dist/index.mjs:1393:23)
    at Object.codeToHtml (file:///Users/lukekarrys/projects/vltpkg/vltpkg/node_modules/.pnpm/@shikijs+core@1.22.2/node_modules/@shikijs/core/dist/index.mjs:1826:37)
    at codeToHtml (file:///Users/lukekarrys/projects/vltpkg/vltpkg/node_modules/.pnpm/@shikijs+core@1.22.2/node_modules/@shikijs/core/dist/index.mjs:1961:20)
    at startCodeBlock (/Users/lukekarrys/projects/vltpkg/vltpkg/src/gui/src/components/ui/shiki.tsx:16:19)

 ✓ test/layout.tsx (5)
 ✓ test/app/dashboard.tsx (1)
 ✓ test/app/error-found.tsx (2)
 ✓ test/app/explorer.tsx (3)
 ✓ test/app/labels.tsx (1)
 ✓ test/app/queries.tsx (1)
 ✓ test/components/search-bar.tsx (3)
 ✓ test/state/load-graph.ts (1)
 ✓ test/components/dashboard-grid/index.tsx (2)
 ✓ test/components/explorer-grid/add-dependencies-popover.tsx (3)
 ✓ test/components/explorer-grid/dependency-side-bar.tsx (4)
 ✓ test/components/explorer-grid/empty-results-state.tsx (1)
 ✓ test/components/explorer-grid/header.tsx (2)
 ✓ test/components/explorer-grid/index.tsx (4)
 ✓ test/components/explorer-grid/query-matches.tsx (1)
 ✓ test/components/explorer-grid/result-item.tsx (9)
 ✓ test/components/explorer-grid/root-button.tsx (1)
 ✓ test/components/explorer-grid/save-query.tsx (1)
 ✓ test/components/explorer-grid/selected-item.tsx (5)
 ✓ test/components/explorer-grid/side-item.tsx (6)
 ✓ test/components/icons/discord.tsx (2)
 ✓ test/components/icons/github.tsx (2)
 ✓ test/components/icons/linkedin.tsx (2)
 ✓ test/components/icons/twitterx.tsx (2)
 ✓ test/components/icons/vlt-v.tsx (2)
 ✓ test/components/navigation/footer.tsx (2)
 ✓ test/components/navigation/header.tsx (6)
 ✓ test/components/labels/create-label-dialog.tsx (1)
 ✓ test/components/labels/create-label.tsx (1)
 ✓ test/components/labels/delete-label.tsx (1)
 ✓ test/components/labels/label-badge.tsx (1)
 ✓ test/components/labels/label-select.tsx (1)
 ✓ test/components/labels/label.tsx (1)
 ✓ test/components/labels/labels-empty-state.tsx (1)
 ✓ test/components/queries/delete-query.tsx (1)
 ✓ test/components/queries/queries-empty-state.tsx (1)
 ✓ test/components/queries/saved-item.tsx (1)
 ✓ test/components/theme-switcher/theme-switcher.tsx (2)
 ✓ test/components/ui/badge.tsx (5)
 ✓ test/components/ui/card.tsx (2)
 ✓ test/components/ui/color-picker.tsx (1)
 ✓ test/components/ui/filter-search.tsx (1)
 ✓ test/components/ui/input.tsx (3)
 ✓ test/components/ui/loading-spinner.tsx (1)
 ✓ test/components/ui/logo.tsx (2)
 ✓ test/components/ui/popover.tsx (2)
 ✓ test/components/ui/select.tsx (2)
 ✓ test/components/ui/sorting-toggle.tsx (1)
 ✓ test/components/ui/title.tsx (2)
 ✓ test/components/ui/toast.tsx (1)
 ✓ test/components/ui/toaster.tsx (1)
 ✓ test/components/navigation/sidebar/footer.tsx (1)
 ✓ test/components/navigation/sidebar/index.tsx (1)
 ✓ test/components/navigation/sidebar/logo.tsx (1)
 ✓ test/components/navigation/sidebar/nav-main.tsx (1)
 ✓ test/components/navigation/sidebar/nav-project-queries.tsx (1)
 ✓ test/components/navigation/sidebar/nav-queries.tsx (1)
 ✓ test/components/navigation/sidebar/trigger.tsx (2)

 Test Files  58 passed (58)
      Tests  118 passed (118)
   Start at  14:32:16
   Duration  6.66s (transform 663ms, setup 273ms, collect 8.11s, tests 1.51s, environment 12.49s, prepare 2.57s)
```
