### PR TITLE
bugfix: gui prevent uninstall redirect

### DIFF
--- a/src/gui/src/components/explorer-grid/side-item.tsx
+++ b/src/gui/src/components/explorer-grid/side-item.tsx
@@ -47,6 +47,7 @@ export const SideItem = ({
     }
   })
   const uninstallItem = (e: MouseEvent) => {
+    e.stopPropagation()
     e.preventDefault()
     if (onUninstall) {
       onUninstall(item)


### PR DESCRIPTION
quick fix to prevent the ui from transitioning to an empty state after uninstall a dependency.
