### PR TITLE
chore: add repository metadata to workspaces

### DIFF
--- a/infra/benchmark/package.json
+++ b/infra/benchmark/package.json
@@ -3,6 +3,11 @@
   "description": "Benchmark scripts for this monorepo",
   "version": "0.0.0-0",
   "private": true,
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/vltpkg/vltpkg.git",
+    "directory": "infra/benchmark"
+  },
   "tshy": {
     "selfLink": false,
     "dialects": [

--- a/infra/build/package.json
+++ b/infra/build/package.json
@@ -3,6 +3,11 @@
   "description": "Build scripts for this monorepo",
   "version": "0.0.0-0",
   "private": true,
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/vltpkg/vltpkg.git",
+    "directory": "infra/build"
+  },
   "tshy": {
     "selfLink": false,
     "dialects": [

--- a/package.json
+++ b/package.json
@@ -2,6 +2,10 @@
   "name": "@vltpkg/vltpkg",
   "version": "0.0.0-0",
   "private": true,
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/vltpkg/vltpkg.git"
+  },
   "dependencies": {
     "@vltpkg/cli": "workspace:*"
   },
@@ -42,9 +46,5 @@
     "test": "pnpm --silent --no-bail --report-summary -r test -- -Rsilent || node scripts/report-test-failures.js"
   },
   "prettier": "./.prettierrc.js",
-  "type": "module",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/vltpkg/vltpkg"
-  }
+  "type": "module"
 }

