### PR TITLE
types: move DependencyType related types to types workspace

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -949,9 +949,6 @@ importers:
       '@vltpkg/error-cause':
         specifier: workspace:*
         version: link:../error-cause
-      '@vltpkg/graph':
-        specifier: workspace:*
-        version: link:../graph
       '@vltpkg/types':
         specifier: workspace:*
         version: link:../types
@@ -11939,7 +11936,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.0(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.7.0(eslint-plugin-import@2.31.0)(eslint@9.17.0(jiti@1.21.6)))(eslint@9.17.0(jiti@1.21.6)):
+  eslint-module-utils@2.12.0(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.7.0)(eslint@9.17.0(jiti@1.21.6)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
@@ -11960,7 +11957,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.17.0(jiti@1.21.6)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.0(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.7.0(eslint-plugin-import@2.31.0)(eslint@9.17.0(jiti@1.21.6)))(eslint@9.17.0(jiti@1.21.6))
+      eslint-module-utils: 2.12.0(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.7.0)(eslint@9.17.0(jiti@1.21.6))
       hasown: 2.0.2
       is-core-module: 2.15.1
       is-glob: 4.0.3

--- a/src/graph/src/actual/load.ts
+++ b/src/graph/src/actual/load.ts
@@ -6,14 +6,10 @@ import {
 } from '@vltpkg/dep-id'
 import { type PackageJson } from '@vltpkg/package-json'
 import { Spec, type SpecOptions } from '@vltpkg/spec'
-import { type Manifest } from '@vltpkg/types'
+import { type Manifest, longDependencyTypes } from '@vltpkg/types'
 import { type Monorepo } from '@vltpkg/workspaces'
 import { type Path, type PathScurry } from 'path-scurry'
-import {
-  longDependencyTypes,
-  type RawDependency,
-  shorten,
-} from '../dependencies.js'
+import { type RawDependency, shorten } from '../dependencies.js'
 import { Graph } from '../graph.js'
 import { loadHidden } from '../lockfile/load.js'
 import { type Node } from '../node.js'

--- a/src/graph/src/browser.ts
+++ b/src/graph/src/browser.ts
@@ -1,8 +1,5 @@
-import {
-  asDependencyTypeShort,
-  longDependencyTypes,
-  shorten,
-} from './dependencies.js'
+import { longDependencyTypes } from '@vltpkg/types'
+import { asDependencyTypeShort, shorten } from './dependencies.js'
 import { getBooleanFlagsFromNum } from './lockfile/types.js'
 import { stringifyNode } from './stringify-node.js'
 import { loadEdges } from './lockfile/load-edges.js'

--- a/src/graph/src/dependencies.ts
+++ b/src/graph/src/dependencies.ts
@@ -1,26 +1,14 @@
 import { type DepID } from '@vltpkg/dep-id'
 import { error } from '@vltpkg/error-cause'
 import { type Spec } from '@vltpkg/spec'
-import { type Manifest } from '@vltpkg/types'
-
-/**
- * Name of the package.json keys used to define different types of dependencies.
- */
-export type DependencyTypeLong =
-  | 'dependencies'
-  | 'devDependencies'
-  | 'optionalDependencies'
-  | 'peerDependencies'
-
-/**
- * Unique keys that define different types of dependencies relationship.
- */
-export type DependencyTypeShort =
-  | 'dev'
-  | 'optional'
-  | 'peer'
-  | 'peerOptional'
-  | 'prod'
+import {
+  type Manifest,
+  type DependencyTypeLong,
+  type DependencyTypeShort,
+  longDependencyTypes,
+  shortDependencyTypes,
+  dependencyTypes,
+} from '@vltpkg/types'
 
 export const isDependencyTypeShort = (
   obj: unknown,
@@ -107,42 +95,6 @@ export const asDependency = (obj: unknown): Dependency => {
   }
   return obj
 }
-
-/**
- * A set of the possible long dependency type names,
- * as used in `package.json` files.
- */
-export const longDependencyTypes = new Set<DependencyTypeLong>([
-  'dependencies',
-  'devDependencies',
-  'peerDependencies',
-  'optionalDependencies',
-])
-
-/**
- * A set of the short type keys used to represent dependency relationships.
- */
-export const shortDependencyTypes = new Set<DependencyTypeShort>([
-  'prod',
-  'dev',
-  'peer',
-  'optional',
-  'peerOptional',
-])
-
-/**
- * Maps between long form names usually used in `package.json` files
- * to a corresponding short form name, used in lockfiles.
- */
-export const dependencyTypes = new Map<
-  DependencyTypeLong,
-  DependencyTypeShort
->([
-  ['dependencies', 'prod'],
-  ['devDependencies', 'dev'],
-  ['peerDependencies', 'peer'],
-  ['optionalDependencies', 'optional'],
-])
 
 /**
  * Get the {@link DependencyTypeShort} from a {@link DependencyTypeLong}.

--- a/src/graph/src/edge.ts
+++ b/src/graph/src/edge.ts
@@ -1,7 +1,7 @@
 import { satisfies } from '@vltpkg/satisfies'
 import { type Spec } from '@vltpkg/spec'
 import { inspect, type InspectOptions } from 'util'
-import { type DependencyTypeShort } from './dependencies.js'
+import { type DependencyTypeShort } from '@vltpkg/types'
 import { type Node } from './node.js'
 import { type EdgeLike } from './types.js'
 

--- a/src/graph/src/graph.ts
+++ b/src/graph/src/graph.ts
@@ -2,10 +2,12 @@ import { getId, joinDepIDTuple, type DepID } from '@vltpkg/dep-id'
 import { error } from '@vltpkg/error-cause'
 import { satisfies } from '@vltpkg/satisfies'
 import { Spec, type SpecOptions } from '@vltpkg/spec'
-import { type Manifest } from '@vltpkg/types'
+import {
+  type Manifest,
+  type DependencyTypeShort,
+} from '@vltpkg/types'
 import { type Monorepo } from '@vltpkg/workspaces'
 import { inspect, type InspectOptions } from 'util'
-import { type DependencyTypeShort } from './dependencies.js'
 import { type Edge } from './edge.js'
 import { lockfileData } from './lockfile/save.js'
 import { Node, type NodeOptions } from './node.js'

--- a/src/graph/src/ideal/append-nodes.ts
+++ b/src/graph/src/ideal/append-nodes.ts
@@ -2,13 +2,15 @@ import { joinDepIDTuple, type DepID } from '@vltpkg/dep-id'
 import { error } from '@vltpkg/error-cause'
 import { type PackageInfoClient } from '@vltpkg/package-info'
 import { Spec, type SpecOptions } from '@vltpkg/spec'
+import {
+  longDependencyTypes,
+  type DependencyTypeLong,
+} from '@vltpkg/types'
 import { type PathScurry } from 'path-scurry'
 import {
   asDependency,
-  longDependencyTypes,
   shorten,
   type Dependency,
-  type DependencyTypeLong,
 } from '../dependencies.js'
 import { type Graph } from '../graph.js'
 import { type Node } from '../node.js'

--- a/src/graph/src/ideal/get-importer-specs.ts
+++ b/src/graph/src/ideal/get-importer-specs.ts
@@ -1,9 +1,9 @@
 import { error } from '@vltpkg/error-cause'
+import { longDependencyTypes } from '@vltpkg/types'
 import {
   type AddImportersDependenciesMap,
   type Dependency,
   type RemoveImportersDependenciesMap,
-  longDependencyTypes,
   shorten,
   asDependency,
 } from '../dependencies.js'

--- a/src/graph/src/lockfile/load-edges.ts
+++ b/src/graph/src/lockfile/load-edges.ts
@@ -2,10 +2,8 @@ import { asDepID } from '@vltpkg/dep-id/browser'
 import { error } from '@vltpkg/error-cause'
 import { fastSplit } from '@vltpkg/fast-split'
 import { Spec, type SpecOptions } from '@vltpkg/spec/browser'
-import {
-  isDependencyTypeShort,
-  longDependencyTypes,
-} from '../dependencies.js'
+import { longDependencyTypes } from '@vltpkg/types'
+import { isDependencyTypeShort } from '../dependencies.js'
 import { type GraphLike } from '../types.js'
 import {
   type LockfileData,

--- a/src/graph/src/lockfile/types.ts
+++ b/src/graph/src/lockfile/types.ts
@@ -1,7 +1,10 @@
 import { type DepID } from '@vltpkg/dep-id'
 import { type Spec, type SpecOptions } from '@vltpkg/spec'
-import { type Integrity, type Manifest } from '@vltpkg/types'
-import { type DependencyTypeShort } from '../dependencies.js'
+import {
+  type Integrity,
+  type Manifest,
+  type DependencyTypeShort,
+} from '@vltpkg/types'
 import { type Graph } from '../graph.js'
 
 /**

--- a/src/graph/src/node.ts
+++ b/src/graph/src/node.ts
@@ -8,8 +8,11 @@ import {
 } from '@vltpkg/dep-id'
 import { typeError } from '@vltpkg/error-cause'
 import { type Spec, type SpecOptions } from '@vltpkg/spec'
-import { type Integrity, type Manifest } from '@vltpkg/types'
-import { type DependencyTypeShort } from './dependencies.js'
+import {
+  type Integrity,
+  type Manifest,
+  type DependencyTypeShort,
+} from '@vltpkg/types'
 import { Edge } from './edge.js'
 import { type GraphLike, type NodeLike } from './types.js'
 import { stringifyNode } from './stringify-node.js'

--- a/src/graph/src/reify/update-importers-package-json.ts
+++ b/src/graph/src/reify/update-importers-package-json.ts
@@ -1,14 +1,16 @@
 import { type DepID, splitDepID } from '@vltpkg/dep-id'
 import { error } from '@vltpkg/error-cause'
 import { type PackageJson } from '@vltpkg/package-json'
-import { type Manifest } from '@vltpkg/types'
+import {
+  type Manifest,
+  type DependencyTypeLong,
+  type DependencyTypeShort,
+  longDependencyTypes,
+} from '@vltpkg/types'
 import { type Graph } from '../graph.js'
 import {
   type AddImportersDependenciesMap,
   type RemoveImportersDependenciesMap,
-  type DependencyTypeLong,
-  type DependencyTypeShort,
-  longDependencyTypes,
   type Dependency,
 } from '../dependencies.js'
 

--- a/src/graph/src/types.ts
+++ b/src/graph/src/types.ts
@@ -1,7 +1,9 @@
 import { type DepID } from '@vltpkg/dep-id'
-import { type Manifest } from '@vltpkg/types'
+import {
+  type Manifest,
+  type DependencyTypeShort,
+} from '@vltpkg/types'
 import { type Spec, type SpecLikeBase } from '@vltpkg/spec'
-import { type DependencyTypeShort } from './dependencies.js'
 
 export type EdgeLike = {
   name: string

--- a/src/graph/test/dependencies.ts
+++ b/src/graph/test/dependencies.ts
@@ -1,23 +1,13 @@
 import t from 'tap'
 import {
-  type DependencyTypeLong,
   asDependency,
   asDependencyTypeShort,
-  dependencyTypes,
   isDependency,
   isDependencyTypeShort,
-  longDependencyTypes,
   shorten,
 } from '../src/dependencies.js'
 import { Spec } from '@vltpkg/spec'
-
-t.test('dependencyTypes', async t => {
-  t.strictSame(
-    [...longDependencyTypes],
-    [...dependencyTypes.keys()],
-    'should have the exact same long dependency types as keys of long types map',
-  )
-})
+import { type DependencyTypeLong } from '@vltpkg/types'
 
 t.test('shorten', async t => {
   t.strictSame(

--- a/src/graph/test/ideal/add-nodes.ts
+++ b/src/graph/test/ideal/add-nodes.ts
@@ -1,4 +1,5 @@
 import { joinDepIDTuple } from '@vltpkg/dep-id'
+import { type DependencyTypeShort } from '@vltpkg/types'
 import { type PackageInfoClient } from '@vltpkg/package-info'
 import { kCustomInspect, Spec, type SpecOptions } from '@vltpkg/spec'
 import { PathScurry } from 'path-scurry'
@@ -6,7 +7,6 @@ import t from 'tap'
 import {
   type AddImportersDependenciesMap,
   type Dependency,
-  type DependencyTypeShort,
 } from '../../src/dependencies.js'
 import { Graph } from '../../src/graph.js'
 import { addNodes } from '../../src/ideal/add-nodes.js'

--- a/src/graph/test/remove-optional-subgraph.ts
+++ b/src/graph/test/remove-optional-subgraph.ts
@@ -1,8 +1,10 @@
 import { joinDepIDTuple } from '@vltpkg/dep-id'
 import { Spec } from '@vltpkg/spec'
-import { type Manifest } from '@vltpkg/types'
+import {
+  type Manifest,
+  type DependencyTypeShort,
+} from '@vltpkg/types'
 import t from 'tap'
-import { type DependencyTypeShort } from '../src/dependencies.js'
 import { Edge } from '../src/edge.js'
 import { Graph } from '../src/graph.js'
 import { type Node } from '../src/node.js'

--- a/src/gui/src/state/load-graph.ts
+++ b/src/gui/src/state/load-graph.ts
@@ -1,4 +1,7 @@
-import { type Manifest } from '@vltpkg/types'
+import {
+  type Manifest,
+  type DependencyTypeShort,
+} from '@vltpkg/types'
 import { lockfile } from '@vltpkg/graph/browser'
 import { type DepID } from '@vltpkg/dep-id/browser'
 import {
@@ -6,7 +9,6 @@ import {
   type LockfileData,
   type GraphLike,
   type NodeLike,
-  type DependencyTypeShort,
 } from '@vltpkg/graph'
 import {
   defaultRegistry,

--- a/src/package-json/package.json
+++ b/src/package-json/package.json
@@ -22,7 +22,6 @@
   },
   "dependencies": {
     "@vltpkg/error-cause": "workspace:*",
-    "@vltpkg/graph": "workspace:*",
     "@vltpkg/types": "workspace:*",
     "polite-json": "catalog:"
   },

--- a/src/package-json/src/index.ts
+++ b/src/package-json/src/index.ts
@@ -1,6 +1,9 @@
 import { error, type ErrorCauseObject } from '@vltpkg/error-cause'
-import { asManifest, type Manifest } from '@vltpkg/types'
-import { longDependencyTypes } from '@vltpkg/graph/browser'
+import {
+  asManifest,
+  type Manifest,
+  longDependencyTypes,
+} from '@vltpkg/types'
 import { readFileSync, writeFileSync } from 'node:fs'
 import { resolve } from 'node:path'
 import { parse, stringify } from 'polite-json'

--- a/src/query/test/fixtures/graph.ts
+++ b/src/query/test/fixtures/graph.ts
@@ -1,15 +1,14 @@
 import { joinDepIDTuple } from '@vltpkg/dep-id'
-import type {
-  DependencyTypeShort,
-  GraphLike,
-  NodeLike,
-} from '@vltpkg/graph'
+import type { GraphLike, NodeLike } from '@vltpkg/graph'
 import {
   Spec,
   type SpecLike,
   type SpecOptions,
 } from '@vltpkg/spec/browser'
-import { Manifest } from '@vltpkg/types'
+import {
+  type Manifest,
+  type DependencyTypeShort,
+} from '@vltpkg/types'
 
 const specOptions = {
   registries: {

--- a/src/types/src/index.ts
+++ b/src/types/src/index.ts
@@ -368,3 +368,58 @@ export const assertPackument: (
 ) => asserts m is Packument = m => {
   asPackument(m)
 }
+
+/**
+ * Name of the package.json keys used to define different types of dependencies.
+ */
+export type DependencyTypeLong =
+  | 'dependencies'
+  | 'devDependencies'
+  | 'optionalDependencies'
+  | 'peerDependencies'
+
+/**
+ * Unique keys that define different types of dependencies relationship.
+ */
+export type DependencyTypeShort =
+  | 'dev'
+  | 'optional'
+  | 'peer'
+  | 'peerOptional'
+  | 'prod'
+
+/**
+ * A set of the possible long dependency type names,
+ * as used in `package.json` files.
+ */
+export const longDependencyTypes = new Set<DependencyTypeLong>([
+  'dependencies',
+  'devDependencies',
+  'peerDependencies',
+  'optionalDependencies',
+])
+
+/**
+ * A set of the short type keys used to represent dependency relationships.
+ */
+export const shortDependencyTypes = new Set<DependencyTypeShort>([
+  'prod',
+  'dev',
+  'peer',
+  'optional',
+  'peerOptional',
+])
+
+/**
+ * Maps between long form names usually used in `package.json` files
+ * to a corresponding short form name, used in lockfiles.
+ */
+export const dependencyTypes = new Map<
+  DependencyTypeLong,
+  DependencyTypeShort
+>([
+  ['dependencies', 'prod'],
+  ['devDependencies', 'dev'],
+  ['peerDependencies', 'peer'],
+  ['optionalDependencies', 'optional'],
+])

--- a/src/types/test/index.ts
+++ b/src/types/test/index.ts
@@ -28,6 +28,8 @@ import {
   type PeerDependenciesMetaValue,
   type Person,
   type Repository,
+  dependencyTypes,
+  longDependencyTypes,
 } from '../src/index.js'
 
 import t from 'tap'
@@ -279,5 +281,17 @@ t.test('type checks', t => {
   r = { type: 'git' }
 
   t.pass('all typechecks passed')
+  t.end()
+})
+
+t.test('dependency types', t => {
+  t.test('dependencyTypes', async t => {
+    t.strictSame(
+      [...longDependencyTypes],
+      [...dependencyTypes.keys()],
+      'should have the exact same long dependency types as keys of long types map',
+    )
+  })
+
   t.end()
 })

--- a/src/vlt/src/parse-add-remove-args.ts
+++ b/src/vlt/src/parse-add-remove-args.ts
@@ -1,8 +1,8 @@
 import { type DepID, joinDepIDTuple } from '@vltpkg/dep-id'
+import { type DependencyTypeShort } from '@vltpkg/types'
 import {
   type AddImportersDependenciesMap,
   type Dependency,
-  type DependencyTypeShort,
   type RemoveImportersDependenciesMap,
   asDependency,
 } from '@vltpkg/graph'

--- a/src/vlt/src/start-gui.ts
+++ b/src/vlt/src/start-gui.ts
@@ -4,11 +4,13 @@ import {
   asDependency,
   type AddImportersDependenciesMap,
   type Dependency,
-  type DependencyTypeShort,
   type RemoveImportersDependenciesMap,
 } from '@vltpkg/graph'
 import { Spec } from '@vltpkg/spec'
-import { type Manifest } from '@vltpkg/types'
+import {
+  type Manifest,
+  type DependencyTypeShort,
+} from '@vltpkg/types'
 import { urlOpen } from '@vltpkg/url-open'
 import {
   cpSync,


### PR DESCRIPTION
The goal here is to break a cycle between `graph` and `package-json` by moving the `DependencyType` related types and helpers to `@vltpkg/types`.

This is not strictly necessary as cycles are fine, but pnpm warns and turborepo (which we dropped) errors in this case. We already have to the types workspace to help alleviate issues like this, so I think these types/helpers are better suited to live there.