### PR TITLE
chore: add root watch/prepare scripts that run on src

### DIFF
--- a/infra/benchmark/package.json
+++ b/infra/benchmark/package.json
@@ -47,7 +47,8 @@
     "presnap": "tshy",
     "snap": "tap",
     "pretest": "tshy",
-    "test": "tap"
+    "test": "tap",
+    "watch": "tshy --watch"
   },
   "tap": {
     "extends": "../../tap-config.yaml"

--- a/infra/build/package.json
+++ b/infra/build/package.json
@@ -50,7 +50,8 @@
     "presnap": "tshy",
     "snap": "tap",
     "pretest": "tshy",
-    "test": "tap"
+    "test": "tap",
+    "watch": "tshy --watch"
   },
   "tap": {
     "extends": "../../tap-config.yaml",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "node": "20 || >=22"
   },
   "scripts": {
-    ".": "./scripts/local-cli vlt",
     "benchmark": "./scripts/benchmark",
     "fix": "pnpm fix:pkg && pnpm lint && pnpm format",
     "fix:pkg": "node scripts/consistent-package-json.js",
@@ -37,9 +36,11 @@
     "format:check": "prettier --check . --ignore-path ./.prettierignore --cache",
     "lint": "eslint . --fix",
     "lint:check": "eslint .",
+    "prepare": "pnpm --recursive --filter \"./src/*\" run prepare",
     "pnpm:devPreinstall": "pnpm --version && node --version && node scripts/make-dist-bins.js",
     "snap": "pnpm --silent --no-bail --report-summary run -r snap &>/dev/null || node scripts/report-test-failures.js",
-    "test": "pnpm --silent --no-bail --report-summary -r test -- -Rsilent || node scripts/report-test-failures.js"
+    "test": "pnpm --silent --no-bail --report-summary -r test -- -Rsilent || node scripts/report-test-failures.js",
+    "watch": "pnpm --parallel --filter \"./src/*\" run watch"
   },
   "prettier": "./.prettierrc.js",
   "type": "module",

--- a/scripts/consistent-package-json.js
+++ b/scripts/consistent-package-json.js
@@ -261,6 +261,7 @@ const fixScripts = async ws => {
         prepare: 'tshy',
         pretest: 'tshy',
         presnap: 'tshy',
+        watch: 'tshy --watch',
       }
     : {},
   )

--- a/src/cache-unzip/package.json
+++ b/src/cache-unzip/package.json
@@ -46,7 +46,8 @@
     "presnap": "tshy",
     "snap": "tap",
     "pretest": "tshy",
