### PR TITLE
graph: fix reinstalling dependencies

### DIFF
--- a/src/graph/src/ideal/get-importer-specs.ts
+++ b/src/graph/src/ideal/get-importer-specs.ts
@@ -70,7 +70,10 @@ export const getImporterSpecs = ({
     // if an edge from the graph is not listed in the manifest,
     // add that edge to the list of dependencies to be removed
     for (const edge of importer.edgesOut.values()) {
-      if (!hasDepName(importer, edge)) {
+      if (
+        !hasDepName(importer, edge) &&
+        !add.get(importer.id)?.has(edge.name)
+      ) {
         removeDeps.add(edge.name)
         removeResult.modifiedDependencies = true
       }

--- a/src/graph/tap-snapshots/test/ideal/get-importer-specs.ts.test.cjs
+++ b/src/graph/tap-snapshots/test/ideal/get-importer-specs.ts.test.cjs
@@ -89,3 +89,15 @@ exports[`test/ideal/get-importer-specs.ts > TAP > graph specs with workspaces an
   }
 }
 `
+
+exports[`test/ideal/get-importer-specs.ts > TAP > installing over a dangling edge > should add the missing dep 1`] = `
+{
+  add: AddImportersDependenciesMapImpl(1) [Map] {
+    'file·.' => Map(1) { 'foo' => { spec: Spec {foo@^1.0.0}, type: 'prod' } },
+    modifiedDependencies: true
+  },
+  remove: RemoveImportersDependenciesMapImpl(0) [Map] {
+    modifiedDependencies: false
+  }
+}
+`


### PR DESCRIPTION
Fix a problem that made it impossible to install a dependency after uninstalling it.

Fixes: https://github.com/vltpkg/vltpkg/issues/294