### PR TITLE
rename root prepare script

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "format:check": "prettier --check . --ignore-path ./.prettierignore --cache",
     "lint": "eslint . --fix",
     "lint:check": "eslint .",
-    "prepare": "pnpm --recursive --filter \"./src/*\" run prepare",
+    "prepare:src": "pnpm --recursive --filter \"./src/*\" run prepare",
     "pnpm:devPreinstall": "pnpm --version && node --version && node scripts/make-dist-bins.js",
     "snap": "pnpm --silent --no-bail --report-summary run -r snap &>/dev/null || node scripts/report-test-failures.js",
     "test": "pnpm --silent --no-bail --report-summary -r test -- -Rsilent || node scripts/report-test-failures.js",


### PR DESCRIPTION
I added this previously as a shortcut to the common operation of preparing all the `src/*` workspaces.

But it should not be called `prepare` otherwise commands like `pnpm install` will run it which will end up preparing everything twice.