### PR TITLE
scripts: run source TS files directly

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -45,11 +45,11 @@ jobs:
         run: pnpm install
 
       - name: Publish
-        run: pnpm -F infra-build exec node dist/esm/bin/publish.js ${{ !inputs.dryRun && '--forReal' || '' }}
+        run: pnpm -F infra-build exec node --no-warnings --experimental-transform-types --conditions=@vltpkg/source src/bin/publish.ts ${{ !inputs.dryRun && '--forReal' || '' }}
         env:
           VLT_CLI_PUBLISH_TOKEN: ${{ secrets.VLT_CLI_PUBLISH_TOKEN }}
 
       - name: Publish Deno
-        run: pnpm -F infra-build exec node dist/esm/bin/publish.js --compile=true --runtime=deno --platform=all --arch=all ${{ !inputs.dryRun && '--forReal' || '' }}
+        run: pnpm -F infra-build exec node --no-warnings --experimental-transform-types --conditions=@vltpkg/source src/bin/publish.ts --compile=true --runtime=deno --platform=all --arch=all ${{ !inputs.dryRun && '--forReal' || '' }}
         env:
           VLT_CLI_PUBLISH_TOKEN: ${{ secrets.VLT_CLI_PUBLISH_TOKEN }}

--- a/infra/benchmark/package.json
+++ b/infra/benchmark/package.json
@@ -22,7 +22,7 @@
     }
   },
   "bin": {
-    "vlt-benchmark-download-fixtures": "./dist/esm/download.js"
+    "vlt-benchmark-download-fixtures": "./src/download.ts"
   },
   "dependencies": {
     "pacote": "catalog:"

--- a/infra/benchmark/src/download.ts
+++ b/infra/benchmark/src/download.ts
@@ -1,3 +1,5 @@
+#!/usr/bin/env -S node --experimental-strip-types --no-warnings --conditions=@vltpkg/source
+
 // run this script as many times in parallel as necessary
 // it'll randomize and skip any it's already downloaded.
 
@@ -6,10 +8,10 @@ import { mkdirSync, writeFileSync, existsSync, renameSync } from 'fs'
 import pacote from 'pacote'
 import { resolve } from 'path'
 import { gunzipSync } from 'zlib'
-import { EXT, randomize, packages, SOURCE } from './index.ts'
+import { type EXT, randomize, packages, SOURCE } from './index.ts'
 
 const download = async (spec: string, ext: EXT) => {
-  if (ext === EXT.tgz) return gunzipSync(await pacote.tarball(spec))
+  if (ext === 'tgz') return gunzipSync(await pacote.tarball(spec))
   return JSON.stringify(await pacote.packument(spec))
 }
 
@@ -20,8 +22,8 @@ const main = async () => {
 
   const names = randomize(
     packages.flatMap(name => [
-      { name, ext: EXT.tgz },
-      { name, ext: EXT.json },
+      { name, ext: 'tgz' } as const,
+      { name, ext: 'json' } as const,
     ]),
   )
 

--- a/infra/benchmark/src/index.ts
+++ b/infra/benchmark/src/index.ts
@@ -13,20 +13,8 @@ export const randomPackages = (count?: number) => {
 export const randomize = <T>(arr: T[]): T[] =>
   [...arr].sort(() => Math.random() - 0.5)
 
-// TODO: make these not enums
-// eslint-disable-next-line no-restricted-syntax
-export enum EXT {
-  tgz = 'tgz',
-  json = 'json',
-}
-
-// eslint-disable-next-line no-restricted-syntax
-export enum UNIT {
-  ns = 'ns',
-  us = 'us',
-  ms = 'ms',
-  s = 's',
-}
+export type EXT = 'tgz' | 'json'
+export type UNIT = 'ns' | 'us' | 'ms' | 's'
 
 export const SOURCE = resolve(import.meta.dirname, '..', '.artifacts')
 
@@ -50,10 +38,10 @@ export const timePromises = async <T>(
 
 export const convertNs = (ns: number, unit?: UNIT) => {
   const c = {
-    s: () => [ns * 1e-9, UNIT.s],
-    ms: () => [ns * 1e-6, UNIT.ms],
-    us: () => [ns * 1e-3, UNIT.us],
-    ns: () => [ns, UNIT.ns],
+    s: () => [ns * 1e-9, 's'],
+    ms: () => [ns * 1e-6, 'ms'],
+    us: () => [ns * 1e-3, 'us'],
+    ns: () => [ns, 'ns'],
   }
   return (
     unit ? c[unit]()
@@ -111,9 +99,9 @@ const copyFixtures = (targetDir: string, ext: EXT) => {
   }
   return randomize(readdirSync(targetDir, { withFileTypes: true }))
 }
-export const copyTarballs = (d: string) => copyFixtures(d, EXT.tgz)
+export const copyTarballs = (d: string) => copyFixtures(d, 'tgz')
 
-export const copyPackuments = (d: string) => copyFixtures(d, EXT.json)
+export const copyPackuments = (d: string) => copyFixtures(d, 'json')
 
 export const resetDir = (...dirs: string[]) => {
   for (const dir of dirs) {

--- a/infra/benchmark/test/index.ts
+++ b/infra/benchmark/test/index.ts
@@ -8,13 +8,13 @@ t.test('basic', async t => {
   t.equal(B.randomPackages().length, 1000)
   t.equal(B.randomPackages(10).length, 10)
 
-  t.strictSame(B.convertNs(1_000_000_000), [1, B.UNIT.s])
-  t.strictSame(B.convertNs(1_000_000), [1, B.UNIT.ms])
-  t.strictSame(B.convertNs(1_000), [1, B.UNIT.us])
-  t.strictSame(B.convertNs(1), [1, B.UNIT.ns])
-  t.strictSame(B.convertNs(1_000_000_000, B.UNIT.ns), [
+  t.strictSame(B.convertNs(1_000_000_000), [1, 's'])
+  t.strictSame(B.convertNs(1_000_000), [1, 'ms'])
+  t.strictSame(B.convertNs(1_000), [1, 'us'])
+  t.strictSame(B.convertNs(1), [1, 'ns'])
+  t.strictSame(B.convertNs(1_000_000_000, 'ns'), [
     1_000_000_000,
-    B.UNIT.ns,
+    'ns',
   ])
 
   t.equal(B.numToFixed(1), '1.00')

--- a/infra/build/package.json
+++ b/infra/build/package.json
@@ -45,8 +45,6 @@
     "pnpm": "9"
   },
   "scripts": {
-    "build:deno": "node dist/esm/bin.js --deno",
-    "build:node": "node dist/esm/bin.js --node",
     "format": "prettier --write . --log-level warn --ignore-path ../../.prettierignore --cache",
     "format:check": "prettier --check . --ignore-path ../../.prettierignore --cache",
     "lint": "eslint . --fix",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,8 @@
     "@eslint/js": "catalog:",
     "@types/eslint__js": "catalog:",
     "@vltpkg/benchmark": "workspace:*",
+    "@vltpkg/semver": "workspace:*",
+    "@vltpkg/spec": "workspace:*",
     "chalk": "catalog:",
     "eslint": "catalog:",
     "eslint-import-resolver-typescript": "^3.7.0",
@@ -37,7 +39,7 @@
   "scripts": {
     "benchmark": "./scripts/benchmark",
     "fix": "pnpm fix:pkg && pnpm lint && pnpm format",
-    "fix:pkg": "node scripts/consistent-package-json.js",
+    "fix:pkg": "node --no-warnings --experimental-transform-types --conditions=@vltpkg/source scripts/consistent-package-json.js",
     "format": "prettier --write . --log-level warn --ignore-path ./.prettierignore --cache",
     "format:check": "prettier --check . --ignore-path ./.prettierignore --cache",
     "lint": "eslint . --fix",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -93,6 +93,12 @@ importers:
       '@vltpkg/benchmark':
         specifier: workspace:*
         version: link:infra/benchmark
+      '@vltpkg/semver':
+        specifier: workspace:*
+        version: link:src/semver
+      '@vltpkg/spec':
+        specifier: workspace:*
+        version: link:src/spec
       chalk:
         specifier: 'catalog:'
         version: 5.3.0
@@ -12078,7 +12084,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.0(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.7.0(eslint-plugin-import@2.31.0)(eslint@9.20.0(jiti@1.21.6)))(eslint@9.20.0(jiti@1.21.6)):
+  eslint-module-utils@2.12.0(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.7.0)(eslint@9.20.0(jiti@1.21.6)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
@@ -12099,7 +12105,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.20.0(jiti@1.21.6)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.0(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.7.0(eslint-plugin-import@2.31.0)(eslint@9.20.0(jiti@1.21.6)))(eslint@9.20.0(jiti@1.21.6))
+      eslint-module-utils: 2.12.0(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.7.0)(eslint@9.20.0(jiti@1.21.6))
       hasown: 2.0.2
       is-core-module: 2.15.1
       is-glob: 4.0.3

--- a/scripts/consistent-package-json.js
+++ b/scripts/consistent-package-json.js
@@ -5,12 +5,8 @@ import {
   existsSync,
 } from 'node:fs'
 import { relative, resolve, basename, dirname, join } from 'node:path'
-import {
-  gt,
-  satisfies,
-  validRange,
-} from '../src/semver/dist/esm/index.js'
-import { Spec } from '../src/spec/dist/esm/index.js'
+import { gt, satisfies, validRange } from '@vltpkg/semver'
+import { Spec } from '@vltpkg/spec'
 import minVersion from 'semver/ranges/min-version.js'
 import {
   ROOT,

--- a/scripts/make-dist-bins.js
+++ b/scripts/make-dist-bins.js
@@ -11,7 +11,7 @@ import {
 
 // Manually add any dirs that have package.json#bin scripts that get
 // linked to built dist/ files.
-const DIRS = ['infra/benchmark', 'src/cache-unzip', 'src/vlt']
+const DIRS = ['src/vlt']
 
 for (const [pkgdir, { bin = {} }] of DIRS.map(d => {
   const dir = resolve(import.meta.dirname, '..', d)

--- a/src/cache-unzip/package.json
+++ b/src/cache-unzip/package.json
@@ -20,9 +20,6 @@
       ".": "./src/index.ts"
     }
   },
-  "bin": {
-    "vlt-cache-unzip": "./dist/esm/unzip.js"
-  },
   "dependencies": {
     "@vltpkg/cache": "workspace:*",
     "@vltpkg/error-cause": "workspace:*"

--- a/src/gui/package.json
+++ b/src/gui/package.json
@@ -76,11 +76,11 @@
     "format:check": "prettier --check . --ignore-path ../../.prettierignore --cache",
     "lint": "eslint . --fix",
     "lint:check": "eslint .",
-    "prepare": "node scripts/prepare.js --production",
+    "prepare": "node --no-warnings --experimental-transform-types --conditions=@vltpkg/source scripts/prepare.js --production",
     "snap": "vitest --no-watch -u",
     "test": "vitest",
     "posttest": "tsc --project tsconfig.test.json",
-    "watch": "node scripts/prepare.js --watch"
+    "watch": "node --no-warnings --experimental-transform-types --conditions=@vltpkg/source scripts/prepare.js --watch"
   },
   "prettier": "../../.prettierrc.js",
   "type": "module",

--- a/src/package-info/package.json
+++ b/src/package-info/package.json
@@ -53,7 +53,7 @@
     "pnpm": "9"
   },
   "scripts": {
-    "benchmark": "node scripts/benchmark.js",
+    "benchmark": "node --no-warnings --experimental-transform-types --conditions=@vltpkg/source scripts/benchmark.js",
     "format": "prettier --write . --log-level warn --ignore-path ../../.prettierignore --cache",
     "format:check": "prettier --check . --ignore-path ../../.prettierignore --cache",
     "lint": "eslint . --fix",

--- a/src/package-info/scripts/benchmark.js
+++ b/src/package-info/scripts/benchmark.js
@@ -1,7 +1,7 @@
 import pacote from 'pacote'
 import { resolve, join } from 'path'
 import { parseArgs } from 'util'
-import { PackageInfoClient } from '../dist/esm/index.js'
+import { PackageInfoClient } from '../src/index.ts'
 import {
   randomPackages,
   convertNs,

--- a/src/pick-manifest/package.json
+++ b/src/pick-manifest/package.json
@@ -46,7 +46,7 @@
   },
   "scripts": {
     "prebenchmark": "pnpm vlt-benchmark-download-fixtures",
-    "benchmark": "node scripts/benchmark.js",
+    "benchmark": "node --no-warnings --experimental-transform-types --conditions=@vltpkg/source scripts/benchmark.js",
     "format": "prettier --write . --log-level warn --ignore-path ../../.prettierignore --cache",
     "format:check": "prettier --check . --ignore-path ../../.prettierignore --cache",
     "lint": "eslint . --fix",

--- a/src/pick-manifest/scripts/benchmark.js
+++ b/src/pick-manifest/scripts/benchmark.js
@@ -1,6 +1,6 @@
 import { readFileSync } from 'fs'
 import npmPickManifest from 'npm-pick-manifest'
-import { pickManifest } from '../dist/esm/index.js'
+import { pickManifest } from '../src/index.ts'
 import { resolve } from 'path'
 import {
   copyPackuments,

--- a/src/semver/benchmarks/this.js
+++ b/src/semver/benchmarks/this.js
@@ -1,2 +1,5 @@
+// This must import the dist file since it is run in a loop by hyperfine
+// and we don't want type stripping to contribute to the benchmark.
+// eslint-disable-next-line import/no-unresolved
 import { satisfies } from '../dist/esm/index.js'
 console.log(satisfies('1.2.3', '^1.0'))

--- a/src/semver/package.json
+++ b/src/semver/package.json
@@ -44,6 +44,7 @@
     "pnpm": "9"
   },
   "scripts": {
+    "prebenchmark": "pnpm -F '@vltpkg/semver...' prepare",
     "benchmark": "./test/fixtures/vs-node-semver.ts",
     "benchmark:bun": "hyperfine --warmup 3 'bun ./benchmarks/bun.js' 'bun ./benchmarks/npm.js' 'bun ./benchmarks/this.js'",
     "benchmark:node": "hyperfine --warmup 3 'node ./benchmarks/deno.js' 'node ./benchmarks/npm.js' 'node ./benchmarks/this.js'",

--- a/src/spec/package.json
+++ b/src/spec/package.json
@@ -44,7 +44,7 @@
     "pnpm": "9"
   },
   "scripts": {
-    "benchmark": "node scripts/benchmark.js",
+    "benchmark": "node --no-warnings --experimental-transform-types --conditions=@vltpkg/source scripts/benchmark.js",
     "format": "prettier --write . --log-level warn --ignore-path ../../.prettierignore --cache",
     "format:check": "prettier --check . --ignore-path ../../.prettierignore --cache",
     "lint": "eslint . --fix",

--- a/src/spec/scripts/benchmark.js
+++ b/src/spec/scripts/benchmark.js
@@ -1,5 +1,5 @@
 import npa from 'npm-package-arg'
-import { Spec } from '../dist/esm/index.js'
+import { Spec } from '../src/index.ts'
 import { numToFixed, runFor } from '@vltpkg/benchmark'
 
 const versions = [

--- a/src/tar/package.json
+++ b/src/tar/package.json
@@ -50,7 +50,7 @@
   },
   "scripts": {
     "prebenchmark": "pnpm vlt-benchmark-download-fixtures",
-    "benchmark": "node scripts/benchmark.js",
+    "benchmark": "node --no-warnings --experimental-transform-types --conditions=@vltpkg/source scripts/benchmark.js",
     "format": "prettier --write . --log-level warn --ignore-path ../../.prettierignore --cache",
     "format:check": "prettier --check . --ignore-path ../../.prettierignore --cache",
     "lint": "eslint . --fix",

--- a/src/tar/scripts/benchmark.js
+++ b/src/tar/scripts/benchmark.js
@@ -1,7 +1,7 @@
 import { readFileSync } from 'fs'
 import pacote from 'pacote'
 import { resolve } from 'path'
-import { Pool } from '../dist/esm/pool.js'
+import { Pool } from '../src/pool.ts'
 import {
   convertNs,
   copyTarballs,
@@ -9,7 +9,7 @@ import {
   numToFixed,
   timePromises,
 } from '@vltpkg/benchmark'
-import { unpack } from '../dist/esm/unpack.js'
+import { unpack } from '../src/unpack.ts'
 
 const DIRS = {
   source: resolve(import.meta.dirname, 'fixtures/artifacts'),


### PR DESCRIPTION
This removes more instances of calling `dist/esm/*` files and instead calling their TS source counterparts.