### PR TITLE
query: add outdated pseudo selector

### DIFF
--- a/src/gui/src/app/explorer.tsx
+++ b/src/gui/src/app/explorer.tsx
@@ -38,7 +38,7 @@ const startGraphData = async ({
     hasDashboard: boolean
   }
   const { graph, specOptions } = load(data)
-  const q = new Query({ graph })
+  const q = new Query({ graph, specOptions })
 
   updateHasDashboard(data.hasDashboard)
   updateGraph(graph)

--- a/src/gui/test/components/explorer-grid/index.tsx
+++ b/src/gui/test/components/explorer-grid/index.tsx
@@ -174,7 +174,7 @@ test('explorer-grid renders workspace with edges in', async () => {
       vltInstalled: true,
     },
   })
-  const q = new Query({ graph })
+  const q = new Query({ graph, specOptions: {} })
   const result = await q.search(':project[name=b]')
 
   const Container = () => {

--- a/src/query/README.md
+++ b/src/query/README.md
@@ -88,6 +88,13 @@ e.g: `#foo` is the same as `[name=foo]`
 - `:has(<selector-list>)` Matches only packages that have valid results for the selector expression used. As an example, here is a query that matches all packages that have a peer dependency on `react`: `:has(.peer[name=react])`
 - `:is(<forgiving-selector-list>)` Useful for writing large selectors in a more compact form, the `:is()` pseudo-class takes a selector list as its arguments and selects any element that can be selected by one of the selectors in that list. As an example, let's say I want to select packages named `a` & `b` that are direct dependencies of my project root: `:root > [name=a], :root > [name=b]` using the `:is()` pseudo-class, that same expression can be shortened to: `:root > :is([name=a], [name=b])`. Similar to the css pseudo-class of the same name, this selector has a forgiving behavior regarding its nested selector list ignoring any usage of non-existing ids, classes, combinators, operators and pseudo-selectors.
 - `:not(<selector-list>)` Negation pseudo-class, select packages that do not match a list of selectors.
+- `:outdated(<type>)` Matches packages that are outdated, the type parameter is optional and can be one of the following:
+  - `any` (default) a version exists that is greater than the current one
+  - `in-range` a version exists that is greater than the current one, and satisfies at least one if its parent's dependencies
+  - `out-of-range` a version exists that is greater than the current one, does not satisfy at least one of its parent's dependencies
+  - `major` a version exists that is a semver major greater than the current one
+  - `minor` a version exists that is a semver minor greater than the current one
+  - `patch` a version exists that is a semver patch greater than the current one
 - `:private` Matches packages that have the property `private` set on their `package.json` file.
 - `:semver(<value>, <function>, <custom-attribute-selector>)` Matches packages based on a semver value, e.g, to retrieve all packages that have a `version` satisfied by the semver value `^1.0.0`: `:semver(^1.0.0)`. It's also possible to define the type of semver comparison function to use by defining a second parameter, e.g: `:semver(^1.0.0, eq)` for an exact match, valid comparison types are: `eq`, `neq`, `gt`, `gte`, `lt`, `lte`, `satisfies` (default). A third parameter allows for specifying a different `package.json` property to use for the comparison, e.g: `:semver(^22, satisfies, :attr(engines, [node]))` for comparing the value of `engines.node`.
 - `:type(registry|file|git|remote|workspace)` Matches packages based on their type, e.g, to retrieve all git dependencies: `:type(git)`.

--- a/src/query/src/index.ts
+++ b/src/query/src/index.ts
@@ -1,5 +1,6 @@
 import { error } from '@vltpkg/error-cause'
 import type { EdgeLike, GraphLike, NodeLike } from '@vltpkg/graph'
+import type { SpecOptions } from '@vltpkg/spec/browser'
 import postcssSelectorParser from 'postcss-selector-parser'
 import { attribute } from './attribute.ts'
 import { classFn } from './class.ts'
@@ -108,15 +109,18 @@ export const walk = async (
 
 export type QueryOptions = {
   graph: GraphLike
+  specOptions: SpecOptions
 }
 
 export class Query {
   #cache: Map<string, QueryResponse>
   #graph: GraphLike
+  #specOptions: SpecOptions
 
-  constructor({ graph }: QueryOptions) {
+  constructor({ graph, specOptions }: QueryOptions) {
     this.#cache = new Map()
     this.#graph = graph
+    this.#specOptions = specOptions
   }
 
   async search(
@@ -161,6 +165,7 @@ export class Query {
       },
       partial: { nodes, edges },
       signal,
+      specOptions: this.#specOptions,
       walk,
     })
 

--- a/src/query/src/pseudo.ts
+++ b/src/query/src/pseudo.ts
@@ -3,6 +3,7 @@ import { error } from '@vltpkg/error-cause'
 import type { EdgeLike, NodeLike } from '@vltpkg/graph'
 import { asManifest } from '@vltpkg/types'
 import { attr } from './pseudo/attr.ts'
+import { outdated } from './pseudo/outdated.ts'
 import { semverParser as semver } from './pseudo/semver.ts'
 import { removeDanglingEdges, removeNode } from './pseudo/helpers.ts'
 import {
@@ -52,6 +53,7 @@ const has = async (state: ParserState) => {
           edges: new Set(state.partial.edges),
           nodes: new Set(state.partial.nodes),
         },
+        specOptions: state.specOptions,
       })
       for (const n of nestedState.collect.nodes) {
         collectNodes.add(n)
@@ -132,6 +134,7 @@ const is = async (state: ParserState) => {
           edges: new Set(state.partial.edges),
         },
         walk: state.walk,
+        specOptions: state.specOptions,
       })
       for (const n of nestedState.collect.nodes) {
         collect.add(n)
@@ -183,6 +186,7 @@ const not = async (state: ParserState) => {
           edges: new Set(state.partial.edges),
         },
         walk: state.walk,
+        specOptions: state.specOptions,
       })
       for (const n of nestedState.collect.nodes) {
         collect.add(n)
@@ -321,7 +325,7 @@ const pseudoSelectors = new Map<string, ParserFn>(
     scope,
     type: typeFn,
     semver,
-    // TODO: outdated
+    outdated,
   }),
 )
 

