### PR TITLE
vlt: install on create-project and fix detection

### DIFF
--- a/src/vlt/src/project-info.ts
+++ b/src/vlt/src/project-info.ts
@@ -35,6 +35,7 @@ const knownTools = new Map<ProjectTools, string[]>([
       'vlt-workspaces.json',
       'vlt.json',
       'node_modules/.vlt',
+      'node_modules/.vlt-lock.json',
     ],
   ],
   ['node', []],
@@ -134,8 +135,12 @@ export const getGraphProjectData = (
       folder,
       scurry,
     ),
-    vltInstalled: !!scurry
-      .lstatSync(folder.resolve('node_modules/.vlt'))
-      ?.isDirectory(),
+    vltInstalled:
+      !!scurry
+        .lstatSync(folder.resolve('node_modules/.vlt'))
+        ?.isDirectory() ||
+      !!scurry
+        .lstatSync(folder.resolve('node_modules/.vlt-lock.json'))
+        ?.isFile(),
   }
 }

--- a/src/vlt/src/start-gui.ts
+++ b/src/vlt/src/start-gui.ts
@@ -447,6 +447,8 @@ export const startGUI = async ({
           mkdirSync(cwd, { recursive: true })
           await init({ cwd, author })
           conf.resetOptions(cwd)
+          await install({ conf })
+          conf.resetOptions(conf.options.projectRoot)
           await updateDashboard()
           updateGraphData(tmp, conf, hasDashboard)
         } catch (err) {

--- a/src/vlt/tap-snapshots/test/project-info.ts.test.cjs
+++ b/src/vlt/tap-snapshots/test/project-info.ts.test.cjs
@@ -93,3 +93,12 @@ Object {
   "vltInstalled": true,
 }
 `
+
+exports[`test/project-info.ts > TAP > getGraphProjectData empty vlt-installed project > should return vltInstalled: true for an empty but installed project 1`] = `
+Object {
+  "tools": Array [
+    "vlt",
+  ],
+  "vltInstalled": true,
+}
+`

--- a/src/vlt/test/project-info.ts
+++ b/src/vlt/test/project-info.ts
@@ -274,7 +274,7 @@ t.test('getGraphProjectData', async t => {
     },
   })
   const packageJson = new PackageJson()
-  const scurry = new PathScurry(t.testdirName)
+  const scurry = new PathScurry(dir)
   const conf: LoadedConfig = {
     options: {
       packageJson,
@@ -318,5 +318,48 @@ t.test('getGraphProjectData', async t => {
   t.matchSnapshot(
     getGraphProjectData(conf),
     'should return emtpy response on missing folder',
+  )
+})
+
+t.test('getGraphProjectData empty vlt-installed project', async t => {
+  const dir = t.testdir({
+    home: {
+      user: {
+        projects: {
+          'my-project': {
+            'package.json': JSON.stringify({
+              name: 'my-project',
+              version: '1.0.0',
+              author: 'Ruy Adorno <ruy@example.com>',
+            }),
+            node_modules: {
+              '.vlt-lock.json': JSON.stringify({
+                nodes: [],
+                edges: [],
+              }),
+            },
+          },
+        },
+      },
+    },
+  })
+  const packageJson = new PackageJson()
+  const scurry = new PathScurry(dir)
+  const conf: LoadedConfig = {
+    options: {
+      packageJson,
+      scurry,
+    } as ConfigOptions,
+  } as LoadedConfig
+
+  const myProject = scurry.lstatSync(
+    resolve(dir, 'home', 'user', 'projects', 'my-project'),
+  )
+  if (!myProject) {
+    throw new Error('my-project is not a valid path')
+  }
+  t.matchSnapshot(
+    getGraphProjectData(conf, myProject),
+    'should return vltInstalled: true for an empty but installed project',
   )
 })

--- a/src/vlt/test/start-gui.ts
+++ b/src/vlt/test/start-gui.ts
@@ -350,6 +350,7 @@ t.test('e2e server test', async t => {
   })
 
   await t.test('/create-project', async t => {
+    ilog = ''
     const port = 8022
     const options = {
       projectRoot: resolve(dir, 'projects/my-project'),
@@ -378,6 +379,7 @@ t.test('e2e server test', async t => {
     t.matchSnapshot(log, 'should log the server start message')
 
     await t.test('standard request', async t => {
+      ilog = ''
       // tests a POST to /create-project
       const reqSelectProject = await fetch(
         `http://localhost:${port}/create-project`,
@@ -405,6 +407,7 @@ t.test('e2e server test', async t => {
     })
 
     await t.test('invalid name', async t => {
+      ilog = ''
       // tests an invalid name POST to /create-project
       const reqSelectProject = await fetch(
         `http://localhost:${port}/create-project`,
@@ -430,6 +433,7 @@ t.test('e2e server test', async t => {
     })
 
     await t.test('invalid long name', async t => {
+      ilog = ''
       // tests an invalid name POST to /create-project
       const reqSelectProject = await fetch(
         `http://localhost:${port}/create-project`,
@@ -455,6 +459,7 @@ t.test('e2e server test', async t => {
     })
 
     await t.test('invalid path', async t => {
+      ilog = ''
       // tests an invalid path POST to /create-project
       const reqSelectProject = await fetch(
         `http://localhost:${port}/create-project`,
@@ -482,6 +487,7 @@ t.test('e2e server test', async t => {
     })
 
     await t.test('cli error', async t => {
+      ilog = ''
       const stderr = console.error
       const port = 8023
 
@@ -536,6 +542,7 @@ t.test('e2e server test', async t => {
   })
 
   await t.test('/install', async t => {
+    ilog = ''
     const port = 8018
     const options = {
       projectRoot: resolve(dir, 'projects/my-project'),


### PR DESCRIPTION
Fixes detection for vlt-installed projects by also taking into account `node_modules/.vlt-lock.json` files.

Also the `/create-project` endpoint will now always run install on the newly created project so that the UI can navigate directly to its graph view after creating a new project.