### PR TITLE
gui: fixes visibility of dep type selection

### DIFF
--- a/src/gui/src/components/explorer-grid/add-dependencies-popover.tsx
+++ b/src/gui/src/components/explorer-grid/add-dependencies-popover.tsx
@@ -163,7 +163,7 @@ export const AddDependenciesPopover = ({
           <SelectTrigger>
             <SelectValue tabIndex={3} />
           </SelectTrigger>
-          <SelectContent>
+          <SelectContent className="z-[10001]">
             <SelectItem value="prod">dependencies</SelectItem>
             <SelectItem value="dev">devDependencies</SelectItem>
             <SelectItem value="optional">

--- a/src/gui/src/components/explorer-grid/side-item.tsx
+++ b/src/gui/src/components/explorer-grid/side-item.tsx
@@ -98,7 +98,7 @@ export const SideItem = ({
                   />
                 </DropdownMenuTrigger>
                 <DropdownMenuContent
-                  className="z-[100000] ml-48 w-48"
+                  className="z-[10000] ml-48 w-48"
                   align="end"
                   onCloseAutoFocus={e => e.preventDefault()}>
                   <DropdownMenuItem

--- a/src/gui/src/components/ui/popover.tsx
+++ b/src/gui/src/components/ui/popover.tsx
@@ -23,7 +23,7 @@ const PopoverContent = React.forwardRef<
         align={align}
         sideOffset={sideOffset}
         className={cn(
-          'z-[100000] w-72 rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
+          'z-[10000] w-72 rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
           className,
         )}
         {...props}

--- a/src/gui/test/components/explorer-grid/__snapshots__/add-dependencies-popover.tsx.snap
+++ b/src/gui/test/components/explorer-grid/__snapshots__/add-dependencies-popover.tsx.snap
@@ -113,7 +113,7 @@ exports[`add-dependencies-popover render default 1`] = `
         <gui-select-value tabindex="3">
         </gui-select-value>
       </gui-select-trigger>
-      <gui-select-content>
+      <gui-select-content classname="z-[10001]">
         <gui-select-item value="prod">
           dependencies
         </gui-select-item>

--- a/src/gui/test/components/ui/__snapshots__/popover.tsx.snap
+++ b/src/gui/test/components/ui/__snapshots__/popover.tsx.snap
@@ -45,7 +45,7 @@ exports[`popover render open 1`] = `
     data-state="open"
     role="dialog"
     id="radix-:r1:"
-    class="z-[100000] w-72 rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2"
+    class="z-[10000] w-72 rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2"
     style="--radix-popover-content-transform-origin: var(--radix-popper-transform-origin); --radix-popover-content-available-width: var(--radix-popper-available-width); --radix-popover-content-available-height: var(--radix-popper-available-height); --radix-popover-trigger-width: var(--radix-popper-anchor-width); --radix-popover-trigger-height: var(--radix-popper-anchor-height); animation: none;"
     tabindex="-1"
   >


### PR DESCRIPTION
When adding a new dependency, the dropdown selector for the dependency type is currently hidden behind the container background. This changeset fixes it so that the dependency type selection is visible.

### Before

<img width="403" alt="Screenshot 2025-02-18 at 4 59 23 PM" src="https://github.com/user-attachments/assets/1eb459ae-84c1-43f9-954d-a4c357927362" />


### After

<img width="407" alt="Screenshot 2025-02-18 at 4 58 43 PM" src="https://github.com/user-attachments/assets/df27a291-6456-4b11-b201-3ca7f6243a99" />

