### PR TITLE
fix: project column names & spec background color in light mode

### DIFF
--- a/src/gui/src/components/dashboard-grid/table-columns.tsx
+++ b/src/gui/src/components/dashboard-grid/table-columns.tsx
@@ -132,7 +132,7 @@ export const dashboardColumns: ColumnDef<DashboardDataProject>[] = [
   },
   {
     accessorKey: 'type',
-    header: 'Modified',
+    header: 'Type',
     cell: ({ row }) => {
       const type =
         row.original.manifest.type ? row.original.manifest.type : null
@@ -145,7 +145,7 @@ export const dashboardColumns: ColumnDef<DashboardDataProject>[] = [
     enableHiding: true,
   },
   {
-    accessorKey: 'time',
+    accessorKey: 'modified',
     header: ({ column }) => (
       <SortingHeader
         className="flex w-full justify-end text-right"

--- a/src/gui/src/components/explorer-grid/side-item.tsx
+++ b/src/gui/src/components/explorer-grid/side-item.tsx
@@ -115,7 +115,7 @@ export const SideItem = ({
             <div className="flex flex-row flex-wrap items-center justify-between gap-2 border-t-[1px] border-muted-foreground/20 px-3 py-2">
               <p className="flex items-center gap-2 text-sm text-muted-foreground">
                 Spec:{' '}
-                <span className="flex items-center justify-center rounded-sm bg-neutral-700/50 px-2 py-1 font-[courier] text-xs">
+                <span className="flex items-center justify-center rounded-sm bg-neutral-700/5 px-2 py-1 font-[courier] text-xs dark:bg-neutral-700/50">
                   {parseItem(item.title)}
                 </span>
               </p>

--- a/src/gui/test/components/explorer-grid/__snapshots__/index.tsx.snap
+++ b/src/gui/test/components/explorer-grid/__snapshots__/index.tsx.snap
@@ -65,7 +65,7 @@ exports[`explorer-grid renders workspace with edges in 1`] = `
             <div class="flex flex-row flex-wrap items-center justify-between gap-2 border-t-[1px] border-muted-foreground/20 px-3 py-2">
               <p class="flex items-center gap-2 text-sm text-muted-foreground">
                 Spec:
-                <span class="flex items-center justify-center rounded-sm bg-neutral-700/50 px-2 py-1 font-[courier] text-xs">
+                <span class="flex items-center justify-center rounded-sm bg-neutral-700/5 px-2 py-1 font-[courier] text-xs dark:bg-neutral-700/50">
                   workspace:*
                 </span>
               </p>

--- a/src/gui/test/components/explorer-grid/__snapshots__/side-item.tsx.snap
+++ b/src/gui/test/components/explorer-grid/__snapshots__/side-item.tsx.snap
@@ -22,7 +22,7 @@ exports[`SideItem render as dependency 1`] = `
         <div class="flex flex-row flex-wrap items-center justify-between gap-2 border-t-[1px] border-muted-foreground/20 px-3 py-2">
           <p class="flex items-center gap-2 text-sm text-muted-foreground">
             Spec:
-            <span class="flex items-center justify-center rounded-sm bg-neutral-700/50 px-2 py-1 font-[courier] text-xs">
+            <span class="flex items-center justify-center rounded-sm bg-neutral-700/5 px-2 py-1 font-[courier] text-xs dark:bg-neutral-700/50">
             </span>
           </p>
           <div>
@@ -65,7 +65,7 @@ exports[`SideItem render as dependency with long name 1`] = `
         <div class="flex flex-row flex-wrap items-center justify-between gap-2 border-t-[1px] border-muted-foreground/20 px-3 py-2">
           <p class="flex items-center gap-2 text-sm text-muted-foreground">
             Spec:
-            <span class="flex items-center justify-center rounded-sm bg-neutral-700/50 px-2 py-1 font-[courier] text-xs">
+            <span class="flex items-center justify-center rounded-sm bg-neutral-700/5 px-2 py-1 font-[courier] text-xs dark:bg-neutral-700/50">
             </span>
           </p>
           <div>
@@ -108,7 +108,7 @@ exports[`SideItem render as dependent 1`] = `
         <div class="flex flex-row flex-wrap items-center justify-between gap-2 border-t-[1px] border-muted-foreground/20 px-3 py-2">
           <p class="flex items-center gap-2 text-sm text-muted-foreground">
             Spec:
-            <span class="flex items-center justify-center rounded-sm bg-neutral-700/50 px-2 py-1 font-[courier] text-xs">
+            <span class="flex items-center justify-center rounded-sm bg-neutral-700/5 px-2 py-1 font-[courier] text-xs dark:bg-neutral-700/50">
             </span>
           </p>
           <div>
@@ -150,7 +150,7 @@ exports[`SideItem render as multi-stacked dependent 1`] = `
         <div class="flex flex-row flex-wrap items-center justify-between gap-2 border-t-[1px] border-muted-foreground/20 px-3 py-2">
           <p class="flex items-center gap-2 text-sm text-muted-foreground">
             Spec:
-            <span class="flex items-center justify-center rounded-sm bg-neutral-700/50 px-2 py-1 font-[courier] text-xs">
+            <span class="flex items-center justify-center rounded-sm bg-neutral-700/5 px-2 py-1 font-[courier] text-xs dark:bg-neutral-700/50">
             </span>
           </p>
           <div>
@@ -188,7 +188,7 @@ exports[`SideItem render as parent 1`] = `
         <div class="flex flex-row flex-wrap items-center justify-between gap-2 border-t-[1px] border-muted-foreground/20 px-3 py-2">
           <p class="flex items-center gap-2 text-sm text-muted-foreground">
             Spec:
-            <span class="flex items-center justify-center rounded-sm bg-neutral-700/50 px-2 py-1 font-[courier] text-xs">
+            <span class="flex items-center justify-center rounded-sm bg-neutral-700/5 px-2 py-1 font-[courier] text-xs dark:bg-neutral-700/50">
             </span>
           </p>
           <div>
@@ -230,7 +230,7 @@ exports[`SideItem render as two-stacked dependent 1`] = `
         <div class="flex flex-row flex-wrap items-center justify-between gap-2 border-t-[1px] border-muted-foreground/20 px-3 py-2">
           <p class="flex items-center gap-2 text-sm text-muted-foreground">
             Spec:
-            <span class="flex items-center justify-center rounded-sm bg-neutral-700/50 px-2 py-1 font-[courier] text-xs">
+            <span class="flex items-center justify-center rounded-sm bg-neutral-700/5 px-2 py-1 font-[courier] text-xs dark:bg-neutral-700/50">
             </span>
           </p>
           <div>


### PR DESCRIPTION
### Before

![Screenshot 2025-02-08 at 11 39 49 AM-1](https://github.com/user-attachments/assets/16c2de7a-3d06-455e-bb8b-70fba0a88ea3)

![Screenshot 2025-02-08 at 11 43 20 AM-1](https://github.com/user-attachments/assets/dfbc6911-af8f-45ba-9765-7bded7df86af)

### After

![Screenshot 2025-02-08 at 2 29 19 PM](https://github.com/user-attachments/assets/05f0ea7e-cb8a-4afc-a68c-a74ba269158c)

![Screenshot 2025-02-08 at 2 29 29 PM](https://github.com/user-attachments/assets/75b743b8-0f70-4a5a-ad45-8b35ed49300f)
