### PR TITLE
query: add ability to cancel search

### DIFF
--- a/src/query/src/attribute.ts
+++ b/src/query/src/attribute.ts
@@ -164,6 +164,8 @@ export const attributeSelectorsMap = new Map<string, ComparatorFn>(
 export const attribute = async (
   state: ParserState,
 ): Promise<ParserState> => {
+  await state.cancellable()
+
   const curr = asAttributeNode(state.current)
   const operatorFn = attributeSelectorsMap.get(String(curr.operator))
   if (!operatorFn) {

--- a/src/query/src/class.ts
+++ b/src/query/src/class.ts
@@ -122,6 +122,8 @@ const classSelectorsMap = new Map<string, ParserFn>(
  * Parse classes, e.g: `.prod`, `.dev`, `.optional`, etc
  */
 export const classFn = async (state: ParserState) => {
+  await state.cancellable()
+
   const curr = asClassNode(state.current)
   const comparatorFn = curr.value && classSelectorsMap.get(curr.value)
   if (!comparatorFn) {

--- a/src/query/src/combinator.ts
+++ b/src/query/src/combinator.ts
@@ -116,6 +116,8 @@ const combinatorSelectorsMap = new Map<string, ParserFn>(
  * Parse css-style combinators, e.g: `>`, `~` and ` `
  */
 export const combinator = async (state: ParserState) => {
+  await state.cancellable()
+
   const curr = asCombinatorNode(state.current)
   const parserFn =
     curr.value && combinatorSelectorsMap.get(curr.value)

--- a/src/query/src/pseudo.ts
+++ b/src/query/src/pseudo.ts
@@ -126,6 +126,7 @@ const has = async (state: ParserState) => {
   for (const node of top.nodes) {
     if (isSelectorNode(node)) {
       const nestedState = await state.walk({
+        cancellable: state.cancellable,
         initial: {
           edges: new Set(state.initial.edges),
           nodes: new Set(state.initial.nodes),
@@ -207,6 +208,7 @@ const is = async (state: ParserState) => {
   for (const node of top.nodes) {
     if (isSelectorNode(node)) {
       const nestedState = await state.walk({
+        cancellable: state.cancellable,
         collect: {
           edges: new Set(),
           nodes: new Set(),
@@ -258,6 +260,7 @@ const not = async (state: ParserState) => {
   for (const node of top.nodes) {
     if (isSelectorNode(node)) {
       const nestedState = await state.walk({
+        cancellable: state.cancellable,
         collect: {
           edges: new Set(),
           nodes: new Set(),
@@ -415,6 +418,8 @@ const pseudoSelectors = new Map<string, ParserFn>(
  * Parsers the `pseudo` node types.
  */
 export const pseudo = async (state: ParserState) => {
+  await state.cancellable()
+
   const curr = asPseudoNode(state.current)
   const parserFn =
     curr.value && pseudoSelectors.get(curr.value.slice(1))

--- a/src/query/src/types.ts
+++ b/src/query/src/types.ts
@@ -37,6 +37,7 @@ export type GraphSelectionState = {
 }
 
 export type ParserState = {
+  cancellable: () => Promise<void>
   collect: GraphSelectionState
   current: PostcssNode
   initial: GraphSelectionState
@@ -44,6 +45,7 @@ export type ParserState = {
   next?: PostcssNode
   prev?: PostcssNode
   result?: NodeLike[]
+  signal?: AbortSignal
   walk: ParserFn
   partial: GraphSelectionState
 }

--- a/src/query/test/attribute.ts
+++ b/src/query/test/attribute.ts
@@ -229,6 +229,7 @@ t.test('filterAttributes', async t => {
     nodes: new Set<NodeLike>(simpleGraph.nodes.values()),
   }
   const state = {
+    cancellable: async () => {},
     collect: {
       edges: new Set<EdgeLike>(),
       nodes: new Set<NodeLike>(),

--- a/src/query/test/fixtures/selector.ts
+++ b/src/query/test/fixtures/selector.ts
@@ -78,6 +78,7 @@ export const selectorFixture =
     }
     if (!current) throw new Error('missing selector?')
     const state: ParserState = {
+      cancellable: async () => {},
       collect: {
         edges: new Set(),
         nodes: new Set(),


### PR DESCRIPTION
`Query.search()` now accepts an `AbortSignal` that allows for cancelling ongoing operations. This is going to be very useful in order to support pseudo selectors that fetch external data but also it should make for a more responsive UI when using in the GUI by cancelling any previous / ongoing search.

Refs: https://github.com/vltpkg/vltpkg/issues/360