### PR TITLE
vlt: add dashboard project locations data

### DIFF
--- a/src/vlt/src/start-gui.ts
+++ b/src/vlt/src/start-gui.ts
@@ -27,7 +27,7 @@ import {
   type Server,
 } from 'node:http'
 import { homedir, tmpdir } from 'node:os'
-import { dirname, posix, resolve, relative, win32 } from 'node:path'
+import { dirname, resolve, relative } from 'node:path'
 import { loadPackageJson } from 'package-json-from-dist'
 import { type PathBase, type PathScurry } from 'path-scurry'
 import handler from 'serve-handler'
@@ -202,7 +202,7 @@ export const inferTools = (
 }
 
 export const getReadablePath = (path: string) =>
-  path.replace(homedir(), '~').replaceAll(win32.sep, posix.sep)
+  path.replace(homedir(), '~')
 
 export const formatDashboardJson = (
   projectFolders: PathBase[],

--- a/src/vlt/tap-snapshots/test/start-gui.ts.test.cjs
+++ b/src/vlt/tap-snapshots/test/start-gui.ts.test.cjs
@@ -93,6 +93,35 @@ exports[`test/start-gui.ts > TAP > e2e server test > /select-project > should wr
 }
 `
 
+exports[`test/start-gui.ts > TAP > formatDashboardJson dashboardProjectLocations > should return the expected dashboard project locations 1`] = `
+Array [
+  Object {
+    "path": "{CWD}/.tap/fixtures/test-start-gui.ts-formatDashboardJson-dashboardProjectLocations",
+    "readablePath": "~",
+  },
+  Object {
+    "path": "{CWD}/.tap/fixtures/test-start-gui.ts-formatDashboardJson-dashboardProjectLocations/projects",
+    "readablePath": "~/projects",
+  },
+  Object {
+    "path": "{CWD}/.tap/fixtures/test-start-gui.ts-formatDashboardJson-dashboardProjectLocations/drafts/more",
+    "readablePath": "~/drafts/more",
+  },
+  Object {
+    "path": "{CWD}/.tap/fixtures/test-start-gui.ts-formatDashboardJson-dashboardProjectLocations/drafts/recent",
+    "readablePath": "~/drafts/recent",
+  },
+  Object {
+    "path": "{CWD}/.tap/fixtures/test-start-gui.ts-formatDashboardJson-dashboardProjectLocations/drafts/previous",
+    "readablePath": "~/drafts/previous",
+  },
+  Object {
+    "path": "{CWD}/.tap/fixtures/test-start-gui.ts-formatDashboardJson-dashboardProjectLocations/drafts/more/util/extra",
+    "readablePath": "~/drafts/more/util/extra",
+  },
+]
+`
+
 exports[`test/start-gui.ts > TAP > parseInstallArgs > multiple item added to root and workspace 1`] = `
 Object {
   "add": AddImportersDependenciesMapImpl {

--- a/src/vlt/tap-snapshots/test/start-gui.ts.test.cjs
+++ b/src/vlt/tap-snapshots/test/start-gui.ts.test.cjs
@@ -94,31 +94,31 @@ exports[`test/start-gui.ts > TAP > e2e server test > /select-project > should wr
 `
 
 exports[`test/start-gui.ts > TAP > formatDashboardJson dashboardProjectLocations > should return the expected dashboard project locations 1`] = `
-Array [
-  Object {
-    "path": "{CWD}/.tap/fixtures/test-start-gui.ts-formatDashboardJson-dashboardProjectLocations",
-    "readablePath": "~",
+[
+  {
+    "path": "{HOMEDIR}",
+    "readablePath": "~"
   },
-  Object {
+  {
     "path": "{CWD}/.tap/fixtures/test-start-gui.ts-formatDashboardJson-dashboardProjectLocations/projects",
-    "readablePath": "~/projects",
+    "readablePath": "~/projects"
   },
-  Object {
+  {
     "path": "{CWD}/.tap/fixtures/test-start-gui.ts-formatDashboardJson-dashboardProjectLocations/drafts/more",
-    "readablePath": "~/drafts/more",
+    "readablePath": "~/drafts/more"
   },
-  Object {
+  {
     "path": "{CWD}/.tap/fixtures/test-start-gui.ts-formatDashboardJson-dashboardProjectLocations/drafts/recent",
-    "readablePath": "~/drafts/recent",
+    "readablePath": "~/drafts/recent"
   },
-  Object {
+  {
     "path": "{CWD}/.tap/fixtures/test-start-gui.ts-formatDashboardJson-dashboardProjectLocations/drafts/previous",
-    "readablePath": "~/drafts/previous",
+    "readablePath": "~/drafts/previous"
   },
-  Object {
+  {
     "path": "{CWD}/.tap/fixtures/test-start-gui.ts-formatDashboardJson-dashboardProjectLocations/drafts/more/util/extra",
-    "readablePath": "~/drafts/more/util/extra",
-  },
+    "readablePath": "~/drafts/more/util/extra"
+  }
 ]
 `
 

--- a/src/vlt/tap-snapshots/test/start-gui.ts.test.cjs
+++ b/src/vlt/tap-snapshots/test/start-gui.ts.test.cjs
@@ -94,31 +94,31 @@ exports[`test/start-gui.ts > TAP > e2e server test > /select-project > should wr
 `
 
 exports[`test/start-gui.ts > TAP > formatDashboardJson dashboardProjectLocations > should return the expected dashboard project locations 1`] = `
-[
-  {
-    "path": "{HOMEDIR}",
-    "readablePath": "~"
+Array [
+  Object {
+    "path": "{CWD}/.tap/fixtures/test-start-gui.ts-formatDashboardJson-dashboardProjectLocations",
+    "readablePath": "~",
   },
-  {
+  Object {
     "path": "{CWD}/.tap/fixtures/test-start-gui.ts-formatDashboardJson-dashboardProjectLocations/projects",
-    "readablePath": "~/projects"
+    "readablePath": "~/projects",
   },
-  {
+  Object {
     "path": "{CWD}/.tap/fixtures/test-start-gui.ts-formatDashboardJson-dashboardProjectLocations/drafts/more",
-    "readablePath": "~/drafts/more"
+    "readablePath": "~/drafts/more",
   },
-  {
+  Object {
     "path": "{CWD}/.tap/fixtures/test-start-gui.ts-formatDashboardJson-dashboardProjectLocations/drafts/recent",
-    "readablePath": "~/drafts/recent"
+    "readablePath": "~/drafts/recent",
   },
-  {
+  Object {
     "path": "{CWD}/.tap/fixtures/test-start-gui.ts-formatDashboardJson-dashboardProjectLocations/drafts/previous",
-    "readablePath": "~/drafts/previous"
+    "readablePath": "~/drafts/previous",
   },
-  {
+  Object {
     "path": "{CWD}/.tap/fixtures/test-start-gui.ts-formatDashboardJson-dashboardProjectLocations/drafts/more/util/extra",
-    "readablePath": "~/drafts/more/util/extra"
-  }
+    "readablePath": "~/drafts/more/util/extra",
+  },
 ]
 `
 

--- a/src/vlt/test/start-gui.ts
+++ b/src/vlt/test/start-gui.ts
@@ -295,28 +295,14 @@ t.test('formatDashboardJson dashboardProjectLocations', async t => {
       },
     },
   )
-  const { dashboardProjectLocations } = formatDashboardJson(
-    projectFolders,
-    {
+  t.matchSnapshot(
+    formatDashboardJson(projectFolders, {
       options: {
         packageJson,
         scurry,
       } as ConfigOptions,
       values: {},
-    } as LoadedConfig,
-  )
-
-  // needs to clean up the string before snapshotting due to the fact
-  // that windows paths are tweaked by the implementation here and thus
-  // will fail to match the default clean up from @tapjs/snapshot
-  const cleanedup = JSON.stringify(
-    dashboardProjectLocations,
-    null,
-    2,
-  ).replace(dir, '{HOMEDIR}')
-
-  t.matchSnapshot(
-    cleanedup,
+    } as LoadedConfig).dashboardProjectLocations,
     'should return the expected dashboard project locations',
   )
 })
@@ -811,8 +797,8 @@ t.test('getReadablePath', async t => {
     ]
     const to = [
       '~',
-      '~/projects/lorem/node_modules/ipsum',
-      'C:/path/to/project/node_modules/a/node_modules/b',
+      '~\\projects\\lorem\\node_modules\\ipsum',
+      'C:\\path\\to\\project\\node_modules\\a\\node_modules\\b',
     ]
     t.strictSame(
       from.map(f => getReadablePath(f)),

--- a/src/vlt/test/start-gui.ts
+++ b/src/vlt/test/start-gui.ts
@@ -24,7 +24,7 @@ t.cleanSnapshot = s =>
       /^(\s+)"projectRoot": ".*"/gm,
       '$1"projectRoot": "{ROOT}"',
     )
-    .replace(/\\/g, '/')
+    .replace(/\\\\/g, '/')
 
 t.test('starts gui data and server', async t => {
   class PackageJson {

--- a/src/vlt/test/start-gui.ts
+++ b/src/vlt/test/start-gui.ts
@@ -19,12 +19,10 @@ import {
 import { actualObject } from './fixtures/actual.ts'
 
 t.cleanSnapshot = s =>
-  s
-    .replace(
-      /^(\s+)"projectRoot": ".*"/gm,
-      '$1"projectRoot": "{ROOT}"',
-    )
-    .replaceAll(/\\/g, '/')
+  s.replace(
+    /^(\s+)"projectRoot": ".*"/gm,
+    '$1"projectRoot": "{ROOT}"',
+  )
 
 t.test('starts gui data and server', async t => {
   class PackageJson {

--- a/src/vlt/test/start-gui.ts
+++ b/src/vlt/test/start-gui.ts
@@ -211,13 +211,97 @@ t.test('formatDashboardJson', async t => {
   const scurry = new PathScurry(t.testdirName)
   t.strictSame(
     formatDashboardJson(scurry.readdirSync(dir), {
-      packageJson,
-      scurry,
-    } as ConfigOptions).projects.map(
+      options: {
+        packageJson,
+        scurry,
+      } as ConfigOptions,
+      values: {},
+    } as LoadedConfig).projects.map(
       ({ name }: { name: string }) => name,
     ),
     ['b'],
     'should skip folders without package.json',
+  )
+})
+
+t.test('formatDashboardJson dashboardProjectLocations', async t => {
+  const dir = t.testdir({
+    foo: {
+      'package.json': JSON.stringify({ name: 'foo' }),
+    },
+    projects: {
+      a: {
+        'package.json': JSON.stringify({ name: 'a' }),
+      },
+      b: {
+        'package.json': JSON.stringify({ name: 'b' }),
+      },
+    },
+    drafts: {
+      recent: {
+        c: {
+          'package.json': JSON.stringify({ name: 'c' }),
+        },
+      },
+      previous: {
+        d: {
+          'package.json': JSON.stringify({ name: 'd' }),
+        },
+        e: {
+          'package.json': JSON.stringify({ name: 'e' }),
+        },
+        f: {
+          'package.json': JSON.stringify({ name: 'f' }),
+        },
+      },
+      more: {
+        util: {
+          extra: {
+            g: {
+              'package.json': JSON.stringify({ name: 'g' }),
+            },
+          },
+        },
+        h: {
+          'package.json': JSON.stringify({ name: 'h' }),
+        },
+      },
+      tmp: {},
+    },
+  })
+  const scurry = new PathScurry(t.testdirName)
+  const projectFolders = [
+    scurry.lstatSync(resolve(dir, 'foo')),
+    scurry.lstatSync(resolve(dir, 'projects/a')),
+    scurry.lstatSync(resolve(dir, 'projects/b')),
+    scurry.lstatSync(resolve(dir, 'drafts/recent/c')),
+    scurry.lstatSync(resolve(dir, 'drafts/previous/d')),
+    scurry.lstatSync(resolve(dir, 'drafts/previous/e')),
+    scurry.lstatSync(resolve(dir, 'drafts/previous/f')),
+    scurry.lstatSync(resolve(dir, 'drafts/more/util/extra/g')),
+    scurry.lstatSync(resolve(dir, 'drafts/more/h')),
+  ]
+  const packageJson = new PackageJson()
+  const { formatDashboardJson } = await t.mockImport(
+    '../src/start-gui.ts',
+    {
+      'node:os': {
+        ...(await import('node:os')),
+        homedir() {
+          return dir
+        },
+      },
+    },
+  )
+  t.matchSnapshot(
+    formatDashboardJson(projectFolders, {
+      options: {
+        packageJson,
+        scurry,
+      } as ConfigOptions,
+      values: {},
+    } as LoadedConfig).dashboardProjectLocations,
+    'should return the expected dashboard project locations',
   )
 })
 
@@ -661,4 +745,63 @@ t.test('parseInstallArgs', async t => {
     }),
     'multiple item added to root and workspace',
   )
+})
+
+t.test('getReadablePath', async t => {
+  await t.test('posix', async t => {
+    const { getReadablePath } = await t.mockImport(
+      '../src/start-gui.js',
+      {
+        'node:os': {
+          ...(await import('node:os')),
+          homedir() {
+            return '/home/user'
+          },
+        },
+      },
+    )
+    const from = [
+      '/home/user/foo',
+      '/home/user/foo/projects/lorem/node_modules/ipsum',
+      '/path/to/project/node_modules/a/node_modules/b',
+    ]
+    const to = [
+      '~/foo',
+      '~/foo/projects/lorem/node_modules/ipsum',
+      '/path/to/project/node_modules/a/node_modules/b',
+    ]
+    t.strictSame(
+      from.map(f => getReadablePath(f)),
+      to,
+      'should return the correct posix readable path',
+    )
+  })
+  await t.test('windows', async t => {
+    const { getReadablePath } = await t.mockImport(
+      '../src/start-gui.js',
+      {
+        'node:os': {
+          ...(await import('node:os')),
+          homedir() {
+            return 'C:\\Users\\username'
+          },
+        },
+      },
+    )
+    const from = [
+      'C:\\Users\\username',
+      'C:\\Users\\username\\projects\\lorem\\node_modules\\ipsum',
+      'C:\\path\\to\\project\\node_modules\\a\\node_modules\\b',
+    ]
+    const to = [
+      '~',
+      '~/projects/lorem/node_modules/ipsum',
+      'C:/path/to/project/node_modules/a/node_modules/b',
+    ]
+    t.strictSame(
+      from.map(f => getReadablePath(f)),
+      to,
+      'should return the correct windows readable path',
+    )
+  })
 })

--- a/src/vlt/test/start-gui.ts
+++ b/src/vlt/test/start-gui.ts
@@ -295,14 +295,28 @@ t.test('formatDashboardJson dashboardProjectLocations', async t => {
       },
     },
   )
-  t.matchSnapshot(
-    formatDashboardJson(projectFolders, {
+  const { dashboardProjectLocations } = formatDashboardJson(
+    projectFolders,
+    {
       options: {
         packageJson,
         scurry,
       } as ConfigOptions,
       values: {},
-    } as LoadedConfig).dashboardProjectLocations,
+    } as LoadedConfig,
+  )
+
+  // needs to clean up the string before snapshotting due to the fact
+  // that windows paths are tweaked by the implementation here and thus
+  // will fail to match the default clean up from @tapjs/snapshot
+  const cleanedup = JSON.stringify(
+    dashboardProjectLocations,
+    null,
+    2,
+  ).replace(dir, '{HOMEDIR}')
+
+  t.matchSnapshot(
+    cleanedup,
     'should return the expected dashboard project locations',
   )
 })

--- a/src/vlt/test/start-gui.ts
+++ b/src/vlt/test/start-gui.ts
@@ -19,10 +19,12 @@ import {
 import { actualObject } from './fixtures/actual.ts'
 
 t.cleanSnapshot = s =>
-  s.replace(
-    /^(\s+)"projectRoot": ".*"/gm,
-    '$1"projectRoot": "{ROOT}"',
-  )
+  s
+    .replace(
+      /^(\s+)"projectRoot": ".*"/gm,
+      '$1"projectRoot": "{ROOT}"',
+    )
+    .replace(/\\/g, '/')
 
 t.test('starts gui data and server', async t => {
   class PackageJson {

--- a/src/vlt/test/start-gui.ts
+++ b/src/vlt/test/start-gui.ts
@@ -19,10 +19,12 @@ import {
 import { actualObject } from './fixtures/actual.ts'
 
 t.cleanSnapshot = s =>
-  s.replace(
-    /^(\s+)"projectRoot": ".*"/gm,
-    '$1"projectRoot": "{ROOT}"',
-  )
+  s
+    .replace(
+      /^(\s+)"projectRoot": ".*"/gm,
+      '$1"projectRoot": "{ROOT}"',
+    )
+    .replaceAll(/\\/g, '/')
 
 t.test('starts gui data and server', async t => {
   class PackageJson {


### PR DESCRIPTION
Add a list of possible project locations to the `dashboard.json` data. This list may be used by the UI to propose locations to create new projects.