### PR TITLE
test: only allow floating promises from tap.[test|skip]

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -236,13 +236,7 @@ export default tseslint.config(
       '@typescript-eslint/no-floating-promises': [
         'error',
         {
-          allowForKnownSafeCalls: [
-            'test',
-            'rejects',
-            'resolveMatch',
-            'resolves',
-            'skip',
-          ].map(name => ({
+          allowForKnownSafeCalls: ['test', 'skip'].map(name => ({
             name,
             from: 'package',
             package: 'tap',

--- a/infra/benchmark/test/index.ts
+++ b/infra/benchmark/test/index.ts
@@ -2,47 +2,49 @@ import t from 'tap'
 import * as B from '../src/index.js'
 import timers from 'timers/promises'
 
-t.equal(B.packages.length, 1000)
-t.equal(B.randomize(B.packages).length, 1000)
-t.equal(B.randomPackages().length, 1000)
-t.equal(B.randomPackages(10).length, 10)
+t.test('basic', async t => {
+  t.equal(B.packages.length, 1000)
+  t.equal(B.randomize(B.packages).length, 1000)
+  t.equal(B.randomPackages().length, 1000)
+  t.equal(B.randomPackages(10).length, 10)
 
-t.strictSame(B.convertNs(1_000_000_000), [1, B.UNIT.s])
-t.strictSame(B.convertNs(1_000_000), [1, B.UNIT.ms])
-t.strictSame(B.convertNs(1_000), [1, B.UNIT.us])
-t.strictSame(B.convertNs(1), [1, B.UNIT.ns])
-t.strictSame(B.convertNs(1_000_000_000, B.UNIT.ns), [
-  1_000_000_000,
-  B.UNIT.ns,
-])
+  t.strictSame(B.convertNs(1_000_000_000), [1, B.UNIT.s])
+  t.strictSame(B.convertNs(1_000_000), [1, B.UNIT.ms])
+  t.strictSame(B.convertNs(1_000), [1, B.UNIT.us])
+  t.strictSame(B.convertNs(1), [1, B.UNIT.ns])
+  t.strictSame(B.convertNs(1_000_000_000, B.UNIT.ns), [
+    1_000_000_000,
+    B.UNIT.ns,
+  ])
 
-t.equal(B.numToFixed(1), '1.00')
-t.equal(B.numToFixed(1, { decimals: 1 }), '1.0')
-t.equal(B.numToFixed(1, { padStart: 2 }), ' 1.00')
+  t.equal(B.numToFixed(1), '1.00')
+  t.equal(B.numToFixed(1, { decimals: 1 }), '1.0')
+  t.equal(B.numToFixed(1, { padStart: 2 }), ' 1.00')
 
-t.match(
-  B.runFor(i => {
-    if (i === 1) {
-      throw new Error('xxx')
-    }
-  }, 100),
-  {
-    elapsed: Number,
-    errors: 1,
-    iterations: Number,
-    per: Number,
-  },
-)
+  t.match(
+    B.runFor(i => {
+      if (i === 1) {
+        throw new Error('xxx')
+      }
+    }, 100),
+    {
+      elapsed: Number,
+      errors: 1,
+      iterations: Number,
+      per: Number,
+    },
+  )
 
-t.resolveMatch(
-  B.timePromises([1, 2, 3], async i => {
-    if (i === 3) {
-      throw new Error('xxx')
-    }
-    await timers.setTimeout(i)
-  }),
-  {
-    time: Number,
-    errors: 1,
-  },
-)
+  await t.resolveMatch(
+    B.timePromises([1, 2, 3], async i => {
+      if (i === 3) {
+        throw new Error('xxx')
+      }
+      await timers.setTimeout(i)
+    }),
+    {
+      time: Number,
+      errors: 1,
+    },
+  )
+})

--- a/src/git/test/spawn.ts
+++ b/src/git/test/spawn.ts
@@ -5,9 +5,11 @@ import t from 'tap'
 import { type GitOptions } from '../src/index.js'
 import { spawn } from '../src/spawn.js'
 
-t.rejects(spawn(['status'], { git: false }), {
-  message: 'No git binary found in $PATH',
-  cause: { code: 'ENOGIT' },
+t.test('no git', async t => {
+  await t.rejects(spawn(['status'], { git: false }), {
+    message: 'No git binary found in $PATH',
+    cause: { code: 'ENOGIT' },
+  })
 })
 
 const slash = (s: string) => s.replace(/\\/g, '/')
@@ -82,7 +84,7 @@ process.exit(1)
   t.end()
 })
 
-t.test('missing pathspec', t => {
+t.test('missing pathspec', async t => {
   const gitMessage =
     "error: pathspec 'foo' did not match any file(s) known to git"
   const te = resolve(repo, 'pathspec-error.js')
@@ -101,7 +103,7 @@ process.exit(1)
     stdout: '',
     stderr: gitMessage,
   })
-  t.rejects(
+  await t.rejects(
     spawn([te], {
       cwd: repo,
       git: process.execPath,
@@ -110,10 +112,9 @@ process.exit(1)
     }),
     er,
   )
-  t.end()
 })
 
-t.test('unknown git error', t => {
+t.test('unknown git error', async t => {
   const gitMessage = 'error: something really bad happened to git'
   const te = resolve(repo, 'unknown-error.js')
   fs.writeFileSync(
@@ -131,7 +132,7 @@ process.exit(1)
     stdout: '',
     stderr: gitMessage,
   })
-  t.rejects(
+  await t.rejects(
     spawn([te], {
       cwd: repo,
       git: process.execPath,
@@ -140,5 +141,4 @@ process.exit(1)
     }),
     er,
   )
-  t.end()
 })

--- a/src/graph/test/ideal/append-nodes.ts
+++ b/src/graph/test/ideal/append-nodes.ts
@@ -290,7 +290,7 @@ t.test('append different type of dependencies', async t => {
     new Set(),
   )
 
-  t.rejects(
+  await t.rejects(
     appendNodes(
       add,
       packageInfo,

--- a/src/package-info/test/index.ts
+++ b/src/package-info/test/index.ts
@@ -583,12 +583,12 @@ t.test('extraction failures', async t => {
     ),
   )
   await t.rejects(
-    await manifest(
+    manifest(
       `abbrev@${defaultRegistry}abbrev/-/abbrev-2.0.0.tgz`,
       options,
     ),
   )
-  await t.rejects(await manifest(`abbrev@${tgzFile}`))
+  await t.rejects(manifest(`abbrev@${tgzFile}`))
 
   await t.rejects(
     extract(`abbrev@${tgzFile}`, dir + '/file', options),
@@ -651,9 +651,8 @@ t.test('git spec must have gitRemote', async t => {
     ),
   )
 })
-t.test(
-  'fails on version that is not present',
-  async t => await t.rejects(resolve('abbrev@999', options)),
+t.test('fails on version that is not present', async t =>
+  t.rejects(resolve('abbrev@999', options)),
 )
 
 t.test('remote spec must have remoteURL', async t => {

--- a/src/package-info/test/index.ts
+++ b/src/package-info/test/index.ts
@@ -573,37 +573,39 @@ t.test('extraction failures', async t => {
       },
     },
   )
-  t.rejects(extract('abbrev@2', dir + '/registry', options))
+  await t.rejects(extract('abbrev@2', dir + '/registry', options))
 
-  t.rejects(
+  await t.rejects(
     extract(
       `abbrev@${defaultRegistry}abbrev/-/abbrev-2.0.0.tgz`,
       dir + '/remote',
       options,
     ),
   )
-  t.rejects(
-    manifest(
+  await t.rejects(
+    await manifest(
       `abbrev@${defaultRegistry}abbrev/-/abbrev-2.0.0.tgz`,
       options,
     ),
   )
-  t.rejects(manifest(`abbrev@${tgzFile}`))
+  await t.rejects(await manifest(`abbrev@${tgzFile}`))
 
-  t.rejects(extract(`abbrev@${tgzFile}`, dir + '/file', options))
+  await t.rejects(
+    extract(`abbrev@${tgzFile}`, dir + '/file', options),
+  )
 })
 
 t.test('manifest must provide actual dist results', async t => {
-  t.rejects(resolve('deleted@latest', options))
-  t.rejects(resolve('no-tgz@latest', options))
-  t.rejects(resolve('no-dist@latest', options))
-  t.rejects(tarball('deleted@latest', options))
-  t.rejects(tarball('no-tgz@latest', options))
-  t.rejects(tarball('no-dist@latest', options))
+  await t.rejects(resolve('deleted@latest', options))
+  await t.rejects(resolve('no-tgz@latest', options))
+  await t.rejects(resolve('no-dist@latest', options))
+  await t.rejects(tarball('deleted@latest', options))
+  await t.rejects(tarball('no-tgz@latest', options))
+  await t.rejects(tarball('no-dist@latest', options))
 })
 
 t.test('git spec must have gitRemote', async t => {
-  t.rejects(
+  await t.rejects(
     resolve({
       toString: () => 'x',
       final: { type: 'git' },
@@ -613,7 +615,7 @@ t.test('git spec must have gitRemote', async t => {
       cause: { code: 'ERESOLVE' },
     },
   )
-  t.rejects(
+  await t.rejects(
     manifest({
       toString: () => 'x',
       final: { type: 'git' },
@@ -623,7 +625,7 @@ t.test('git spec must have gitRemote', async t => {
       cause: { code: 'ERESOLVE' },
     },
   )
-  t.rejects(
+  await t.rejects(
     packument({
       toString: () => 'x',
       final: { type: 'git' },
@@ -633,13 +635,13 @@ t.test('git spec must have gitRemote', async t => {
       cause: { code: 'ERESOLVE' },
     },
   )
-  t.rejects(
+  await t.rejects(
     tarball({
       toString: () => 'x',
       final: { type: 'git' },
     } as Spec),
   )
-  t.rejects(
+  await t.rejects(
     extract(
       {
         toString: () => 'x',
@@ -649,12 +651,13 @@ t.test('git spec must have gitRemote', async t => {
     ),
   )
 })
-t.test('fails on version that is not present', async t =>
-  t.rejects(resolve('abbrev@999', options)),
+t.test(
+  'fails on version that is not present',
+  async t => await t.rejects(resolve('abbrev@999', options)),
 )
 
 t.test('remote spec must have remoteURL', async t => {
-  t.rejects(
+  await t.rejects(
     resolve(
       {
         toString: () => 'x',
@@ -663,7 +666,7 @@ t.test('remote spec must have remoteURL', async t => {
       options,
     ),
   )
-  t.rejects(
+  await t.rejects(
     packument(
       {
         toString: () => 'x',
@@ -672,7 +675,7 @@ t.test('remote spec must have remoteURL', async t => {
       options,
     ),
   )
-  t.rejects(
+  await t.rejects(
     manifest(
       {
         toString: () => 'x',
@@ -681,38 +684,35 @@ t.test('remote spec must have remoteURL', async t => {
       options,
     ),
   )
-  t.rejects(
-    tarball(
-      {
-        toString: () => 'x',
-        final: { type: 'remote' },
-      } as Spec,
-      options,
-    ),
+  await t.rejects(
+    tarball({
+      toString: () => 'x',
+      final: { type: 'remote' },
+    } as Spec),
   )
-  t.rejects(packument(`x@git+${pkgDir}`, options))
+  await t.rejects(packument(`x@git+${pkgDir}`, options))
 })
 
 t.test('file spec must have file', async t => {
-  t.rejects(
+  await t.rejects(
     resolve({
       toString: () => 'x',
       final: { type: 'file' },
     } as Spec),
   )
-  t.rejects(
+  await t.rejects(
     packument({
       toString: () => 'x',
       final: { type: 'file' },
     } as Spec),
   )
-  t.rejects(
+  await t.rejects(
     manifest({
       toString: () => 'x',
       final: { type: 'file' },
     } as Spec),
   )
-  t.rejects(
+  await t.rejects(
     tarball({
       toString: () => 'x',
       final: { type: 'file' },
@@ -887,7 +887,7 @@ t.test('path git selector', async t => {
   await t.test('manifest', async t => {
     const m = await manifest(spec, options)
     t.strictSame(m, pkg)
-    t.rejects(() => manifest(badSpec, options))
+    await t.rejects(() => manifest(badSpec, options))
   })
 
   await t.test('tarball', async t => {

--- a/src/registry-client/test/index.ts
+++ b/src/registry-client/test/index.ts
@@ -333,7 +333,7 @@ t.test('follow redirects', { saveFixture: true }, async t => {
     ]
     t.plan(urls.length)
     for (const u of urls) {
-      t.rejects(rc.request(`${registryURL}/${u}`), {
+      await t.rejects(rc.request(`${registryURL}/${u}`), {
         message: 'Maximum redirections exceeded',
         cause: {
           found: Array,

--- a/src/tar/test/unpack-request.ts
+++ b/src/tar/test/unpack-request.ts
@@ -1,15 +1,18 @@
 import t from 'tap'
 import { UnpackRequest } from '../dist/esm/unpack-request.js'
 
-t.test('basic', async t => {
+t.test('rejects', async t => {
+  t.plan(2)
   const a = new UnpackRequest(Buffer.from('aaaa'), './a')
-  const b = new UnpackRequest(Buffer.from('bbbb'), './b')
-
   t.equal(a.id, 1)
-  t.equal(b.id, 2)
-
-  await t.rejects(a.promise, new Error('reason'))
-  await t.resolves(b.promise)
+  void t.rejects(a.promise, new Error('reason'))
   a.reject(new Error('reason'))
+})
+
+t.test('resolves', async t => {
+  t.plan(2)
+  const b = new UnpackRequest(Buffer.from('bbbb'), './b')
+  t.equal(b.id, 2)
+  void t.resolves(b.promise)
   b.resolve()
 })

--- a/src/tar/test/unpack-request.ts
+++ b/src/tar/test/unpack-request.ts
@@ -1,13 +1,15 @@
 import t from 'tap'
 import { UnpackRequest } from '../dist/esm/unpack-request.js'
 
-const a = new UnpackRequest(Buffer.from('aaaa'), './a')
-const b = new UnpackRequest(Buffer.from('bbbb'), './b')
+t.test('basic', async t => {
+  const a = new UnpackRequest(Buffer.from('aaaa'), './a')
+  const b = new UnpackRequest(Buffer.from('bbbb'), './b')
 
-t.equal(a.id, 1)
-t.equal(b.id, 2)
+  t.equal(a.id, 1)
+  t.equal(b.id, 2)
 
-t.rejects(a.promise, new Error('reason'))
-t.resolves(b.promise)
-a.reject(new Error('reason'))
-b.resolve()
+  await t.rejects(a.promise, new Error('reason'))
+  await t.resolves(b.promise)
+  a.reject(new Error('reason'))
+  b.resolve()
+})

--- a/src/vlt/test/commands/config.ts
+++ b/src/vlt/test/commands/config.ts
@@ -174,8 +174,8 @@ t.test('edit', async t => {
     })
   }
   t.test('no editor', async t => {
-    t.rejects(run(t, ['edit'], { editor: '' }))
-    t.rejects(
+    await t.rejects(run(t, ['edit'], { editor: '' }))
+    await t.rejects(
       run(t, ['edit'], { editor: 'BAD_EDITOR --not-good' }, () => ({
         status: 100,
       })),

--- a/src/which/test/index.ts
+++ b/src/which/test/index.ts
@@ -81,7 +81,7 @@ t.test('windows style', async t => {
     await which('foo', { path, pathExt: '.SH;.CMD' }),
     /foo\.sh$/i,
   )
-  t.rejects(which('foo', { path, pathExt: '.EXE' }))
+  await t.rejects(which('foo', { path, pathExt: '.EXE' }))
 
   t.match(
     await which('foo', {

--- a/src/workspaces/test/index.ts
+++ b/src/workspaces/test/index.ts
@@ -9,7 +9,7 @@ import {
 } from '../src/index.js'
 import { resolve } from 'node:path'
 
-t.test('load some workspaces', t => {
+t.test('load some workspaces', async t => {
   const dir = t.testdir({
     'vlt-workspaces.json': JSON.stringify({
       packages: ['./src/*'],
@@ -99,7 +99,7 @@ t.test('load some workspaces', t => {
   t.throws(() => new Monorepo(dir).runSync(() => {}), {
     message: 'No workspaces loaded',
   })
-  t.rejects(
+  await t.rejects(
     new Monorepo(dir).run(() => {}),
     {
       message: 'No workspaces loaded',
@@ -110,7 +110,7 @@ t.test('load some workspaces', t => {
     t.equal(m.get(ws.path), ws)
     t.equal(m.get(ws.name), ws)
   }
-  t.resolveMatch(
+  await t.resolveMatch(
     m.run(ws => ws.name),
     new Map([
       [{ name: 'foo' }, 'foo'],
@@ -186,8 +186,6 @@ t.test('load some workspaces', t => {
     ['src/noname', '@company/bar', 'foo'],
     'should return the selected workspace from a glob pattern match',
   )
-
-  t.end()
 })
 
 t.test('cyclic intra-project ws deps are handled', async t => {

--- a/tap-config.yaml
+++ b/tap-config.yaml
@@ -2,6 +2,7 @@
 
 coverage-map: './coverage-map.js'
 typecheck: true
+timeout: 600 # 10 minutes
 
 # globs are always relative to the project root regardless.
 exclude:


### PR DESCRIPTION
Previously linting ignored floating promises from all tap function calls. Now only `t.test` and `t.skip` are allowed to not be `await`-ed.

There were some top-level `t.resolves` calls and similar that I chose to wrap in new `t.test` functions which is just a preference of mine.

This will either fix some flaky tests or rule out this being an issue with flaky tests.

Also bump the tap timeout to 10 minutes in the global tap config, because thats a really long time and I don't want our tests to ever fail for timeouts unless its an infinite loop or something.

![9j699e](https://github.com/user-attachments/assets/95693e3e-5eaa-4386-9b09-88354205c791)
