### PR TITLE
vlt: refactor start-gui project-info

### DIFF
--- a/src/vlt/src/project-info.ts
+++ b/src/vlt/src/project-info.ts
@@ -1,0 +1,141 @@
+import { homedir } from 'node:os'
+import { type PathBase, type PathScurry } from 'path-scurry'
+import { type LoadedConfig } from './types.ts'
+import { type Manifest } from '@vltpkg/types'
+
+export type ProjectTools =
+  | 'vlt'
+  | 'node'
+  | 'deno'
+  | 'bun'
+  | 'npm'
+  | 'pnpm'
+  | 'yarn'
+  | 'js'
+
+export type DashboardProjectData = {
+  name: string
+  readablePath: string
+  path: string
+  manifest: Manifest
+  tools: ProjectTools[]
+  mtime?: number
+}
+
+export type GraphProjectData = {
+  tools: ProjectTools[]
+  vltInstalled: boolean
+}
+
+const knownTools = new Map<ProjectTools, string[]>([
+  [
+    'vlt',
+    [
+      'vlt-lock.json',
+      'vlt-workspaces.json',
+      'vlt.json',
+      'node_modules/.vlt',
+    ],
+  ],
+  ['node', []],
+  ['deno', ['deno.json']],
+  ['bun', ['bun.lockb', 'bunfig.toml']],
+  ['npm', ['package-lock.json', 'node_modules/.package-lock.json']],
+  [
+    'pnpm',
+    ['pnpm-lock.yaml', 'pnpm-workspace.yaml', 'node_modules/.pnpm'],
+  ],
+  ['yarn', ['yarn.lock']],
+])
+
+export const isProjectTools = (str: string): str is ProjectTools =>
+  knownTools.has(str as ProjectTools)
+
+export const asProjectTools = (str: string): ProjectTools => {
+  if (!isProjectTools(str)) {
+    throw new Error(`Invalid dashboard tool: ${str}`)
+  }
+  return str
+}
+
+export const inferTools = (
+  manifest: Manifest,
+  folder: PathBase,
+  scurry: PathScurry,
+) => {
+  const tools: ProjectTools[] = []
+  // check if known tools names are found in the manifest file
+  for (const knownName of knownTools.keys()) {
+    if (
+      Object.hasOwn(manifest, knownName) ||
+      (manifest.engines && Object.hasOwn(manifest.engines, knownName))
+    ) {
+      tools.push(asProjectTools(knownName))
+    }
+  }
+
+  // check for known file names
+  for (const [knownName, files] of knownTools) {
+    for (const file of files) {
+      if (scurry.lstatSync(folder.resolve(file))) {
+        tools.push(asProjectTools(knownName))
+        break
+      }
+    }
+  }
+
+  // defaults to js if no tools are found
+  if (tools.length === 0) {
+    tools.push('js')
+  }
+  return tools
+}
+
+export const getReadablePath = (path: string) =>
+  path.replace(homedir(), '~')
+
+export const getDashboardProjectData = (
+  folder: PathBase,
+  conf: LoadedConfig,
+): DashboardProjectData | undefined => {
+  const { packageJson, scurry } = conf.options
+  let manifest
+  try {
+    manifest = packageJson.read(folder.fullpath())
+  } catch {
+    return
+  }
+  const path = folder.fullpath()
+  return {
+    name: manifest.name || folder.name,
+    readablePath: getReadablePath(path),
+    path,
+    manifest,
+    tools: inferTools(manifest, folder, scurry),
+    mtime: folder.lstatSync()?.mtimeMs,
+  }
+}
+
+export const getGraphProjectData = (
+  conf: LoadedConfig,
+  folder?: PathBase,
+) => {
+  if (!folder) {
+    return {
+      tools: [],
+      vltInstalled: false,
+    }
+  }
+
+  const { packageJson, scurry } = conf.options
+  return {
+    tools: inferTools(
+      packageJson.read(folder.fullpath()),
+      folder,
+      scurry,
+    ),
+    vltInstalled: !!scurry
+      .lstatSync(folder.resolve('node_modules/.vlt'))
+      ?.isDirectory(),
+  }
+}

