### PR TITLE
lint: warn with reminder about console.log/error in certain tests being captured

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -284,6 +284,18 @@ export default tseslint.config(
     },
   },
   {
+    files: ['infra/build/test/**/*.ts', 'src/vlt/test/**/*/*.ts'],
+    rules: {
+      'no-restricted-syntax': [
+        'warn',
+        ...['log', 'error'].map(method => ({
+          selector: `CallExpression[callee.object.name='console'][callee.property.name='${method}']`,
+          message: `\`console.${method}\` is often captured in these tests so calling it might not show anything. Use another method like \`console.info\` or \`t.comment\` instead.`,
+        })),
+      ],
+    },
+  },
+  {
     /**
      * Plain JS code.
      * TODO: there is a way to get typechecking with tseslint for


### PR DESCRIPTION
I use `console.log` and `console.error` to debug tests sometimes and it usually takes me a minute to realize they are being `t.capture`'d so I won't see them. This is a lint rule for certain tests where we do this so it will warn with a message saying use another method.