--- a/src/query/src/pseudo/outdated.ts
+++ b/src/query/src/pseudo/outdated.ts
@@ -1,0 +1,303 @@
+import { hydrate, splitDepID } from '@vltpkg/dep-id/browser'
+import { error } from '@vltpkg/error-cause'
+import type { NodeLike } from '@vltpkg/graph'
+import type { SpecOptions } from '@vltpkg/spec/browser'
+import {
+  compare,
+  gt,
+  major,
+  minor,
+  patch,
+  satisfies,
+} from '@vltpkg/semver'
+import type { Packument } from '@vltpkg/types'
+import {
+  asPostcssNodeWithChildren,
+  asStringNode,
+  asTagNode,
+  isStringNode,
+  isTagNode,
+} from '../types.ts'
+import type { ParserState, PostcssNode } from '../types.ts'
+import { removeNode, removeQuotes } from './helpers.ts'
+
+/**
+ * The possible values accepted by the :outdated() pseudo selector.
+ */
+export type OutdatedKinds =
+  | 'any'
+  | 'major'
+  | 'minor'
+  | 'patch'
+  | 'in-range'
+  | 'out-of-range'
+
+/**
+ * Result of the internal parsing of the :outdated() pseudo selector.
+ */
+export type OutdatedInternals = {
+  kind: OutdatedKinds
+}
+
+/**
+ * Extracts a semver type from a version string.
+ */
+export type SemverTypeExtraction = (
+  version: string,
+) => number | undefined
+
+const kinds = new Set<OutdatedKinds>([
+  'any',
+  'major',
+  'minor',
+  'patch',
+  'in-range',
+  'out-of-range',
+])
+
+/**
+ * Checks if a string is a valid {@link OutdatedKinds}.
+ */
+export const isOutdatedKind = (
+  value: string,
+): value is OutdatedKinds => kinds.has(value as OutdatedKinds)
+
+/**
+ * Asserts that a string is a valid {@link OutdatedKinds}.
+ */
+export const asOutdatedKind = (value: string): OutdatedKinds => {
+  if (!isOutdatedKind(value)) {
+    throw error('Expected a valid outdated kind', {
+      found: value,
+      validOptions: Array.from(kinds),
+    })
+  }
+  return value
+}
+
+/**
+ * Fetches the available versions of a package from the npm registry.
+ */
+export const retrieveRemoteVersions = async (
+  node: NodeLike,
+  specOptions: SpecOptions,
+): Promise<string[]> => {
+  const spec = hydrate(node.id, String(node.name), specOptions)
+  if (!spec.registry || !node.name) {
+    return []
+  }
+
+  const url = new URL(spec.registry)
+  url.pathname = `/${node.name}`
+
+  try {
+    const response = await fetch(String(url), {
+      headers: {
+        Accept: 'application/vnd.npm.install-v1+json',
+      },
+    })
+    if (!response.ok) {
+      // eslint-disable-next-line no-console
+      console.warn(
+        error('Failed to fetch packument', {
+          name: String(node.name),
+          spec,
+          response,
+        }),
+      )
+      return []
+    }
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+    const packument: Packument = await response.json()
+    return Object.keys(packument.versions).sort(compare)
+  } catch (e) {
+    const err = e as Error
+    // eslint-disable-next-line no-console
+    console.warn(
+      error('Could not retrieve registry versions', {
+        name: String(node.name),
+        spec,
+        cause: err,
+      }),
+    )
+    return []
+  }
+}
+
+/**
+ * Retrieves what kind of check the :outdated selector should perform.
+ */
+export const parseInternals = (
+  nodes: PostcssNode[],
+): OutdatedInternals => {
+  let kind: OutdatedKinds = 'any'
+
+  if (isStringNode(asPostcssNodeWithChildren(nodes[0]).nodes[0])) {
+    kind = asOutdatedKind(
+      removeQuotes(
+        asStringNode(asPostcssNodeWithChildren(nodes[0]).nodes[0])
+          .value,
+      ),
+    )
+  } else if (
+    isTagNode(asPostcssNodeWithChildren(nodes[0]).nodes[0])
+  ) {
+    kind = asOutdatedKind(
+      asTagNode(asPostcssNodeWithChildren(nodes[0]).nodes[0]).value,
+    )
+  }
+
+  return { kind }
+}
+
+/**
+ * Filter nodes by queueing up for removal those that are not outdated.
+ */
+export const queueNode = async (
+  state: ParserState,
+  node: NodeLike,
+  kind: OutdatedKinds,
+): Promise<NodeLike | undefined> => {
+  if (!node.name || !node.version) {
+    return node
+  }
+
+  const nodeVersion: string = node.version
+  const versions = await retrieveRemoteVersions(
+    node,
+    state.specOptions,
+  )
+
+  const greaterVersions = versions.filter((version: string) =>
+    gt(version, nodeVersion),
+  )
+
+  // if there are no greater versions, then the node is not outdated
+  if (!greaterVersions.length) {
+    return node
+  }
+
+  const checkKind = new Map<OutdatedKinds, SemverTypeExtraction>([
+    ['major', major],
+    ['minor', minor],
+    ['patch', patch],
+  ])
+
+  switch (kind) {
+    case 'any':
+      return
+    case 'major':
+    case 'minor':
+    case 'patch': {
+      return (
+          greaterVersions.some((version: string) => {
+            const va = checkKind.get(kind)?.(version)
+            const vb = checkKind.get(kind)?.(nodeVersion)
+            /* c8 ignore next - impossible but typescript doesn't know */
+            if (va === undefined || vb === undefined) return false
+            return va > vb
+          })
+        ) ?
+          undefined
+        : node
+    }
+    // the node should be part of the result as long as it has at least
+    // one parent node that has a spec definition that satisfies one
+    // of the available remove versions
+    case 'in-range': {
+      for (const edge of node.edgesIn) {
+        // if the edge is not part of the partial results, skip it
+        /* c8 ignore next */
+        if (!state.partial.edges.has(edge)) continue
+
+        if (
+          greaterVersions.some(
+            version =>
+              edge.spec.final.range &&
+              satisfies(version, edge.spec.final.range),
+          )
+        ) {
+          return
+        }
+      }
+      return node
+    }
+    // the node is part of the result as long as none of its parents has
+    // a spec definition that satisfies one of the available remote versions
+    case 'out-of-range': {
+      for (const edge of node.edgesIn) {
+        // if the edge is not part of the partial results, skip it
+        /* c8 ignore next */
+        if (!state.partial.edges.has(edge)) continue
+
+        if (
+          greaterVersions.some(
+            version =>
+              edge.spec.final.range &&
+              satisfies(version, edge.spec.final.range),
+          )
+        ) {
+          return node
+        }
+      }
+      return
+    }
+  }
+}
+
+/**
+ * Filters out nodes that are not outdated.
+ *
+ * The :outdated() pseudo selector supports one `type` argument,
+ * possible values are the following:
+ *
+ * - `any`: Selects all nodes that have a greater version available.
+ * - `major`: Selects all nodes that have a greater major version available.
+ * - `minor`: Selects all nodes that have a greater minor version available.
+ * - `patch`: Selects all nodes that have a greater patch version available.
+ * - `in-range`: Selects all nodes that have a parent node with a spec definition
+ *  that satisfies one of the available remote versions.
+ *  - `out-of-range`: Selects all nodes that have a parent node with a spec definition
+ *  that does not satisfy any of the available remote versions.
+ */
+export const outdated = async (state: ParserState) => {
+  let internals
+  try {
+    internals = parseInternals(
+      asPostcssNodeWithChildren(state.current).nodes,
+    )
+  } catch (err) {
+    throw error('Failed to parse :outdated selector', {
+      cause: err,
+    })
+  }
+
+  const { kind } = internals
+  const queue = []
+
+  for (const node of state.partial.nodes) {
+    // filter out nodes that are always ignored by the outdated selector
+    if (
+      node.mainImporter ||
+      node.manifest?.private ||
+      splitDepID(node.id)[0] !== 'registry'
+    ) {
+      removeNode(state, node)
+      continue
+    }
+
+    // fetchs outdated info and performs checks to define
+    // whether or not a node should be filtered out
+    queue.push(queueNode(state, node, kind))
+  }
+
+  // nodes queued for removal are then finally removed
+  const removeNodeQueue = await Promise.all(queue)
+  for (const node of removeNodeQueue) {
+    if (node) {
+      removeNode(state, node)
+    }
+  }
+
+  return state
+}

