### PR TITLE
vlt: save aliases to package.json

### DIFF
--- a/src/graph/src/reify/update-importers-package-json.ts
+++ b/src/graph/src/reify/update-importers-package-json.ts
@@ -111,9 +111,11 @@ const addOrRemoveDeps = (
       dependencies[name] =
         (
           nodeType === 'registry' &&
-          (!dep.spec.semver || !dep.spec.range)
+          (!dep.spec.final.semver || !dep.spec.final.range)
         ) ?
-          `${SAVE_PREFIX}${node.version}`
+          dep.spec.subspec && dep.spec.namedRegistry ?
+            `${dep.spec.final.namedRegistry}:${dep.spec.final.name}@${SAVE_PREFIX}${node.version}`
+          : `${SAVE_PREFIX}${node.version}`
         : dep.spec.bareSpec
       manifestChanged = true
     }

--- a/src/graph/tap-snapshots/test/reify/update-importers-package-json.ts.test.cjs
+++ b/src/graph/tap-snapshots/test/reify/update-importers-package-json.ts.test.cjs
@@ -5,6 +5,60 @@
  * Make sure to inspect the output below.  Do not ignore changes!
  */
 'use strict'
+exports[`test/reify/update-importers-package-json.ts > TAP > updatePackageJson > aliased install > should use provided aliased in package json save 1`] = `
+Array [
+  Object {
+    "dependencies": Object {
+      "b": "npm:a@1.0.0",
+      "git": "github:a/b",
+    },
+    "devDependencies": Object {
+      "def": "^1.0.0",
+      "gtor": ">=1.1.0 || 2",
+      "range": "~1.1.0",
+    },
+    "name": "root",
+    "version": "1.0.0",
+  },
+]
+`
+
+exports[`test/reify/update-importers-package-json.ts > TAP > updatePackageJson > aliased install from dist-tag > should use resolved version in package json save 1`] = `
+Array [
+  Object {
+    "dependencies": Object {
+      "b": "npm:a@^1.0.0",
+      "git": "github:a/b",
+    },
+    "devDependencies": Object {
+      "def": "^1.0.0",
+      "gtor": ">=1.1.0 || 2",
+      "range": "~1.1.0",
+    },
+    "name": "root",
+    "version": "1.0.0",
+  },
+]
+`
+
+exports[`test/reify/update-importers-package-json.ts > TAP > updatePackageJson > custom aliased install > should use custom aliased registry in package json save 1`] = `
+Array [
+  Object {
+    "dependencies": Object {
+      "b": "custom:a@^1.0.0",
+      "git": "github:a/b",
+    },
+    "devDependencies": Object {
+      "def": "^1.0.0",
+      "gtor": ">=1.1.0 || 2",
+      "range": "~1.1.0",
+    },
+    "name": "root",
+    "version": "1.0.0",
+  },
+]
+`
+
 exports[`test/reify/update-importers-package-json.ts > TAP > updatePackageJson > no semver dep > should use provided def in package json save 1`] = `
 Array [
   Object {


### PR DESCRIPTION
Fixes using the correct spec to `package.json` when using aliases on `vlt install` 

e.g: `vlt install underscore@npm:lodash`

Fixes: https://github.com/vltpkg/vltpkg/issues/390