-    "test": "tap"
+    "test": "tap",
+    "watch": "tshy --watch"
   },
   "tap": {
     "extends": "../../tap-config.yaml"

--- a/src/cache/package.json
+++ b/src/cache/package.json
@@ -46,7 +46,8 @@
     "presnap": "tshy",
     "snap": "tap",
     "pretest": "tshy",
-    "test": "tap"
+    "test": "tap",
+    "watch": "tshy --watch"
   },
   "tap": {
     "extends": "../../tap-config.yaml"

--- a/src/dep-id/package.json
+++ b/src/dep-id/package.json
@@ -45,7 +45,8 @@
     "presnap": "tshy",
     "snap": "tap",
     "pretest": "tshy",
-    "test": "tap"
+    "test": "tap",
+    "watch": "tshy --watch"
   },
   "tap": {
     "extends": "../../tap-config.yaml"

--- a/src/dot-prop/package.json
+++ b/src/dot-prop/package.json
@@ -40,7 +40,8 @@
     "presnap": "tshy",
     "snap": "tap",
     "pretest": "tshy",
-    "test": "tap"
+    "test": "tap",
+    "watch": "tshy --watch"
   },
   "tap": {
     "extends": "../../tap-config.yaml"

--- a/src/error-cause/package.json
+++ b/src/error-cause/package.json
@@ -39,7 +39,8 @@
     "presnap": "tshy",
     "snap": "tap",
     "pretest": "tshy",
-    "test": "tap"
+    "test": "tap",
+    "watch": "tshy --watch"
   },
   "tap": {
     "extends": "../../tap-config.yaml"

--- a/src/fast-split/package.json
+++ b/src/fast-split/package.json
@@ -40,7 +40,8 @@
     "presnap": "tshy",
     "snap": "tap",
     "pretest": "tshy",
-    "test": "tap"
+    "test": "tap",
+    "watch": "tshy --watch"
   },
   "tap": {
     "extends": "../../tap-config.yaml"

--- a/src/git-scp-url/package.json
+++ b/src/git-scp-url/package.json
@@ -39,7 +39,8 @@
     "presnap": "tshy",
     "snap": "tap",
     "pretest": "tshy",
-    "test": "tap"
+    "test": "tap",
+    "watch": "tshy --watch"
   },
   "tap": {
     "extends": "../../tap-config.yaml"

--- a/src/git/package.json
+++ b/src/git/package.json
@@ -54,7 +54,8 @@
     "presnap": "tshy",
     "snap": "tap",
     "pretest": "tshy",
-    "test": "tap"
+    "test": "tap",
+    "watch": "tshy --watch"
   },
   "tap": {
     "extends": "../../tap-config.yaml"

--- a/src/graph/package.json
+++ b/src/graph/package.json
@@ -62,7 +62,8 @@
     "presnap": "tshy",
     "snap": "tap",
     "pretest": "tshy",
-    "test": "tap"
+    "test": "tap",
+    "watch": "tshy --watch"
   },
   "tap": {
     "extends": "../../tap-config.yaml"

--- a/src/keychain/package.json
+++ b/src/keychain/package.json
@@ -46,7 +46,8 @@
     "presnap": "tshy",
     "snap": "tap",
     "pretest": "tshy",
-    "test": "tap"
+    "test": "tap",
+    "watch": "tshy --watch"
   },
   "tap": {
     "extends": "../../tap-config.yaml"

--- a/src/output/package.json
+++ b/src/output/package.json
@@ -39,7 +39,8 @@
     "presnap": "tshy",
     "snap": "tap",
     "pretest": "tshy",
-    "test": "tap"
+    "test": "tap",
+    "watch": "tshy --watch"
   },
   "tap": {
     "extends": "../../tap-config.yaml"

--- a/src/package-info/package.json
+++ b/src/package-info/package.json
@@ -56,7 +56,8 @@
     "presnap": "tshy",
     "snap": "tap",
     "pretest": "tshy",
-    "test": "tap"
+    "test": "tap",
+    "watch": "tshy --watch"
   },
   "tap": {
     "extends": "../../tap-config.yaml"

--- a/src/package-json/package.json
+++ b/src/package-json/package.json
@@ -45,7 +45,8 @@
     "presnap": "tshy",
     "snap": "tap",
     "pretest": "tshy",
-    "test": "tap"
+    "test": "tap",
+    "watch": "tshy --watch"
   },
   "tap": {
     "extends": "../../tap-config.yaml"

--- a/src/pick-manifest/package.json
+++ b/src/pick-manifest/package.json
@@ -49,7 +49,8 @@
     "presnap": "tshy",
     "snap": "tap",
     "pretest": "tshy",
-    "test": "tap"
+    "test": "tap",
+    "watch": "tshy --watch"
   },
   "tap": {
     "extends": "../../tap-config.yaml"

--- a/src/promise-spawn/package.json
+++ b/src/promise-spawn/package.json
@@ -43,7 +43,8 @@
     "presnap": "tshy",
     "snap": "tap",
     "pretest": "tshy",
-    "test": "tap"
+    "test": "tap",
+    "watch": "tshy --watch"
   },
   "tap": {
     "extends": "../../tap-config.yaml"

--- a/src/query/package.json
+++ b/src/query/package.json
@@ -47,7 +47,8 @@
     "presnap": "tshy",
     "snap": "tap",
     "pretest": "tshy",
-    "test": "tap"
+    "test": "tap",
+    "watch": "tshy --watch"
   },
   "tap": {
     "extends": "../../tap-config.yaml"

--- a/src/registry-client/package.json
+++ b/src/registry-client/package.json
@@ -54,7 +54,8 @@
     "presnap": "tshy",
     "snap": "tap",
     "pretest": "tshy",
-    "test": "tap"
+    "test": "tap",
+    "watch": "tshy --watch"
   },
   "tap": {
     "extends": "../../tap-config.yaml"

--- a/src/rollback-remove/package.json
+++ b/src/rollback-remove/package.json
@@ -36,7 +36,8 @@
     "presnap": "tshy",
     "snap": "tap",
     "pretest": "tshy",
-    "test": "tap"
+    "test": "tap",
+    "watch": "tshy --watch"
   },
   "tap": {
     "extends": "../../tap-config.yaml"

--- a/src/run/package.json
+++ b/src/run/package.json
@@ -47,7 +47,8 @@
     "presnap": "tshy",
     "snap": "tap",
     "pretest": "tshy",
-    "test": "tap"
+    "test": "tap",
+    "watch": "tshy --watch"
   },
   "tap": {
     "extends": "../../tap-config.yaml"

--- a/src/satisfies/package.json
+++ b/src/satisfies/package.json
@@ -46,7 +46,8 @@
     "presnap": "tshy",
     "snap": "tap",
     "pretest": "tshy",
-    "test": "tap"
+    "test": "tap",
+    "watch": "tshy --watch"
   },
   "tap": {
     "extends": "../../tap-config.yaml"

--- a/src/semver/package.json
+++ b/src/semver/package.json
@@ -49,7 +49,8 @@
     "presnap": "tshy",
     "snap": "tap",
     "pretest": "tshy",
-    "test": "tap"
+    "test": "tap",
+    "watch": "tshy --watch"
   },
   "tap": {
     "extends": "../../tap-config.yaml"

--- a/src/spec/package.json
+++ b/src/spec/package.json
@@ -47,7 +47,8 @@
     "presnap": "tshy",
     "snap": "tap",
     "pretest": "tshy",
-    "test": "tap"
+    "test": "tap",
+    "watch": "tshy --watch"
   },
   "tap": {
     "extends": "../../tap-config.yaml"

--- a/src/tar/package.json
+++ b/src/tar/package.json
@@ -53,7 +53,8 @@
     "presnap": "tshy",
     "snap": "tap",
     "pretest": "tshy",
-    "test": "tap"
+    "test": "tap",
+    "watch": "tshy --watch"
   },
   "tap": {
     "extends": "../../tap-config.yaml"

--- a/src/types/package.json
+++ b/src/types/package.json
@@ -42,7 +42,8 @@
     "presnap": "tshy",
     "snap": "tap",
     "pretest": "tshy",
-    "test": "tap"
+    "test": "tap",
+    "watch": "tshy --watch"
   },
   "tap": {
     "extends": "../../tap-config.yaml"

--- a/src/url-open/package.json
+++ b/src/url-open/package.json
@@ -42,7 +42,8 @@
     "presnap": "tshy",
     "snap": "tap",
     "pretest": "tshy",
-    "test": "tap"
+    "test": "tap",
+    "watch": "tshy --watch"
   },
   "tap": {
     "extends": "../../tap-config.yaml"

--- a/src/vlt/package.json
+++ b/src/vlt/package.json
@@ -85,7 +85,8 @@
     "presnap": "tshy",
     "snap": "tap",
     "pretest": "tshy",
-    "test": "tap"
+    "test": "tap",
+    "watch": "tshy --watch"
   },
   "tap": {
     "extends": "../../tap-config.yaml",

--- a/src/which/package.json
+++ b/src/which/package.json
@@ -42,7 +42,8 @@
     "presnap": "tshy",
     "snap": "tap",
     "pretest": "tshy",
-    "test": "tap"
+    "test": "tap",
+    "watch": "tshy --watch"
   },
   "tap": {
     "extends": "../../tap-config.yaml"

--- a/src/workspaces/package.json
+++ b/src/workspaces/package.json
@@ -51,7 +51,8 @@
     "presnap": "tshy",
     "snap": "tap",
     "pretest": "tshy",
-    "test": "tap"
+    "test": "tap",
+    "watch": "tshy --watch"
   },
   "tap": {
     "extends": "../../tap-config.yaml"

--- a/src/xdg/package.json
+++ b/src/xdg/package.json
@@ -39,7 +39,8 @@
     "presnap": "tshy",
     "snap": "tap",
     "pretest": "tshy",
-    "test": "tap"
+    "test": "tap",
+    "watch": "tshy --watch"
   },
   "tap": {
     "extends": "../../tap-config.yaml"


### PR DESCRIPTION
I've been using these commands a lot for local dev and thought they'd be helpful to live in the root package.json.

- `pnpm watch` will run the watch script in all the `src/*` workspaces. This PR also adds `tshy --watch` as a watch script to the `tshy` workspaces
- `pnpm prepare` will run `prepare` in all the `src/*` workspaces