### PR TITLE
gui: refactor start-dashboard-data

### DIFF
--- a/src/gui/src/app/dashboard.tsx
+++ b/src/gui/src/app/dashboard.tsx
@@ -1,21 +1,7 @@
 import { useEffect } from 'react'
 import { DashboardGrid } from '@/components/dashboard-grid/index.jsx'
-import { type Action, type State } from '@/state/types.js'
 import { useGraphStore } from '@/state/index.js'
-
-type StartDashboardData = {
-  updateDashboard: Action['updateDashboard']
-  stamp: State['stamp']
-}
-
-const startDashboardData = async ({
-  updateDashboard,
-  stamp,
-}: StartDashboardData) => {
-  const res = await fetch('./dashboard.json?random=' + stamp)
-  const data = (await res.json()) as State['dashboard']
-  updateDashboard(data)
-}
+import { startDashboardData } from '@/lib/start-dashboard-data.js'
 
 export const Dashboard = () => {
   const dashboard = useGraphStore(state => state.dashboard)
@@ -30,30 +16,21 @@ export const Dashboard = () => {
   )
   const stamp = useGraphStore(state => state.stamp)
 
-  // only load dashboard data when we want to manually update the
-  // state in the app, to make sure we're controlling it, we use the
-  // stamp state as a dependency of `useEffect` to trigger the load.
   useEffect(() => {
-    async function startDashboard() {
-      await startDashboardData({
-        updateDashboard,
-        stamp,
-      })
-
-      history.pushState(
-        { query: '', route: '/dashboard' },
-        '',
-        '/dashboard',
-      )
-      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-      window.scrollTo?.(0, 0)
-    }
-
-    startDashboard().catch((err: unknown) => {
-      console.error(err)
-      updateActiveRoute('/error')
-      updateErrorCause('Failed to initialize dashboard.')
+    startDashboardData({
+      updateActiveRoute,
+      updateErrorCause,
+      updateDashboard,
+      stamp,
     })
+
+    history.pushState(
+      { query: '', route: '/dashboard' },
+      '',
+      '/dashboard',
+    )
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+    window.scrollTo?.(0, 0)
   }, [stamp])
 
   return (

--- a/src/gui/src/lib/start-dashboard-data.ts
+++ b/src/gui/src/lib/start-dashboard-data.ts
@@ -1,0 +1,41 @@
+import { type Action, type State } from '@/state/types.js'
+
+export type RequestDashboardDataOptions = {
+  stamp: State['stamp']
+}
+
+export type StartDashboardDataOptions = {
+  updateActiveRoute: Action['updateActiveRoute']
+  updateDashboard: Action['updateDashboard']
+  updateErrorCause: Action['updateErrorCause']
+  stamp: State['stamp']
+}
+
+export const requestDashboardData = async ({
+  stamp,
+}: RequestDashboardDataOptions): Promise<State['dashboard']> => {
+  const req = await fetch('./dashboard.json?random=' + stamp)
+  const res = (await req.json()) as State['dashboard']
+  return res
+}
+
+export const startDashboardData = ({
+  updateActiveRoute,
+  updateDashboard,
+  updateErrorCause,
+  stamp,
+}: StartDashboardDataOptions) => {
+  async function _startDashboard() {
+    const dashboardData = await requestDashboardData({
+      stamp,
+    })
+    updateDashboard(dashboardData)
+  }
+
+  void _startDashboard().catch((err: unknown) => {
+    // eslint-disable-next-line no-console
+    console.error(err)
+    updateActiveRoute('/error')
+    updateErrorCause('Failed to initialize dashboard.')
+  })
+}

--- a/src/gui/test/lib/__snapshots__/start-dashboard-data.ts.snap
+++ b/src/gui/test/lib/__snapshots__/start-dashboard-data.ts.snap
@@ -1,0 +1,37 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`standard dashboard response > should return standard dashboard data 1`] = `
+{
+  "buildVersion": "1.0.0",
+  "cwd": "/path/to/cwd",
+  "projects": [
+    {
+      "manifest": {
+        "name": "project-foo",
+        "version": "1.0.0",
+      },
+      "mtime": 1730498483044,
+      "name": "project-foo",
+      "path": "/home/user/project-foo",
+      "readablePath": "~/project-foo",
+      "tools": [
+        "node",
+        "vlt",
+      ],
+    },
+    {
+      "manifest": {
+        "name": "project-bar",
+        "version": "1.0.0",
+      },
+      "mtime": 1730498491029,
+      "name": "project-bar",
+      "path": "/home/user/project-bar",
+      "readablePath": "~/project-foo",
+      "tools": [
+        "pnpm",
+      ],
+    },
+  ],
+}
+`;

--- a/src/gui/test/lib/start-dashboard-data.ts
+++ b/src/gui/test/lib/start-dashboard-data.ts
@@ -1,0 +1,86 @@
+import { afterEach, beforeEach, expect, test, vi } from 'vitest'
+import { startDashboardData } from '@/lib/start-dashboard-data.js'
+
+const stderr = console.error
+
+afterEach(() => {
+  console.error = stderr
+  vi.clearAllMocks()
+})
+
+beforeEach(() => {
+  global.fetch = vi.fn(async url => ({
+    json: async () => {
+      switch (new URL(`file://${url}`).searchParams.get('random')) {
+        case 'standard': {
+          return {
+            buildVersion: '1.0.0',
+            cwd: '/path/to/cwd',
+            projects: [
+              {
+                name: 'project-foo',
+                readablePath: '~/project-foo',
+                path: '/home/user/project-foo',
+                manifest: { name: 'project-foo', version: '1.0.0' },
+                tools: ['node', 'vlt'],
+                mtime: 1730498483044,
+              },
+              {
+                name: 'project-bar',
+                readablePath: '~/project-foo',
+                path: '/home/user/project-bar',
+                manifest: { name: 'project-bar', version: '1.0.0' },
+                tools: ['pnpm'],
+                mtime: 1730498491029,
+              },
+            ],
+          }
+        }
+        default: {
+          throw Object.assign({ status: 404 }, new Error('Not found'))
+        }
+      }
+    },
+  })) as unknown as typeof global.fetch
+})
+
+test('standard dashboard response', async () => {
+  await new Promise<void>((res, rej) => {
+    try {
+      startDashboardData({
+        updateActiveRoute: vi.fn(),
+        updateDashboard: dashboardData => {
+          expect(dashboardData).toMatchSnapshot(
+            'should return standard dashboard data',
+          )
+          res()
+        },
+        updateErrorCause: rej,
+        stamp: 'standard',
+      })
+    } catch (err) {
+      rej(err as Error)
+    }
+  })
+})
+
+test('missing dashboard response', async () => {
+  console.error = vi.fn()
+  await new Promise<void>((res, rej) => {
+    try {
+      startDashboardData({
+        updateActiveRoute: route => {
+          expect(route).toBe('/error')
+          res()
+        },
+        updateDashboard: () => {
+          throw new Error('Should not have dashboard data')
+        },
+        updateErrorCause: vi.fn(),
+        stamp: 'missing',
+      })
+    } catch (err) {
+      rej(err as Error)
+    }
+  })
+})


### PR DESCRIPTION
Refactored the logic to load dashboard data into its own helper method so that it can be reused in the create new project page. This refactor also makes it easier to start tests for it which are included here.