### PR TITLE
gui: ignore things from luke's home dir

### DIFF
--- a/src/vlt/src/ignored-homedir-folder-names.ts
+++ b/src/vlt/src/ignored-homedir-folder-names.ts
@@ -12,6 +12,9 @@ export const ignoredHomedirFolderNames = [
   'library',
   'desktop',
   'dropbox',
+  '.config',
+  '.cache',
+  '.vscode',
 ].concat(
   process.platform === 'darwin' ?
     [
@@ -21,6 +24,7 @@ export const ignoredHomedirFolderNames = [
       'applications (parallels)',
       'sites',
       'sync',
+      '.trash',
     ]
   : process.platform === 'win32' ?
     [

--- a/src/vlt/tap-snapshots/test/ignored-homedir-folder-names.ts.test.cjs
+++ b/src/vlt/tap-snapshots/test/ignored-homedir-folder-names.ts.test.cjs
@@ -7,6 +7,10 @@
 'use strict'
 exports[`test/ignored-homedir-folder-names.ts > TAP > darwin > must match snapshot 1`] = `
 Array [
+  ".cache",
+  ".config",
+  ".trash",
+  ".vscode",
   "applications",
   "applications (parallels)",
   "desktop",
@@ -26,6 +30,9 @@ Array [
 
 exports[`test/ignored-homedir-folder-names.ts > TAP > linux > must match snapshot 1`] = `
 Array [
+  ".cache",
+  ".config",
+  ".vscode",
   "desktop",
   "downloads",
   "dropbox",
@@ -41,6 +48,9 @@ Array [
 
 exports[`test/ignored-homedir-folder-names.ts > TAP > win32 > must match snapshot 1`] = `
 Array [
+  ".cache",
+  ".config",
+  ".vscode",
   "appdata",
   "application data",
   "contacts",


### PR DESCRIPTION
`.config` and `.cache` are my `$XDG_CONFIG_HOME` and `$XDG_CACHE_HOME` respectively so it might be possible to use `@vltpkg/xdg` to ignore those. But this seemed easier as an interim solution. My goal is to get the default dashboard a bit more usable on my machine since it was detecting a lot of projects in these dirs.

**.vscode**
<img width="1312" alt="Screenshot 2025-02-19 at 11 27 02 PM" src="https://github.com/user-attachments/assets/557060f7-2ea4-48ba-8717-3acbaabfcdb9" />

**.config**
<img width="1304" alt="Screenshot 2025-02-19 at 11 26 54 PM" src="https://github.com/user-attachments/assets/058857b8-9290-4033-b855-f83d767b2ced" />

**.cache**
<img width="1325" alt="Screenshot 2025-02-19 at 11 26 40 PM" src="https://github.com/user-attachments/assets/8edc552e-e382-440d-8fe4-6d5d255e2986" />
