### PR TITLE
gui: refactor request route transition

### DIFF
--- a/src/gui/src/lib/request-route-transition.ts
+++ b/src/gui/src/lib/request-route-transition.ts
@@ -1,0 +1,59 @@
+import { type Action } from '@/state/types.js'
+import { DEFAULT_QUERY } from '@/state/index.js'
+
+export type RequestRouteTransitionOptions<T> = {
+  updateActiveRoute: Action['updateActiveRoute']
+  updateErrorCause: Action['updateErrorCause']
+  updateQuery: Action['updateQuery']
+  updateStamp: Action['updateStamp']
+  body: T
+  url: string
+  destinationRoute: string
+  errorMessage: string
+}
+
+export const requestRouteTransition = async <T>({
+  updateActiveRoute,
+  updateErrorCause,
+  updateQuery,
+  updateStamp,
+  body,
+  url,
+  destinationRoute,
+  errorMessage,
+}: RequestRouteTransitionOptions<T>) => {
+  let req
+  try {
+    req = await fetch(url, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(body),
+    })
+  } catch (err) {
+    // eslint-disable-next-line no-console
+    console.error(err)
+    updateActiveRoute('/error')
+    updateErrorCause('Failed to submit request.')
+    return
+  }
+
+  let projectSelected = false
+  try {
+    projectSelected = (await req.json()) === 'ok'
+  } catch (err) {
+    // eslint-disable-next-line no-console
+    console.error(err)
+  }
+
+  if (projectSelected) {
+    window.scrollTo(0, 0)
+    updateQuery(DEFAULT_QUERY)
+    updateActiveRoute(destinationRoute)
+    updateStamp()
+  } else {
+    updateActiveRoute('/error')
+    updateErrorCause(errorMessage)
+  }
+}

--- a/src/gui/test/lib/request-route-transition.ts
+++ b/src/gui/test/lib/request-route-transition.ts
@@ -1,0 +1,122 @@
+import { afterEach, beforeEach, expect, test, vi } from 'vitest'
+import { requestRouteTransition } from '@/lib/request-route-transition.js'
+
+const stderr = console.error
+
+afterEach(() => {
+  console.error = stderr
+  vi.clearAllMocks()
+})
+
+beforeEach(() => {
+  global.fetch = (async (url: string) => {
+    if (url === '/throw') {
+      throw new Error('ERR')
+    }
+
+    return {
+      json: async () => {
+        switch (url) {
+          case '/ok': {
+            return 'ok'
+          }
+          case '/error': {
+            return 'error'
+          }
+          default: {
+            throw Object.assign(
+              { status: 404 },
+              new Error('Not found'),
+            )
+          }
+        }
+      },
+    }
+  }) as unknown as typeof global.fetch
+})
+
+test('requestRouteTransition success', async () => {
+  const updateActiveRoute = vi.fn()
+  const updateErrorCause = vi.fn()
+  const updateQuery = vi.fn()
+  const updateStamp = vi.fn()
+  await requestRouteTransition({
+    updateActiveRoute,
+    updateErrorCause,
+    updateQuery,
+    updateStamp,
+    body: {},
+    url: '/ok',
+    destinationRoute: '/next-route',
+    errorMessage: 'Unexpected error.',
+  })
+  expect(updateErrorCause).not.toHaveBeenCalled()
+  expect(updateActiveRoute).toHaveBeenCalledWith('/next-route')
+  expect(updateStamp).toHaveBeenCalled()
+})
+
+test('requestRouteTransition failure', async () => {
+  const updateActiveRoute = vi.fn()
+  const updateErrorCause = vi.fn()
+  const updateQuery = vi.fn()
+  const updateStamp = vi.fn()
+  await requestRouteTransition({
+    updateActiveRoute,
+    updateErrorCause,
+    updateQuery,
+    updateStamp,
+    body: {},
+    url: '/error',
+    destinationRoute: '/next-route',
+    errorMessage: 'Failed.',
+  })
+  expect(updateActiveRoute).toHaveBeenCalledWith('/error')
+  expect(updateErrorCause).toHaveBeenCalledWith('Failed.')
+  expect(updateStamp).not.toHaveBeenCalled()
+})
+
+test('requestRouteTransition 404', async () => {
+  console.error = vi.fn()
+  const updateActiveRoute = vi.fn()
+  const updateErrorCause = vi.fn()
+  const updateQuery = vi.fn()
+  const updateStamp = vi.fn()
+  await requestRouteTransition({
+    updateActiveRoute,
+    updateErrorCause,
+    updateQuery,
+    updateStamp,
+    body: {},
+    url: '/missing',
+    destinationRoute: '/next-route',
+    errorMessage: 'Failed.',
+  })
+  expect(console.error).toHaveBeenCalled()
+  expect(updateActiveRoute).toHaveBeenCalledWith('/error')
+  expect(updateErrorCause).toHaveBeenCalledWith('Failed.')
+  expect(updateStamp).not.toHaveBeenCalled()
+})
+
+test('requestRouteTransition throw', async () => {
+  console.error = vi.fn()
+  const updateActiveRoute = vi.fn()
+  const updateErrorCause = vi.fn()
+  const updateQuery = vi.fn()
+  const updateStamp = vi.fn()
+  await requestRouteTransition({
+    updateActiveRoute,
+    updateErrorCause,
+    updateQuery,
+    updateStamp,
+    body: {},
+    url: '/throw',
+    destinationRoute: '/next-route',
+    errorMessage: 'Failed.',
+  })
+  expect(console.error).toHaveBeenCalled()
+  expect(updateActiveRoute).toHaveBeenCalledWith('/error')
+  expect(updateErrorCause).toHaveBeenCalledWith(
+    'Failed to submit request.',
+  )
+  expect(updateStamp).not.toHaveBeenCalled()
+})


### PR DESCRIPTION
Refactored the method used by the dashboard grid component to switch project into a reusable helper that can be used for other different backend interactions that will require a route change in the GUI.