### PR TITLE
fix: margin bottom issues where background is visible

### DIFF
--- a/src/gui/src/components/dashboard-grid/index.tsx
+++ b/src/gui/src/components/dashboard-grid/index.tsx
@@ -145,7 +145,7 @@ export const DashboardGrid = () => {
 
   return (
     <div className="flex grow flex-col bg-secondary px-8 py-8 dark:bg-black">
-      <div className="mb-8 flex gap-2">
+      <div className="flex gap-2 pb-8">
         {currentView === 'table' ?
           <TableFilterSearch
             filterValue={tableFilterValue}

--- a/src/gui/src/components/explorer-grid/empty-results-state.tsx
+++ b/src/gui/src/components/explorer-grid/empty-results-state.tsx
@@ -15,7 +15,7 @@ const EmptyResultsState = () => {
 
   return (
     <section className="flex h-full min-h-[70svh] w-full flex-col items-center justify-center px-8 pt-4">
-      <div className="relative -mt-10 mb-8 flex h-fit w-fit flex-col items-center justify-center">
+      <div className="relative -mt-10 flex h-fit w-fit flex-col items-center justify-center pb-8">
         <MiniQuery className="-mb-6 h-[64px] w-[275px] opacity-30" />
         <MiniQuery className="z-[1] shadow-lg" />
         <MiniQuery className="-mt-6 h-[64px] w-[275px] opacity-30" />

--- a/src/gui/src/components/explorer-grid/index.tsx
+++ b/src/gui/src/components/explorer-grid/index.tsx
@@ -354,7 +354,7 @@ export const ExplorerGrid = () => {
   if (!items.length) return <EmptyResultsState />
 
   return (
-    <div className="mb-8 grid grow grid-cols-7 gap-4 bg-secondary px-8 dark:bg-black">
+    <div className="grid grow grid-cols-7 gap-4 bg-secondary px-8 pb-8 dark:bg-black">
       <div className="col-span-2">
         {parentItem ?
           <>

--- a/src/gui/test/components/dashboard-grid/__snapshots__/index.tsx.snap
+++ b/src/gui/test/components/dashboard-grid/__snapshots__/index.tsx.snap
@@ -4,7 +4,7 @@ exports[`dashboard-grid render default 1`] = `
 
 <div>
   <div class="flex grow flex-col bg-secondary px-8 py-8 dark:bg-black">
-    <div class="mb-8 flex gap-2">
+    <div class="flex gap-2 pb-8">
       <gui-filter-search
         placeholder="Filter Projects"
         items
@@ -49,7 +49,7 @@ exports[`dashboard-grid with results 1`] = `
 
 <div>
   <div class="flex grow flex-col bg-secondary px-8 py-8 dark:bg-black">
-    <div class="mb-8 flex gap-2">
+    <div class="flex gap-2 pb-8">
       <gui-filter-search
         placeholder="Filter Projects"
         items="[object Object],[object Object]"

--- a/src/gui/test/components/explorer-grid/__snapshots__/empty-results-state.tsx.snap
+++ b/src/gui/test/components/explorer-grid/__snapshots__/empty-results-state.tsx.snap
@@ -3,7 +3,7 @@
 exports[`render default 1`] = `
 
 <section class="flex h-full min-h-[70svh] w-full flex-col items-center justify-center px-8 pt-4">
-  <div class="relative -mt-10 mb-8 flex h-fit w-fit flex-col items-center justify-center">
+  <div class="relative -mt-10 flex h-fit w-fit flex-col items-center justify-center pb-8">
     <div class="flex h-[70px] w-[300px] flex-col rounded-sm border-[1px] border-neutral-200 bg-muted dark:border-neutral-800 dark:bg-black -mb-6 h-[64px] w-[275px] opacity-30">
       <div class="flex items-center justify-between border-b-[1px] border-neutral-200 p-2 dark:border-neutral-800">
         <div class="h-[18px] w-[80px] rounded-sm border-[1px] border-neutral-300 bg-neutral-200 dark:border-neutral-800 dark:bg-neutral-950">

--- a/src/gui/test/components/explorer-grid/__snapshots__/index.tsx.snap
+++ b/src/gui/test/components/explorer-grid/__snapshots__/index.tsx.snap
@@ -12,7 +12,7 @@ exports[`explorer-grid render default 1`] = `
 exports[`explorer-grid renders workspace with edges in 1`] = `
 
 <div>
-  <div class="mb-8 grid grow grid-cols-7 gap-4 bg-secondary px-8 dark:bg-black">
+  <div class="grid grow grid-cols-7 gap-4 bg-secondary px-8 pb-8 dark:bg-black">
     <div class="col-span-2">
       <div class="text-md flex flex-row items-center pt-6 font-medium">
         <svg
@@ -307,7 +307,7 @@ exports[`explorer-grid renders workspace with edges in 1`] = `
 exports[`explorer-grid with results 1`] = `
 
 <div>
-  <div class="mb-8 grid grow grid-cols-7 gap-4 bg-secondary px-8 dark:bg-black">
+  <div class="grid grow grid-cols-7 gap-4 bg-secondary px-8 pb-8 dark:bg-black">
     <div class="col-span-2">
     </div>
     <div class="col-span-3">
@@ -412,7 +412,7 @@ exports[`explorer-grid with results 1`] = `
 exports[`explorer-grid with stack 1`] = `
 
 <div>
-  <div class="mb-8 grid grow grid-cols-7 gap-4 bg-secondary px-8 dark:bg-black">
+  <div class="grid grow grid-cols-7 gap-4 bg-secondary px-8 pb-8 dark:bg-black">
     <div class="col-span-2">
     </div>
     <div class="col-span-3">


### PR DESCRIPTION
### Description
Changes the class on the container from being a margin to padding which resolves the whitespace issue where you'd see the background at the bottom of the page.

### Before
![Screenshot 2025-02-12 at 1 17 38 PM](https://github.com/user-attachments/assets/95382201-5166-4d9b-9dba-9979294f38a3)

### After
![Screenshot 2025-02-12 at 1 19 09 PM](https://github.com/user-attachments/assets/096ce291-67b1-485f-bca9-4dbff1b804d6)
