### PR TITLE
allow control regex because this is a CLI

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -81,6 +81,8 @@ export default tseslint.config(
           destructuring: 'all',
         },
       ],
+      // this is mostly a CLI which needs to match control characters
+      'no-control-regex': 'off',
       // emulate TypeScript behavior of allowing unused prefixed with _
       '@typescript-eslint/no-unused-vars': [
         'error',

--- a/src/rollback-remove/src/remove.ts
+++ b/src/rollback-remove/src/remove.ts
@@ -14,7 +14,6 @@ const main = () => {
   process.stdin.on('end', () => {
     const paths = Buffer.concat(input)
       .toString()
-      // eslint-disable-next-line no-control-regex
       .replace(/^\u0000+|\u0000+$/, '')
       .split('\u0000')
     if (paths.length) void rimraf(paths)

--- a/src/rollback-remove/test/index.ts
+++ b/src/rollback-remove/test/index.ts
@@ -83,9 +83,7 @@ t.test('delete some stuff', async t => {
       args: [/[\\/]remove\.js$/],
       options: { detached: true },
       written: [
-        // eslint-disable-next-line no-control-regex
         /^a[\\/]\.VLT\.DELETE\.[0-9]+\.b\x00$/,
-        // eslint-disable-next-line no-control-regex
         /^.[\\/]\.VLT\.DELETE\.[0-9]+\.d\x00$/,
       ],
       stdinEnded: true,

--- a/src/vlt/src/commands/token.ts
+++ b/src/vlt/src/commands/token.ts
@@ -29,7 +29,6 @@ export const command: CommandFn = async conf => {
     }
 
     default: {
-      //eslint-disable-next-line no-console
       throw error('Invalid token subcommand', {
         found: conf.positionals[0],
         validOptions: ['add', 'rm'],

--- a/src/vlt/src/read-password.ts
+++ b/src/vlt/src/read-password.ts
@@ -22,9 +22,7 @@ export const readPassword = async (
       }
 
       input += String(c)
-      //eslint-disable-next-line no-control-regex
       if (/\r|\n|\x04|\x03/.test(input)) {
-        //eslint-disable-next-line no-control-regex
         input = input.replace(/(\r|\n|\x04|\x03)/g, '')
         stdin.setRawMode(false)
         stdin.pause()


### PR DESCRIPTION
From https://eslint.org/docs/latest/rules/no-control-regex

> Control characters are special, invisible characters in the ASCII range 0-31. These characters are rarely used in JavaScript strings so a regular expression containing elements that explicitly match these characters is most likely a mistake.

We're writing a CLI where these are not rarely used. And as a mistake it's unlikely and not worth the cost of ignoring it.