### PR TITLE
gui: queries should be always trimmed

### DIFF
--- a/src/gui/src/components/explorer-grid/index.tsx
+++ b/src/gui/src/components/explorer-grid/index.tsx
@@ -276,7 +276,7 @@ const getItemQuery = (item: GridItemData) => {
   const name = item.to.name ? `[name="${item.to.name}"]` : ''
   const version =
     item.to.version ? `[version="${item.to.version}"]` : ''
-  return `${name}${version}`
+  return `${name}${version}`.trim()
 }
 
 export const ExplorerGrid = () => {
@@ -323,13 +323,13 @@ export const ExplorerGrid = () => {
         query.endsWith(`> ${selectedName}${selectedVersion}`) &&
         query.slice(0, query.lastIndexOf('>'))
       if (newQuery) {
-        updateQuery(newQuery)
+        updateQuery(newQuery.trim())
       } else {
         const name =
           item.from?.name ? `[name="${item.from.name}"]` : ''
         const version =
           item.from?.version ? `[version="${item.from.version}"]` : ''
-        updateQuery(`${name}${version}`)
+        updateQuery(`${name}${version}`.trim())
       }
       return undefined
     }


### PR DESCRIPTION
Fixes an issue found when clicking on dependents.

Previously clicking on the root node would take you to:
`http://localhost:7017/explore?query=%3Aroot%20`

Now it takes you to:
`http://localhost:7017/explore?query=%3Aroot`