### PR TITLE
vlt: mock file system lookup on start-gui tests

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,6 +51,9 @@ catalogs:
     prettier:
       specifier: ^3.4.2
       version: 3.4.2
+    promise-call-limit:
+      specifier: ^3.0.2
+      version: 3.0.2
     rimraf:
       specifier: ^6.0.1
       version: 6.0.1
@@ -591,7 +594,7 @@ importers:
         specifier: 'catalog:'
         version: 2.0.0
       promise-call-limit:
-        specifier: ^3.0.2
+        specifier: 'catalog:'
         version: 3.0.2
     devDependencies:
       '@eslint/js':
@@ -1606,6 +1609,9 @@ importers:
       polite-json:
         specifier: 'catalog:'
         version: 5.0.0
+      promise-call-limit:
+        specifier: 'catalog:'
+        version: 3.0.2
       react:
         specifier: ^18.3.1
         version: 18.3.1
@@ -12170,7 +12176,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.0(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.7.0)(eslint@9.20.0(jiti@1.21.6)):
+  eslint-module-utils@2.12.0(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.7.0(eslint-plugin-import@2.31.0)(eslint@9.20.0(jiti@1.21.6)))(eslint@9.20.0(jiti@1.21.6)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
@@ -12191,7 +12197,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.20.0(jiti@1.21.6)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.0(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.7.0)(eslint@9.20.0(jiti@1.21.6))
+      eslint-module-utils: 2.12.0(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.7.0(eslint-plugin-import@2.31.0)(eslint@9.20.0(jiti@1.21.6)))(eslint@9.20.0(jiti@1.21.6))
       hasown: 2.0.2
       is-core-module: 2.15.1
       is-glob: 4.0.3

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -18,6 +18,7 @@ catalog:
   path-scurry: ^2.0.0
   polite-json: ^5.0.0
   prettier: ^3.4.2
+  promise-call-limit: ^3.0.2
   rimraf: ^6.0.1
   semver: ^7.7.1
   tap: ^21.0.2

--- a/src/graph/package.json
+++ b/src/graph/package.json
@@ -39,7 +39,7 @@
     "@vltpkg/workspaces": "workspace:*",
     "graph-run": "catalog:",
     "path-scurry": "catalog:",
-    "promise-call-limit": "^3.0.2"
+    "promise-call-limit": "catalog:"
   },
   "devDependencies": {
     "@eslint/js": "catalog:",

--- a/src/semver/benchmarks/this.js
+++ b/src/semver/benchmarks/this.js
@@ -1,5 +1,5 @@
 // This must import the dist file since it is run in a loop by hyperfine
 // and we don't want type stripping to contribute to the benchmark.
-// eslint-disable-next-line import/no-unresolved
+
 import { satisfies } from '../dist/esm/index.js'
 console.log(satisfies('1.2.3', '^1.0'))

--- a/src/vlt/package.json
+++ b/src/vlt/package.json
@@ -52,6 +52,7 @@
     "package-json-from-dist": "catalog:",
     "path-scurry": "catalog:",
     "polite-json": "catalog:",
+    "promise-call-limit": "catalog:",
     "react": "^18.3.1",
     "serve-handler": "^6.1.5",
     "walk-up-path": "catalog:"

--- a/src/vlt/src/commands/gui.ts
+++ b/src/vlt/src/commands/gui.ts
@@ -1,7 +1,7 @@
 import { commandUsage } from '../config/usage.ts'
 import { type CommandFn, type CommandUsage } from '../index.ts'
 import { startGUI } from '../start-gui.ts'
-import { ViewFn } from '../view.ts'
+import { type ViewFn } from '../view.ts'
 
 // this command is only a view, it doesn't actually do anything at this time
 export const views: ViewFn<null> = async (_, __, conf) => {

--- a/src/vlt/src/commands/gui.ts
+++ b/src/vlt/src/commands/gui.ts
@@ -1,6 +1,13 @@
 import { commandUsage } from '../config/usage.ts'
 import { type CommandFn, type CommandUsage } from '../index.ts'
 import { startGUI } from '../start-gui.ts'
+import { ViewFn } from '../view.ts'
+
+// this command is only a view, it doesn't actually do anything at this time
+export const views: ViewFn<null> = async (_, __, conf) => {
+  await startGUI({ conf })
+  return ''
+}
 
 export const usage: CommandUsage = () =>
   commandUsage({
@@ -9,6 +16,4 @@ export const usage: CommandUsage = () =>
     description: 'Launch a graphical user interface in a browser',
   })
 
-export const command: CommandFn<void> = async conf => {
-  await startGUI({ conf })
-}
+export const command: CommandFn = async () => null

--- a/src/vlt/src/ignored-homedir-folder-names.ts
+++ b/src/vlt/src/ignored-homedir-folder-names.ts
@@ -1,22 +1,36 @@
 /**
  * A list of folder names that are ignored when reading the user's home dir.
+ *
+ * Note: these are lower-case, must be compared case-insensitively.
  */
 export const ignoredHomedirFolderNames = [
-  'Downloads',
-  'Movies',
-  'Music',
-  'Pictures',
+  'downloads',
+  'movies',
+  'music',
+  'pictures',
+  'private',
+  'library',
+  'desktop',
+  'dropbox',
 ].concat(
-  process.platform === 'darwin' ? ['Library', 'Public']
+  process.platform === 'darwin' ?
+    [
+      'public',
+      'private',
+      'applications',
+      'applications (parallels)',
+      'sites',
+      'sync',
+    ]
   : process.platform === 'win32' ?
     [
-      'AppData',
-      'Application Data',
-      'Favorites',
-      'Links',
-      'Videos',
-      'Contacts',
-      'Searches',
+      'appdata',
+      'application data',
+      'favorites',
+      'links',
+      'videos',
+      'contacts',
+      'searches',
     ]
-  : ['Videos', 'Public'],
+  : ['videos', 'public'],
 )

--- a/src/vlt/src/read-project-folders.ts
+++ b/src/vlt/src/read-project-folders.ts
@@ -1,6 +1,10 @@
-import os from 'node:os'
+import { availableParallelism, homedir } from 'os'
 import { type PathBase, type PathScurry } from 'path-scurry'
+import { callLimit } from 'promise-call-limit'
 import { ignoredHomedirFolderNames } from './ignored-homedir-folder-names.ts'
+
+const limit = Math.max(availableParallelism() - 1, 1) * 8
+const home = homedir()
 
 type ProjectFolderOptions = {
   /**
@@ -26,72 +30,76 @@ type ProjectFolderOptions = {
  * be find, always stopping at the first level where a package.json
  * is present.
  */
-export const readProjectFolders = ({
-  path = os.homedir(),
+export const readProjectFolders = async ({
+  path = home,
   scurry,
   userDefinedProjectPaths,
-}: ProjectFolderOptions): PathBase[] => {
+}: ProjectFolderOptions): Promise<PathBase[]> => {
   const result: PathBase[] = []
-  const traverse: PathBase[] = []
-
-  // collectResult will return true in case it finds a directory that
-  // has no package.json file in it but that can still be potentially
-  // recursive traversed in the future
-  const collectResult = (entry: PathBase) => {
-    let foundDir = false
-    if (
-      entry.isDirectory() &&
-      !entry.isSymbolicLink() &&
-      entry.name !== 'node_modules' &&
-      !entry.name.startsWith('.') &&
-      !ignoredHomedirFolderNames.includes(entry.name.toLowerCase())
-    ) {
-      const resolved = entry.fullpath()
-      const statPackageJson = scurry.lstatSync(
-        `${resolved}/package.json`,
-      )
-      const hasDotGit = scurry.lstatSync(`${resolved}/.git`)
-      const hasValidPackageJson =
-        statPackageJson &&
-        statPackageJson.isFile() &&
-        !statPackageJson.isSymbolicLink()
-      if (hasValidPackageJson) {
-        result.push(entry)
-      } else {
-        // do not descend if we're in a root of a git project or C project
-        // TODO: make this more consistent with how we determine
-        // "project-root-ness" in the walk up the folder tree.
-        foundDir = !hasDotGit
-      }
-    }
-    return foundDir
-  }
+  const homeEntry = scurry.cwd.resolve(home)
 
   // read entry point folders to collect which ones
   // should we recursively traverse to collect project folders
   const paths =
     userDefinedProjectPaths.length ? userDefinedProjectPaths : [path]
-  for (const path of paths) {
-    for (const entry of scurry.readdirSync(path, {
-      withFileTypes: true,
-    })) {
-      if (collectResult(entry)) {
-        traverse.push(entry)
+
+  const step = (entry: PathBase) => async () => {
+    for (const child of await entry.readdir()) {
+      if (collectResult(child, result, scurry, entry === homeEntry)) {
+        traverse.push(step(child))
       }
     }
   }
 
-  // traverse nested directories starting
-  // at the entry points previously found
-  for (const entry of traverse) {
-    for (const child of scurry.readdirSync(entry.fullpath(), {
-      withFileTypes: true,
-    })) {
-      if (collectResult(child)) {
-        traverse.push(child)
-      }
-    }
-  }
+  let traverse = (
+    await Promise.all(paths.map(path => scurry.lstat(path)))
+  )
+    .filter(p => !!p)
+    .map(step)
+
+  // have to do it in phases this way because pushing into the queue
+  // during the promise-call-limit confuses its tracking.
+  let t: (() => Promise<void>)[]
+  do {
+    t = traverse
+    traverse = []
+    await callLimit(t, { limit })
+  } while (traverse.length)
 
   return result
+}
+
+// collectResult will return true in case it finds a directory that
+// has no package.json file in it but that can still be potentially
+// recursive traversed in the future
+const collectResult = (
+  entry: PathBase,
+  result: PathBase[],
+  scurry: PathScurry,
+  fromHome: boolean,
+): boolean => {
+  if (
+    !entry.isDirectory() ||
+    entry.isSymbolicLink() ||
+    entry.name === 'node_modules' ||
+    (fromHome &&
+      ignoredHomedirFolderNames.includes(entry.name.toLowerCase()))
+  ) {
+    return false
+  }
+
+  const resolved = entry.fullpath()
+  const statPackageJson = scurry.lstatSync(`${resolved}/package.json`)
+  const hasDotGit = scurry.lstatSync(`${resolved}/.git`)
+  const hasValidPackageJson =
+    statPackageJson &&
+    statPackageJson.isFile() &&
+    !statPackageJson.isSymbolicLink()
+
+  if (hasValidPackageJson) result.push(entry)
+
+  // do not descend if we're in a root of a git project or C project
+  // TODO: make this more consistent with how we determine
+  // "project-root-ness" in the walk up the folder tree.
+  return !hasDotGit && !hasValidPackageJson
 }

--- a/src/vlt/src/read-project-folders.ts
+++ b/src/vlt/src/read-project-folders.ts
@@ -44,12 +44,13 @@ export const readProjectFolders = ({
       !entry.isSymbolicLink() &&
       entry.name !== 'node_modules' &&
       !entry.name.startsWith('.') &&
-      !ignoredHomedirFolderNames.includes(entry.name)
+      !ignoredHomedirFolderNames.includes(entry.name.toLowerCase())
     ) {
       const resolved = entry.fullpath()
       const statPackageJson = scurry.lstatSync(
         `${resolved}/package.json`,
       )
+      const hasDotGit = scurry.lstatSync(`${resolved}/.git`)
       const hasValidPackageJson =
         statPackageJson &&
         statPackageJson.isFile() &&
@@ -57,7 +58,10 @@ export const readProjectFolders = ({
       if (hasValidPackageJson) {
         result.push(entry)
       } else {
-        foundDir = true
+        // do not descend if we're in a root of a git project or C project
+        // TODO: make this more consistent with how we determine
+        // "project-root-ness" in the walk up the folder tree.
+        foundDir = !hasDotGit
       }
     }
     return foundDir

--- a/src/vlt/src/start-gui.ts
+++ b/src/vlt/src/start-gui.ts
@@ -219,7 +219,7 @@ const updateDashboardData = async (
 ) => {
   const userDefinedProjectPaths = conf.values['dashboard-root'] ?? []
   const dashboard = await formatDashboardJson(
-    readProjectFolders({
+    await readProjectFolders({
       ...conf.options,
       userDefinedProjectPaths,
     }),

--- a/src/vlt/tap-snapshots/test/ignored-homedir-folder-names.ts.test.cjs
+++ b/src/vlt/tap-snapshots/test/ignored-homedir-folder-names.ts.test.cjs
@@ -7,38 +7,54 @@
 'use strict'
 exports[`test/ignored-homedir-folder-names.ts > TAP > darwin > must match snapshot 1`] = `
 Array [
-  "Downloads",
-  "Library",
-  "Movies",
-  "Music",
-  "Pictures",
-  "Public",
+  "applications",
+  "applications (parallels)",
+  "desktop",
+  "downloads",
+  "dropbox",
+  "library",
+  "movies",
+  "music",
+  "pictures",
+  "private",
+  "private",
+  "public",
+  "sites",
+  "sync",
 ]
 `
 
 exports[`test/ignored-homedir-folder-names.ts > TAP > linux > must match snapshot 1`] = `
 Array [
-  "Downloads",
-  "Movies",
-  "Music",
-  "Pictures",
-  "Public",
-  "Videos",
+  "desktop",
+  "downloads",
+  "dropbox",
+  "library",
+  "movies",
+  "music",
+  "pictures",
+  "private",
+  "public",
+  "videos",
 ]
 `
 
 exports[`test/ignored-homedir-folder-names.ts > TAP > win32 > must match snapshot 1`] = `
 Array [
-  "AppData",
-  "Application Data",
-  "Contacts",
-  "Downloads",
-  "Favorites",
-  "Links",
-  "Movies",
-  "Music",
-  "Pictures",
-  "Searches",
-  "Videos",
+  "appdata",
+  "application data",
+  "contacts",
+  "desktop",
+  "downloads",
+  "dropbox",
+  "favorites",
+  "library",
+  "links",
+  "movies",
+  "music",
+  "pictures",
+  "private",
+  "searches",
+  "videos",
 ]
 `

--- a/src/vlt/tap-snapshots/test/read-project-folders.ts.test.cjs
+++ b/src/vlt/tap-snapshots/test/read-project-folders.ts.test.cjs
@@ -5,7 +5,18 @@
  * Make sure to inspect the output below.  Do not ignore changes!
  */
 'use strict'
-exports[`test/read-project-folders.ts > TAP > read nested dirs if nothing is found at first level > should nested found folders 1`] = `
+exports[`test/read-project-folders.ts > TAP > read nested dirs if nothing is found at first level > defaulting to home > should nested found folders 1`] = `
+Array [
+  "c",
+  "b",
+  "a",
+  "d",
+  "foo",
+  "bar",
+]
+`
+
+exports[`test/read-project-folders.ts > TAP > read nested dirs if nothing is found at first level > with path specified > should nested found folders 1`] = `
 Array [
   "c",
   "b",

--- a/src/vlt/test/commands/gui.ts
+++ b/src/vlt/test/commands/gui.ts
@@ -4,7 +4,7 @@ import { type StartGUIOptions } from '../../src/start-gui.ts'
 
 t.test('starts gui data and server', async t => {
   let startGUIOptions: StartGUIOptions | undefined
-  const { usage, command } = await t.mockImport<
+  const { usage, command, views } = await t.mockImport<
     typeof import('../../src/commands/gui.ts')
   >('../../src/commands/gui.ts', {
     '../../src/start-gui.js': {
@@ -16,11 +16,18 @@ t.test('starts gui data and server', async t => {
 
   t.matchSnapshot(usage().usage(), 'usage')
 
-  await command({
+  const conf = {
     options: {
       projectRoot: '/path/to/project',
     },
-  } as LoadedConfig)
+  } as LoadedConfig
+  const res = await command(conf)
+  t.equal(res, null)
+  t.equal(
+    await views(res as null, {}, conf),
+    '',
+    'prints nothing on completion',
+  )
 
   t.matchStrict(
     startGUIOptions,


### PR DESCRIPTION
start-gui tests should not lookup the actual file system on its tests. Instead we should mock these internal calls to have a deterministic and faster way to run these tests in different systems.