--- a/src/vlt/tap-snapshots/test/project-info.ts.test.cjs
+++ b/src/vlt/tap-snapshots/test/project-info.ts.test.cjs
@@ -1,0 +1,95 @@
+/* IMPORTANT
+ * This snapshot file is auto-generated, but designed for humans.
+ * It should be checked into source control and tracked carefully.
+ * Re-generate by setting TAP_SNAPSHOT=1 and running tests.
+ * Make sure to inspect the output below.  Do not ignore changes!
+ */
+'use strict'
+exports[`test/project-info.ts > TAP > getDashboardProjectData > should return the correct dashboard project data 1`] = `
+Array [
+  Object {
+    "manifest": Object {
+      [Symbol.for(indent)]: "",
+      [Symbol.for(newline)]: "",
+      "version": "1.0.0",
+    },
+    "mtime": 1,
+    "name": "d",
+    "path": "{CWD}/.tap/fixtures/test-project-info.ts-getDashboardProjectData/home/user/projects/d",
+    "readablePath": "~/projects/d",
+    "tools": Array [
+      "pnpm",
+    ],
+  },
+  Object {
+    "manifest": Object {
+      "name": "c",
+      [Symbol.for(indent)]: "",
+      [Symbol.for(newline)]: "",
+      "version": "1.0.0",
+    },
+    "mtime": 1,
+    "name": "c",
+    "path": "{CWD}/.tap/fixtures/test-project-info.ts-getDashboardProjectData/home/user/projects/c",
+    "readablePath": "~/projects/c",
+    "tools": Array [
+      "vlt",
+    ],
+  },
+  Object {
+    "manifest": Object {
+      "engines": Object {
+        "node": ">=20",
+        "npm": ">=10",
+      },
+      "name": "a",
+      [Symbol.for(indent)]: "",
+      [Symbol.for(newline)]: "",
+      "version": "1.0.0",
+    },
+    "mtime": 1,
+    "name": "a",
+    "path": "{CWD}/.tap/fixtures/test-project-info.ts-getDashboardProjectData/home/user/projects/a",
+    "readablePath": "~/projects/a",
+    "tools": Array [
+      "node",
+      "npm",
+    ],
+  },
+]
+`
+
+exports[`test/project-info.ts > TAP > getGraphProjectData > should return emtpy response on missing folder 1`] = `
+Object {
+  "tools": Array [],
+  "vltInstalled": false,
+}
+`
+
+exports[`test/project-info.ts > TAP > getGraphProjectData > should return the correct graph project data for a node+npm project 1`] = `
+Object {
+  "tools": Array [
+    "node",
+    "npm",
+  ],
+  "vltInstalled": false,
+}
+`
+
+exports[`test/project-info.ts > TAP > getGraphProjectData > should return the correct graph project data for a non-installed vlt project 1`] = `
+Object {
+  "tools": Array [
+    "vlt",
+  ],
+  "vltInstalled": false,
+}
+`
+
+exports[`test/project-info.ts > TAP > getGraphProjectData > should return the correct graph project data for a vlt project 1`] = `
+Object {
+  "tools": Array [
+    "vlt",
+  ],
+  "vltInstalled": true,
+}
+`