--- a/scripts/consistent-package-json.js
+++ b/scripts/consistent-package-json.js
@@ -113,6 +113,7 @@ const sortObject = (o, ...args) => {
 const parseWS = path => ({
   isRoot: path === ROOT,
   relDir: `${path == ROOT ? '.' : relative(path, ROOT)}/`,
+  relDirToWorkspace: relative(ROOT, path),
   path: resolve(path, 'package.json'),
   dir: path,
   workspaceDir: basename(dirname(path)),
@@ -362,6 +363,13 @@ const fixLicense = ws => {
 const fixPackage = async (ws, opts) => {
   ws.pj.files = undefined
   ws.pj.engines = { node: '20 || >=22' }
+  ws.pj.repository = {
+    type: 'git',
+    url: 'git+https://github.com/vltpkg/vltpkg.git',
+    ...(ws.relDirToWorkspace ?
+      { directory: ws.relDirToWorkspace }
+    : {}),
+  }
   ws.pj.private =
     (
       ws.isRoot ||
@@ -384,6 +392,7 @@ const fixPackage = async (ws, opts) => {
     'description',
     'version',
     'private',
+    'repository',
     'tshy',
     'bin',
     'dependencies',

--- a/src/cache-unzip/package.json
+++ b/src/cache-unzip/package.json
@@ -2,6 +2,11 @@
   "name": "@vltpkg/cache-unzip",
   "description": "Daemon that manages the @vltpkg/cache disk store",
   "version": "0.0.0-0.1730239248325",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/vltpkg/vltpkg.git",
+    "directory": "src/cache-unzip"
+  },
   "tshy": {
     "selfLink": false,
     "dialects": [

--- a/src/cache/package.json
+++ b/src/cache/package.json
@@ -2,6 +2,11 @@
   "name": "@vltpkg/cache",
   "description": "The filesystem cache for `@vlt/registry-client`",
   "version": "0.0.0-0.1730239248325",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/vltpkg/vltpkg.git",
+    "directory": "src/cache"
+  },
   "tshy": {
     "selfLink": false,
     "dialects": [

--- a/src/dep-id/package.json
+++ b/src/dep-id/package.json
@@ -2,6 +2,11 @@
   "name": "@vltpkg/dep-id",
   "description": "create and hydrate dependency IDs",
   "version": "0.0.0-0.1730239248325",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/vltpkg/vltpkg.git",
+    "directory": "src/dep-id"
+  },
   "tshy": {
     "selfLink": false,
     "dialects": [

--- a/src/dot-prop/package.json
+++ b/src/dot-prop/package.json
@@ -2,6 +2,11 @@
   "name": "@vltpkg/dot-prop",
   "description": "Get and manipulate an object using strings",
   "version": "0.0.0-0.1730239248325",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/vltpkg/vltpkg.git",
+    "directory": "src/dot-prop"
+  },
   "tshy": {
     "selfLink": false,
     "dialects": [

--- a/src/error-cause/package.json
+++ b/src/error-cause/package.json
@@ -2,6 +2,11 @@
   "name": "@vltpkg/error-cause",
   "description": "vlts Error.cause convention",
   "version": "0.0.0-0.1730239248325",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/vltpkg/vltpkg.git",
+    "directory": "src/error-cause"
+  },
   "tshy": {
     "selfLink": false,
     "dialects": [

--- a/src/fast-split/package.json
+++ b/src/fast-split/package.json
@@ -2,6 +2,11 @@
   "name": "@vltpkg/fast-split",
   "description": "A fast way to split small-to-medium sized strings by small string delimiters",
   "version": "0.0.0-0.1730239248325",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/vltpkg/vltpkg.git",
+    "directory": "src/fast-split"
+  },
   "tshy": {
     "selfLink": false,
     "dialects": [

--- a/src/git-scp-url/package.json
+++ b/src/git-scp-url/package.json
@@ -2,6 +2,11 @@
   "name": "@vltpkg/git-scp-url",
   "description": "Parse scp-style git URLs like `git+ssh://host:some/path`",
   "version": "0.0.0-0.1730239248325",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/vltpkg/vltpkg.git",
+    "directory": "src/git-scp-url"
+  },
   "tshy": {
     "selfLink": false,
     "dialects": [

--- a/src/git/package.json
+++ b/src/git/package.json
@@ -2,6 +2,11 @@
   "name": "@vltpkg/git",
   "description": "a util for spawning git from npm CLI contexts",
   "version": "0.0.0-0.1730239248325",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/vltpkg/vltpkg.git",
+    "directory": "src/git"
+  },
   "tshy": {
     "selfLink": false,
     "dialects": [

--- a/src/graph/package.json
+++ b/src/graph/package.json
@@ -2,6 +2,11 @@
   "name": "@vltpkg/graph",
   "description": "A library that helps understanding & expressing what happens on an install",
   "version": "0.0.0-0.1730239248325",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/vltpkg/vltpkg.git",
+    "directory": "src/graph"
+  },
   "tshy": {
     "selfLink": false,
     "dialects": [

--- a/src/gui/package.json
+++ b/src/gui/package.json
@@ -3,6 +3,11 @@
   "description": "Look under the hood of a vlt install in HD",
   "version": "0.0.0-0",
   "private": true,
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/vltpkg/vltpkg.git",
+    "directory": "src/gui"
+  },
   "dependencies": {
     "@radix-ui/react-avatar": "^1.1.2",
     "@radix-ui/react-checkbox": "^1.1.3",

--- a/src/keychain/package.json
+++ b/src/keychain/package.json
@@ -2,6 +2,11 @@
   "name": "@vltpkg/keychain",
   "description": "The filesystem keychain for `@vlt/registry-client`",
   "version": "0.0.0-0.1730239248325",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/vltpkg/vltpkg.git",
+    "directory": "src/keychain"
+  },
   "tshy": {
     "selfLink": false,
     "dialects": [

--- a/src/output/package.json
+++ b/src/output/package.json
@@ -2,6 +2,11 @@
   "name": "@vltpkg/output",
   "description": "Generate output from the vlt CLI",
   "version": "0.0.0-0.1730239248325",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/vltpkg/vltpkg.git",
+    "directory": "src/output"
+  },
   "tshy": {
     "selfLink": false,
     "dialects": [

--- a/src/package-info/package.json
+++ b/src/package-info/package.json
@@ -2,6 +2,11 @@
   "name": "@vltpkg/package-info",
   "description": "Resolve and fetch package metadata and tarballs",
   "version": "0.0.0-0.1730239248325",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/vltpkg/vltpkg.git",
+    "directory": "src/package-info"
+  },
   "tshy": {
     "selfLink": false,
     "dialects": [

--- a/src/package-info/test/index.ts
+++ b/src/package-info/test/index.ts
@@ -907,7 +907,10 @@ t.test('path git selector', async t => {
     )
   })
 
-  await t.test('extract', async t => {
+  // git-cloning in a resource constrained machine running plenty
+  // of tests in parallel might take a lot more time than usual,
+  // so we have a generous timeout here to satisfy windows CI.
+  await t.test('extract', { timeout: 10_000 }, async t => {
     const target = t.testdir()
     await extract(spec, target, options)
     const found = JSON.parse(

--- a/src/package-json/package.json
+++ b/src/package-json/package.json
@@ -2,6 +2,11 @@
   "name": "@vltpkg/package-json",
   "description": "Manage reading package.json files",
   "version": "0.0.0-0.1730239248325",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/vltpkg/vltpkg.git",
+    "directory": "src/package-json"
+  },
   "tshy": {
     "selfLink": false,
     "dialects": [

--- a/src/pick-manifest/package.json
+++ b/src/pick-manifest/package.json
@@ -2,6 +2,11 @@
   "name": "@vltpkg/pick-manifest",
   "description": "Choose a manifest from a packument",
   "version": "0.0.0-0.1730239248325",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/vltpkg/vltpkg.git",
+    "directory": "src/pick-manifest"
+  },
   "tshy": {
     "selfLink": false,
     "dialects": [

--- a/src/promise-spawn/package.json
+++ b/src/promise-spawn/package.json
@@ -2,6 +2,11 @@
   "name": "@vltpkg/promise-spawn",
   "description": "Spawn a process and return a promise that resolves when it finishes",
   "version": "0.0.0-0.1730239248325",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/vltpkg/vltpkg.git",
+    "directory": "src/promise-spawn"
+  },
   "tshy": {
     "selfLink": false,
     "dialects": [

--- a/src/query/package.json
+++ b/src/query/package.json
@@ -2,6 +2,11 @@
   "name": "@vltpkg/query",
   "description": "Query syntax parser that retrieves items from a graph",
   "version": "0.0.0-0.1730239248325",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/vltpkg/vltpkg.git",
+    "directory": "src/query"
+  },
   "tshy": {
     "selfLink": false,
     "dialects": [

--- a/src/registry-client/package.json
+++ b/src/registry-client/package.json
@@ -2,6 +2,11 @@
   "name": "@vltpkg/registry-client",
   "description": "Fetch package artifacts and metadata from registries",
   "version": "0.0.0-0.1730239248325",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/vltpkg/vltpkg.git",
+    "directory": "src/registry-client"
+  },
   "tshy": {
     "selfLink": false,
     "dialects": [

--- a/src/rollback-remove/package.json
+++ b/src/rollback-remove/package.json
@@ -2,6 +2,11 @@
   "name": "@vltpkg/rollback-remove",
   "description": "Mark paths as removed, then remove them or roll back",
   "version": "0.0.0-0.1730239248325",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/vltpkg/vltpkg.git",
+    "directory": "src/rollback-remove"
+  },
   "tshy": {
     "selfLink": false,
     "dialects": [

--- a/src/run/package.json
+++ b/src/run/package.json
@@ -2,6 +2,11 @@
   "name": "@vltpkg/run",
   "description": "Run package.json scripts and execute commands",
   "version": "0.0.0-0.1730239248325",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/vltpkg/vltpkg.git",
+    "directory": "src/run"
+  },
   "tshy": {
     "selfLink": false,
     "dialects": [

--- a/src/satisfies/package.json
+++ b/src/satisfies/package.json
@@ -2,6 +2,11 @@
   "name": "@vltpkg/satisfies",
   "description": "method for determining if a DepID satisfies a Spec",
   "version": "0.0.0-0.1730239248325",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/vltpkg/vltpkg.git",
+    "directory": "src/satisfies"
+  },
   "tshy": {
     "selfLink": false,
     "dialects": [

--- a/src/semver/package.json
+++ b/src/semver/package.json
@@ -2,6 +2,11 @@
   "name": "@vltpkg/semver",
   "description": "The semantic version parser used by vlt",
   "version": "0.0.0-0.1730239248325",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/vltpkg/vltpkg.git",
+    "directory": "src/semver"
+  },
   "tshy": {
     "selfLink": false,
     "dialects": [

--- a/src/spec/package.json
+++ b/src/spec/package.json
@@ -2,6 +2,11 @@
   "name": "@vltpkg/spec",
   "description": "Package specifier library",
   "version": "0.0.0-0.1730239248325",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/vltpkg/vltpkg.git",
+    "directory": "src/spec"
+  },
   "tshy": {
     "selfLink": false,
     "dialects": [

--- a/src/tar/package.json
+++ b/src/tar/package.json
@@ -2,6 +2,11 @@
   "name": "@vltpkg/tar",
   "description": "An extremely limited and very fast tar extractor",
   "version": "0.0.0-0.1730239248325",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/vltpkg/vltpkg.git",
+    "directory": "src/tar"
+  },
   "tshy": {
     "selfLink": false,
     "dialects": [

--- a/src/types/package.json
+++ b/src/types/package.json
@@ -2,6 +2,11 @@
   "name": "@vltpkg/types",
   "description": "definitions for some of vlt's core types",
   "version": "0.0.0-0.1730239248325",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/vltpkg/vltpkg.git",
+    "directory": "src/types"
+  },
   "tshy": {
     "selfLink": false,
     "dialects": [

--- a/src/url-open/package.json
+++ b/src/url-open/package.json
@@ -2,6 +2,11 @@
   "name": "@vltpkg/url-open",
   "description": "Open URLs using the system's default web browser",
   "version": "0.0.0-0.1730239248325",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/vltpkg/vltpkg.git",
+    "directory": "src/url-open"
+  },
   "tshy": {
     "selfLink": false,
     "dialects": [

--- a/src/vlt/package.json
+++ b/src/vlt/package.json
@@ -3,6 +3,11 @@
   "description": "The vlt CLI",
   "version": "0.0.0-0",
   "private": true,
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/vltpkg/vltpkg.git",
+    "directory": "src/vlt"
+  },
   "tshy": {
     "selfLink": false,
     "dialects": [

--- a/src/which/package.json
+++ b/src/which/package.json
@@ -2,6 +2,11 @@
   "name": "@vltpkg/which",
   "description": "Find the first executable in the path (TS port of 'which')",
   "version": "0.0.0-0.1730239248325",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/vltpkg/vltpkg.git",
+    "directory": "src/which"
+  },
   "tshy": {
     "selfLink": false,
     "dialects": [

--- a/src/workspaces/package.json
+++ b/src/workspaces/package.json
@@ -2,6 +2,11 @@
   "name": "@vltpkg/workspaces",
   "description": "Utility for working with vlt workspaces",
   "version": "0.0.0-0.1730239248325",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/vltpkg/vltpkg.git",
+    "directory": "src/workspaces"
+  },
   "tshy": {
     "selfLink": false,
     "dialects": [

--- a/src/xdg/package.json
+++ b/src/xdg/package.json
@@ -2,6 +2,11 @@
   "name": "@vltpkg/xdg",
   "description": "platform-specific app directories following XDG spec",
   "version": "0.0.0-0.1730239248325",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/vltpkg/vltpkg.git",
+    "directory": "src/xdg"
+  },
   "tshy": {
     "selfLink": false,
     "dialects": [

--- a/www/docs/package.json
+++ b/www/docs/package.json
@@ -2,6 +2,11 @@
   "name": "@vltpkg/docs",
   "version": "0.0.2",
   "private": true,
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/vltpkg/vltpkg.git",
+    "directory": "www/docs"
+  },
   "dependencies": {
     "@astrojs/check": "^0.9.4",
     "@astrojs/mdx": "^4.0.2",


### PR DESCRIPTION
Will make it possible to render the favicon for our own workspaces when navigating the GUI and will also make sure that metadata is available in other places such as npmjs.com