### PR TITLE
gui: fix uninstall dependencies dropdown

### DIFF
--- a/src/gui/src/components/explorer-grid/side-item.tsx
+++ b/src/gui/src/components/explorer-grid/side-item.tsx
@@ -109,7 +109,7 @@ export const SideItem = ({
               <Ellipsis className="text-muted-foreground" size={20} />
             </DropdownMenuTrigger>
             <DropdownMenuContent
-              className="w-48 ml-48"
+              className="w-48 ml-48 z-[100000]"
               onCloseAutoFocus={e => e.preventDefault()}>
               <DropdownMenuItem onClick={uninstallItem}>
                 <PackageMinus size={16} />

--- a/src/gui/src/components/ui/toast.tsx
+++ b/src/gui/src/components/ui/toast.tsx
@@ -16,7 +16,7 @@ const ToastViewport = React.forwardRef<
   <ToastPrimitives.Viewport
     ref={ref}
     className={cn(
-      'fixed top-0 z-[100] flex max-h-screen w-full flex-col-reverse p-4 sm:bottom-0 sm:right-0 sm:top-auto sm:flex-col md:max-w-[420px]',
+      'fixed top-0 z-[10001] flex max-h-screen w-full flex-col-reverse p-4 sm:bottom-0 sm:right-0 sm:top-auto sm:flex-col md:max-w-[420px]',
       className,
     )}
     {...props}

--- a/src/gui/test/components/ui/__snapshots__/toast.tsx.snap
+++ b/src/gui/test/components/ui/__snapshots__/toast.tsx.snap
@@ -17,7 +17,7 @@ exports[`toaster render default 1`] = `
     </span>
     <ol
       tabindex="-1"
-      class="fixed top-0 z-[100] flex max-h-screen w-full flex-col-reverse p-4 sm:bottom-0 sm:right-0 sm:top-auto sm:flex-col md:max-w-[420px]"
+      class="fixed top-0 z-[10001] flex max-h-screen w-full flex-col-reverse p-4 sm:bottom-0 sm:right-0 sm:top-auto sm:flex-col md:max-w-[420px]"
     >
       <li
         role="status"

--- a/src/gui/test/components/ui/__snapshots__/toaster.tsx.snap
+++ b/src/gui/test/components/ui/__snapshots__/toaster.tsx.snap
@@ -11,7 +11,7 @@ exports[`toaster render default 1`] = `
   >
     <ol
       tabindex="-1"
-      class="fixed top-0 z-[100] flex max-h-screen w-full flex-col-reverse p-4 sm:bottom-0 sm:right-0 sm:top-auto sm:flex-col md:max-w-[420px]"
+      class="fixed top-0 z-[10001] flex max-h-screen w-full flex-col-reverse p-4 sm:bottom-0 sm:right-0 sm:top-auto sm:flex-col md:max-w-[420px]"
     >
     </ol>
   </div>


### PR DESCRIPTION
Fixes another issue with z-indexes, both the uninstall dependencies popup and the toaster should be visible now.