### PR TITLE
graph: remove edge when removing node

### DIFF
--- a/src/graph/src/graph.ts
+++ b/src/graph/src/graph.ts
@@ -394,6 +394,7 @@ export class Graph implements GraphLike {
         edge.to = replacement
       } else {
         edge.from.edgesOut.delete(edge.spec.name)
+        this.edges.delete(edge)
       }
     }
   }

--- a/src/graph/tap-snapshots/test/graph.ts.test.cjs
+++ b/src/graph/tap-snapshots/test/graph.ts.test.cjs
@@ -26,8 +26,7 @@ exports[`test/graph.ts > TAP > using placePackage > should find and fix nameless
     'file·. missing': 'prod ^1.0.0 MISSING',
     'file·. bar': 'prod ^1.0.0 ··bar@1.0.0',
     'file·. foo': 'prod ^1.0.0 ··foo@1.0.0',
-    'file·. a': 'prod file:./a file·a',
-    '··bar@1.0.0 baz': 'prod ^1.0.0 ··baz@1.0.0'
+    'file·. a': 'prod file:./a file·a'
   }
 }
 `
@@ -47,8 +46,7 @@ exports[`test/graph.ts > TAP > using placePackage > should have removed baz from
   edges: {
     'file·. missing': 'prod ^1.0.0 MISSING',
     'file·. bar': 'prod ^1.0.0 ··bar@1.0.0',
-    'file·. foo': 'prod ^1.0.0 ··foo@1.0.0',
-    '··bar@1.0.0 baz': 'prod ^1.0.0 ··baz@1.0.0'
+    'file·. foo': 'prod ^1.0.0 ··foo@1.0.0'
   }
 }
 `

--- a/src/graph/tap-snapshots/test/ideal/remove-nodes.ts.test.cjs
+++ b/src/graph/tap-snapshots/test/ideal/remove-nodes.ts.test.cjs
@@ -1,0 +1,16 @@
+/* IMPORTANT
+ * This snapshot file is auto-generated, but designed for humans.
+ * It should be checked into source control and tracked carefully.
+ * Re-generate by setting TAP_SNAPSHOT=1 and running tests.
+ * Make sure to inspect the output below.  Do not ignore changes!
+ */
+'use strict'
+exports[`test/ideal/remove-nodes.ts > TAP > removeNodes > should remove the node and edge from the graph 1`] = `
+Object {
+  "edges": Object {},
+  "nodes": Object {},
+  "options": Object {
+    "registries": Object {},
+  },
+}
+`

--- a/src/graph/tap-snapshots/test/reify/optional-fail.ts.test.cjs
+++ b/src/graph/tap-snapshots/test/reify/optional-fail.ts.test.cjs
@@ -8,8 +8,6 @@
 exports[`test/reify/optional-fail.ts > TAP > register and optional node failure > must match snapshot 1`] = `
 Object {
   "edges": Object {
-    "··bar@1.2.3 baz": "prod * ··baz@1.2.3",
-    "··foo@1.2.3 bar": "prod * ··bar@1.2.3",
     "file·. foo": "optional * ··foo@1.2.3",
   },
   "nodes": Object {

--- a/src/graph/test/ideal/remove-nodes.ts
+++ b/src/graph/test/ideal/remove-nodes.ts
@@ -1,0 +1,77 @@
+// write tap tests for removing a node from the graph
+import t from 'tap'
+import { Spec, type SpecOptions } from '@vltpkg/spec'
+import { removeNodes } from '../../src/ideal/remove-nodes.js'
+import { Graph } from '../../src/graph.js'
+import { type RemoveImportersDependenciesMap } from '../../src/dependencies.js'
+import { joinDepIDTuple } from '@vltpkg/dep-id'
+
+const configData = {
+  registry: 'https://registry.npmjs.org/',
+  registries: {
+    npm: 'https://registry.npmjs.org/',
+  },
+} satisfies SpecOptions
+
+t.test('removeNodes', async t => {
+  const mainManifest = {
+    name: 'my-project',
+    version: '1.0.0',
+    dependencies: {
+      foo: '^1.0.0',
+    },
+  }
+  const graph = new Graph({
+    ...configData,
+    mainManifest,
+    projectRoot: t.testdirName,
+  })
+
+  graph.placePackage(
+    graph.mainImporter,
+    'prod',
+    Spec.parse('foo', '^1.0.0'),
+    {
+      name: 'foo',
+      version: '1.0.0',
+    },
+  )
+
+  const remove: RemoveImportersDependenciesMap = Object.assign(
+    new Map([[graph.mainImporter.id, new Set(['foo'])]]),
+    { modifiedDependencies: true },
+  )
+  removeNodes({
+    graph,
+    remove,
+  })
+
+  t.matchSnapshot(
+    graph.toJSON(),
+    'should remove the node and edge from the graph',
+  )
+})
+
+t.test('missing importer', async t => {
+  const mainManifest = {
+    name: 'my-project',
+    version: '1.0.0',
+  }
+  const graph = new Graph({
+    ...configData,
+    mainManifest,
+    projectRoot: t.testdirName,
+  })
+  const remove: RemoveImportersDependenciesMap = Object.assign(
+    new Map([
+      [joinDepIDTuple(['workspace', 'bar']), new Set(['foo'])],
+    ]),
+    { modifiedDependencies: true },
+  )
+
+  t.throws(
+    () => removeNodes({ graph, remove }),
+    /Could not find importer/,
+    'should throw an error when the importer is not found',
+  )
+})


### PR DESCRIPTION
When removing a node from the graph using `Graph.removeNode` the
previous implementation would leave previous edges still registered
in the `Graph.edges` Set. This leaves edges in lockfiles after
uninstalling a package, e.g:

    $ cat package.json
    {
      "name": "my-project",
      "dependencies": {
        "abbrev": "^3.0.0"
      }
    }
    $ cat vlt-lock.json
    {
      "options": {},
      "nodes": {
        "··abbrev@3.0.0": [0,"abbrev","sha512-+/kfrslGQ7TNV2ecmQwMJj/B65g5KVq1/L3SGVZ3tCYGqlzFuFCGBZJtMP99wH3NpEUyAjn0zPdPUg0D+DwrOA=="]
      },
      "edges": {
        "file·. abbrev": "prod ^3.0.0 ··abbrev@3.0.0"
      }
    }

    $ vlt uninstall abbrev
    $ cat vlt-lock.json
    {
      "options": {},
      "nodes": {},
      "edges": {
        "file·. abbrev": "prod * ··abbrev@3.0.0"
      }
    }

This PR fixes it by making sure edges are removed from the
edge of sets whenever a node is removed from the graph. e.g:

    $ vlt uninstall abbrev
    $ cat vlt-lock.json
    {
      "options": {},
      "nodes": {},
      "edges": {}
    }

Refs: https://github.com/vltpkg/vltpkg/issues/294