### PR TITLE
gui: fix `LoadingSpinner` height

### DIFF
--- a/src/gui/src/components/explorer-grid/setup-project.tsx
+++ b/src/gui/src/components/explorer-grid/setup-project.tsx
@@ -42,7 +42,7 @@ export const SetupProject = () => {
 
   if (inProgress) {
     return (
-      <div className="flex h-96 items-center justify-center">
+      <div className="flex grow items-center justify-center">
         <LoadingSpinner />
       </div>
     )


### PR DESCRIPTION
When the "Install dependencies" button is clicked, the footer moves to the top.

![image](https://github.com/user-attachments/assets/065a46d6-e0a1-425f-b603-630fe8be1a06)
