### PR TITLE
vlt: add start-gui create-project endpoint

### DIFF
--- a/src/vlt/src/get-author-from-git-user.ts
+++ b/src/vlt/src/get-author-from-git-user.ts
@@ -1,0 +1,13 @@
+import { type GitUser } from '@vltpkg/git'
+
+export const getAuthorFromGitUser = (user?: GitUser): string => {
+  if (!user) return ''
+  const { name, email } = user
+  let res = ''
+  if (name) res += name
+  if (email) {
+    if (name) res += ' '
+    res += `<${email}>`
+  }
+  return res
+}

--- a/src/vlt/tap-snapshots/test/init.ts.test.cjs
+++ b/src/vlt/tap-snapshots/test/init.ts.test.cjs
@@ -33,6 +33,34 @@ Modify & add package.json properties using \`vlt pkg\`, e.g:
 
 `
 
+exports[`test/init.ts > TAP > init with author info > should init a new package.json file with author info 1`] = `
+{
+  "name": "my-project",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "author": "Ruy Adorno"
+}
+
+`
+
+exports[`test/init.ts > TAP > init with author info > should output expected message with author info 1`] = `
+Wrote to {CWD}/.tap/fixtures/test-init.ts-init-with-author-info/my-project/package.json:
+
+{
+  "name": "my-project",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "author": "Ruy Adorno"
+}
+
+Modify & add package.json properties using \`vlt pkg\`, e.g:
+
+  vlt pkg set "description=My new project"
+
+`
+
 exports[`test/init.ts > TAP > missing user info > should init a new package.json file with no user info 1`] = `
 {
   "name": "my-project",

--- a/src/vlt/tap-snapshots/test/start-gui.ts.test.cjs
+++ b/src/vlt/tap-snapshots/test/start-gui.ts.test.cjs
@@ -5,6 +5,43 @@
  * Make sure to inspect the output below.  Do not ignore changes!
  */
 'use strict'
+exports[`test/start-gui.ts > TAP > e2e server test > /create-project > should log the server start message 1`] = `
+Array [
+  "⚡️ vlt GUI running at http://localhost:8017",
+  "⚡️ vlt GUI running at http://localhost:8022",
+]
+`
+
+exports[`test/start-gui.ts > TAP > e2e server test > /create-project > standard request > should update graph.json with new project data 1`] = `
+{
+  "hasDashboard": true,
+  "importers": [
+    {
+      "id": "file·.",
+      "name": "new-project",
+      "version": "1.0.0",
+      "location": ".",
+      "importer": true,
+      "manifest": {
+        "name": "new-project",
+        "version": "1.0.0",
+        "description": "",
+        "main": "index.js",
+        "author": "Ruy Adorno"
+      },
+      "projectRoot": "{ROOT}",
+      "dev": false,
+      "optional": false
+    }
+  ],
+  "lockfile": {
+    "options": {},
+    "nodes": {},
+    "edges": {}
+  }
+}
+`
+
 exports[`test/start-gui.ts > TAP > e2e server test > /install > should install dependencies 1`] = `
 install
 

--- a/src/vlt/test/get-author-from-git-user.ts
+++ b/src/vlt/test/get-author-from-git-user.ts
@@ -1,0 +1,51 @@
+import t from 'tap'
+import { getAuthorFromGitUser } from '../src/get-author-from-git-user.ts'
+
+t.strictSame(
+  getAuthorFromGitUser({
+    name: 'Ruy Adorno',
+    email: 'ruy@example.com',
+  }),
+  'Ruy Adorno <ruy@example.com>',
+  'should return the expected author string',
+)
+
+t.strictSame(
+  getAuthorFromGitUser(),
+  '',
+  'should return an empty string if no user provided',
+)
+
+t.strictSame(
+  getAuthorFromGitUser({
+    name: 'Foo',
+  }),
+  'Foo',
+  'should return name only',
+)
+
+t.strictSame(
+  getAuthorFromGitUser({
+    email: 'foo@bar.ca',
+  }),
+  '<foo@bar.ca>',
+  'should return email only',
+)
+
+t.strictSame(
+  getAuthorFromGitUser({
+    name: '',
+    email: 'foo@bar.ca',
+  }),
+  '<foo@bar.ca>',
+  'should return email ignoring empty name',
+)
+
+t.strictSame(
+  getAuthorFromGitUser({
+    name: 'Lorem Ipsum',
+    email: '',
+  }),
+  'Lorem Ipsum',
+  'should return name ignoring empty email',
+)

--- a/src/vlt/test/init.ts
+++ b/src/vlt/test/init.ts
@@ -94,3 +94,22 @@ t.test('missing user info', async t => {
     'should init a new package.json file with no user info',
   )
 })
+
+t.test('init with author info', async t => {
+  const dir = t.testdir({
+    'my-project': {},
+  })
+
+  t.matchSnapshot(
+    await init({
+      cwd: resolve(dir, 'my-project'),
+      author: 'Ruy Adorno',
+    }),
+    'should output expected message with author info',
+  )
+
+  t.matchSnapshot(
+    readFileSync(resolve(dir, 'my-project', 'package.json'), 'utf8'),
+    'should init a new package.json file with author info',
+  )
+})


### PR DESCRIPTION
Add a `/create-project` endpoint that creates a new folder and sets up a new project using `init`.