--- a/src/vlt/tap-snapshots/test/start-gui.ts.test.cjs
+++ b/src/vlt/tap-snapshots/test/start-gui.ts.test.cjs
@@ -38,6 +38,12 @@ exports[`test/start-gui.ts > TAP > e2e server test > /create-project > standard 
     "options": {},
     "nodes": {},
     "edges": {}
+  },
+  "projectInfo": {
+    "tools": [
+      "js"
+    ],
+    "vltInstalled": false
   }
 }
 `
@@ -74,6 +80,12 @@ exports[`test/start-gui.ts > TAP > e2e server test > /select-project > should up
     "options": {},
     "nodes": {},
     "edges": {}
+  },
+  "projectInfo": {
+    "tools": [
+      "pnpm"
+    ],
+    "vltInstalled": false
   }
 }
 `
@@ -126,6 +138,12 @@ exports[`test/start-gui.ts > TAP > e2e server test > /select-project > should wr
       "file·. link": "prod file:./linked MISSING",
       "file·. missing": "prod ^1.0.0 MISSING"
     }
+  },
+  "projectInfo": {
+    "tools": [
+      "vlt"
+    ],
+    "vltInstalled": true
   }
 }
 `
@@ -468,6 +486,12 @@ Object {
     "importers": Array [],
     "nodes": Object {},
     "options": Object {},
+  },
+  "projectInfo": Object {
+    "tools": Array [
+      "js",
+    ],
+    "vltInstalled": false,
   },
 }
 `

--- a/src/vlt/test/project-info.ts
+++ b/src/vlt/test/project-info.ts
@@ -1,0 +1,322 @@
+import { resolve } from 'node:path'
+import t from 'tap'
+import { type PathBase, PathScurry } from 'path-scurry'
+import { PackageJson } from '@vltpkg/package-json'
+import { type Manifest } from '@vltpkg/types'
+import {
+  asProjectTools,
+  isProjectTools,
+  inferTools,
+  type ProjectTools,
+  type DashboardProjectData,
+  getGraphProjectData,
+} from '../src/project-info.ts'
+import {
+  type ConfigOptions,
+  type LoadedConfig,
+} from '../src/types.ts'
+
+t.cleanSnapshot = s => s.replace(/\\\\/g, '/')
+
+t.test('isProjectTools', async t => {
+  t.ok(isProjectTools('vlt'), 'should return true for vlt')
+  t.notOk(
+    isProjectTools('non-indexed-tool'),
+    'should return false for unknown tool',
+  )
+})
+
+t.test('asProjectTools', async t => {
+  const tool: ProjectTools = asProjectTools('vlt')
+  t.equal(tool, 'vlt', 'should return type casted string')
+  t.throws(
+    () => asProjectTools('non-indexed-tool'),
+    /Invalid dashboard tool: non-indexed-tool/,
+    'should throw an error for unknown tool',
+  )
+})
+
+t.test('inferTools', async t => {
+  const dir = t.testdir({
+    'with-engines': {
+      'package.json': JSON.stringify({
+        name: 'manifest-with-engines',
+        engines: {
+          node: '>=20',
+          npm: '>=10',
+        },
+      }),
+    },
+    empty: {
+      'package.json': JSON.stringify({
+        name: 'empty-manifest',
+      }),
+    },
+    'with-config-props': {
+      'package.json': JSON.stringify({
+        name: 'manifest-with-config-props',
+        pnpm: {
+          hooks: {
+            readPackage: 'echo "Hello"',
+          },
+        },
+      }),
+    },
+    'with-pnpm-lockfile': {
+      'package.json': JSON.stringify({
+        name: 'manifest-with-pnpm-lockfile',
+      }),
+      'pnpm-lock.yaml': '',
+    },
+  })
+  const packageJson = new PackageJson()
+  const scurry = new PathScurry(t.testdirName)
+  const folders = new Map<string, PathBase>()
+  const manis = new Map<string, Manifest>()
+  for (const entry of scurry.readdirSync(dir)) {
+    folders.set(entry.name, entry)
+    manis.set(entry.name, packageJson.read(entry.fullpath()))
+  }
+
+  const mainWithEnginesFolder = folders.get('with-engines')!
+  const mainWithEnginesMani = manis.get('with-engines')!
+  t.strictSame(
+    inferTools(mainWithEnginesMani, mainWithEnginesFolder, scurry),
+    ['node', 'npm'],
+  )
+
+  const emptyFolder = folders.get('empty')!
+  const emptyMani = manis.get('empty')!
+  t.strictSame(inferTools(emptyMani, emptyFolder, scurry), ['js'])
+
+  const withConfigPropsFolder = folders.get('with-config-props')!
+  const withConfigPropsMani = manis.get('with-config-props')!
+  t.strictSame(
+    inferTools(withConfigPropsMani, withConfigPropsFolder, scurry),
+    ['pnpm'],
+  )
+
+  const withPnpmLockfileFolder = folders.get('with-pnpm-lockfile')!
+  const withPnpmLockfileMani = manis.get('with-pnpm-lockfile')!
+  t.strictSame(
+    inferTools(withPnpmLockfileMani, withPnpmLockfileFolder, scurry),
+    ['pnpm'],
+  )
+})
+
+t.test('getReadablePath', async t => {
+  await t.test('posix', async t => {
+    const { getReadablePath } = await t.mockImport(
+      '../src/project-info.ts',
+      {
+        'node:os': {
+          homedir() {
+            return '/home/user'
+          },
+        },
+      },
+    )
+    const from = [
+      '/home/user/foo',
+      '/home/user/foo/projects/lorem/node_modules/ipsum',
+      '/path/to/project/node_modules/a/node_modules/b',
+    ]
+    const to = [
+      '~/foo',
+      '~/foo/projects/lorem/node_modules/ipsum',
+      '/path/to/project/node_modules/a/node_modules/b',
+    ]
+    t.strictSame(
+      from.map(f => getReadablePath(f)),
+      to,
+      'should return the correct posix readable path',
+    )
+  })
+  await t.test('windows', async t => {
+    const { getReadablePath } = await t.mockImport(
+      '../src/project-info.ts',
+      {
+        'node:os': {
+          homedir() {
+            return 'C:\\Users\\username'
+          },
+        },
+      },
+    )
+    const from = [
+      'C:\\Users\\username',
+      'C:\\Users\\username\\projects\\lorem\\node_modules\\ipsum',
+      'C:\\path\\to\\project\\node_modules\\a\\node_modules\\b',
+    ]
+    const to = [
+      '~',
+      '~\\projects\\lorem\\node_modules\\ipsum',
+      'C:\\path\\to\\project\\node_modules\\a\\node_modules\\b',
+    ]
+    t.strictSame(
+      from.map(f => getReadablePath(f)),
+      to,
+      'should return the correct windows readable path',
+    )
+  })
+})
+
+t.test('getDashboardProjectData', async t => {
+  const dir = t.testdir({
+    home: {
+      user: {
+        projects: {
+          a: {
+            'package.json': JSON.stringify({
+              name: 'a',
+              version: '1.0.0',
+              engines: {
+                node: '>=20',
+                npm: '>=10',
+              },
+            }),
+          },
+          b: {}, // no package.json file in **b**
+          c: {
+            'package.json': JSON.stringify({
+              name: 'c',
+              version: '1.0.0',
+            }),
+            'vlt.json': {},
+          },
+          d: {
+            'package.json': JSON.stringify({
+              version: '1.0.0',
+            }),
+            'pnpm-lock.yaml': {},
+          },
+        },
+      },
+    },
+  })
+  const { getDashboardProjectData } = await t.mockImport(
+    '../src/project-info.ts',
+    {
+      'node:os': {
+        homedir() {
+          return resolve(dir, 'home', 'user')
+        },
+      },
+    },
+  )
+  const packageJson = new PackageJson()
+  const scurry = new PathScurry(t.testdirName)
+  const folders: PathBase[] = []
+  const conf: LoadedConfig = {
+    options: {
+      packageJson,
+      scurry,
+    } as ConfigOptions,
+  } as LoadedConfig
+
+  // read all folders in projects, creating a list of PathBase objects
+  for (const entry of scurry.readdirSync(
+    resolve(dir, 'home', 'user', 'projects'),
+  )) {
+    folders.push(entry)
+  }
+
+  const res: DashboardProjectData[] = []
+  for (const folder of folders) {
+    // mock fixed mtime
+    folder.lstatSync = () => ({ mtimeMs: 1 }) as any
+
+    // collect dashboard project data
+    const data = getDashboardProjectData(folder, conf)
+    if (data) {
+      res.push(data)
+    }
+  }
+  t.matchSnapshot(
+    res,
+    'should return the correct dashboard project data',
+  )
+})
+
+t.test('getGraphProjectData', async t => {
+  const dir = t.testdir({
+    home: {
+      user: {
+        projects: {
+          a: {
+            'package.json': JSON.stringify({
+              name: 'a',
+              version: '1.0.0',
+              engines: {
+                node: '>=20',
+                npm: '>=10',
+              },
+            }),
+          },
+          b: {
+            'package.json': JSON.stringify({
+              name: 'b',
+              version: '1.0.0',
+            }),
+            node_modules: {
+              '.vlt': {},
+            },
+          },
+          c: {
+            'package.json': JSON.stringify({
+              name: 'c',
+              version: '1.0.0',
+            }),
+            'vlt.json': {},
+          },
+        },
+      },
+    },
+  })
+  const packageJson = new PackageJson()
+  const scurry = new PathScurry(t.testdirName)
+  const conf: LoadedConfig = {
+    options: {
+      packageJson,
+      scurry,
+    } as ConfigOptions,
+  } as LoadedConfig
+
+  const a = scurry.lstatSync(
+    resolve(dir, 'home', 'user', 'projects', 'a'),
+  )
+  if (!a) {
+    throw new Error('a is not a valid path')
+  }
+  t.matchSnapshot(
+    getGraphProjectData(conf, a),
+    'should return the correct graph project data for a node+npm project',
+  )
+
+  const b = scurry.lstatSync(
+    resolve(dir, 'home', 'user', 'projects', 'b'),
+  )
+  if (!b) {
+    throw new Error('b is not a valid path')
+  }
+  t.matchSnapshot(
+    getGraphProjectData(conf, b),
+    'should return the correct graph project data for a vlt project',
+  )
+
+  const c = scurry.lstatSync(
+    resolve(dir, 'home', 'user', 'projects', 'c'),
+  )
+  if (!c) {
+    throw new Error('c is not a valid path')
+  }
+  t.matchSnapshot(
+    getGraphProjectData(conf, c),
+    'should return the correct graph project data for a non-installed vlt project',
+  )
+
+  t.matchSnapshot(
+    getGraphProjectData(conf),
+    'should return emtpy response on missing folder',
+  )
+})


### PR DESCRIPTION
Extracted the bits responsible for retrieving project info into a separate `src/vlt/src/project-info.ts` module.

Added a `projectInfo` to `graph.json` to provide the GUI info on whether the current explored project is installed using the vlt client and other associated tools.