### PR TITLE
publish: create release workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -46,11 +46,11 @@ jobs:
         run: pnpm install
 
       - name: Publish
-        run: pnpm run build:bundle --action=publish ${{ !inputs.dryRun && '--forReal' || '' }}
+        run: pnpm run build:bundle --action=publish --appendTimestamp ${{ !inputs.dryRun && '--forReal' || '' }}
         env:
           VLT_CLI_PUBLISH_TOKEN: ${{ secrets.VLT_CLI_PUBLISH_TOKEN }}
 
       - name: Publish Compiled
-        run: pnpm run build:compile --action=publish --platform=all --arch=all ${{ !inputs.dryRun && '--forReal' || '' }}
+        run: pnpm run build:compile --action=publish --platform=all --arch=all --appendTimestamp ${{ !inputs.dryRun && '--forReal' || '' }}
         env:
           VLT_CLI_PUBLISH_TOKEN: ${{ secrets.VLT_CLI_PUBLISH_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,126 @@
+name: Release
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  detect-action:
+    name: Detect Release Action
+    runs-on: ubuntu-latest
+    outputs:
+      action: ${{ steps.determine-action.outputs.action }}
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+
+      - name: Get Commit Message
+        id: get-message
+        run: echo "msg=$(git log -1 --pretty=%B)" >> $GITHUB_ENV
+
+      - name: Determine Action
+        id: determine-action
+        run: |
+          if [[ "$msg" == *"Release v"* ]]; then
+            echo "action=publish" >> $GITHUB_OUTPUT
+          else
+            echo "action=pr" >> $GITHUB_OUTPUT
+          fi
+
+  pr:
+    name: Release PR
+    runs-on: ubuntu-latest
+    needs: detect-action
+    if: needs.detect-action.outputs.action == 'pr'
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+          run_install: false
+
+      - name: Setup Nodejs
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+          cache: pnpm
+          check-latest: true
+
+      - name: Increment Version
+        run: pnpm -F cli exec npm version prerelease --no-git-tag-version
+
+      - name: Get Version Number
+        id: get-version
+        run: echo "version=$(jq -r .version ./src/vlt/package.json)" >> $GITHUB_ENV
+
+      - name: Create or Update PR
+        id: pr
+        uses: peter-evans/create-pull-request@v7
+        with:
+          token: ${{ secrets.RELEASE_WORKFLOW_TOKEN }}
+          branch: release
+          title: 'Release v${{ steps.get-version.outputs.version }}'
+          body: 'This PR was created automatically to publish the package.'
+          commit-message: 'Release v${{ steps.get-version.outputs.version }}'
+          author: 'vltops <vltops@users.noreply.github.com>'
+          committer: 'vltops <vltops@users.noreply.github.com>'
+          labels: 'release'
+          base: main
+
+      - name: Dry Run Publish
+        run: pnpm run build:bundle --action=pack
+
+      - name: Upload Artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: dry-run-publish-artifacts
+          path: |
+            .build-bundle/vlt-*.tgz
+
+  publish:
+    name: Publish
+    runs-on: ubuntu-latest
+    needs: detect-action
+    if: needs.detect-action.outputs.action == 'publish'
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+        with:
+          ref: release
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+          run_install: false
+
+      - uses: denoland/setup-deno@v2
+        with:
+          deno-version: v2.x
+
+      - name: Setup Nodejs
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+          cache: pnpm
+          check-latest: true
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Publish
+        run: pnpm run build:bundle --action=publish ${{ github.event_name == 'push' && '--forReal' || '' }}
+        env:
+          VLT_CLI_PUBLISH_TOKEN: ${{ secrets.VLT_CLI_PUBLISH_TOKEN }}
+
+      - name: Publish Compiled
+        run: pnpm run build:compile --action=publish --platform=all --arch=all ${{ github.event_name == 'push' && '--forReal' || '' }}
+        env:
+          VLT_CLI_PUBLISH_TOKEN: ${{ secrets.VLT_CLI_PUBLISH_TOKEN }}

--- a/infra/build/src/bin/publish.ts
+++ b/infra/build/src/bin/publish.ts
@@ -100,6 +100,7 @@ const parseArgs = () => {
     forReal,
     action = 'build',
     quiet,
+    appendTimestamp,
     ...matrix
   } = nodeParseArgs({
     options: {
@@ -107,6 +108,7 @@ const parseArgs = () => {
       forReal: { type: 'boolean' },
       action: { type: 'string' },
       quiet: { type: 'boolean' },
+      appendTimestamp: { type: 'boolean' },
       ...matrixConfig,
     },
   }).values
@@ -123,6 +125,7 @@ const parseArgs = () => {
     dryRun: !forReal,
     action: action as Action,
     verbose: !quiet,
+    appendTimestamp,
     matrix: getMatrix(matrix),
   }
 }
@@ -288,7 +291,8 @@ const publishCompiled = (
 }
 
 const main = async () => {
-  const { outdir, matrix, dryRun, action, verbose } = parseArgs()
+  const { outdir, matrix, dryRun, action, verbose, appendTimestamp } =
+    parseArgs()
 
   assert(
     action === 'publish' && !dryRun ? TOKEN : true,
@@ -307,7 +311,7 @@ const main = async () => {
       '.npmrc': `//registry.npmjs.org/:_authToken=\${NPM_PUBLISH_TOKEN}`,
       'package.json': {
         name: 'vlt',
-        version: `${FILES.PACKAGE_JSON.version}${PRERELEASE_ID}`,
+        version: `${FILES.PACKAGE_JSON.version}${appendTimestamp ? PRERELEASE_ID : ''}`,
         description: FILES.PACKAGE_JSON.description,
         license: FILES.PACKAGE_JSON.license,
         keywords: FILES.PACKAGE_JSON.keywords,


### PR DESCRIPTION
This is another step towards reproducible builds.

This PR creates a `release.yml` workflow which will run on commits to main. For the latest commit to main it will create or update a release PR with the `src/vlt/package.json` version bumped to `0.0.0-$INCREMENTED_PRERELEASE_NUMBER`.

When that PR is merged it will publish that version the same way the current `publish.yml` workflow does when run manually.

Once this lands and works, the publish.yml workflow can be removed. But since GitHub actions are difficult to test it is kept around for publishing purposes.