### PR TITLE
cli: await view fn since it can be async

### DIFF
--- a/src/vlt/src/output.ts
+++ b/src/vlt/src/output.ts
@@ -47,7 +47,9 @@ export const startView = <T>(
   views?: Views<T>,
   { start }: { start: number } = { start: Date.now() },
 ): {
-  onDone: (result: T) => string | undefined
+  onDone: (
+    result: T,
+  ) => Promise<string | undefined> | string | undefined
   onError?: (err: unknown) => void
 } => {
   const View = getView<T>(conf, views)
@@ -65,9 +67,9 @@ export const startView = <T>(
     }
   } else {
     return {
-      onDone(r): string | undefined {
+      async onDone(r): Promise<string | undefined> {
         if (r === undefined && r !== null) return
-        const res = View(r, opts, conf)
+        const res = await View(r, opts, conf)
         return conf.values.view === 'json' ?
             JSON.stringify(res, null, 2)
           : formatWithOptions(
@@ -98,7 +100,7 @@ export const outputCommand = async <T>(
   const { onDone, onError } = startView(conf, views, { start })
 
   try {
-    const output = onDone(await command(conf))
+    const output = await onDone(await command(conf))
     if (output !== undefined) {
       stdout(output)
     }

--- a/src/vlt/test/output.ts
+++ b/src/vlt/test/output.ts
@@ -97,7 +97,7 @@ t.test('startView', async t => {
     mermaid: (x: true) => ({ underthesea: x }),
   }
 
-  t.test('using view class', t => {
+  t.test('using view class', async t => {
     const { onDone, onError } = startView(
       confHuman as unknown as LoadedConfig,
       views,
@@ -106,7 +106,7 @@ t.test('startView', async t => {
     t.equal(startCalled, true)
     t.equal(doneCalled, false)
     t.equal(errCalled, false)
-    onDone(true)
+    await onDone(true)
     t.equal(doneCalled, true)
     t.equal(errCalled, false)
     const p = new Error('poop')
@@ -115,25 +115,25 @@ t.test('startView', async t => {
     t.end()
   })
 
-  t.test('using a view function for JSON', t => {
+  t.test('using a view function for JSON', async t => {
     const { onDone, onError } = startView(
       confJson as unknown as LoadedConfig,
       views,
     )
     t.equal(onError, undefined)
-    t.equal(onDone(true), 'true')
-    t.equal(onDone(undefined as unknown as true), undefined)
+    t.equal(await onDone(true), 'true')
+    t.equal(await onDone(undefined as unknown as true), undefined)
     t.end()
   })
 
-  t.test('using a view function not json', t => {
+  t.test('using a view function not json', async t => {
     const { onDone, onError } = startView(
       confMermaid as unknown as LoadedConfig,
       views,
     )
     t.equal(onError, undefined)
-    t.equal(onDone(true), '{ underthesea: true }')
-    t.equal(onDone(undefined as unknown as true), undefined)
+    t.equal(await onDone(true), '{ underthesea: true }')
+    t.equal(await onDone(undefined as unknown as true), undefined)
     t.end()
   })
 })


### PR DESCRIPTION
Fixes #465

**before**
```sh
╰❯ pnpm -s vlt gui
Promise { <pending> }
⚡️ vlt GUI running at http://localhost:7017
Opening a web browser to: http://localhost:7017/explore?query=%3Aroot
```

**after**
```sh
╰❯ pnpm -s vlt gui
⚡️ vlt GUI running at http://localhost:7017
Opening a web browser to: http://localhost:7017/explore?query=%3Aroot
```