--- a/src/query/src/types.ts
+++ b/src/query/src/types.ts
@@ -1,5 +1,6 @@
 import { error } from '@vltpkg/error-cause'
 import type { EdgeLike, NodeLike } from '@vltpkg/graph'
+import type { SpecOptions } from '@vltpkg/spec/browser'
 import type {
   Tag,
   String,
@@ -48,6 +49,7 @@ export type ParserState = {
   signal?: AbortSignal
   walk: ParserFn
   partial: GraphSelectionState
+  specOptions: SpecOptions
 }
 
 export type QueryResponse = {

--- a/src/query/tap-snapshots/test/pseudo/outdated.ts.test.cjs
+++ b/src/query/tap-snapshots/test/pseudo/outdated.ts.test.cjs
@@ -1,0 +1,96 @@
+/* IMPORTANT
+ * This snapshot file is auto-generated, but designed for humans.
+ * It should be checked into source control and tracked carefully.
+ * Re-generate by setting TAP_SNAPSHOT=1 and running tests.
+ * Make sure to inspect the output below.  Do not ignore changes!
+ */
+'use strict'
+exports[`test/pseudo/outdated.ts > TAP > select from outdated definition > outdated kind any > must match snapshot 1`] = `
+Object {
+  "edges": Array [
+    "a",
+    "c",
+    "d",
+    "e",
+    "g",
+    "e",
+  ],
+  "nodes": Array [
+    "a",
+    "c",
+    "d",
+    "e",
+    "g",
+    "e",
+  ],
+}
+`
+
+exports[`test/pseudo/outdated.ts > TAP > select from outdated definition > outdated kind in-range > must match snapshot 1`] = `
+Object {
+  "edges": Array [
+    "c",
+    "e",
+  ],
+  "nodes": Array [
+    "c",
+    "e",
+  ],
+}
+`
+
+exports[`test/pseudo/outdated.ts > TAP > select from outdated definition > outdated kind major > must match snapshot 1`] = `
+Object {
+  "edges": Array [
+    "a",
+    "c",
+    "e",
+    "e",
+  ],
+  "nodes": Array [
+    "a",
+    "c",
+    "e",
+    "e",
+  ],
+}
+`
+
+exports[`test/pseudo/outdated.ts > TAP > select from outdated definition > outdated kind minor > must match snapshot 1`] = `
+Object {
+  "edges": Array [
+    "e",
+  ],
+  "nodes": Array [
+    "e",
+  ],
+}
+`
+
+exports[`test/pseudo/outdated.ts > TAP > select from outdated definition > outdated kind out-of-range > must match snapshot 1`] = `
+Object {
+  "edges": Array [
+    "a",
+    "d",
+    "g",
+    "e",
+  ],
+  "nodes": Array [
+    "a",
+    "d",
+    "g",
+    "e",
+  ],
+}
+`
+
+exports[`test/pseudo/outdated.ts > TAP > select from outdated definition > outdated kind patch > must match snapshot 1`] = `
+Object {
+  "edges": Array [
+    "d",
+  ],
+  "nodes": Array [
+    "d",
+  ],
+}
+`

--- a/src/query/test/attribute.ts
+++ b/src/query/test/attribute.ts
@@ -239,6 +239,7 @@ t.test('filterAttributes', async t => {
     partial: all,
     loose: false,
     walk: async (state: ParserState) => state,
+    specOptions: {},
   }
   filterAttributes(
     state,

--- a/src/query/test/fixtures/graph.ts
+++ b/src/query/test/fixtures/graph.ts
@@ -62,6 +62,19 @@ const newEdge = (
   from.graph.edges.add(edge)
 }
 
+const updateNodeVersion = (
+  node: NodeLike,
+  version: string,
+  protocol = '',
+) => {
+  node.version = version
+  node.id = joinDepIDTuple([
+    'registry',
+    protocol,
+    `${node.name}@${version}`,
+  ])
+}
+
 // Returns a graph that looks like:
 //
 // my-project (#a.prod, #b.dev, #e.prod, #@x/y.dev)
@@ -370,12 +383,12 @@ export const getSemverRichGraph = (): GraphLike => {
       e: '<=120',
     },
   }
-  a.version = '1.0.1'
+  updateNodeVersion(a, '1.0.1')
   a.manifest = {
     ...a.manifest,
     version: '1.0.1',
   }
-  b.version = '2.2.1'
+  updateNodeVersion(b, '2.2.1')
   b.manifest = {
     ...b.manifest,
     version: '2.2.1',
@@ -387,7 +400,7 @@ export const getSemverRichGraph = (): GraphLike => {
       node: '>=10',
     },
   }
-  c.version = '3.4.0'
+  updateNodeVersion(c, '3.4.0', 'custom')
   c.manifest = {
     ...c.manifest,
     engines: {
@@ -395,7 +408,7 @@ export const getSemverRichGraph = (): GraphLike => {
     },
     version: '3.4.0',
   }
-  d.version = '2.3.4'
+  updateNodeVersion(d, '2.3.4')
   d.manifest = {
     ...d.manifest,
     version: '2.3.4',
@@ -404,7 +417,7 @@ export const getSemverRichGraph = (): GraphLike => {
       f: '4.x.x',
     },
   }
-  e.version = '120.0.0'
+  updateNodeVersion(e, '120.0.0')
   e.manifest = {
     ...e.manifest,
     version: '120.0.0',
@@ -417,13 +430,13 @@ export const getSemverRichGraph = (): GraphLike => {
     'prod',
     e2,
   )
-  f.version = '4.5.6'
+  updateNodeVersion(f, '4.5.6')
   f.manifest = {
     ...f.manifest,
     version: '4.5.6',
     arbitrarySemverValue: '2.0.0',
   } as Manifest
-  g.version = '1.2.3-rc.1+rev.2'
+  updateNodeVersion(g, '1.2.3-rc.1+rev.2')
   g.manifest = {
     ...g.manifest,
     version: '1.2.3-rc.1+rev.2',

--- a/src/query/test/fixtures/selector.ts
+++ b/src/query/test/fixtures/selector.ts
@@ -87,6 +87,7 @@ export const selectorFixture =
       initial,
       partial,
       walk,
+      specOptions: {},
     }
     const res = await testFn(state)
     return {

--- a/src/query/test/index.ts
+++ b/src/query/test/index.ts
@@ -10,6 +10,13 @@ import { copyGraphSelectionState } from './fixtures/selector.ts'
 
 type TestCase = [string, string[]]
 
+const specOptions = {
+  registry: 'https://registry.npmjs.org',
+  registries: {
+    custom: 'http://example.com',
+  },
+}
+
 const testBrokenState = (): ParserState => {
   const graph = getSimpleGraph()
   const initial = {
@@ -27,6 +34,7 @@ const testBrokenState = (): ParserState => {
     initial: copyGraphSelectionState(initial),
     partial: copyGraphSelectionState(initial),
     walk,
+    specOptions,
   }
   return state
 }
@@ -70,7 +78,7 @@ t.test('simple graph', async t => {
     ['#a', ['a']], // identifier
   ])
 
-  const query = new Query({ graph })
+  const query = new Query({ graph, specOptions })
   for (const [q, expected] of queryToExpected) {
     t.strictSame(
       (await query.search(q)).nodes.map(i => i.name),
@@ -90,7 +98,7 @@ t.test('workspace', async t => {
     [':root > :root', ['ws']], // :root always places a ref to root
     ['/* do something */ [name^=w]', ['ws', 'w']], // support comments
   ])
-  const query = new Query({ graph })
+  const query = new Query({ graph, specOptions })
   for (const [q, expected] of queryToExpected) {
     t.strictSame(
       (await query.search(q)).nodes.map(i => i.name),
@@ -111,7 +119,7 @@ t.test('cycle', async t => {
     ['/* do something */ [name^=a]', ['a']], // support comments
     [':root > :root > .prod > *', ['b']], // mixed selectors
   ])
-  const query = new Query({ graph })
+  const query = new Query({ graph, specOptions })
   for (const [q, expected] of queryToExpected) {
     t.strictSame(
       (await query.search(q)).nodes.map(i => i.name),
@@ -123,7 +131,7 @@ t.test('cycle', async t => {
 
 t.test('bad search argument', async t => {
   const graph = getSimpleGraph()
-  const query = new Query({ graph })
+  const query = new Query({ graph, specOptions })
   await t.rejects(
     query.search(null as unknown as string),
     /Query search argument needs to be a string/,
@@ -148,7 +156,7 @@ t.test('bad selector type [loose mode]', async t => {
 
 t.test('trying to use tag selectors', async t => {
   await t.rejects(
-    new Query({ graph: getSimpleGraph() }).search('foo'),
+    new Query({ graph: getSimpleGraph(), specOptions }).search('foo'),
     /Unsupported selector/,
     'should throw an unsupported selector error',
   )
@@ -156,7 +164,9 @@ t.test('trying to use tag selectors', async t => {
 
 t.test('trying to use string selectors', async t => {
   await t.rejects(
-    new Query({ graph: getSimpleGraph() }).search('"foo"'),
+    new Query({ graph: getSimpleGraph(), specOptions }).search(
+      '"foo"',
+    ),
     /Unsupported selector/,
     'should throw an unsupported selector error',
   )
@@ -164,7 +174,7 @@ t.test('trying to use string selectors', async t => {
 
 t.test('cancellable search', async t => {
   const graph = getSingleWorkspaceGraph()
-  const query = new Query({ graph })
+  const query = new Query({ graph, specOptions })
   const ac = new AbortController()
   const q = ':root > * > *'
   await t.rejects(

--- a/src/query/test/pseudo/outdated.ts
+++ b/src/query/test/pseudo/outdated.ts
@@ -1,0 +1,288 @@
+import t from 'tap'
+import type { SpecOptions } from '@vltpkg/spec/browser'
+import { joinDepIDTuple } from '@vltpkg/dep-id'
+import type { NodeLike } from '@vltpkg/graph'
+import postcssSelectorParser from 'postcss-selector-parser'
+import {
+  outdated,
+  parseInternals,
+  queueNode,
+  retrieveRemoteVersions,
+} from '../../src/pseudo/outdated.ts'
+import { asPostcssNodeWithChildren } from '../../src/types.ts'
+import type { ParserState } from '../../src/types.ts'
+import { getSemverRichGraph } from '../fixtures/graph.ts'
+
+const specOptions = {
+  registry: 'https://registry.npmjs.org',
+  registries: {
+    custom: 'http://example.com',
+  },
+} as SpecOptions
+
+global.fetch = (async (url: string) => {
+  if (url === 'https://registry.npmjs.org/h') {
+    return {
+      ok: false,
+    }
+  } else if (url === 'https://registry.npmjs.org/i') {
+    throw new Error('ERR')
+  }
+  return {
+    ok: true,
+    json: async () => {
+      switch (url) {
+        case 'https://registry.npmjs.org/a': {
+          return {
+            versions: {
+              '1.0.0': {},
+              '2.0.0': {},
+              '3.0.0': {},
+            },
+          }
+        }
+        case 'https://registry.npmjs.org/b': {
+          return {
+            versions: {
+              '1.0.0': {},
+              '2.0.0': {},
+              '2.1.0': {},
+              '2.2.0': {},
+            },
+          }
+        }
+        case 'http://example.com/c': {
+          return {
+            versions: {
+              '3.0.0': {},
+              '3.4.0': {},
+              '4.0.0': {},
+              '5.0.0': {},
+            },
+          }
+        }
+        case 'https://registry.npmjs.org/d': {
+          return {
+            versions: {
+              '1.0.0': {},
+              '1.2.0': {},
+              '2.3.4': {},
+              '2.3.5': {},
+            },
+          }
+        }
+        case 'https://registry.npmjs.org/e': {
+          return {
+            versions: {
+              '120.0.0': {},
+              '120.1.0': {},
+              '121.0.0': {},
+              '122.0.0': {},
+            },
+          }
+        }
+        case 'https://registry.npmjs.org/f': {
+          return {
+            versions: {
+              '4.0.0': {},
+              '4.5.6': {},
+            },
+          }
+        }
+        case 'https://registry.npmjs.org/g': {
+          return {
+            versions: {
+              '1.2.3-rc.1+rev.1': {},
+              '1.2.3-rc.1+rev.2': {},
+              '1.2.3-rc.2+rev.3': {},
+              '1.2.3-rc.3+rev.4': {},
+            },
+          }
+        }
+      }
+    },
+  }
+}) as unknown as typeof global.fetch
+
+const getState = (query: string, graph = getSemverRichGraph()) => {
+  const ast = postcssSelectorParser().astSync(query)
+  const current = asPostcssNodeWithChildren(ast.first.first)
+  const state: ParserState = {
+    current,
+    initial: {
+      edges: new Set(graph.edges.values()),
+      nodes: new Set(graph.nodes.values()),
+    },
+    partial: {
+      edges: new Set(graph.edges.values()),
+      nodes: new Set(graph.nodes.values()),
+    },
+    collect: {
+      edges: new Set(),
+      nodes: new Set(),
+    },
+    cancellable: async () => {},
+    walk: async i => i,
+    specOptions,
+  }
+  return state
+}
+
+t.test('select from outdated definition', async t => {
+  await t.test('outdated kind any', async t => {
+    const res = await outdated(getState(':outdated(any)'))
+    t.strictSame(
+      [...res.partial.nodes].map(n => n.name),
+      ['a', 'c', 'd', 'e', 'g', 'e'],
+      'should have expected result using outdated kind "any"',
+    )
+    t.matchSnapshot({
+      nodes: [...res.partial.nodes].map(n => n.name),
+      edges: [...res.partial.edges].map(e => e.name),
+    })
+  })
+
+  await t.test('outdated kind major', async t => {
+    const res = await outdated(getState(':outdated(major)'))
+    t.strictSame(
+      [...res.partial.nodes].map(n => n.name),
+      ['a', 'c', 'e', 'e'],
+      'should have expected result using outdated kind "major"',
+    )
+    t.matchSnapshot({
+      nodes: [...res.partial.nodes].map(n => n.name),
+      edges: [...res.partial.edges].map(e => e.name),
+    })
+  })
+
+  await t.test('outdated kind minor', async t => {
+    const res = await outdated(getState(':outdated("minor")'))
+    t.strictSame(
+      [...res.partial.nodes].map(n => n.name),
+      ['e'],
+      'should have expected result using outdated kind "minor"',
+    )
+    t.matchSnapshot({
+      nodes: [...res.partial.nodes].map(n => n.name),
+      edges: [...res.partial.edges].map(e => e.name),
+    })
+  })
+
+  await t.test('outdated kind patch', async t => {
+    const res = await outdated(getState(':outdated("patch")'))
+    t.strictSame(
+      [...res.partial.nodes].map(n => n.name),
+      ['d'],
+      'should have expected result using outdated kind "patch"',
+    )
+    t.matchSnapshot({
+      nodes: [...res.partial.nodes].map(n => n.name),
+      edges: [...res.partial.edges].map(e => e.name),
+    })
+  })
+
+  await t.test('outdated kind in-range', async t => {
+    const res = await outdated(getState(':outdated(in-range)'))
+    t.strictSame(
+      [...res.partial.nodes].map(n => n.name),
+      ['c', 'e'],
+      'should have expected result using outdated kind "in-range"',
+    )
+    t.matchSnapshot({
+      nodes: [...res.partial.nodes].map(n => n.name),
+      edges: [...res.partial.edges].map(e => e.name),
+    })
+  })
+
+  await t.test('outdated kind out-of-range', async t => {
+    const res = await outdated(getState(':outdated(out-of-range)'))
+    t.strictSame(
+      [...res.partial.nodes].map(n => n.name),
+      ['a', 'd', 'g', 'e'],
+      'should have expected result using outdated kind "out-of-range"',
+    )
+    t.matchSnapshot({
+      nodes: [...res.partial.nodes].map(n => n.name),
+      edges: [...res.partial.edges].map(e => e.name),
+    })
+  })
+
+  await t.test('invalid pseudo selector usage', async t => {
+    await t.rejects(
+      outdated(getState(':semver')),
+      /Failed to parse :outdated selector/,
+      'should throw an error for invalid pseudo selector usage',
+    )
+  })
+})
+
+t.test('parseInternals', async t => {
+  const ast = postcssSelectorParser().astSync(':outdated(any)')
+  const nodes = asPostcssNodeWithChildren(ast.first.first).nodes
+  const internals = parseInternals(nodes)
+  t.strictSame(
+    internals,
+    { kind: 'any' },
+    'should correctly parse internals from outdated selector',
+  )
+})
+
+t.test('invalid outdated kind', async t => {
+  const ast = postcssSelectorParser().astSync(
+    ':outdated(unsupported)',
+  )
+  const nodes = asPostcssNodeWithChildren(ast.first.first).nodes
+  t.throws(
+    () => parseInternals(nodes),
+    /Expected a valid outdated kind/,
+    'should throw an error for invalid outdated kind',
+  )
+})
+
+t.test('retrieveRemoveVersions', async t => {
+  t.capture(console, 'warn')
+
+  const missingName = {
+    id: joinDepIDTuple(['registry', '', 'a@1.0.0']),
+  } as NodeLike
+  t.strictSame(
+    await retrieveRemoteVersions(missingName, specOptions),
+    [],
+    'should return an empty array if missing essential info',
+  )
+
+  await t.test('no response from registry', async t => {
+    const missingName = {
+      name: 'h',
+      id: joinDepIDTuple(['registry', '', 'h@1.0.0']),
+    } as NodeLike
+    t.strictSame(
+      await retrieveRemoteVersions(missingName, specOptions),
+      [],
+      'should return an empty array if registry has no response',
+    )
+  })
+
+  await t.test('fetch error', async t => {
+    const missingName = {
+      name: 'i',
+      id: joinDepIDTuple(['registry', '', 'i@1.0.0']),
+    } as NodeLike
+    t.strictSame(
+      await retrieveRemoteVersions(missingName, specOptions),
+      [],
+      'should return an empty array if fetch throws',
+    )
+  })
+})
+
+t.test('queueNode', async t => {
+  const missingName = {
+    id: joinDepIDTuple(['registry', '', 'a@1.0.0']),
+  } as NodeLike
+  t.strictSame(
+    await queueNode(getState(':outdated(any)'), missingName, 'any'),
+    missingName,
+    'should return an empty array if missing essential info',
+  )
+})

--- a/src/query/test/pseudo/semver.ts
+++ b/src/query/test/pseudo/semver.ts
@@ -33,6 +33,7 @@ t.test('select from semver definition', async t => {
       },
       cancellable: async () => {},
       walk: async i => i,
+      specOptions: {},
     }
     return state
   }

--- a/src/vlt/src/commands/list.ts
+++ b/src/vlt/src/commands/list.ts
@@ -84,7 +84,7 @@ export const command: CommandFn<ListResult> = async conf => {
   const queryString = conf.positionals
     .map(k => (/^[@\w-]/.test(k) ? `#${k.replace(/\//, '\\/')}` : k))
     .join(', ')
-  const query = new Query({ graph })
+  const query = new Query({ graph, specOptions: conf.options })
   const projectQueryString = ':project, :project > *'
   const selectImporters: string[] = []
 

--- a/src/vlt/src/commands/query.ts
+++ b/src/vlt/src/commands/query.ts
@@ -78,7 +78,7 @@ export const command: CommandFn<QueryResult> = async conf => {
 
   const defaultQueryString = '*'
   const queryString = conf.positionals[0]
-  const query = new Query({ graph })
+  const query = new Query({ graph, specOptions: conf.options })
   const { edges, nodes } = await query.search(
     queryString || defaultQueryString,
   )


### PR DESCRIPTION
Add a new `:outdated()` pseudo selector to the query language.

It supports a `type` parameter that can be one of the following values:
  - `any` (default) a version exists that is greater than the current one
  - `in-range` a version exists that is greater than the current one, and satisfies at least one if its parent's dependencies
  - `out-of-range` a version exists that is greater than the current one, does not satisfy at least one of its parent's dependencies
  - `major` a version exists that is a semver major greater than the current one
  - `minor` a version exists that is a semver minor greater than the current one
  - `patch` a version exists that is a semver patch greater than the current one

Example:

  Selects any package that has a greater version published to its
  configured registry:

    :outdated("any")