### PR TITLE
lint: set correct tsconfig path for import/resolver when run from workspace

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -7,6 +7,9 @@ import jsdoc from 'eslint-plugin-jsdoc'
 import importPlugin from 'eslint-plugin-import'
 import { defaultConditionNames } from 'eslint-import-resolver-typescript'
 
+const MONO_ROOT = import.meta.dirname
+const CWD = process.cwd()
+
 // 'error' to fix, or 'warn' to see
 const BE_EXTRA = process.env.LINT_SUPER_CONSISTENT ?? 'off'
 
@@ -22,7 +25,7 @@ const unsafeRules = value => ({
 export default tseslint.config(
   {
     ignores: [
-      ...readFileSync(resolve(import.meta.dirname, '.prettierignore'))
+      ...readFileSync(resolve(MONO_ROOT, '.prettierignore'))
         .toString()
         .trim()
         .split('\n')
@@ -58,11 +61,16 @@ export default tseslint.config(
             '@vltpkg/source',
             ...defaultConditionNames,
           ],
-          project: [
-            'src/*/tsconfig.json',
-            'infra/*/tsconfig.json',
-            'www/*/tsconfig.json',
-          ],
+          project:
+            // If run from the root specify glob patterns to all ts projects
+            // otherwise just use the tsconfig.json in the current directory
+            CWD === MONO_ROOT ?
+              [
+                'src/*/tsconfig.json',
+                'infra/*/tsconfig.json',
+                'www/*/tsconfig.json',
+              ]
+            : ['tsconfig.json'],
         },
         node: true,
       },


### PR DESCRIPTION
This fixes an issue where you could not run eslint from the GUI workspace (eg `pnpm -F gui lint`) since it has a different tsconfig than others. It still worked in CI because linting is run from the root in the ci.yml workflow.

A future optimization could filter which workspaces get linted based on what has changed, similar to what we do for tests. This is not a pressing need right now as linting and testing are run in parallel and linting is almost always finished before tests.