### PR TITLE
gui: fix render of non-registry dep-ids

### DIFF
--- a/src/gui/src/components/explorer-grid/selected-item.tsx
+++ b/src/gui/src/components/explorer-grid/selected-item.tsx
@@ -86,7 +86,11 @@ const SpecOrigin = ({
       case 'workspace':
       case 'file':
       case 'remote': {
-        return <div>{ref}</div>
+        return (
+          <div className="px-1 py-1 text-xs text-muted-foreground font-mono m-0 align-baseline truncate">
+            {depType}:{ref}
+          </div>
+        )
       }
     }
   }

--- a/src/gui/test/components/explorer-grid/__snapshots__/selected-item.tsx.snap
+++ b/src/gui/test/components/explorer-grid/__snapshots__/selected-item.tsx.snap
@@ -251,8 +251,8 @@ exports[`SelectedItem render with default git host 1`] = `
                 1.0.0
               </span>
             </div>
-            <div>
-              github:a/b
+            <div class="px-1 py-1 text-xs text-muted-foreground font-mono m-0 align-baseline truncate">
+              git:github:a/b
             </div>
           </div>
         </div>


### PR DESCRIPTION
Small design tweak / follow up from https://github.com/vltpkg/vltpkg/pull/368

### Before

![Screenshot 2025-01-31 at 3 14 22 PM](https://github.com/user-attachments/assets/ac773db4-f69d-47d5-ab9f-d5b29617e6ac)

### After
![Screenshot 2025-01-31 at 3 14 05 PM](https://github.com/user-attachments/assets/5f17b32a-9298-4a9d-9604-0e0ceb5dc234)
