### PR TITLE
install: dont use tsx for now

### DIFF
--- a/src/vlt/src/commands/install.ts
+++ b/src/vlt/src/commands/install.ts
@@ -7,7 +7,7 @@ import {
 } from '../types.ts'
 import { commandUsage } from '../config/usage.ts'
 import { install } from '../install.ts'
-import { InstallReporter } from './install/reporter.tsx'
+import { InstallReporter } from './install/reporter.ts'
 
 export const usage: CommandUsage = () =>
   commandUsage({

--- a/src/vlt/src/commands/install/reporter.ts
+++ b/src/vlt/src/commands/install/reporter.ts
@@ -1,5 +1,10 @@
 import { emitter, type Events } from '@vltpkg/output'
-import React, { useState, useLayoutEffect } from 'react'
+import {
+  Fragment,
+  createElement as $,
+  useState,
+  useLayoutEffect,
+} from 'react'
 import { render, Text, Box, type Instance } from 'ink'
 import Spinner from 'ink-spinner'
 import { type ViewInstance } from '../../types.ts'
@@ -11,16 +16,17 @@ type Step = {
 
 const GraphStep = ({ text, step }: { text: string; step: Step }) => {
   if (step.state === 'waiting') {
-    return <Text color="gray">{text}</Text>
+    return $(Text, { color: 'gray' }, text)
   }
   if (step.state === 'in_progress') {
-    return (
-      <Text color="yellow">
-        {text} <Spinner type="dots" />
-      </Text>
+    return $(
+      Text,
+      { color: 'yellow' },
+      text,
+      $(Spinner, { type: 'dots' }),
     )
   }
-  return <Text color="green">{text} ✓</Text>
+  return $(Text, { color: 'green' }, text, ' ✓')
 }
 
 const App = () => {
@@ -60,25 +66,25 @@ const App = () => {
     return () => emitter.off('graphStep', update)
   }, [])
 
-  return (
-    <>
-      <Box>
-        {(['build', 'actual', 'reify'] as const).map(
-          (step, idx, list) => {
-            const separator = idx === list.length - 1 ? '' : ' > '
-            return (
-              <Text key={step}>
-                <GraphStep text={step} step={steps[step]} />
-                <Text color="gray">{separator}</Text>
-              </Text>
-            )
-          },
-        )}
-      </Box>
-      {requests > 0 ?
-        <Text>{requests} requests</Text>
-      : null}
-    </>
+  return $(
+    Fragment,
+    null,
+    $(
+      Box,
+      null,
+      ...(['build', 'actual', 'reify'] as const).map(
+        (step, idx, list) => {
+          const separator = idx === list.length - 1 ? '' : ' > '
+          return $(
+            Text,
+            { key: step },
+            $(GraphStep, { text: step, step: steps[step] }),
+            $(Text, { color: 'gray' }, separator),
+          )
+        },
+      ),
+    ),
+    requests > 0 ? $(Text, null, `${requests} requests`) : null,
   )
 }
 
@@ -90,7 +96,7 @@ export class InstallReporter implements ViewInstance {
   }
 
   start() {
-    this.#instance = render(<App />)
+    this.#instance = render($(App))
   }
 
   done(_result: unknown, { time }: { time: number }) {


### PR DESCRIPTION
This is a stop-gap to allow the CLI TypeScript source to be run completely with Node.

A future PR will revert this commit while also moving it to a new workspace that will require building in order to compile the JSX to JS.

I'll do this the next time I add a new `ink` based reporter.