### PR TITLE
gui: add setup project

### DIFF
--- a/src/gui/src/app/explorer.tsx
+++ b/src/gui/src/app/explorer.tsx
@@ -14,6 +14,7 @@ import { Kbd } from '@/components/ui/kbd.jsx'
 import Save from '@/components/explorer-grid/save-query.jsx'
 import { QueryMatches } from '@/components/explorer-grid/query-matches.jsx'
 import { RootButton } from '@/components/explorer-grid/root-button.jsx'
+import { SetupProject } from '@/components/explorer-grid/setup-project.jsx'
 
 export type ExplorerOptions = {
   projectRoot?: string
@@ -22,6 +23,7 @@ export type ExplorerOptions = {
 type StartGraphData = {
   updateHasDashboard: Action['updateHasDashboard']
   updateGraph: Action['updateGraph']
+  updateProjectInfo: Action['updateProjectInfo']
   updateQ: Action['updateQ']
   updateSpecOptions: Action['updateSpecOptions']
   stamp: State['stamp']
@@ -30,6 +32,7 @@ type StartGraphData = {
 const startGraphData = async ({
   updateHasDashboard,
   updateGraph,
+  updateProjectInfo,
   updateQ,
   updateSpecOptions,
   stamp,
@@ -43,6 +46,7 @@ const startGraphData = async ({
 
   updateHasDashboard(data.hasDashboard)
   updateGraph(graph)
+  updateProjectInfo(data.projectInfo)
   updateSpecOptions(specOptions)
   updateQ(q)
 }
@@ -58,6 +62,9 @@ export const Explorer = () => {
     state => state.updateHasDashboard,
   )
   const updateGraph = useGraphStore(state => state.updateGraph)
+  const updateProjectInfo = useGraphStore(
+    state => state.updateProjectInfo,
+  )
   const updateQ = useGraphStore(state => state.updateQ)
   const updateSpecOptions = useGraphStore(
     state => state.updateSpecOptions,
@@ -70,6 +77,7 @@ export const Explorer = () => {
     startGraphData({
       updateHasDashboard,
       updateGraph,
+      updateProjectInfo,
       updateQ,
       updateSpecOptions,
       stamp,
@@ -88,6 +96,7 @@ const ExplorerContent = () => {
   const updateEdges = useGraphStore(state => state.updateEdges)
   const updateNodes = useGraphStore(state => state.updateNodes)
   const graph = useGraphStore(state => state.graph)
+  const projectInfo = useGraphStore(state => state.projectInfo)
   const query = useGraphStore(state => state.query)
   const q = useGraphStore(state => state.q)
 
@@ -122,10 +131,20 @@ const ExplorerContent = () => {
     updateQueryData().catch((err: unknown) => console.error(err))
   }, [query, q])
 
+  // avoids flash of content
+  if (!graph) {
+    return undefined
+  }
+
+  // intentional check for `false` in order to avoid flashing content
+  if (projectInfo.vltInstalled === false) {
+    return <SetupProject />
+  }
+
   return (
     <section className="flex grow flex-col justify-between bg-white dark:bg-black">
       <div className="flex w-full items-center justify-between border-t-[1px] px-8 pt-4">
-        {graph?.projectRoot ?
+        {graph.projectRoot ?
           <p className="font-mono text-xs font-light text-muted-foreground">
             :host-context(file:{graph.projectRoot})
           </p>

--- a/src/gui/src/components/explorer-grid/setup-project.tsx
+++ b/src/gui/src/components/explorer-grid/setup-project.tsx
@@ -1,0 +1,65 @@
+import { type SyntheticEvent, useState } from 'react'
+import { useGraphStore } from '@/state/index.js'
+import { Button } from '@/components/ui/button.jsx'
+import { Card } from '@/components/ui/card.jsx'
+import { requestRouteTransition } from '@/lib/request-route-transition.js'
+import { Download } from 'lucide-react'
+import { LoadingSpinner } from '@/components/ui/loading-spinner.jsx'
+
+export const SetupProject = () => {
+  const updateActiveRoute = useGraphStore(
+    state => state.updateActiveRoute,
+  )
+  const updateErrorCause = useGraphStore(
+    state => state.updateErrorCause,
+  )
+  const updateQuery = useGraphStore(state => state.updateQuery)
+  const updateStamp = useGraphStore(state => state.updateStamp)
+  const [inProgress, setInProgress] = useState<boolean>(false)
+
+  const onInstallClick = (e: SyntheticEvent) => {
+    e.stopPropagation()
+    e.preventDefault()
+    setInProgress(true)
+    void requestRouteTransition<{ add: Record<string, string>[] }>({
+      updateActiveRoute,
+      updateErrorCause,
+      updateQuery,
+      updateStamp,
+      body: {
+        add: [],
+      },
+      url: '/install',
+      destinationRoute: '/explore',
+      errorMessage: 'Failed to setup project.',
+    })
+  }
+
+  if (inProgress) {
+    return (
+      <div className="flex h-96 items-center justify-center">
+        <LoadingSpinner />
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex grow flex-col bg-secondary px-8 py-8 dark:bg-black">
+      <Card className="container mx-auto w-full px-8 py-8 lg:w-[1024px]">
+        <h1 className="mb-2 text-3xl font-bold">Setup Project</h1>
+        <p className="mb-6 text-gray-600">
+          Initializing your project with the <strong>vlt</strong>{' '}
+          client will replace your{' '}
+          <code className="rounded-md bg-gray-200 px-1 dark:bg-gray-900">
+            node_modules
+          </code>{' '}
+          folder with a fully compatible install managed by volt.
+        </p>
+        <Button onClick={onInstallClick}>
+          <Download size={16} />
+          Install dependencies
+        </Button>
+      </Card>
+    </div>
+  )
+}

--- a/src/gui/src/state/index.ts
+++ b/src/gui/src/state/index.ts
@@ -41,6 +41,10 @@ const initialState: State = {
   hasDashboard: false,
   linePositionReference: 258,
   nodes: [],
+  projectInfo: {
+    tools: [],
+    vltInstalled: undefined,
+  },
   query:
     new URL(
       window.location.href || 'http://localhost',
@@ -99,6 +103,8 @@ export const useGraphStore = create<Action & State>((set, get) => {
     updateLinePositionReference: (position: number) =>
       set(() => ({ linePositionReference: position })),
     updateNodes: (nodes: State['nodes']) => set(() => ({ nodes })),
+    updateProjectInfo: (projectInfo: State['projectInfo']) =>
+      set(() => ({ projectInfo })),
     updateSelectedNode: (selectedNode: State['selectedNode']) =>
       set(() => ({ selectedNode })),
     updateSpecOptions: (specOptions: State['specOptions']) =>

--- a/src/gui/src/state/types.ts
+++ b/src/gui/src/state/types.ts
@@ -20,6 +20,7 @@ export type Action = {
   updateHasDashboard: (hasDashboard: State['hasDashboard']) => void
   updateLinePositionReference: (position: number) => void
   updateNodes: (nodes: State['nodes']) => void
+  updateProjectInfo: (projectInfo: State['projectInfo']) => void
   updateSelectedNode: (node: State['selectedNode']) => void
   updateSpecOptions: (specOptions: State['specOptions']) => void
   updateStamp: () => void
@@ -34,11 +35,27 @@ export type Action = {
 }
 
 /**
+ * Project information present in the transfer data object.
+ */
+export type ProjectInfo = {
+  /**
+   * Other tools used by this project, such as runtime and package mangager.
+   */
+  tools: DashboardTools[]
+  /**
+   * `true` if this package node_modules folder was installed
+   * using the vlt client.
+   */
+  vltInstalled?: boolean
+}
+
+/**
  * Transfer data object used to send data from the cli.
  */
 export type TransferData = {
   importers: RawNode[]
   lockfile: LockfileData
+  projectInfo: ProjectInfo
 }
 
 export type RawNode = {
@@ -95,6 +112,10 @@ export type State = {
    * List of selected nodes returned after querying the graph.
    */
   nodes: NodeLike[]
+  /**
+   * Information about the current project being explored.
+   */
+  projectInfo: ProjectInfo
   /**
    * Holds the reference to the {@link Query} instance object.
    */

--- a/src/gui/test/app/__snapshots__/explorer.tsx.snap
+++ b/src/gui/test/app/__snapshots__/explorer.tsx.snap
@@ -29,28 +29,18 @@ exports[`explorer has project root info 1`] = `
 
 `;
 
+exports[`explorer not vlt installed 1`] = `
+
+<div>
+  <gui-setup-project>
+  </gui-setup-project>
+</div>
+
+`;
+
 exports[`render default 1`] = `
 
 <div>
-  <section class="flex grow flex-col justify-between bg-white dark:bg-black">
-    <div class="flex w-full items-center justify-between border-t-[1px] px-8 pt-4">
-    </div>
-    <section class="flex items-center border-b-[1px] border-solid px-8 py-4">
-      <div class="flex w-full flex-row gap-2">
-        <gui-root-button>
-        </gui-root-button>
-        <gui-search-bar
-          tabindex="0"
-          classname="w-full bg-muted-foreground/5"
-          startcontent="[object Object]"
-          endcontent="[object Object]"
-        >
-        </gui-search-bar>
-      </div>
-    </section>
-    <gui-explorer-grid>
-    </gui-explorer-grid>
-  </section>
 </div>
 
 `;

--- a/src/gui/test/app/explorer.tsx
+++ b/src/gui/test/app/explorer.tsx
@@ -44,6 +44,10 @@ vi.mock('@/components/explorer-grid/index.jsx', () => ({
   ExplorerGrid: 'gui-explorer-grid',
 }))
 
+vi.mock('@/components/explorer-grid/setup-project.jsx', () => ({
+  SetupProject: 'gui-setup-project',
+}))
+
 vi.mock('@/components/explorer-grid/root-button.jsx', () => ({
   RootButton: 'gui-root-button',
 }))
@@ -88,13 +92,24 @@ afterEach(() => {
 afterAll(() => server.close())
 
 test('render default', async () => {
-  render(<Explorer />)
+  const Container = () => {
+    const updateProjectInfo = useStore(
+      state => state.updateProjectInfo,
+    )
+    updateProjectInfo({ tools: ['vlt'], vltInstalled: true })
+    return <Explorer />
+  }
+  render(<Container />)
   expect(window.document.body.innerHTML).toMatchSnapshot()
 })
 
 test('explorer has project root info', async () => {
   const Container = () => {
+    const updateProjectInfo = useStore(
+      state => state.updateProjectInfo,
+    )
     const updateGraph = useStore(state => state.updateGraph)
+    updateProjectInfo({ tools: ['vlt'], vltInstalled: true })
     updateGraph({ projectRoot: '/path/to/project' } as GraphLike)
     return <Explorer />
   }
@@ -103,8 +118,6 @@ test('explorer has project root info', async () => {
 })
 
 test('update nodes and edges info on query change', async () => {
-  render(<Explorer />)
-
   const nodes: NodeLike[] = []
   const edges: EdgeLike[] = []
   const q = {
@@ -114,8 +127,14 @@ test('update nodes and edges info on query change', async () => {
   }
 
   const Container = () => {
+    const updateGraph = useStore(state => state.updateGraph)
+    const updateProjectInfo = useStore(
+      state => state.updateProjectInfo,
+    )
     const updateQ = useStore(state => state.updateQ)
     const updateQuery = useStore(state => state.updateQuery)
+    updateGraph({ projectRoot: '/path/to/project' } as GraphLike)
+    updateProjectInfo({ tools: ['vlt'], vltInstalled: true })
     updateQ(q as unknown as Query)
     updateQuery('#foo')
     return <Explorer />
@@ -141,4 +160,18 @@ test('update nodes and edges info on query change', async () => {
     nodes,
     'should update nodes with result from query',
   )
+})
+
+test('explorer not vlt installed', async () => {
+  const Container = () => {
+    const updateGraph = useStore(state => state.updateGraph)
+    const updateProjectInfo = useStore(
+      state => state.updateProjectInfo,
+    )
+    updateGraph({ projectRoot: '/path/to/project' } as GraphLike)
+    updateProjectInfo({ tools: [], vltInstalled: false })
+    return <Explorer />
+  }
+  render(<Container />)
+  expect(window.document.body.innerHTML).toMatchSnapshot()
 })

--- a/src/gui/test/components/explorer-grid/__snapshots__/setup-project.tsx.snap
+++ b/src/gui/test/components/explorer-grid/__snapshots__/setup-project.tsx.snap
@@ -1,0 +1,29 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`setup-project 1`] = `
+
+<div class="flex grow flex-col bg-secondary px-8 py-8 dark:bg-black">
+  <gui-card classname="container mx-auto w-full px-8 py-8 lg:w-[1024px]">
+    <h1 class="mb-2 text-3xl font-bold">
+      Setup Project
+    </h1>
+    <p class="mb-6 text-gray-600">
+      Initializing your project with the
+      <strong>
+        vlt
+      </strong>
+      client will replace your
+      <code class="rounded-md bg-gray-200 px-1 dark:bg-gray-900">
+        node_modules
+      </code>
+      folder with a fully compatible install managed by volt.
+    </p>
+    <gui-button>
+      <gui-download size="16">
+      </gui-download>
+      Install dependencies
+    </gui-button>
+  </gui-card>
+</div>
+
+`;

--- a/src/gui/test/components/explorer-grid/index.tsx
+++ b/src/gui/test/components/explorer-grid/index.tsx
@@ -169,6 +169,10 @@ test('explorer-grid renders workspace with edges in', async () => {
         optional: false,
       } as RawNode,
     ],
+    projectInfo: {
+      tools: ['vlt'],
+      vltInstalled: true,
+    },
   })
   const q = new Query({ graph })
   const result = await q.search(':project[name=b]')

--- a/src/gui/test/components/explorer-grid/setup-project.tsx
+++ b/src/gui/test/components/explorer-grid/setup-project.tsx
@@ -1,0 +1,42 @@
+import React from 'react'
+import { vi, test, expect, afterEach } from 'vitest'
+import { cleanup, render } from '@testing-library/react'
+import html from 'diffable-html'
+import { useGraphStore as useStore } from '@/state/index.js'
+import { SetupProject } from '@/components/explorer-grid/setup-project.jsx'
+
+vi.mock('@/components/ui/button.jsx', () => ({
+  Button: 'gui-button',
+}))
+
+vi.mock('@/components/ui/card.jsx', () => ({
+  Card: 'gui-card',
+}))
+
+vi.mock('@/components/ui/loading-spinner.jsx', () => ({
+  LoadingSpinner: 'gui-loading-spinner',
+}))
+
+vi.mock('lucide-react', () => ({
+  Download: 'gui-download',
+}))
+
+expect.addSnapshotSerializer({
+  serialize: v => html(v),
+  test: () => true,
+})
+
+afterEach(() => {
+  const CleanUp = () => (useStore(state => state.reset)(), '')
+  render(<CleanUp />)
+  cleanup()
+})
+
+test('setup-project', () => {
+  const Container = () => {
+    return <SetupProject />
+  }
+
+  const { container } = render(<Container />)
+  expect(container.innerHTML).toMatchSnapshot()
+})

--- a/src/gui/test/state/load-graph.ts
+++ b/src/gui/test/state/load-graph.ts
@@ -82,6 +82,10 @@ const transferData: TransferData = {
       '··foo@1.0.0 bar': 'prod ^1.0.0 ··bar@1.0.0',
     },
   },
+  projectInfo: {
+    tools: ['vlt'],
+    vltInstalled: true,
+  },
 }
 
 test('load graph', () => {


### PR DESCRIPTION
For projects that are not installed using the vlt client, the GUI will now render a view that allows users to run an initial `vlt install` prior to navigating to the explore dependencies view.