### PR TITLE
fix: add back the desktop as a potential lookup location

### DIFF
--- a/src/vlt/src/ignored-homedir-folder-names.ts
+++ b/src/vlt/src/ignored-homedir-folder-names.ts
@@ -2,7 +2,6 @@
  * A list of folder names that are ignored when reading the user's home dir.
  */
 export const ignoredHomedirFolderNames = [
-  'Desktop',
   'Downloads',
   'Movies',
   'Music',


### PR DESCRIPTION
### Description
I store a ton of tests/demos/projects on my desktop & that may seem weird but I don't think I'm the only one. Most other ignored directories have an explicit usecase which is codified in their name but `"Desktop"` is a bit more ambiguous.