### PR TITLE
typescript@5.7.3 and typecheck tests with tsc

### DIFF
--- a/infra/benchmark/package.json
+++ b/infra/benchmark/package.json
@@ -54,6 +54,7 @@
     "snap": "tap",
     "pretest": "tshy",
     "test": "tap",
+    "posttest": "tsc --project tsconfig.test.json",
     "watch": "tshy --watch"
   },
   "tap": {

--- a/infra/benchmark/tsconfig.test.json
+++ b/infra/benchmark/tsconfig.test.json
@@ -1,0 +1,13 @@
+{
+  "extends": "./tsconfig.json",
+  "include": [
+    "./test/**/*.ts",
+    "./test/**/*.mts",
+    "./test/**/*.tsx",
+    "./test/**/*.json"
+  ],
+  "compilerOptions": {
+    "noEmit": true,
+    "incremental": false
+  }
+}

--- a/infra/build/package.json
+++ b/infra/build/package.json
@@ -56,6 +56,7 @@
     "snap": "tap",
     "pretest": "tshy",
     "test": "tap",
+    "posttest": "tsc --project tsconfig.test.json",
     "watch": "tshy --watch"
   },
   "tap": {

--- a/infra/build/tsconfig.test.json
+++ b/infra/build/tsconfig.test.json
@@ -1,0 +1,13 @@
+{
+  "extends": "./tsconfig.json",
+  "include": [
+    "./test/**/*.ts",
+    "./test/**/*.mts",
+    "./test/**/*.tsx",
+    "./test/**/*.json"
+  ],
+  "compilerOptions": {
+    "noEmit": true,
+    "incremental": false
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -67,8 +67,8 @@ catalogs:
       specifier: ^3.0.2
       version: 3.0.2
     typescript:
-      specifier: 5.5.4
-      version: 5.5.4
+      specifier: 5.7.3
+      version: 5.7.3
     typescript-eslint:
       specifier: ^8.23.0
       version: 8.23.0
@@ -131,10 +131,10 @@ importers:
         version: 7.7.1
       typescript:
         specifier: 'catalog:'
-        version: 5.5.4
+        version: 5.7.3
       typescript-eslint:
         specifier: 'catalog:'
-        version: 8.23.0(eslint@9.20.0(jiti@1.21.6))(typescript@5.5.4)
+        version: 8.23.0(eslint@9.20.0(jiti@1.21.6))(typescript@5.7.3)
       yaml:
         specifier: ^2.7.0
         version: 2.7.0
@@ -165,16 +165,16 @@ importers:
         version: 3.4.2
       tap:
         specifier: 'catalog:'
-        version: 21.0.1(@types/node@22.13.1)(@types/react@18.3.18)(react-devtools-core@4.28.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
+        version: 21.0.1(@types/node@22.13.1)(@types/react@18.3.18)(react-devtools-core@4.28.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.7.3)
       tshy:
         specifier: 'catalog:'
         version: 3.0.2
       typescript:
         specifier: 'catalog:'
-        version: 5.5.4
+        version: 5.7.3
       typescript-eslint:
         specifier: 'catalog:'
-        version: 8.23.0(eslint@9.20.0(jiti@1.21.6))(typescript@5.5.4)
+        version: 8.23.0(eslint@9.20.0(jiti@1.21.6))(typescript@5.7.3)
 
   infra/build:
     dependencies:
@@ -211,16 +211,16 @@ importers:
         version: 3.4.2
       tap:
         specifier: 'catalog:'
-        version: 21.0.1(@types/node@22.13.1)(@types/react@18.3.18)(react-devtools-core@4.28.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
+        version: 21.0.1(@types/node@22.13.1)(@types/react@18.3.18)(react-devtools-core@4.28.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.7.3)
       tshy:
         specifier: 'catalog:'
         version: 3.0.2
       typescript:
         specifier: 'catalog:'
-        version: 5.5.4
+        version: 5.7.3
       typescript-eslint:
         specifier: 'catalog:'
-        version: 8.23.0(eslint@9.20.0(jiti@1.21.6))(typescript@5.5.4)
+        version: 8.23.0(eslint@9.20.0(jiti@1.21.6))(typescript@5.7.3)
 
   src/cache:
     dependencies:
@@ -257,16 +257,16 @@ importers:
         version: 3.4.2
       tap:
         specifier: 'catalog:'
-        version: 21.0.1(@types/node@22.13.1)(@types/react@18.3.18)(react-devtools-core@4.28.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
+        version: 21.0.1(@types/node@22.13.1)(@types/react@18.3.18)(react-devtools-core@4.28.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.7.3)
       tshy:
         specifier: 'catalog:'
         version: 3.0.2
       typescript:
         specifier: 'catalog:'
-        version: 5.5.4
+        version: 5.7.3
       typescript-eslint:
         specifier: 'catalog:'
-        version: 8.23.0(eslint@9.20.0(jiti@1.21.6))(typescript@5.5.4)
+        version: 8.23.0(eslint@9.20.0(jiti@1.21.6))(typescript@5.7.3)
 
   src/cache-unzip:
     dependencies:
@@ -294,16 +294,16 @@ importers:
         version: 3.4.2
       tap:
         specifier: 'catalog:'
-        version: 21.0.1(@types/node@22.13.1)(@types/react@18.3.18)(react-devtools-core@4.28.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
+        version: 21.0.1(@types/node@22.13.1)(@types/react@18.3.18)(react-devtools-core@4.28.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.7.3)
       tshy:
         specifier: 'catalog:'
         version: 3.0.2
       typescript:
         specifier: 'catalog:'
-        version: 5.5.4
+        version: 5.7.3
       typescript-eslint:
         specifier: 'catalog:'
-        version: 8.23.0(eslint@9.20.0(jiti@1.21.6))(typescript@5.5.4)
+        version: 8.23.0(eslint@9.20.0(jiti@1.21.6))(typescript@5.7.3)
 
   src/dep-id:
     dependencies:
@@ -334,16 +334,16 @@ importers:
         version: 3.4.2
       tap:
         specifier: 'catalog:'
-        version: 21.0.1(@types/node@22.13.1)(@types/react@18.3.18)(react-devtools-core@4.28.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
+        version: 21.0.1(@types/node@22.13.1)(@types/react@18.3.18)(react-devtools-core@4.28.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.7.3)
       tshy:
         specifier: 'catalog:'
         version: 3.0.2
       typescript:
         specifier: 'catalog:'
-        version: 5.5.4
+        version: 5.7.3
       typescript-eslint:
         specifier: 'catalog:'
-        version: 8.23.0(eslint@9.20.0(jiti@1.21.6))(typescript@5.5.4)
+        version: 8.23.0(eslint@9.20.0(jiti@1.21.6))(typescript@5.7.3)
 
   src/dot-prop:
     devDependencies:
@@ -364,16 +364,16 @@ importers:
         version: 3.4.2
       tap:
         specifier: 'catalog:'
-        version: 21.0.1(@types/node@22.13.1)(@types/react@18.3.18)(react-devtools-core@4.28.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
+        version: 21.0.1(@types/node@22.13.1)(@types/react@18.3.18)(react-devtools-core@4.28.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.7.3)
       tshy:
         specifier: 'catalog:'
         version: 3.0.2
       typescript:
         specifier: 'catalog:'
-        version: 5.5.4
+        version: 5.7.3
       typescript-eslint:
         specifier: 'catalog:'
-        version: 8.23.0(eslint@9.20.0(jiti@1.21.6))(typescript@5.5.4)
+        version: 8.23.0(eslint@9.20.0(jiti@1.21.6))(typescript@5.7.3)
 
   src/error-cause:
     devDependencies:
@@ -394,16 +394,16 @@ importers:
         version: 3.4.2
       tap:
         specifier: 'catalog:'
-        version: 21.0.1(@types/node@22.13.1)(@types/react@18.3.18)(react-devtools-core@4.28.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
+        version: 21.0.1(@types/node@22.13.1)(@types/react@18.3.18)(react-devtools-core@4.28.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.7.3)
       tshy:
         specifier: 'catalog:'
         version: 3.0.2
       typescript:
         specifier: 'catalog:'
-        version: 5.5.4
+        version: 5.7.3
       typescript-eslint:
         specifier: 'catalog:'
-        version: 8.23.0(eslint@9.20.0(jiti@1.21.6))(typescript@5.5.4)
+        version: 8.23.0(eslint@9.20.0(jiti@1.21.6))(typescript@5.7.3)
 
   src/fast-split:
     devDependencies:
@@ -424,16 +424,16 @@ importers:
         version: 3.4.2
       tap:
         specifier: 'catalog:'
-        version: 21.0.1(@types/node@22.13.1)(@types/react@18.3.18)(react-devtools-core@4.28.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
+        version: 21.0.1(@types/node@22.13.1)(@types/react@18.3.18)(react-devtools-core@4.28.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.7.3)
       tshy:
         specifier: 'catalog:'
         version: 3.0.2
       typescript:
         specifier: 'catalog:'
-        version: 5.5.4
+        version: 5.7.3
       typescript-eslint:
         specifier: 'catalog:'
-        version: 8.23.0(eslint@9.20.0(jiti@1.21.6))(typescript@5.5.4)
+        version: 8.23.0(eslint@9.20.0(jiti@1.21.6))(typescript@5.7.3)
 
   src/git:
     dependencies:
@@ -494,16 +494,16 @@ importers:
         version: 3.4.2
       tap:
         specifier: 'catalog:'
-        version: 21.0.1(@types/node@22.13.1)(@types/react@18.3.18)(react-devtools-core@4.28.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
+        version: 21.0.1(@types/node@22.13.1)(@types/react@18.3.18)(react-devtools-core@4.28.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.7.3)
       tshy:
         specifier: 'catalog:'
         version: 3.0.2
       typescript:
         specifier: 'catalog:'
-        version: 5.5.4
+        version: 5.7.3
       typescript-eslint:
         specifier: 'catalog:'
-        version: 8.23.0(eslint@9.20.0(jiti@1.21.6))(typescript@5.5.4)
+        version: 8.23.0(eslint@9.20.0(jiti@1.21.6))(typescript@5.7.3)
 
   src/git-scp-url:
     devDependencies:
@@ -524,16 +524,16 @@ importers:
         version: 3.4.2
       tap:
         specifier: 'catalog:'
-        version: 21.0.1(@types/node@22.13.1)(@types/react@18.3.18)(react-devtools-core@4.28.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
+        version: 21.0.1(@types/node@22.13.1)(@types/react@18.3.18)(react-devtools-core@4.28.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.7.3)
       tshy:
         specifier: 'catalog:'
         version: 3.0.2
       typescript:
         specifier: 'catalog:'
-        version: 5.5.4
+        version: 5.7.3
       typescript-eslint:
         specifier: 'catalog:'
-        version: 8.23.0(eslint@9.20.0(jiti@1.21.6))(typescript@5.5.4)
+        version: 8.23.0(eslint@9.20.0(jiti@1.21.6))(typescript@5.7.3)
 
   src/graph:
     dependencies:
@@ -612,7 +612,7 @@ importers:
         version: 3.4.2
       tap:
         specifier: 'catalog:'
-        version: 21.0.1(@types/node@22.13.1)(@types/react@18.3.18)(react-devtools-core@4.28.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
+        version: 21.0.1(@types/node@22.13.1)(@types/react@18.3.18)(react-devtools-core@4.28.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.7.3)
       tar:
         specifier: 'catalog:'
         version: 7.4.3
@@ -621,10 +621,10 @@ importers:
         version: 3.0.2
       typescript:
         specifier: 'catalog:'
-        version: 5.5.4
+        version: 5.7.3
       typescript-eslint:
         specifier: 'catalog:'
-        version: 8.23.0(eslint@9.20.0(jiti@1.21.6))(typescript@5.5.4)
+        version: 8.23.0(eslint@9.20.0(jiti@1.21.6))(typescript@5.7.3)
 
   src/gui:
     dependencies:
@@ -778,19 +778,19 @@ importers:
         version: 25.0.1
       msw:
         specifier: ^2.7.0
-        version: 2.7.0(@types/node@22.13.1)(typescript@5.5.4)
+        version: 2.7.0(@types/node@22.13.1)(typescript@5.7.3)
       prettier:
         specifier: 'catalog:'
         version: 3.4.2
       typescript:
         specifier: 'catalog:'
-        version: 5.5.4
+        version: 5.7.3
       typescript-eslint:
         specifier: 'catalog:'
-        version: 8.23.0(eslint@9.20.0(jiti@1.21.6))(typescript@5.5.4)
+        version: 8.23.0(eslint@9.20.0(jiti@1.21.6))(typescript@5.7.3)
       vitest:
         specifier: ^2.1.9
-        version: 2.1.9(@types/node@22.13.1)(jsdom@25.0.1)(msw@2.7.0(@types/node@22.13.1)(typescript@5.5.4))
+        version: 2.1.9(@types/node@22.13.1)(jsdom@25.0.1)(msw@2.7.0(@types/node@22.13.1)(typescript@5.7.3))
 
   src/keychain:
     dependencies:
@@ -827,16 +827,16 @@ importers:
         version: 3.4.2
       tap:
         specifier: 'catalog:'
-        version: 21.0.1(@types/node@22.13.1)(@types/react@18.3.18)(react-devtools-core@4.28.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
+        version: 21.0.1(@types/node@22.13.1)(@types/react@18.3.18)(react-devtools-core@4.28.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.7.3)
       tshy:
         specifier: 'catalog:'
         version: 3.0.2
       typescript:
         specifier: 'catalog:'
-        version: 5.5.4
+        version: 5.7.3
       typescript-eslint:
         specifier: 'catalog:'
-        version: 8.23.0(eslint@9.20.0(jiti@1.21.6))(typescript@5.5.4)
+        version: 8.23.0(eslint@9.20.0(jiti@1.21.6))(typescript@5.7.3)
 
   src/output:
     devDependencies:
@@ -857,16 +857,16 @@ importers:
         version: 3.4.2
       tap:
         specifier: 'catalog:'
-        version: 21.0.1(@types/node@22.13.1)(@types/react@18.3.18)(react-devtools-core@4.28.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
+        version: 21.0.1(@types/node@22.13.1)(@types/react@18.3.18)(react-devtools-core@4.28.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.7.3)
       tshy:
         specifier: 'catalog:'
         version: 3.0.2
       typescript:
         specifier: 'catalog:'
-        version: 5.5.4
+        version: 5.7.3
       typescript-eslint:
         specifier: 'catalog:'
-        version: 8.23.0(eslint@9.20.0(jiti@1.21.6))(typescript@5.5.4)
+        version: 8.23.0(eslint@9.20.0(jiti@1.21.6))(typescript@5.7.3)
 
   src/package-info:
     dependencies:
@@ -930,16 +930,16 @@ importers:
         version: 3.4.2
       tap:
         specifier: 'catalog:'
-        version: 21.0.1(@types/node@22.13.1)(@types/react@18.3.18)(react-devtools-core@4.28.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
+        version: 21.0.1(@types/node@22.13.1)(@types/react@18.3.18)(react-devtools-core@4.28.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.7.3)
       tshy:
         specifier: 'catalog:'
         version: 3.0.2
       typescript:
         specifier: 'catalog:'
-        version: 5.5.4
+        version: 5.7.3
       typescript-eslint:
         specifier: 'catalog:'
-        version: 8.23.0(eslint@9.20.0(jiti@1.21.6))(typescript@5.5.4)
+        version: 8.23.0(eslint@9.20.0(jiti@1.21.6))(typescript@5.7.3)
 
   src/package-json:
     dependencies:
@@ -970,16 +970,16 @@ importers:
         version: 3.4.2
       tap:
         specifier: 'catalog:'
-        version: 21.0.1(@types/node@22.13.1)(@types/react@18.3.18)(react-devtools-core@4.28.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
+        version: 21.0.1(@types/node@22.13.1)(@types/react@18.3.18)(react-devtools-core@4.28.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.7.3)
       tshy:
         specifier: 'catalog:'
         version: 3.0.2
       typescript:
         specifier: 'catalog:'
-        version: 5.5.4
+        version: 5.7.3
       typescript-eslint:
         specifier: 'catalog:'
-        version: 8.23.0(eslint@9.20.0(jiti@1.21.6))(typescript@5.5.4)
+        version: 8.23.0(eslint@9.20.0(jiti@1.21.6))(typescript@5.7.3)
 
   src/pick-manifest:
     dependencies:
@@ -1019,16 +1019,16 @@ importers:
         version: 3.4.2
       tap:
         specifier: 'catalog:'
-        version: 21.0.1(@types/node@22.13.1)(@types/react@18.3.18)(react-devtools-core@4.28.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
+        version: 21.0.1(@types/node@22.13.1)(@types/react@18.3.18)(react-devtools-core@4.28.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.7.3)
       tshy:
         specifier: 'catalog:'
         version: 3.0.2
       typescript:
         specifier: 'catalog:'
-        version: 5.5.4
+        version: 5.7.3
       typescript-eslint:
         specifier: 'catalog:'
-        version: 8.23.0(eslint@9.20.0(jiti@1.21.6))(typescript@5.5.4)
+        version: 8.23.0(eslint@9.20.0(jiti@1.21.6))(typescript@5.7.3)
 
   src/promise-spawn:
     dependencies:
@@ -1056,16 +1056,16 @@ importers:
         version: 1.8.2
       tap:
         specifier: 'catalog:'
-        version: 21.0.1(@types/node@22.13.1)(@types/react@18.3.18)(react-devtools-core@4.28.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
+        version: 21.0.1(@types/node@22.13.1)(@types/react@18.3.18)(react-devtools-core@4.28.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.7.3)
       tshy:
         specifier: 'catalog:'
         version: 3.0.2
       typescript:
         specifier: 'catalog:'
-        version: 5.5.4
+        version: 5.7.3
       typescript-eslint:
         specifier: 'catalog:'
-        version: 8.23.0(eslint@9.20.0(jiti@1.21.6))(typescript@5.5.4)
+        version: 8.23.0(eslint@9.20.0(jiti@1.21.6))(typescript@5.7.3)
 
   src/query:
     dependencies:
@@ -1105,16 +1105,16 @@ importers:
         version: 3.4.2
       tap:
         specifier: 'catalog:'
-        version: 21.0.1(@types/node@22.13.1)(@types/react@18.3.18)(react-devtools-core@4.28.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
+        version: 21.0.1(@types/node@22.13.1)(@types/react@18.3.18)(react-devtools-core@4.28.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.7.3)
       tshy:
         specifier: 'catalog:'
         version: 3.0.2
       typescript:
         specifier: 'catalog:'
-        version: 5.5.4
+        version: 5.7.3
       typescript-eslint:
         specifier: 'catalog:'
-        version: 8.23.0(eslint@9.20.0(jiti@1.21.6))(typescript@5.5.4)
+        version: 8.23.0(eslint@9.20.0(jiti@1.21.6))(typescript@5.7.3)
 
   src/registry-client:
     dependencies:
@@ -1172,16 +1172,16 @@ importers:
         version: 3.4.2
       tap:
         specifier: 'catalog:'
-        version: 21.0.1(@types/node@22.13.1)(@types/react@18.3.18)(react-devtools-core@4.28.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
+        version: 21.0.1(@types/node@22.13.1)(@types/react@18.3.18)(react-devtools-core@4.28.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.7.3)
       tshy:
         specifier: 'catalog:'
         version: 3.0.2
       typescript:
         specifier: 'catalog:'
-        version: 5.5.4
+        version: 5.7.3
       typescript-eslint:
         specifier: 'catalog:'
-        version: 8.23.0(eslint@9.20.0(jiti@1.21.6))(typescript@5.5.4)
+        version: 8.23.0(eslint@9.20.0(jiti@1.21.6))(typescript@5.7.3)
 
   src/rollback-remove:
     dependencies:
@@ -1209,16 +1209,16 @@ importers:
         version: 3.4.2
       tap:
         specifier: 'catalog:'
-        version: 21.0.1(@types/node@22.13.1)(@types/react@18.3.18)(react-devtools-core@4.28.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
+        version: 21.0.1(@types/node@22.13.1)(@types/react@18.3.18)(react-devtools-core@4.28.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.7.3)
       tshy:
         specifier: 'catalog:'
         version: 3.0.2
       typescript:
         specifier: 'catalog:'
-        version: 5.5.4
+        version: 5.7.3
       typescript-eslint:
         specifier: 'catalog:'
-        version: 8.23.0(eslint@9.20.0(jiti@1.21.6))(typescript@5.5.4)
+        version: 8.23.0(eslint@9.20.0(jiti@1.21.6))(typescript@5.7.3)
 
   src/run:
     dependencies:
@@ -1258,16 +1258,16 @@ importers:
         version: 3.4.2
       tap:
         specifier: 'catalog:'
-        version: 21.0.1(@types/node@22.13.1)(@types/react@18.3.18)(react-devtools-core@4.28.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
+        version: 21.0.1(@types/node@22.13.1)(@types/react@18.3.18)(react-devtools-core@4.28.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.7.3)
       tshy:
         specifier: 'catalog:'
         version: 3.0.2
       typescript:
         specifier: 'catalog:'
-        version: 5.5.4
+        version: 5.7.3
       typescript-eslint:
         specifier: 'catalog:'
-        version: 8.23.0(eslint@9.20.0(jiti@1.21.6))(typescript@5.5.4)
+        version: 8.23.0(eslint@9.20.0(jiti@1.21.6))(typescript@5.7.3)
 
   src/satisfies:
     dependencies:
@@ -1304,16 +1304,16 @@ importers:
         version: 3.4.2
       tap:
         specifier: 'catalog:'
-        version: 21.0.1(@types/node@22.13.1)(@types/react@18.3.18)(react-devtools-core@4.28.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
+        version: 21.0.1(@types/node@22.13.1)(@types/react@18.3.18)(react-devtools-core@4.28.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.7.3)
       tshy:
         specifier: 'catalog:'
         version: 3.0.2
       typescript:
         specifier: 'catalog:'
-        version: 5.5.4
+        version: 5.7.3
       typescript-eslint:
         specifier: 'catalog:'
-        version: 8.23.0(eslint@9.20.0(jiti@1.21.6))(typescript@5.5.4)
+        version: 8.23.0(eslint@9.20.0(jiti@1.21.6))(typescript@5.7.3)
 
   src/semver:
     dependencies:
@@ -1350,16 +1350,16 @@ importers:
         version: 7.7.1
       tap:
         specifier: 'catalog:'
-        version: 21.0.1(@types/node@22.13.1)(@types/react@18.3.18)(react-devtools-core@4.28.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
+        version: 21.0.1(@types/node@22.13.1)(@types/react@18.3.18)(react-devtools-core@4.28.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.7.3)
       tshy:
         specifier: 'catalog:'
         version: 3.0.2
       typescript:
         specifier: 'catalog:'
-        version: 5.5.4
+        version: 5.7.3
       typescript-eslint:
         specifier: 'catalog:'
-        version: 8.23.0(eslint@9.20.0(jiti@1.21.6))(typescript@5.5.4)
+        version: 8.23.0(eslint@9.20.0(jiti@1.21.6))(typescript@5.7.3)
 
   src/spec:
     dependencies:
@@ -1393,16 +1393,16 @@ importers:
         version: 3.4.2
       tap:
         specifier: 'catalog:'
-        version: 21.0.1(@types/node@22.13.1)(@types/react@18.3.18)(react-devtools-core@4.28.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
+        version: 21.0.1(@types/node@22.13.1)(@types/react@18.3.18)(react-devtools-core@4.28.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.7.3)
       tshy:
         specifier: 'catalog:'
         version: 3.0.2
       typescript:
         specifier: 'catalog:'
-        version: 5.5.4
+        version: 5.7.3
       typescript-eslint:
         specifier: 'catalog:'
-        version: 8.23.0(eslint@9.20.0(jiti@1.21.6))(typescript@5.5.4)
+        version: 8.23.0(eslint@9.20.0(jiti@1.21.6))(typescript@5.7.3)
 
   src/tar:
     dependencies:
@@ -1445,16 +1445,16 @@ importers:
         version: 3.4.2
       tap:
         specifier: 'catalog:'
-        version: 21.0.1(@types/node@22.13.1)(@types/react@18.3.18)(react-devtools-core@4.28.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
+        version: 21.0.1(@types/node@22.13.1)(@types/react@18.3.18)(react-devtools-core@4.28.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.7.3)
       tshy:
         specifier: 'catalog:'
         version: 3.0.2
       typescript:
         specifier: 'catalog:'
-        version: 5.5.4
+        version: 5.7.3
       typescript-eslint:
         specifier: 'catalog:'
-        version: 8.23.0(eslint@9.20.0(jiti@1.21.6))(typescript@5.5.4)
+        version: 8.23.0(eslint@9.20.0(jiti@1.21.6))(typescript@5.7.3)
 
   src/types:
     dependencies:
@@ -1479,16 +1479,16 @@ importers:
         version: 3.4.2
       tap:
         specifier: 'catalog:'
-        version: 21.0.1(@types/node@22.13.1)(@types/react@18.3.18)(react-devtools-core@4.28.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
+        version: 21.0.1(@types/node@22.13.1)(@types/react@18.3.18)(react-devtools-core@4.28.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.7.3)
       tshy:
         specifier: 'catalog:'
         version: 3.0.2
       typescript:
         specifier: 'catalog:'
-        version: 5.5.4
+        version: 5.7.3
       typescript-eslint:
         specifier: 'catalog:'
-        version: 8.23.0(eslint@9.20.0(jiti@1.21.6))(typescript@5.5.4)
+        version: 8.23.0(eslint@9.20.0(jiti@1.21.6))(typescript@5.7.3)
 
   src/url-open:
     dependencies:
@@ -1513,16 +1513,16 @@ importers:
         version: 3.4.2
       tap:
         specifier: 'catalog:'
-        version: 21.0.1(@types/node@22.13.1)(@types/react@18.3.18)(react-devtools-core@4.28.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
+        version: 21.0.1(@types/node@22.13.1)(@types/react@18.3.18)(react-devtools-core@4.28.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.7.3)
       tshy:
         specifier: 'catalog:'
         version: 3.0.2
       typescript:
         specifier: 'catalog:'
-        version: 5.5.4
+        version: 5.7.3
       typescript-eslint:
         specifier: 'catalog:'
-        version: 8.23.0(eslint@9.20.0(jiti@1.21.6))(typescript@5.5.4)
+        version: 8.23.0(eslint@9.20.0(jiti@1.21.6))(typescript@5.7.3)
 
   src/vlt:
     dependencies:
@@ -1640,16 +1640,16 @@ importers:
         version: 4.28.5
       tap:
         specifier: 'catalog:'
-        version: 21.0.1(@types/node@22.13.1)(@types/react@18.3.18)(react-devtools-core@4.28.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
+        version: 21.0.1(@types/node@22.13.1)(@types/react@18.3.18)(react-devtools-core@4.28.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.7.3)
       tshy:
         specifier: 'catalog:'
         version: 3.0.2
       typescript:
         specifier: 'catalog:'
-        version: 5.5.4
+        version: 5.7.3
       typescript-eslint:
         specifier: 'catalog:'
-        version: 8.23.0(eslint@9.20.0(jiti@1.21.6))(typescript@5.5.4)
+        version: 8.23.0(eslint@9.20.0(jiti@1.21.6))(typescript@5.7.3)
 
   src/which:
     dependencies:
@@ -1674,16 +1674,16 @@ importers:
         version: 3.4.2
       tap:
         specifier: 'catalog:'
-        version: 21.0.1(@types/node@22.13.1)(@types/react@18.3.18)(react-devtools-core@4.28.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
+        version: 21.0.1(@types/node@22.13.1)(@types/react@18.3.18)(react-devtools-core@4.28.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.7.3)
       tshy:
         specifier: 'catalog:'
         version: 3.0.2
       typescript:
         specifier: 'catalog:'
-        version: 5.5.4
+        version: 5.7.3
       typescript-eslint:
         specifier: 'catalog:'
-        version: 8.23.0(eslint@9.20.0(jiti@1.21.6))(typescript@5.5.4)
+        version: 8.23.0(eslint@9.20.0(jiti@1.21.6))(typescript@5.7.3)
 
   src/workspaces:
     dependencies:
@@ -1735,16 +1735,16 @@ importers:
         version: 3.4.2
       tap:
         specifier: 'catalog:'
-        version: 21.0.1(@types/node@22.13.1)(@types/react@18.3.18)(react-devtools-core@4.28.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
+        version: 21.0.1(@types/node@22.13.1)(@types/react@18.3.18)(react-devtools-core@4.28.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.7.3)
       tshy:
         specifier: 'catalog:'
         version: 3.0.2
       typescript:
         specifier: 'catalog:'
-        version: 5.5.4
+        version: 5.7.3
       typescript-eslint:
         specifier: 'catalog:'
-        version: 8.23.0(eslint@9.20.0(jiti@1.21.6))(typescript@5.5.4)
+        version: 8.23.0(eslint@9.20.0(jiti@1.21.6))(typescript@5.7.3)
 
   src/xdg:
     devDependencies:
@@ -1765,37 +1765,37 @@ importers:
         version: 3.4.2
       tap:
         specifier: 'catalog:'
-        version: 21.0.1(@types/node@22.13.1)(@types/react@18.3.18)(react-devtools-core@4.28.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
+        version: 21.0.1(@types/node@22.13.1)(@types/react@18.3.18)(react-devtools-core@4.28.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.7.3)
       tshy:
         specifier: 'catalog:'
         version: 3.0.2
       typescript:
         specifier: 'catalog:'
-        version: 5.5.4
+        version: 5.7.3
       typescript-eslint:
         specifier: 'catalog:'
-        version: 8.23.0(eslint@9.20.0(jiti@1.21.6))(typescript@5.5.4)
+        version: 8.23.0(eslint@9.20.0(jiti@1.21.6))(typescript@5.7.3)
 
   www/docs:
     dependencies:
       '@astrojs/check':
         specifier: ^0.9.4
-        version: 0.9.4(prettier-plugin-astro@0.14.1)(prettier@3.4.2)(typescript@5.5.4)
+        version: 0.9.4(prettier-plugin-astro@0.14.1)(prettier@3.4.2)(typescript@5.7.3)
       '@astrojs/mdx':
         specifier: ^4.0.2
-        version: 4.0.2(astro@5.0.5(@types/node@22.13.1)(jiti@1.21.6)(rollup@4.24.0)(tsx@4.19.2)(typescript@5.5.4)(yaml@2.7.0))
+        version: 4.0.2(astro@5.0.5(@types/node@22.13.1)(jiti@1.21.6)(rollup@4.24.0)(tsx@4.19.2)(typescript@5.7.3)(yaml@2.7.0))
       '@astrojs/react':
         specifier: ^4.1.0
         version: 4.1.0(@types/node@22.13.1)(@types/react-dom@18.3.1)(@types/react@18.3.11)(jiti@1.21.6)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tsx@4.19.2)(yaml@2.7.0)
       '@astrojs/starlight':
         specifier: ^0.30.1
-        version: 0.30.1(astro@5.0.5(@types/node@22.13.1)(jiti@1.21.6)(rollup@4.24.0)(tsx@4.19.2)(typescript@5.5.4)(yaml@2.7.0))
+        version: 0.30.1(astro@5.0.5(@types/node@22.13.1)(jiti@1.21.6)(rollup@4.24.0)(tsx@4.19.2)(typescript@5.7.3)(yaml@2.7.0))
       '@astrojs/tailwind':
         specifier: ^5.1.3
-        version: 5.1.3(astro@5.0.5(@types/node@22.13.1)(jiti@1.21.6)(rollup@4.24.0)(tsx@4.19.2)(typescript@5.5.4)(yaml@2.7.0))(tailwindcss@3.4.14)
+        version: 5.1.3(astro@5.0.5(@types/node@22.13.1)(jiti@1.21.6)(rollup@4.24.0)(tsx@4.19.2)(typescript@5.7.3)(yaml@2.7.0))(tailwindcss@3.4.14)
       '@astrojs/vercel':
         specifier: ^8.0.1
-        version: 8.0.1(astro@5.0.5(@types/node@22.13.1)(jiti@1.21.6)(rollup@4.24.0)(tsx@4.19.2)(typescript@5.5.4)(yaml@2.7.0))(encoding@0.1.13)(react@18.3.1)(rollup@4.24.0)
+        version: 8.0.1(astro@5.0.5(@types/node@22.13.1)(jiti@1.21.6)(rollup@4.24.0)(tsx@4.19.2)(typescript@5.7.3)(yaml@2.7.0))(encoding@0.1.13)(react@18.3.1)(rollup@4.24.0)
       '@radix-ui/react-collapsible':
         specifier: ^1.1.1
         version: 1.1.1(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -1831,7 +1831,7 @@ importers:
         version: link:../../src/vlt
       astro:
         specifier: ^5.0.5
-        version: 5.0.5(@types/node@22.13.1)(jiti@1.21.6)(rollup@4.24.0)(tsx@4.19.2)(typescript@5.5.4)(yaml@2.7.0)
+        version: 5.0.5(@types/node@22.13.1)(jiti@1.21.6)(rollup@4.24.0)(tsx@4.19.2)(typescript@5.7.3)(yaml@2.7.0)
       class-variance-authority:
         specifier: ^0.7.0
         version: 0.7.0
@@ -1867,7 +1867,7 @@ importers:
         version: 1.7.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       starlight-links-validator:
         specifier: ^0.14.0
-        version: 0.14.0(@astrojs/starlight@0.30.1(astro@5.0.5(@types/node@22.13.1)(jiti@1.21.6)(rollup@4.24.0)(tsx@4.19.2)(typescript@5.5.4)(yaml@2.7.0)))
+        version: 0.14.0(@astrojs/starlight@0.30.1(astro@5.0.5(@types/node@22.13.1)(jiti@1.21.6)(rollup@4.24.0)(tsx@4.19.2)(typescript@5.7.3)(yaml@2.7.0)))
       tailwind-merge:
         specifier: ^2.5.2
         version: 2.5.4
@@ -1879,16 +1879,16 @@ importers:
         version: 1.0.7(tailwindcss@3.4.14)
       typedoc:
         specifier: ^0.27.6
-        version: 0.27.6(typescript@5.5.4)
+        version: 0.27.6(typescript@5.7.3)
       typedoc-plugin-frontmatter:
         specifier: ^1.1.2
-        version: 1.1.2(typedoc-plugin-markdown@4.4.0(typedoc@0.27.6(typescript@5.5.4)))
+        version: 1.1.2(typedoc-plugin-markdown@4.4.0(typedoc@0.27.6(typescript@5.7.3)))
       typedoc-plugin-markdown:
         specifier: ^4.4.0
-        version: 4.4.0(typedoc@0.27.6(typescript@5.5.4))
+        version: 4.4.0(typedoc@0.27.6(typescript@5.7.3))
       typedoc-plugin-remark:
         specifier: ^1.2.2
-        version: 1.2.2(typedoc-plugin-markdown@4.4.0(typedoc@0.27.6(typescript@5.5.4)))
+        version: 1.2.2(typedoc-plugin-markdown@4.4.0(typedoc@0.27.6(typescript@5.7.3)))
       vaul:
         specifier: ^1.1.1
         version: 1.1.1(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -1931,10 +1931,10 @@ importers:
         version: 3.4.2
       typescript:
         specifier: 'catalog:'
-        version: 5.5.4
+        version: 5.7.3
       typescript-eslint:
         specifier: 'catalog:'
-        version: 8.23.0(eslint@9.20.0(jiti@1.21.6))(typescript@5.5.4)
+        version: 8.23.0(eslint@9.20.0(jiti@1.21.6))(typescript@5.7.3)
       unified:
         specifier: ^11.0.5
         version: 11.0.5
@@ -7630,8 +7630,8 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
-  typescript@5.7.2:
-    resolution: {integrity: sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg==}
+  typescript@5.7.3:
+    resolution: {integrity: sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==}
     engines: {node: '>=14.17'}
     hasBin: true
 
@@ -8239,12 +8239,12 @@ snapshots:
       '@jridgewell/gen-mapping': 0.3.5
       '@jridgewell/trace-mapping': 0.3.25
 
-  '@astrojs/check@0.9.4(prettier-plugin-astro@0.14.1)(prettier@3.4.2)(typescript@5.5.4)':
+  '@astrojs/check@0.9.4(prettier-plugin-astro@0.14.1)(prettier@3.4.2)(typescript@5.7.3)':
     dependencies:
-      '@astrojs/language-server': 2.15.3(prettier-plugin-astro@0.14.1)(prettier@3.4.2)(typescript@5.5.4)
+      '@astrojs/language-server': 2.15.3(prettier-plugin-astro@0.14.1)(prettier@3.4.2)(typescript@5.7.3)
       chokidar: 4.0.1
       kleur: 4.1.5
-      typescript: 5.5.4
+      typescript: 5.7.3
       yargs: 17.7.2
     transitivePeerDependencies:
       - prettier
@@ -8254,12 +8254,12 @@ snapshots:
 
   '@astrojs/internal-helpers@0.4.2': {}
 
-  '@astrojs/language-server@2.15.3(prettier-plugin-astro@0.14.1)(prettier@3.4.2)(typescript@5.5.4)':
+  '@astrojs/language-server@2.15.3(prettier-plugin-astro@0.14.1)(prettier@3.4.2)(typescript@5.7.3)':
     dependencies:
       '@astrojs/compiler': 2.10.3
       '@astrojs/yaml2ts': 0.2.1
       '@jridgewell/sourcemap-codec': 1.5.0
-      '@volar/kit': 2.4.6(typescript@5.5.4)
+      '@volar/kit': 2.4.6(typescript@5.7.3)
       '@volar/language-core': 2.4.6
       '@volar/language-server': 2.4.6
       '@volar/language-service': 2.4.6
@@ -8304,12 +8304,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@astrojs/mdx@4.0.2(astro@5.0.5(@types/node@22.13.1)(jiti@1.21.6)(rollup@4.24.0)(tsx@4.19.2)(typescript@5.5.4)(yaml@2.7.0))':
+  '@astrojs/mdx@4.0.2(astro@5.0.5(@types/node@22.13.1)(jiti@1.21.6)(rollup@4.24.0)(tsx@4.19.2)(typescript@5.7.3)(yaml@2.7.0))':
     dependencies:
       '@astrojs/markdown-remark': 6.0.1
       '@mdx-js/mdx': 3.1.0(acorn@8.14.0)
       acorn: 8.14.0
-      astro: 5.0.5(@types/node@22.13.1)(jiti@1.21.6)(rollup@4.24.0)(tsx@4.19.2)(typescript@5.5.4)(yaml@2.7.0)
+      astro: 5.0.5(@types/node@22.13.1)(jiti@1.21.6)(rollup@4.24.0)(tsx@4.19.2)(typescript@5.7.3)(yaml@2.7.0)
       es-module-lexer: 1.5.4
       estree-util-visit: 2.0.0
       hast-util-to-html: 9.0.3
@@ -8356,16 +8356,16 @@ snapshots:
       stream-replace-string: 2.0.0
       zod: 3.23.8
 
-  '@astrojs/starlight@0.30.1(astro@5.0.5(@types/node@22.13.1)(jiti@1.21.6)(rollup@4.24.0)(tsx@4.19.2)(typescript@5.5.4)(yaml@2.7.0))':
+  '@astrojs/starlight@0.30.1(astro@5.0.5(@types/node@22.13.1)(jiti@1.21.6)(rollup@4.24.0)(tsx@4.19.2)(typescript@5.7.3)(yaml@2.7.0))':
     dependencies:
-      '@astrojs/mdx': 4.0.2(astro@5.0.5(@types/node@22.13.1)(jiti@1.21.6)(rollup@4.24.0)(tsx@4.19.2)(typescript@5.5.4)(yaml@2.7.0))
+      '@astrojs/mdx': 4.0.2(astro@5.0.5(@types/node@22.13.1)(jiti@1.21.6)(rollup@4.24.0)(tsx@4.19.2)(typescript@5.7.3)(yaml@2.7.0))
       '@astrojs/sitemap': 3.2.1
       '@pagefind/default-ui': 1.1.1
       '@types/hast': 3.0.4
       '@types/js-yaml': 4.0.9
       '@types/mdast': 4.0.4
-      astro: 5.0.5(@types/node@22.13.1)(jiti@1.21.6)(rollup@4.24.0)(tsx@4.19.2)(typescript@5.5.4)(yaml@2.7.0)
-      astro-expressive-code: 0.38.3(astro@5.0.5(@types/node@22.13.1)(jiti@1.21.6)(rollup@4.24.0)(tsx@4.19.2)(typescript@5.5.4)(yaml@2.7.0))
+      astro: 5.0.5(@types/node@22.13.1)(jiti@1.21.6)(rollup@4.24.0)(tsx@4.19.2)(typescript@5.7.3)(yaml@2.7.0)
+      astro-expressive-code: 0.38.3(astro@5.0.5(@types/node@22.13.1)(jiti@1.21.6)(rollup@4.24.0)(tsx@4.19.2)(typescript@5.7.3)(yaml@2.7.0))
       bcp-47: 2.1.0
       hast-util-from-html: 2.0.3
       hast-util-select: 6.0.3
@@ -8386,9 +8386,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@astrojs/tailwind@5.1.3(astro@5.0.5(@types/node@22.13.1)(jiti@1.21.6)(rollup@4.24.0)(tsx@4.19.2)(typescript@5.5.4)(yaml@2.7.0))(tailwindcss@3.4.14)':
+  '@astrojs/tailwind@5.1.3(astro@5.0.5(@types/node@22.13.1)(jiti@1.21.6)(rollup@4.24.0)(tsx@4.19.2)(typescript@5.7.3)(yaml@2.7.0))(tailwindcss@3.4.14)':
     dependencies:
-      astro: 5.0.5(@types/node@22.13.1)(jiti@1.21.6)(rollup@4.24.0)(tsx@4.19.2)(typescript@5.5.4)(yaml@2.7.0)
+      astro: 5.0.5(@types/node@22.13.1)(jiti@1.21.6)(rollup@4.24.0)(tsx@4.19.2)(typescript@5.7.3)(yaml@2.7.0)
       autoprefixer: 10.4.20(postcss@8.4.49)
       postcss: 8.4.49
       postcss-load-config: 4.0.2(postcss@8.4.49)
@@ -8408,13 +8408,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@astrojs/vercel@8.0.1(astro@5.0.5(@types/node@22.13.1)(jiti@1.21.6)(rollup@4.24.0)(tsx@4.19.2)(typescript@5.5.4)(yaml@2.7.0))(encoding@0.1.13)(react@18.3.1)(rollup@4.24.0)':
+  '@astrojs/vercel@8.0.1(astro@5.0.5(@types/node@22.13.1)(jiti@1.21.6)(rollup@4.24.0)(tsx@4.19.2)(typescript@5.7.3)(yaml@2.7.0))(encoding@0.1.13)(react@18.3.1)(rollup@4.24.0)':
     dependencies:
       '@astrojs/internal-helpers': 0.4.2
       '@vercel/analytics': 1.4.1(react@18.3.1)
       '@vercel/edge': 1.1.4
       '@vercel/nft': 0.27.9(encoding@0.1.13)(rollup@4.24.0)
-      astro: 5.0.5(@types/node@22.13.1)(jiti@1.21.6)(rollup@4.24.0)(tsx@4.19.2)(typescript@5.5.4)(yaml@2.7.0)
+      astro: 5.0.5(@types/node@22.13.1)(jiti@1.21.6)(rollup@4.24.0)(tsx@4.19.2)(typescript@5.7.3)(yaml@2.7.0)
       esbuild: 0.24.0
       fast-glob: 3.3.2
     transitivePeerDependencies:
@@ -9319,6 +9319,22 @@ snapshots:
       diff: 4.0.2
       make-error: 1.3.6
       typescript: 5.5.4
+      v8-compile-cache-lib: 3.0.1
+
+  '@isaacs/ts-node-temp-fork-for-pr-2009@10.9.7(@types/node@22.13.1)(typescript@5.7.3)':
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      '@tsconfig/node14': 14.1.2
+      '@tsconfig/node16': 16.1.3
+      '@tsconfig/node18': 18.2.4
+      '@tsconfig/node20': 20.1.4
+      '@types/node': 22.13.1
+      acorn: 8.14.0
+      acorn-walk: 8.3.3
+      arg: 4.1.3
+      diff: 4.0.2
+      make-error: 1.3.6
+      typescript: 5.7.3
       v8-compile-cache-lib: 3.0.1
 
   '@istanbuljs/schema@0.1.3': {}
@@ -10706,6 +10722,16 @@ snapshots:
       - '@types/node'
       - typescript
 
+  '@tapjs/typescript@3.0.0(@tapjs/core@4.0.0(@types/node@22.13.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@types/node@22.13.1)(typescript@5.7.3)':
+    dependencies:
+      '@isaacs/ts-node-temp-fork-for-pr-2009': 10.9.7(@types/node@22.13.1)(typescript@5.7.3)
+      '@tapjs/core': 4.0.0(@types/node@22.13.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+    transitivePeerDependencies:
+      - '@swc/core'
+      - '@swc/wasm'
+      - '@types/node'
+      - typescript
+
   '@tapjs/worker@4.0.0(@tapjs/core@4.0.0(@types/node@22.13.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))':
     dependencies:
       '@tapjs/core': 4.0.0(@types/node@22.13.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -10914,32 +10940,32 @@ snapshots:
 
   '@types/unist@3.0.3': {}
 
-  '@typescript-eslint/eslint-plugin@8.23.0(@typescript-eslint/parser@8.23.0(eslint@9.20.0(jiti@1.21.6))(typescript@5.5.4))(eslint@9.20.0(jiti@1.21.6))(typescript@5.5.4)':
+  '@typescript-eslint/eslint-plugin@8.23.0(@typescript-eslint/parser@8.23.0(eslint@9.20.0(jiti@1.21.6))(typescript@5.7.3))(eslint@9.20.0(jiti@1.21.6))(typescript@5.7.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.1
-      '@typescript-eslint/parser': 8.23.0(eslint@9.20.0(jiti@1.21.6))(typescript@5.5.4)
+      '@typescript-eslint/parser': 8.23.0(eslint@9.20.0(jiti@1.21.6))(typescript@5.7.3)
       '@typescript-eslint/scope-manager': 8.23.0
-      '@typescript-eslint/type-utils': 8.23.0(eslint@9.20.0(jiti@1.21.6))(typescript@5.5.4)
-      '@typescript-eslint/utils': 8.23.0(eslint@9.20.0(jiti@1.21.6))(typescript@5.5.4)
+      '@typescript-eslint/type-utils': 8.23.0(eslint@9.20.0(jiti@1.21.6))(typescript@5.7.3)
+      '@typescript-eslint/utils': 8.23.0(eslint@9.20.0(jiti@1.21.6))(typescript@5.7.3)
       '@typescript-eslint/visitor-keys': 8.23.0
       eslint: 9.20.0(jiti@1.21.6)
       graphemer: 1.4.0
       ignore: 5.3.2
       natural-compare: 1.4.0
-      ts-api-utils: 2.0.1(typescript@5.5.4)
-      typescript: 5.5.4
+      ts-api-utils: 2.0.1(typescript@5.7.3)
+      typescript: 5.7.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.23.0(eslint@9.20.0(jiti@1.21.6))(typescript@5.5.4)':
+  '@typescript-eslint/parser@8.23.0(eslint@9.20.0(jiti@1.21.6))(typescript@5.7.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.23.0
       '@typescript-eslint/types': 8.23.0
-      '@typescript-eslint/typescript-estree': 8.23.0(typescript@5.5.4)
+      '@typescript-eslint/typescript-estree': 8.23.0(typescript@5.7.3)
       '@typescript-eslint/visitor-keys': 8.23.0
       debug: 4.3.7
       eslint: 9.20.0(jiti@1.21.6)
-      typescript: 5.5.4
+      typescript: 5.7.3
     transitivePeerDependencies:
       - supports-color
 
@@ -10948,20 +10974,20 @@ snapshots:
       '@typescript-eslint/types': 8.23.0
       '@typescript-eslint/visitor-keys': 8.23.0
 
-  '@typescript-eslint/type-utils@8.23.0(eslint@9.20.0(jiti@1.21.6))(typescript@5.5.4)':
+  '@typescript-eslint/type-utils@8.23.0(eslint@9.20.0(jiti@1.21.6))(typescript@5.7.3)':
     dependencies:
-      '@typescript-eslint/typescript-estree': 8.23.0(typescript@5.5.4)
-      '@typescript-eslint/utils': 8.23.0(eslint@9.20.0(jiti@1.21.6))(typescript@5.5.4)
+      '@typescript-eslint/typescript-estree': 8.23.0(typescript@5.7.3)
+      '@typescript-eslint/utils': 8.23.0(eslint@9.20.0(jiti@1.21.6))(typescript@5.7.3)
       debug: 4.3.7
       eslint: 9.20.0(jiti@1.21.6)
-      ts-api-utils: 2.0.1(typescript@5.5.4)
-      typescript: 5.5.4
+      ts-api-utils: 2.0.1(typescript@5.7.3)
+      typescript: 5.7.3
     transitivePeerDependencies:
       - supports-color
 
   '@typescript-eslint/types@8.23.0': {}
 
-  '@typescript-eslint/typescript-estree@8.23.0(typescript@5.5.4)':
+  '@typescript-eslint/typescript-estree@8.23.0(typescript@5.7.3)':
     dependencies:
       '@typescript-eslint/types': 8.23.0
       '@typescript-eslint/visitor-keys': 8.23.0
@@ -10970,19 +10996,19 @@ snapshots:
       is-glob: 4.0.3
       minimatch: 9.0.5
       semver: 7.7.1
-      ts-api-utils: 2.0.1(typescript@5.5.4)
-      typescript: 5.5.4
+      ts-api-utils: 2.0.1(typescript@5.7.3)
+      typescript: 5.7.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.23.0(eslint@9.20.0(jiti@1.21.6))(typescript@5.5.4)':
+  '@typescript-eslint/utils@8.23.0(eslint@9.20.0(jiti@1.21.6))(typescript@5.7.3)':
     dependencies:
       '@eslint-community/eslint-utils': 4.4.0(eslint@9.20.0(jiti@1.21.6))
       '@typescript-eslint/scope-manager': 8.23.0
       '@typescript-eslint/types': 8.23.0
-      '@typescript-eslint/typescript-estree': 8.23.0(typescript@5.5.4)
+      '@typescript-eslint/typescript-estree': 8.23.0(typescript@5.7.3)
       eslint: 9.20.0(jiti@1.21.6)
-      typescript: 5.5.4
+      typescript: 5.7.3
     transitivePeerDependencies:
       - supports-color
 
@@ -11047,13 +11073,13 @@ snapshots:
       chai: 5.1.2
       tinyrainbow: 1.2.0
 
-  '@vitest/mocker@2.1.9(msw@2.7.0(@types/node@22.13.1)(typescript@5.5.4))(vite@5.4.14(@types/node@22.13.1))':
+  '@vitest/mocker@2.1.9(msw@2.7.0(@types/node@22.13.1)(typescript@5.7.3))(vite@5.4.14(@types/node@22.13.1))':
     dependencies:
       '@vitest/spy': 2.1.9
       estree-walker: 3.0.3
       magic-string: 0.30.15
     optionalDependencies:
-      msw: 2.7.0(@types/node@22.13.1)(typescript@5.5.4)
+      msw: 2.7.0(@types/node@22.13.1)(typescript@5.7.3)
       vite: 5.4.14(@types/node@22.13.1)
 
   '@vitest/pretty-format@2.1.9':
@@ -11081,12 +11107,12 @@ snapshots:
       loupe: 3.1.2
       tinyrainbow: 1.2.0
 
-  '@volar/kit@2.4.6(typescript@5.5.4)':
+  '@volar/kit@2.4.6(typescript@5.7.3)':
     dependencies:
       '@volar/language-service': 2.4.6
       '@volar/typescript': 2.4.6
       typesafe-path: 0.2.2
-      typescript: 5.5.4
+      typescript: 5.7.3
       vscode-languageserver-textdocument: 1.0.12
       vscode-uri: 3.0.8
 
@@ -11296,12 +11322,12 @@ snapshots:
 
   astring@1.9.0: {}
 
-  astro-expressive-code@0.38.3(astro@5.0.5(@types/node@22.13.1)(jiti@1.21.6)(rollup@4.24.0)(tsx@4.19.2)(typescript@5.5.4)(yaml@2.7.0)):
+  astro-expressive-code@0.38.3(astro@5.0.5(@types/node@22.13.1)(jiti@1.21.6)(rollup@4.24.0)(tsx@4.19.2)(typescript@5.7.3)(yaml@2.7.0)):
     dependencies:
-      astro: 5.0.5(@types/node@22.13.1)(jiti@1.21.6)(rollup@4.24.0)(tsx@4.19.2)(typescript@5.5.4)(yaml@2.7.0)
+      astro: 5.0.5(@types/node@22.13.1)(jiti@1.21.6)(rollup@4.24.0)(tsx@4.19.2)(typescript@5.7.3)(yaml@2.7.0)
       rehype-expressive-code: 0.38.3
 
-  astro@5.0.5(@types/node@22.13.1)(jiti@1.21.6)(rollup@4.24.0)(tsx@4.19.2)(typescript@5.5.4)(yaml@2.7.0):
+  astro@5.0.5(@types/node@22.13.1)(jiti@1.21.6)(rollup@4.24.0)(tsx@4.19.2)(typescript@5.7.3)(yaml@2.7.0):
     dependencies:
       '@astrojs/compiler': 2.10.3
       '@astrojs/internal-helpers': 0.4.2
@@ -11348,7 +11374,7 @@ snapshots:
       semver: 7.7.1
       shiki: 1.24.2
       tinyexec: 0.3.1
-      tsconfck: 3.1.4(typescript@5.5.4)
+      tsconfck: 3.1.4(typescript@5.7.3)
       ultrahtml: 1.5.3
       unist-util-visit: 5.0.0
       vfile: 6.0.3
@@ -11360,7 +11386,7 @@ snapshots:
       yocto-spinner: 0.1.2
       zod: 3.23.8
       zod-to-json-schema: 3.23.5(zod@3.23.8)
-      zod-to-ts: 1.2.0(typescript@5.5.4)(zod@3.23.8)
+      zod-to-ts: 1.2.0(typescript@5.7.3)(zod@3.23.8)
     optionalDependencies:
       sharp: 0.33.5
     transitivePeerDependencies:
@@ -13770,7 +13796,7 @@ snapshots:
 
   ms@2.1.3: {}
 
-  msw@2.7.0(@types/node@22.13.1)(typescript@5.5.4):
+  msw@2.7.0(@types/node@22.13.1)(typescript@5.7.3):
     dependencies:
       '@bundled-es-modules/cookie': 2.0.1
       '@bundled-es-modules/statuses': 1.0.1
@@ -13791,7 +13817,7 @@ snapshots:
       type-fest: 4.30.0
       yargs: 17.7.2
     optionalDependencies:
-      typescript: 5.5.4
+      typescript: 5.7.3
     transitivePeerDependencies:
       - '@types/node'
 
@@ -14940,9 +14966,9 @@ snapshots:
 
   stackback@0.0.2: {}
 
-  starlight-links-validator@0.14.0(@astrojs/starlight@0.30.1(astro@5.0.5(@types/node@22.13.1)(jiti@1.21.6)(rollup@4.24.0)(tsx@4.19.2)(typescript@5.5.4)(yaml@2.7.0))):
+  starlight-links-validator@0.14.0(@astrojs/starlight@0.30.1(astro@5.0.5(@types/node@22.13.1)(jiti@1.21.6)(rollup@4.24.0)(tsx@4.19.2)(typescript@5.7.3)(yaml@2.7.0))):
     dependencies:
-      '@astrojs/starlight': 0.30.1(astro@5.0.5(@types/node@22.13.1)(jiti@1.21.6)(rollup@4.24.0)(tsx@4.19.2)(typescript@5.5.4)(yaml@2.7.0))
+      '@astrojs/starlight': 0.30.1(astro@5.0.5(@types/node@22.13.1)(jiti@1.21.6)(rollup@4.24.0)(tsx@4.19.2)(typescript@5.7.3)(yaml@2.7.0))
       '@types/picomatch': 3.0.1
       github-slugger: 2.0.0
       hast-util-from-html: 2.0.3
@@ -15146,7 +15172,7 @@ snapshots:
       yaml: 2.7.0
       yaml-types: 0.4.0(yaml@2.7.0)
 
-  tap@21.0.1(@types/node@22.13.1)(@types/react@18.3.18)(react-devtools-core@4.28.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4):
+  tap@21.0.1(@types/node@22.13.1)(@types/react@18.3.18)(react-devtools-core@4.28.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.7.3):
     dependencies:
       '@tapjs/after': 3.0.0(@tapjs/core@4.0.0(@types/node@22.13.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       '@tapjs/after-each': 4.0.0(@tapjs/core@4.0.0(@types/node@22.13.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
@@ -15165,7 +15191,7 @@ snapshots:
       '@tapjs/spawn': 4.0.0(@tapjs/core@4.0.0(@types/node@22.13.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       '@tapjs/stdin': 4.0.0(@tapjs/core@4.0.0(@types/node@22.13.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       '@tapjs/test': 4.0.0(@tapjs/core@4.0.0(@types/node@22.13.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@types/node@22.13.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@tapjs/typescript': 3.0.0(@tapjs/core@4.0.0(@types/node@22.13.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@types/node@22.13.1)(typescript@5.5.4)
+      '@tapjs/typescript': 3.0.0(@tapjs/core@4.0.0(@types/node@22.13.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@types/node@22.13.1)(typescript@5.7.3)
       '@tapjs/worker': 4.0.0(@tapjs/core@4.0.0(@types/node@22.13.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       resolve-import: 2.0.0
     transitivePeerDependencies:
@@ -15281,15 +15307,15 @@ snapshots:
 
   trough@2.2.0: {}
 
-  ts-api-utils@2.0.1(typescript@5.5.4):
+  ts-api-utils@2.0.1(typescript@5.7.3):
     dependencies:
-      typescript: 5.5.4
+      typescript: 5.7.3
 
   ts-interface-checker@0.1.13: {}
 
-  tsconfck@3.1.4(typescript@5.5.4):
+  tsconfck@3.1.4(typescript@5.7.3):
     optionalDependencies:
-      typescript: 5.5.4
+      typescript: 5.7.3
 
   tsconfig-paths@3.15.0:
     dependencies:
@@ -15309,7 +15335,7 @@ snapshots:
       resolve-import: 2.0.0
       rimraf: 6.0.1
       sync-content: 2.0.1
-      typescript: 5.7.2
+      typescript: 5.7.3
       walk-up-path: 4.0.0
 
   tslib@2.7.0: {}
@@ -15370,34 +15396,34 @@ snapshots:
       is-typed-array: 1.1.13
       possible-typed-array-names: 1.0.0
 
-  typedoc-plugin-frontmatter@1.1.2(typedoc-plugin-markdown@4.4.0(typedoc@0.27.6(typescript@5.5.4))):
+  typedoc-plugin-frontmatter@1.1.2(typedoc-plugin-markdown@4.4.0(typedoc@0.27.6(typescript@5.7.3))):
     dependencies:
-      typedoc-plugin-markdown: 4.4.0(typedoc@0.27.6(typescript@5.5.4))
+      typedoc-plugin-markdown: 4.4.0(typedoc@0.27.6(typescript@5.7.3))
       yaml: 2.6.1
 
-  typedoc-plugin-markdown@4.4.0(typedoc@0.27.6(typescript@5.5.4)):
+  typedoc-plugin-markdown@4.4.0(typedoc@0.27.6(typescript@5.7.3)):
     dependencies:
-      typedoc: 0.27.6(typescript@5.5.4)
+      typedoc: 0.27.6(typescript@5.7.3)
 
-  typedoc-plugin-remark@1.2.2(typedoc-plugin-markdown@4.4.0(typedoc@0.27.6(typescript@5.5.4))):
+  typedoc-plugin-remark@1.2.2(typedoc-plugin-markdown@4.4.0(typedoc@0.27.6(typescript@5.7.3))):
     dependencies:
       remark: 15.0.1
       remark-frontmatter: 5.0.0
       remark-gfm: 4.0.0
       remark-mdx: 3.1.0
       to-vfile: 8.0.0
-      typedoc-plugin-markdown: 4.4.0(typedoc@0.27.6(typescript@5.5.4))
+      typedoc-plugin-markdown: 4.4.0(typedoc@0.27.6(typescript@5.7.3))
       unist-util-visit: 5.0.0
     transitivePeerDependencies:
       - supports-color
 
-  typedoc@0.27.6(typescript@5.5.4):
+  typedoc@0.27.6(typescript@5.7.3):
     dependencies:
       '@gerrit0/mini-shiki': 1.24.2
       lunr: 2.3.9
       markdown-it: 14.1.0
       minimatch: 9.0.5
-      typescript: 5.5.4
+      typescript: 5.7.3
       yaml: 2.6.1
 
   typesafe-path@0.2.2: {}
@@ -15406,19 +15432,19 @@ snapshots:
     dependencies:
       semver: 7.7.1
 
-  typescript-eslint@8.23.0(eslint@9.20.0(jiti@1.21.6))(typescript@5.5.4):
+  typescript-eslint@8.23.0(eslint@9.20.0(jiti@1.21.6))(typescript@5.7.3):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 8.23.0(@typescript-eslint/parser@8.23.0(eslint@9.20.0(jiti@1.21.6))(typescript@5.5.4))(eslint@9.20.0(jiti@1.21.6))(typescript@5.5.4)
-      '@typescript-eslint/parser': 8.23.0(eslint@9.20.0(jiti@1.21.6))(typescript@5.5.4)
-      '@typescript-eslint/utils': 8.23.0(eslint@9.20.0(jiti@1.21.6))(typescript@5.5.4)
+      '@typescript-eslint/eslint-plugin': 8.23.0(@typescript-eslint/parser@8.23.0(eslint@9.20.0(jiti@1.21.6))(typescript@5.7.3))(eslint@9.20.0(jiti@1.21.6))(typescript@5.7.3)
+      '@typescript-eslint/parser': 8.23.0(eslint@9.20.0(jiti@1.21.6))(typescript@5.7.3)
+      '@typescript-eslint/utils': 8.23.0(eslint@9.20.0(jiti@1.21.6))(typescript@5.7.3)
       eslint: 9.20.0(jiti@1.21.6)
-      typescript: 5.5.4
+      typescript: 5.7.3
     transitivePeerDependencies:
       - supports-color
 
   typescript@5.5.4: {}
 
-  typescript@5.7.2: {}
+  typescript@5.7.3: {}
 
   uc.micro@2.1.0: {}
 
@@ -15643,10 +15669,10 @@ snapshots:
     optionalDependencies:
       vite: 6.0.3(@types/node@22.13.1)(jiti@1.21.6)(tsx@4.19.2)(yaml@2.7.0)
 
-  vitest@2.1.9(@types/node@22.13.1)(jsdom@25.0.1)(msw@2.7.0(@types/node@22.13.1)(typescript@5.5.4)):
+  vitest@2.1.9(@types/node@22.13.1)(jsdom@25.0.1)(msw@2.7.0(@types/node@22.13.1)(typescript@5.7.3)):
     dependencies:
       '@vitest/expect': 2.1.9
-      '@vitest/mocker': 2.1.9(msw@2.7.0(@types/node@22.13.1)(typescript@5.5.4))(vite@5.4.14(@types/node@22.13.1))
+      '@vitest/mocker': 2.1.9(msw@2.7.0(@types/node@22.13.1)(typescript@5.7.3))(vite@5.4.14(@types/node@22.13.1))
       '@vitest/pretty-format': 2.1.9
       '@vitest/runner': 2.1.9
       '@vitest/snapshot': 2.1.9
@@ -15964,9 +15990,9 @@ snapshots:
     dependencies:
       zod: 3.23.8
 
-  zod-to-ts@1.2.0(typescript@5.5.4)(zod@3.23.8):
+  zod-to-ts@1.2.0(typescript@5.7.3)(zod@3.23.8):
     dependencies:
-      typescript: 5.5.4
+      typescript: 5.7.3
       zod: 3.23.8
 
   zod@3.23.8: {}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -23,6 +23,6 @@ catalog:
   tap: ^21.0.1
   tar: ^7.4.3
   tshy: ^3.0.2
-  typescript: 5.5.4
+  typescript: 5.7.3
   typescript-eslint: ^8.23.0
   walk-up-path: ^4.0.0

--- a/scripts/consistent-package-json.js
+++ b/scripts/consistent-package-json.js
@@ -248,13 +248,13 @@ const fixScripts = async ws => {
       {
         test: 'tap',
         snap: 'tap',
+        posttest: 'tsc --project tsconfig.test.json',
       }
     : ws.pj.devDependencies.vitest ?
       {
         test: 'vitest',
         snap: 'vitest --no-watch -u',
-        posttest:
-          ws.pj.name !== '@vltpkg/docs' ? 'tsc --noEmit' : undefined,
+        posttest: 'tsc --project tsconfig.test.json',
       }
     : {},
     ws.pj.devDependencies.tshy ?
@@ -314,6 +314,21 @@ const fixTools = async ws => {
       },
       ['extends'],
     )
+  }
+  if (ws.pj.devDependencies.vitest || ws.pj.devDependencies.tap) {
+    writeJson(resolve(ws.dir, 'tsconfig.test.json'), {
+      extends: './tsconfig.json',
+      include: [
+        './test/**/*.ts',
+        './test/**/*.mts',
+        './test/**/*.tsx',
+        './test/**/*.json',
+      ],
+      compilerOptions: {
+        noEmit: true,
+        incremental: false,
+      },
+    })
   }
   if (ws.pj.devDependencies.prettier) {
     ws.pj.prettier = `${ws.relDir}.prettierrc.js`

--- a/src/cache-unzip/package.json
+++ b/src/cache-unzip/package.json
@@ -53,6 +53,7 @@
     "snap": "tap",
     "pretest": "tshy",
     "test": "tap",
+    "posttest": "tsc --project tsconfig.test.json",
     "watch": "tshy --watch"
   },
   "tap": {

--- a/src/cache-unzip/tsconfig.test.json
+++ b/src/cache-unzip/tsconfig.test.json
@@ -1,0 +1,13 @@
+{
+  "extends": "./tsconfig.json",
+  "include": [
+    "./test/**/*.ts",
+    "./test/**/*.mts",
+    "./test/**/*.tsx",
+    "./test/**/*.json"
+  ],
+  "compilerOptions": {
+    "noEmit": true,
+    "incremental": false
+  }
+}

--- a/src/cache/package.json
+++ b/src/cache/package.json
@@ -53,6 +53,7 @@
     "snap": "tap",
     "pretest": "tshy",
     "test": "tap",
+    "posttest": "tsc --project tsconfig.test.json",
     "watch": "tshy --watch"
   },
   "tap": {

--- a/src/cache/tsconfig.test.json
+++ b/src/cache/tsconfig.test.json
@@ -1,0 +1,13 @@
+{
+  "extends": "./tsconfig.json",
+  "include": [
+    "./test/**/*.ts",
+    "./test/**/*.mts",
+    "./test/**/*.tsx",
+    "./test/**/*.json"
+  ],
+  "compilerOptions": {
+    "noEmit": true,
+    "incremental": false
+  }
+}

--- a/src/dep-id/package.json
+++ b/src/dep-id/package.json
@@ -52,6 +52,7 @@
     "snap": "tap",
     "pretest": "tshy",
     "test": "tap",
+    "posttest": "tsc --project tsconfig.test.json",
     "watch": "tshy --watch"
   },
   "tap": {

--- a/src/dep-id/tsconfig.test.json
+++ b/src/dep-id/tsconfig.test.json
@@ -1,0 +1,13 @@
+{
+  "extends": "./tsconfig.json",
+  "include": [
+    "./test/**/*.ts",
+    "./test/**/*.mts",
+    "./test/**/*.tsx",
+    "./test/**/*.json"
+  ],
+  "compilerOptions": {
+    "noEmit": true,
+    "incremental": false
+  }
+}

--- a/src/dot-prop/package.json
+++ b/src/dot-prop/package.json
@@ -47,6 +47,7 @@
     "snap": "tap",
     "pretest": "tshy",
     "test": "tap",
+    "posttest": "tsc --project tsconfig.test.json",
     "watch": "tshy --watch"
   },
   "tap": {

--- a/src/dot-prop/tsconfig.test.json
+++ b/src/dot-prop/tsconfig.test.json
@@ -1,0 +1,13 @@
+{
+  "extends": "./tsconfig.json",
+  "include": [
+    "./test/**/*.ts",
+    "./test/**/*.mts",
+    "./test/**/*.tsx",
+    "./test/**/*.json"
+  ],
+  "compilerOptions": {
+    "noEmit": true,
+    "incremental": false
+  }
+}

--- a/src/error-cause/package.json
+++ b/src/error-cause/package.json
@@ -46,6 +46,7 @@
     "snap": "tap",
     "pretest": "tshy",
     "test": "tap",
+    "posttest": "tsc --project tsconfig.test.json",
     "watch": "tshy --watch"
   },
   "tap": {

--- a/src/error-cause/tsconfig.test.json
+++ b/src/error-cause/tsconfig.test.json
@@ -1,0 +1,13 @@
+{
+  "extends": "./tsconfig.json",
+  "include": [
+    "./test/**/*.ts",
+    "./test/**/*.mts",
+    "./test/**/*.tsx",
+    "./test/**/*.json"
+  ],
+  "compilerOptions": {
+    "noEmit": true,
+    "incremental": false
+  }
+}

--- a/src/fast-split/package.json
+++ b/src/fast-split/package.json
@@ -47,6 +47,7 @@
     "snap": "tap",
     "pretest": "tshy",
     "test": "tap",
+    "posttest": "tsc --project tsconfig.test.json",
     "watch": "tshy --watch"
   },
   "tap": {

--- a/src/fast-split/tsconfig.test.json
+++ b/src/fast-split/tsconfig.test.json
@@ -1,0 +1,13 @@
+{
+  "extends": "./tsconfig.json",
+  "include": [
+    "./test/**/*.ts",
+    "./test/**/*.mts",
+    "./test/**/*.tsx",
+    "./test/**/*.json"
+  ],
+  "compilerOptions": {
+    "noEmit": true,
+    "incremental": false
+  }
+}

--- a/src/git-scp-url/package.json
+++ b/src/git-scp-url/package.json
@@ -46,6 +46,7 @@
     "snap": "tap",
     "pretest": "tshy",
     "test": "tap",
+    "posttest": "tsc --project tsconfig.test.json",
     "watch": "tshy --watch"
   },
   "tap": {

--- a/src/git-scp-url/tsconfig.test.json
+++ b/src/git-scp-url/tsconfig.test.json
@@ -1,0 +1,13 @@
+{
+  "extends": "./tsconfig.json",
+  "include": [
+    "./test/**/*.ts",
+    "./test/**/*.mts",
+    "./test/**/*.tsx",
+    "./test/**/*.json"
+  ],
+  "compilerOptions": {
+    "noEmit": true,
+    "incremental": false
+  }
+}

--- a/src/git/package.json
+++ b/src/git/package.json
@@ -61,6 +61,7 @@
     "snap": "tap",
     "pretest": "tshy",
     "test": "tap",
+    "posttest": "tsc --project tsconfig.test.json",
     "watch": "tshy --watch"
   },
   "tap": {

--- a/src/git/tsconfig.test.json
+++ b/src/git/tsconfig.test.json
@@ -1,0 +1,13 @@
+{
+  "extends": "./tsconfig.json",
+  "include": [
+    "./test/**/*.ts",
+    "./test/**/*.mts",
+    "./test/**/*.tsx",
+    "./test/**/*.json"
+  ],
+  "compilerOptions": {
+    "noEmit": true,
+    "incremental": false
+  }
+}

--- a/src/graph/package.json
+++ b/src/graph/package.json
@@ -69,6 +69,7 @@
     "snap": "tap",
     "pretest": "tshy",
     "test": "tap",
+    "posttest": "tsc --project tsconfig.test.json",
     "watch": "tshy --watch"
   },
   "tap": {

--- a/src/graph/tsconfig.test.json
+++ b/src/graph/tsconfig.test.json
@@ -1,0 +1,13 @@
+{
+  "extends": "./tsconfig.json",
+  "include": [
+    "./test/**/*.ts",
+    "./test/**/*.mts",
+    "./test/**/*.tsx",
+    "./test/**/*.json"
+  ],
+  "compilerOptions": {
+    "noEmit": true,
+    "incremental": false
+  }
+}

--- a/src/gui/package.json
+++ b/src/gui/package.json
@@ -79,7 +79,7 @@
     "prepare": "node scripts/prepare.js --production",
     "snap": "vitest --no-watch -u",
     "test": "vitest",
-    "posttest": "tsc --noEmit",
+    "posttest": "tsc --project tsconfig.test.json",
     "watch": "node scripts/prepare.js --watch"
   },
   "prettier": "../../.prettierrc.js",

--- a/src/gui/tsconfig.test.json
+++ b/src/gui/tsconfig.test.json
@@ -1,0 +1,13 @@
+{
+  "extends": "./tsconfig.json",
+  "include": [
+    "./test/**/*.ts",
+    "./test/**/*.mts",
+    "./test/**/*.tsx",
+    "./test/**/*.json"
+  ],
+  "compilerOptions": {
+    "noEmit": true,
+    "incremental": false
+  }
+}

--- a/src/keychain/package.json
+++ b/src/keychain/package.json
@@ -53,6 +53,7 @@
     "snap": "tap",
     "pretest": "tshy",
     "test": "tap",
+    "posttest": "tsc --project tsconfig.test.json",
     "watch": "tshy --watch"
   },
   "tap": {

--- a/src/keychain/tsconfig.test.json
+++ b/src/keychain/tsconfig.test.json
@@ -1,0 +1,13 @@
+{
+  "extends": "./tsconfig.json",
+  "include": [
+    "./test/**/*.ts",
+    "./test/**/*.mts",
+    "./test/**/*.tsx",
+    "./test/**/*.json"
+  ],
+  "compilerOptions": {
+    "noEmit": true,
+    "incremental": false
+  }
+}

--- a/src/output/package.json
+++ b/src/output/package.json
@@ -46,6 +46,7 @@
     "snap": "tap",
     "pretest": "tshy",
     "test": "tap",
+    "posttest": "tsc --project tsconfig.test.json",
     "watch": "tshy --watch"
   },
   "tap": {

--- a/src/output/tsconfig.test.json
+++ b/src/output/tsconfig.test.json
@@ -1,0 +1,13 @@
+{
+  "extends": "./tsconfig.json",
+  "include": [
+    "./test/**/*.ts",
+    "./test/**/*.mts",
+    "./test/**/*.tsx",
+    "./test/**/*.json"
+  ],
+  "compilerOptions": {
+    "noEmit": true,
+    "incremental": false
+  }
+}

--- a/src/package-info/package.json
+++ b/src/package-info/package.json
@@ -63,6 +63,7 @@
     "snap": "tap",
     "pretest": "tshy",
     "test": "tap",
+    "posttest": "tsc --project tsconfig.test.json",
     "watch": "tshy --watch"
   },
   "tap": {

--- a/src/package-info/tsconfig.test.json
+++ b/src/package-info/tsconfig.test.json
@@ -1,0 +1,13 @@
+{
+  "extends": "./tsconfig.json",
+  "include": [
+    "./test/**/*.ts",
+    "./test/**/*.mts",
+    "./test/**/*.tsx",
+    "./test/**/*.json"
+  ],
+  "compilerOptions": {
+    "noEmit": true,
+    "incremental": false
+  }
+}

--- a/src/package-json/package.json
+++ b/src/package-json/package.json
@@ -51,6 +51,7 @@
     "snap": "tap",
     "pretest": "tshy",
     "test": "tap",
+    "posttest": "tsc --project tsconfig.test.json",
     "watch": "tshy --watch"
   },
   "tap": {

--- a/src/package-json/tsconfig.test.json
+++ b/src/package-json/tsconfig.test.json
@@ -1,0 +1,13 @@
+{
+  "extends": "./tsconfig.json",
+  "include": [
+    "./test/**/*.ts",
+    "./test/**/*.mts",
+    "./test/**/*.tsx",
+    "./test/**/*.json"
+  ],
+  "compilerOptions": {
+    "noEmit": true,
+    "incremental": false
+  }
+}

--- a/src/pick-manifest/package.json
+++ b/src/pick-manifest/package.json
@@ -56,6 +56,7 @@
     "snap": "tap",
     "pretest": "tshy",
     "test": "tap",
+    "posttest": "tsc --project tsconfig.test.json",
     "watch": "tshy --watch"
   },
   "tap": {

--- a/src/pick-manifest/tsconfig.test.json
+++ b/src/pick-manifest/tsconfig.test.json
@@ -1,0 +1,13 @@
+{
+  "extends": "./tsconfig.json",
+  "include": [
+    "./test/**/*.ts",
+    "./test/**/*.mts",
+    "./test/**/*.tsx",
+    "./test/**/*.json"
+  ],
+  "compilerOptions": {
+    "noEmit": true,
+    "incremental": false
+  }
+}

--- a/src/promise-spawn/package.json
+++ b/src/promise-spawn/package.json
@@ -50,6 +50,7 @@
     "snap": "tap",
     "pretest": "tshy",
     "test": "tap",
+    "posttest": "tsc --project tsconfig.test.json",
     "watch": "tshy --watch"
   },
   "tap": {

--- a/src/promise-spawn/tsconfig.test.json
+++ b/src/promise-spawn/tsconfig.test.json
@@ -1,0 +1,13 @@
+{
+  "extends": "./tsconfig.json",
+  "include": [
+    "./test/**/*.ts",
+    "./test/**/*.mts",
+    "./test/**/*.tsx",
+    "./test/**/*.json"
+  ],
+  "compilerOptions": {
+    "noEmit": true,
+    "incremental": false
+  }
+}

--- a/src/query/package.json
+++ b/src/query/package.json
@@ -54,6 +54,7 @@
     "snap": "tap",
     "pretest": "tshy",
     "test": "tap",
+    "posttest": "tsc --project tsconfig.test.json",
     "watch": "tshy --watch"
   },
   "tap": {

--- a/src/query/tsconfig.test.json
+++ b/src/query/tsconfig.test.json
@@ -1,0 +1,13 @@
+{
+  "extends": "./tsconfig.json",
+  "include": [
+    "./test/**/*.ts",
+    "./test/**/*.mts",
+    "./test/**/*.tsx",
+    "./test/**/*.json"
+  ],
+  "compilerOptions": {
+    "noEmit": true,
+    "incremental": false
+  }
+}

--- a/src/registry-client/package.json
+++ b/src/registry-client/package.json
@@ -61,6 +61,7 @@
     "snap": "tap",
     "pretest": "tshy",
     "test": "tap",
+    "posttest": "tsc --project tsconfig.test.json",
     "watch": "tshy --watch"
   },
   "tap": {

--- a/src/registry-client/tsconfig.test.json
+++ b/src/registry-client/tsconfig.test.json
@@ -1,0 +1,13 @@
+{
+  "extends": "./tsconfig.json",
+  "include": [
+    "./test/**/*.ts",
+    "./test/**/*.mts",
+    "./test/**/*.tsx",
+    "./test/**/*.json"
+  ],
+  "compilerOptions": {
+    "noEmit": true,
+    "incremental": false
+  }
+}

--- a/src/rollback-remove/package.json
+++ b/src/rollback-remove/package.json
@@ -50,6 +50,7 @@
     "snap": "tap",
     "pretest": "tshy",
     "test": "tap",
+    "posttest": "tsc --project tsconfig.test.json",
     "watch": "tshy --watch"
   },
   "tap": {

--- a/src/rollback-remove/tsconfig.test.json
+++ b/src/rollback-remove/tsconfig.test.json
@@ -1,0 +1,13 @@
+{
+  "extends": "./tsconfig.json",
+  "include": [
+    "./test/**/*.ts",
+    "./test/**/*.mts",
+    "./test/**/*.tsx",
+    "./test/**/*.json"
+  ],
+  "compilerOptions": {
+    "noEmit": true,
+    "incremental": false
+  }
+}

--- a/src/run/package.json
+++ b/src/run/package.json
@@ -54,6 +54,7 @@
     "snap": "tap",
     "pretest": "tshy",
     "test": "tap",
+    "posttest": "tsc --project tsconfig.test.json",
     "watch": "tshy --watch"
   },
   "tap": {

--- a/src/run/tsconfig.test.json
+++ b/src/run/tsconfig.test.json
@@ -1,0 +1,13 @@
+{
+  "extends": "./tsconfig.json",
+  "include": [
+    "./test/**/*.ts",
+    "./test/**/*.mts",
+    "./test/**/*.tsx",
+    "./test/**/*.json"
+  ],
+  "compilerOptions": {
+    "noEmit": true,
+    "incremental": false
+  }
+}

--- a/src/satisfies/package.json
+++ b/src/satisfies/package.json
@@ -53,6 +53,7 @@
     "snap": "tap",
     "pretest": "tshy",
     "test": "tap",
+    "posttest": "tsc --project tsconfig.test.json",
     "watch": "tshy --watch"
   },
   "tap": {

--- a/src/satisfies/tsconfig.test.json
+++ b/src/satisfies/tsconfig.test.json
@@ -1,0 +1,13 @@
+{
+  "extends": "./tsconfig.json",
+  "include": [
+    "./test/**/*.ts",
+    "./test/**/*.mts",
+    "./test/**/*.tsx",
+    "./test/**/*.json"
+  ],
+  "compilerOptions": {
+    "noEmit": true,
+    "incremental": false
+  }
+}

--- a/src/semver/package.json
+++ b/src/semver/package.json
@@ -56,6 +56,7 @@
     "snap": "tap",
     "pretest": "tshy",
     "test": "tap",
+    "posttest": "tsc --project tsconfig.test.json",
     "watch": "tshy --watch"
   },
   "tap": {

--- a/src/semver/tsconfig.test.json
+++ b/src/semver/tsconfig.test.json
@@ -1,0 +1,13 @@
+{
+  "extends": "./tsconfig.json",
+  "include": [
+    "./test/**/*.ts",
+    "./test/**/*.mts",
+    "./test/**/*.tsx",
+    "./test/**/*.json"
+  ],
+  "compilerOptions": {
+    "noEmit": true,
+    "incremental": false
+  }
+}

--- a/src/spec/package.json
+++ b/src/spec/package.json
@@ -54,6 +54,7 @@
     "snap": "tap",
     "pretest": "tshy",
     "test": "tap",
+    "posttest": "tsc --project tsconfig.test.json",
     "watch": "tshy --watch"
   },
   "tap": {

--- a/src/spec/tsconfig.test.json
+++ b/src/spec/tsconfig.test.json
@@ -1,0 +1,13 @@
+{
+  "extends": "./tsconfig.json",
+  "include": [
+    "./test/**/*.ts",
+    "./test/**/*.mts",
+    "./test/**/*.tsx",
+    "./test/**/*.json"
+  ],
+  "compilerOptions": {
+    "noEmit": true,
+    "incremental": false
+  }
+}

--- a/src/tar/package.json
+++ b/src/tar/package.json
@@ -60,6 +60,7 @@
     "snap": "tap",
     "pretest": "tshy",
     "test": "tap",
+    "posttest": "tsc --project tsconfig.test.json",
     "watch": "tshy --watch"
   },
   "tap": {

--- a/src/tar/tsconfig.test.json
+++ b/src/tar/tsconfig.test.json
@@ -1,0 +1,13 @@
+{
+  "extends": "./tsconfig.json",
+  "include": [
+    "./test/**/*.ts",
+    "./test/**/*.mts",
+    "./test/**/*.tsx",
+    "./test/**/*.json"
+  ],
+  "compilerOptions": {
+    "noEmit": true,
+    "incremental": false
+  }
+}

--- a/src/types/package.json
+++ b/src/types/package.json
@@ -49,6 +49,7 @@
     "snap": "tap",
     "pretest": "tshy",
     "test": "tap",
+    "posttest": "tsc --project tsconfig.test.json",
     "watch": "tshy --watch"
   },
   "tap": {

--- a/src/types/tsconfig.test.json
+++ b/src/types/tsconfig.test.json
@@ -1,0 +1,13 @@
+{
+  "extends": "./tsconfig.json",
+  "include": [
+    "./test/**/*.ts",
+    "./test/**/*.mts",
+    "./test/**/*.tsx",
+    "./test/**/*.json"
+  ],
+  "compilerOptions": {
+    "noEmit": true,
+    "incremental": false
+  }
+}

--- a/src/url-open/package.json
+++ b/src/url-open/package.json
@@ -49,6 +49,7 @@
     "snap": "tap",
     "pretest": "tshy",
     "test": "tap",
+    "posttest": "tsc --project tsconfig.test.json",
     "watch": "tshy --watch"
   },
   "tap": {

--- a/src/url-open/tsconfig.test.json
+++ b/src/url-open/tsconfig.test.json
@@ -1,0 +1,13 @@
+{
+  "extends": "./tsconfig.json",
+  "include": [
+    "./test/**/*.ts",
+    "./test/**/*.mts",
+    "./test/**/*.tsx",
+    "./test/**/*.json"
+  ],
+  "compilerOptions": {
+    "noEmit": true,
+    "incremental": false
+  }
+}

--- a/src/vlt/package.json
+++ b/src/vlt/package.json
@@ -93,6 +93,7 @@
     "snap": "tap",
     "pretest": "tshy",
     "test": "tap",
+    "posttest": "tsc --project tsconfig.test.json",
     "watch": "tshy --watch"
   },
   "tap": {

--- a/src/vlt/tsconfig.test.json
+++ b/src/vlt/tsconfig.test.json
@@ -1,0 +1,13 @@
+{
+  "extends": "./tsconfig.json",
+  "include": [
+    "./test/**/*.ts",
+    "./test/**/*.mts",
+    "./test/**/*.tsx",
+    "./test/**/*.json"
+  ],
+  "compilerOptions": {
+    "noEmit": true,
+    "incremental": false
+  }
+}

--- a/src/which/package.json
+++ b/src/which/package.json
@@ -49,6 +49,7 @@
     "snap": "tap",
     "pretest": "tshy",
     "test": "tap",
+    "posttest": "tsc --project tsconfig.test.json",
     "watch": "tshy --watch"
   },
   "tap": {

--- a/src/which/tsconfig.test.json
+++ b/src/which/tsconfig.test.json
@@ -1,0 +1,13 @@
+{
+  "extends": "./tsconfig.json",
+  "include": [
+    "./test/**/*.ts",
+    "./test/**/*.mts",
+    "./test/**/*.tsx",
+    "./test/**/*.json"
+  ],
+  "compilerOptions": {
+    "noEmit": true,
+    "incremental": false
+  }
+}

--- a/src/workspaces/package.json
+++ b/src/workspaces/package.json
@@ -58,6 +58,7 @@
     "snap": "tap",
     "pretest": "tshy",
     "test": "tap",
+    "posttest": "tsc --project tsconfig.test.json",
     "watch": "tshy --watch"
   },
   "tap": {

--- a/src/workspaces/tsconfig.test.json
+++ b/src/workspaces/tsconfig.test.json
@@ -1,0 +1,13 @@
+{
+  "extends": "./tsconfig.json",
+  "include": [
+    "./test/**/*.ts",
+    "./test/**/*.mts",
+    "./test/**/*.tsx",
+    "./test/**/*.json"
+  ],
+  "compilerOptions": {
+    "noEmit": true,
+    "incremental": false
+  }
+}

--- a/src/xdg/package.json
+++ b/src/xdg/package.json
@@ -46,6 +46,7 @@
     "snap": "tap",
     "pretest": "tshy",
     "test": "tap",
+    "posttest": "tsc --project tsconfig.test.json",
     "watch": "tshy --watch"
   },
   "tap": {

--- a/src/xdg/tsconfig.test.json
+++ b/src/xdg/tsconfig.test.json
@@ -1,0 +1,13 @@
+{
+  "extends": "./tsconfig.json",
+  "include": [
+    "./test/**/*.ts",
+    "./test/**/*.mts",
+    "./test/**/*.tsx",
+    "./test/**/*.json"
+  ],
+  "compilerOptions": {
+    "noEmit": true,
+    "incremental": false
+  }
+}

--- a/tap-config.yaml
+++ b/tap-config.yaml
@@ -1,7 +1,6 @@
 # vim: set filetype=yaml :
 
 coverage-map: './coverage-map.js'
-typecheck: true
 timeout: 600 # 10 minutes
 
 # globs are always relative to the project root regardless.


### PR DESCRIPTION
It seems like `typescript@>=5.6` does not work to run `tap` with `typecheck: true`. I opened an issue on tap with a reproduction here: https://github.com/tapjs/tapjs/issues/1049

But in the meantime, this updates us to `typescript@5.7.3` but turning off tap's typechecking of test files and running `tsc` on them directly in a `posttest` script.

The biggest reason I want to use the latest typescript is that it has `--rewriteRelativeImportExtensions` which when turned on (and with some src changes) allows the CLI to be run without a build step with `node --experimental-strip-types ./src/vlt/src/bins/vlt.ts` 