### PR TITLE
vlt: refresh dashboard data

### DIFF
--- a/src/vlt/src/start-gui.ts
+++ b/src/vlt/src/start-gui.ts
@@ -443,13 +443,18 @@ export const startGUI = async ({
   // dashboard data is optional since the GUI might be started from a
   // project in order to just explore its graph data
   let hasDashboard = false
-  try {
-    hasDashboard = await updateDashboardData(tmp, conf)
-    /* c8 ignore next */
-  } catch {}
-  if (!hasDashboard) {
-    rmSync(resolve(tmp, 'dashboard.json'), { force: true })
+
+  const updateDashboard = async () => {
+    try {
+      hasDashboard = await updateDashboardData(tmp, conf)
+      /* c8 ignore next */
+    } catch {}
+    if (!hasDashboard) {
+      rmSync(resolve(tmp, 'dashboard.json'), { force: true })
+    }
   }
+
+  await updateDashboard()
 
   // reading graph data is optional since the command might be run from a
   // parend directory of any given project root, in which case the GUI is
@@ -491,6 +496,7 @@ export const startGUI = async ({
         const data = await json<{ path: unknown }>()
         conf.resetOptions(String(data.path))
         updateGraphData(tmp, conf, hasDashboard)
+        await updateDashboard()
         return jsonOk('ok')
       }
       case 'POST /create-project': {
@@ -525,6 +531,7 @@ export const startGUI = async ({
           await init({ cwd, author })
           conf.resetOptions(cwd)
           updateGraphData(tmp, conf, hasDashboard)
+          await updateDashboard()
         } catch (err) {
           // eslint-disable-next-line no-console
           console.error(err)


### PR DESCRIPTION
After processing one of dashboard operations such as create or select project the dashboard data needs refreshing otherwise any modification to the file system is going to be ignored.