### PR TITLE
hard wrap markdown and mdx with prettier

### DIFF
--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -18,5 +18,11 @@ export default {
         parser: 'astro',
       },
     },
+    {
+      files: '*.md',
+      options: {
+        proseWrap: 'always',
+      },
+    },
   ],
 }

--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -24,5 +24,11 @@ export default {
         proseWrap: 'always',
       },
     },
+    {
+      files: '*.mdx',
+      options: {
+        proseWrap: 'always',
+      },
+    },
   ],
 }

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -3,16 +3,17 @@
 ## Our Pledge
 
 In the interest of fostering an open and welcoming environment, we as
-contributors and maintainers pledge to make participation in our project and
-our community a harassment-free experience for everyone, regardless of age, body
-size, disability, ethnicity, sex characteristics, gender identity and expression,
-level of experience, education, socio-economic status, nationality, personal
-appearance, race, religion, or sexual identity and orientation.
+contributors and maintainers pledge to make participation in our
+project and our community a harassment-free experience for everyone,
+regardless of age, body size, disability, ethnicity, sex
+characteristics, gender identity and expression, level of experience,
+education, socio-economic status, nationality, personal appearance,
+race, religion, or sexual identity and orientation.
 
 ## Our Standards
 
-Examples of behavior that contributes to creating a positive environment
-include:
+Examples of behavior that contributes to creating a positive
+environment include:
 
 - Using welcoming and inclusive language
 - Being respectful of differing viewpoints and experiences
@@ -22,53 +23,59 @@ include:
 
 Examples of unacceptable behavior by participants include:
 
-- The use of sexualized language or imagery and unwelcome sexual attention or
-  advances
-- Trolling, insulting/derogatory comments, and personal or political attacks
+- The use of sexualized language or imagery and unwelcome sexual
+  attention or advances
+- Trolling, insulting/derogatory comments, and personal or political
+  attacks
 - Public or private harassment
-- Publishing others' private information, such as a physical or electronic
-  address, without explicit permission
-- Other conduct which could reasonably be considered inappropriate in a
-  professional setting
+- Publishing others' private information, such as a physical or
+  electronic address, without explicit permission
+- Other conduct which could reasonably be considered inappropriate in
+  a professional setting
 
 ## Our Responsibilities
 
-Project maintainers are responsible for clarifying the standards of acceptable
-behavior and are expected to take appropriate and fair corrective action in
-response to any instances of unacceptable behavior.
+Project maintainers are responsible for clarifying the standards of
+acceptable behavior and are expected to take appropriate and fair
+corrective action in response to any instances of unacceptable
+behavior.
 
-Project maintainers have the right and responsibility to remove, edit, or
-reject comments, commits, code, wiki edits, issues, and other contributions
-that are not aligned to this Code of Conduct, or to ban temporarily or
-permanently any contributor for other behaviors that they deem inappropriate,
-threatening, offensive, or harmful.
+Project maintainers have the right and responsibility to remove, edit,
+or reject comments, commits, code, wiki edits, issues, and other
+contributions that are not aligned to this Code of Conduct, or to ban
+temporarily or permanently any contributor for other behaviors that
+they deem inappropriate, threatening, offensive, or harmful.
 
 ## Scope
 
-This Code of Conduct applies within all project spaces, and it also applies when
-an individual is representing the project or its community in public spaces.
-Examples of representing a project or community include using an official
-project e-mail address, posting via an official social media account, or acting
-as an appointed representative at an online or offline event. Representation of
-a project may be further defined and clarified by project maintainers.
+This Code of Conduct applies within all project spaces, and it also
+applies when an individual is representing the project or its
+community in public spaces. Examples of representing a project or
+community include using an official project e-mail address, posting
+via an official social media account, or acting as an appointed
+representative at an online or offline event. Representation of a
+project may be further defined and clarified by project maintainers.
 
 ## Enforcement
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by contacting the project team at [support@vlt.sh](mailto:support@vlt.sh). All
-complaints will be reviewed and investigated and will result in a response that
-is deemed necessary and appropriate to the circumstances. The project team is
-obligated to maintain confidentiality with regard to the reporter of an incident.
-Further details of specific enforcement policies may be posted separately.
+Instances of abusive, harassing, or otherwise unacceptable behavior
+may be reported by contacting the project team at
+[support@vlt.sh](mailto:support@vlt.sh). All complaints will be
+reviewed and investigated and will result in a response that is deemed
+necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of
+an incident. Further details of specific enforcement policies may be
+posted separately.
 
-Project maintainers who do not follow or enforce the Code of Conduct in good
-faith may face temporary or permanent repercussions as determined by other
-members of the project's leadership.
+Project maintainers who do not follow or enforce the Code of Conduct
+in good faith may face temporary or permanent repercussions as
+determined by other members of the project's leadership.
 
 ## Attribution
 
-This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
-available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
+This Code of Conduct is adapted from the [Contributor
+Covenant][homepage], version 1.4, available at
+https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
 
 [homepage]: https://www.contributor-covenant.org
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,14 +4,13 @@
 
 The workspaces are divided among a few top-level directories.
 
-Be sure to check out the `CONTRIBUTING.md` file in the workspace
-where changes are being made, as this may provide contribution
-guidance specific to that component.
+Be sure to check out the `CONTRIBUTING.md` file in the workspace where
+changes are being made, as this may provide contribution guidance
+specific to that component.
 
 ### [`src`](./src/)
 
-These workspaces are all are direct dependencies of the `vlt`
-CLI.
+These workspaces are all are direct dependencies of the `vlt` CLI.
 
 The actual CLI is also a workspace in [`src/vlt`](./src/vlt/).
 
@@ -19,39 +18,41 @@ Most of these are also published separately under the `@vltpkg` scope.
 
 ### [`infra`](./infra/)
 
-These workspaces are internal tools that we use for tasks like building,
-bundling, and benchmarking the other workspaces.
+These workspaces are internal tools that we use for tasks like
+building, bundling, and benchmarking the other workspaces.
 
 These are internal and highly coupled to our monorepo setup, so they
 are not published to any registry.
 
 ### [`www`](./www/)
 
-These are websites that get deployed. Currently only [docs.vlt.sh](https://docs.vlt.sh).
+These are websites that get deployed. Currently only
+[docs.vlt.sh](https://docs.vlt.sh).
 
 ## Linting / Formatting
 
-Run `pnpm -w fix` to report any formatting or linting issues with your code,
-and to attempt to fix them.
+Run `pnpm -w fix` to report any formatting or linting issues with your
+code, and to attempt to fix them.
 
 ## Running TypeScript Directly
 
-If you are on the latest version of Node, you can run TypeScript
-files directly using `node ./path/to/file.ts`.
+If you are on the latest version of Node, you can run TypeScript files
+directly using `node ./path/to/file.ts`.
 
 If you are on Node 22, you can use `node --experimental-strip-types`.
 
 For both of those options you will see a warning. If that bothers you
 then you can run with `--no-warnings` as well.
 
-In order to make this work for all places where we might spawn a
-node process, run `export NODE_OPTIONS=--experimental-strip-types --no-warnings` to
-set this in the environment, rather than on each command.
+In order to make this work for all places where we might spawn a node
+process, run
+`export NODE_OPTIONS=--experimental-strip-types --no-warnings` to set
+this in the environment, rather than on each command.
 
 ## `nave` Conveniences
 
-If you use [nave](https://npm.im/nave) then you can enable `nave
-auto` behavior in your bash profile by adding something like this:
+If you use [nave](https://npm.im/nave) then you can enable `nave auto`
+behavior in your bash profile by adding something like this:
 
 ```bash
 # .bashrc or .bash_profile or wherever you put these things
@@ -65,14 +66,14 @@ __nave_prompt_command () {
 export PROMPT_COMMAND="__nave_prompt_command || true; ${PROMPT_COMMAND}"
 ```
 
-Then, the appropriate node version and `NODE_OPTIONS` flags will
-be set to be able to always run TypeScript files directly in the
-context of this project.
+Then, the appropriate node version and `NODE_OPTIONS` flags will be
+set to be able to always run TypeScript files directly in the context
+of this project.
 
 ## Root Level Scripts
 
-This root of this repo has scripts for each named bin that
-can be run via `pnpm` for testing locally.
+This root of this repo has scripts for each named bin that can be run
+via `pnpm` for testing locally.
 
 These scripts set the correct `NODE_OPTIONS` to run the TypeScript
 source directly.
@@ -87,10 +88,11 @@ $ pnpm -s vlt --version
 
 ## Running the CLI from Other Directories
 
-A directory of `sh` executables is located at `./scripts/bins`. These call the TypeScript
-source bin files with the correct `NODE_OPTIONS`. This directory is designed to be put at
-the beginning of your path temporarily to make running of `vlt` and its related CLIs run
-directly from source.
+A directory of `sh` executables is located at `./scripts/bins`. These
+call the TypeScript source bin files with the correct `NODE_OPTIONS`.
+This directory is designed to be put at the beginning of your path
+temporarily to make running of `vlt` and its related CLIs run directly
+from source.
 
 ```bash
 export PATH=~/projects/vltpkg/vltpkg/scripts/bins:$PATH
@@ -99,20 +101,25 @@ vlt --version
 
 ## Publishing
 
-All workspace directories are designed so `pnpm publish` can be run from that directory.
+All workspace directories are designed so `pnpm publish` can be run
+from that directory.
 
-On all pushes to `main` a GitHub Actions workflow will run to create a release PR. That
-PR will be updated for all subsequent pushes. The PR will contain any release related
-commits, usually just the bumping of `package.json` version numbers.
+On all pushes to `main` a GitHub Actions workflow will run to create a
+release PR. That PR will be updated for all subsequent pushes. The PR
+will contain any release related commits, usually just the bumping of
+`package.json` version numbers.
 
-When that PR is merged the same workflow will then publish the bumped packages.
+When that PR is merged the same workflow will then publish the bumped
+packages.
 
 ## Release Manager
 
-The weekly release manager's role is to merge the release PR. Pretty simple :smile:
+The weekly release manager's role is to merge the release PR. Pretty
+simple :smile:
 
-The release PR will be created as a `draft`. When it is time to release, merging other
-PRs should be temporarily paused and the release PR should be:
+The release PR will be created as a `draft`. When it is time to
+release, merging other PRs should be temporarily paused and the
+release PR should be:
 
 1. Marked as ready for review
 1. Approved
@@ -123,25 +130,27 @@ PRs should be temporarily paused and the release PR should be:
 The following packages are published as part of the CLI:
 
 - `vlt` This is currently the bundled JS version of the CLI
-- `@vltpkg/cli-compiled` The is the compiled version of the CLI that we are testing
-  so it can be made the default in the future. This package only has placeholder bins
-  that are swapped out in a postinstall for one of the platform variants below.
+- `@vltpkg/cli-compiled` The is the compiled version of the CLI that
+  we are testing so it can be made the default in the future. This
+  package only has placeholder bins that are swapped out in a
+  postinstall for one of the platform variants below.
 - `@vltpkg/cli-darmin-arm64`
 - `@vltpkg/cli-darmin-x64`
 - `@vltpkg/cli-linux-arm64`
 - `@vltpkg/cli-linux-x64`
 - `@vltpkg/cli-win32-x64`
 
-Note that the platform specific variants do not have any `package.json#bin` entries
-because that is incompatible with the postinstall strategy of the parent `@vltpkg/cli-compiled`
-package. If you need to install one of those directly, you will need to move/run
+Note that the platform specific variants do not have any
+`package.json#bin` entries because that is incompatible with the
+postinstall strategy of the parent `@vltpkg/cli-compiled` package. If
+you need to install one of those directly, you will need to move/run
 the included `vlt` executable manually.
 
 ## GUI Live Reload
 
-When run locally the GUI can be set to use live reload so that any changes to GUI source
-code will cause the browser to reload. To enable this set `__VLT_INTERNAL_LIVE_RELOAD=1`
-when running the GUI:
+When run locally the GUI can be set to use live reload so that any
+changes to GUI source code will cause the browser to reload. To enable
+this set `__VLT_INTERNAL_LIVE_RELOAD=1` when running the GUI:
 
 ```bash
 __VLT_INTERNAL_LIVE_RELOAD=1 node ~/path/to/vltpkg/vltpkg/src/vlt/bins/vlt.ts gui
@@ -149,18 +158,22 @@ __VLT_INTERNAL_LIVE_RELOAD=1 node ~/path/to/vltpkg/vltpkg/src/vlt/bins/vlt.ts gu
 
 ## Bundling Caveats
 
-When publishing, all of the source code is first bundled and code-split with esbuild.
+When publishing, all of the source code is first bundled and
+code-split with esbuild.
 
-There are some values in the source code that aren't statically analyzed by esbuild,
-and instead are read from environment variables. This is to make it explicit and
-because previous attempts to parse the AST and detect those values were slow and brittle.
+There are some values in the source code that aren't statically
+analyzed by esbuild, and instead are read from environment variables.
+This is to make it explicit and because previous attempts to parse the
+AST and detect those values were slow and brittle.
 
-All the environment variables follow the pattern `__VLT_INTERNAL_*` in order to distinguish
-them from the `VLT_*` environment variables that are set by the CLI's config system.
+All the environment variables follow the pattern `__VLT_INTERNAL_*` in
+order to distinguish them from the `VLT_*` environment variables that
+are set by the CLI's config system.
 
 ## Testing Builds
 
-Building for publishing is handled by the [`infra/build`](./infra/build) workspace.
+Building for publishing is handled by the
+[`infra/build`](./infra/build) workspace.
 
 There are some root level scripts that can be run to generate these
 builds for testing locally.
@@ -173,25 +186,27 @@ pnpm build:bundle
 pnpm build:compile
 ```
 
-To generate compiled builds for other platforms use the `--platform` and `--arch` flags.
+To generate compiled builds for other platforms use the `--platform`
+and `--arch` flags.
 
 ```bash
 pnpm build:compile --platform=win32 --arch=x64
 ```
 
-You can also run `pnpm pack` in any of the `./infra/cli*` directories to generate a tarball
-of the build.
+You can also run `pnpm pack` in any of the `./infra/cli*` directories
+to generate a tarball of the build.
 
 ## FAQ
 
 ### Test coverage is failing but it shouldn't be
 
-If you are testing a file that has side effects when imported, such as reading from `process.platform`
-to run different code, then this file can't be imported with a static import and instead must use
+If you are testing a file that has side effects when imported, such as
+reading from `process.platform` to run different code, then this file
+can't be imported with a static import and instead must use
 `t.mockImport` for all instances.
 
-Even though this code is valid and the tests will pass, coverage will most likely fail depending
-on the implementation.
+Even though this code is valid and the tests will pass, coverage will
+most likely fail depending on the implementation.
 
 ```ts
 // ❌ dont do this

--- a/README.md
+++ b/README.md
@@ -10,11 +10,13 @@
 
 **Develop. Run. Distribute.**
 
-This is the source monorepo for the [vlt](https://www.vlt.sh) package manager.
+This is the source monorepo for the [vlt](https://www.vlt.sh) package
+manager.
 
 ### Documentation
 
-Full documentation, startup guides & API references can be found at [docs.vlt.sh](https://docs.vlt.sh).
+Full documentation, startup guides & API references can be found at
+[docs.vlt.sh](https://docs.vlt.sh).
 
 #### Development
 
@@ -30,7 +32,8 @@ pnpm install
 pnpm vlt # OR ./node_modules/.bin/vlt
 ```
 
-See the [contributing guide](./CONTRIBUTING.md) for more information on how to build and develop the various workspaces.
+See the [contributing guide](./CONTRIBUTING.md) for more information
+on how to build and develop the various workspaces.
 
 ### License
 

--- a/infra/cli-compiled/README.md
+++ b/infra/cli-compiled/README.md
@@ -6,4 +6,5 @@ The command line interface for `vlt` (compiled).
 
 ## Documentation
 
-Visit [docs.vlt.sh](https://docs.vlt.sh) to see the full documentation.
+Visit [docs.vlt.sh](https://docs.vlt.sh) to see the full
+documentation.

--- a/infra/cli-darwin-arm64/README.md
+++ b/infra/cli-darwin-arm64/README.md
@@ -6,4 +6,5 @@ The command line interface for `vlt` (darwin-arm64).
 
 ## Documentation
 
-Visit [docs.vlt.sh](https://docs.vlt.sh) to see the full documentation.
+Visit [docs.vlt.sh](https://docs.vlt.sh) to see the full
+documentation.

--- a/infra/cli-darwin-x64/README.md
+++ b/infra/cli-darwin-x64/README.md
@@ -6,4 +6,5 @@ The command line interface for `vlt` (darwin-x64).
 
 ## Documentation
 
-Visit [docs.vlt.sh](https://docs.vlt.sh) to see the full documentation.
+Visit [docs.vlt.sh](https://docs.vlt.sh) to see the full
+documentation.

--- a/infra/cli-linux-arm64/README.md
+++ b/infra/cli-linux-arm64/README.md
@@ -6,4 +6,5 @@ The command line interface for `vlt` (linux-arm64).
 
 ## Documentation
 
-Visit [docs.vlt.sh](https://docs.vlt.sh) to see the full documentation.
+Visit [docs.vlt.sh](https://docs.vlt.sh) to see the full
+documentation.

--- a/infra/cli-linux-x64/README.md
+++ b/infra/cli-linux-x64/README.md
@@ -6,4 +6,5 @@ The command line interface for `vlt` (linux-x64).
 
 ## Documentation
 
-Visit [docs.vlt.sh](https://docs.vlt.sh) to see the full documentation.
+Visit [docs.vlt.sh](https://docs.vlt.sh) to see the full
+documentation.

--- a/infra/cli-win32-x64/README.md
+++ b/infra/cli-win32-x64/README.md
@@ -6,4 +6,5 @@ The command line interface for `vlt` (win32-x64).
 
 ## Documentation
 
-Visit [docs.vlt.sh](https://docs.vlt.sh) to see the full documentation.
+Visit [docs.vlt.sh](https://docs.vlt.sh) to see the full
+documentation.

--- a/infra/cli/README.md
+++ b/infra/cli/README.md
@@ -6,4 +6,5 @@ The command line interface for `vlt`.
 
 ## Documentation
 
-Visit [docs.vlt.sh](https://docs.vlt.sh) to see the full documentation.
+Visit [docs.vlt.sh](https://docs.vlt.sh) to see the full
+documentation.

--- a/src/cache-unzip/README.md
+++ b/src/cache-unzip/README.md
@@ -2,16 +2,15 @@
 
 # @vltpkg/cache-unzip
 
-This is a script that can be run as a detached background process to un-gzip any cached response bodies in the vlt cache.
+This is a script that can be run as a detached background process to
+un-gzip any cached response bodies in the vlt cache.
 
-**[Usage](#usage)**
-·
-**[Why Do This?](#why-do-this)**
+**[Usage](#usage)** · **[Why Do This?](#why-do-this)**
 
 ## Usage
 
-Whenever you get a cache entry with a gzipped body, tell this
-module about it.
+Whenever you get a cache entry with a gzipped body, tell this module
+about it.
 
 ```js
 import { register } from '@vltpkg/cache-unzip'
@@ -30,10 +29,13 @@ if (response.isGzip) {
 }
 ```
 
-On process exit, these registered keys will be passed as arguments to a detached deref'ed `vlt-cache-unzip` process. So,
-the main program exits normally, but the worker ignores the `SIGHUP` and keeps going until it's done. The next time that
-cache entry is read, it won't have to be unzipped.
+On process exit, these registered keys will be passed as arguments to
+a detached deref'ed `vlt-cache-unzip` process. So, the main program
+exits normally, but the worker ignores the `SIGHUP` and keeps going
+until it's done. The next time that cache entry is read, it won't have
+to be unzipped.
 
 ## Why Do This
 
-Because it's faster to not have to decompress the same content more times than necessary.
+Because it's faster to not have to decompress the same content more
+times than necessary.

--- a/src/cache/README.md
+++ b/src/cache/README.md
@@ -2,17 +2,16 @@
 
 # @vltpkg/cache
 
-The filesystem cache for `@vltpkg/registry-client`, but also, a general-purpose filesystem-backed [LRUCache](http://npm.im/lru-cache)
+The filesystem cache for `@vltpkg/registry-client`, but also, a
+general-purpose filesystem-backed [LRUCache](http://npm.im/lru-cache)
 
-**[Usage](#usage)**
-·
-**[Note](#note)**
+**[Usage](#usage)** · **[Note](#note)**
 
 ## Overview
 
-This is very minimal on features, because it has a very narrow use case, but if you want to have a persistently fs-backed LRU
-memory cache of Buffers using strings as keys, then this is the
-thing to use.
+This is very minimal on features, because it has a very narrow use
+case, but if you want to have a persistently fs-backed LRU memory
+cache of Buffers using strings as keys, then this is the thing to use.
 
 ## Usage
 
@@ -68,5 +67,7 @@ const otherValue = await cache.fetch(otherKey, {
 
 ## Note
 
-- The key type must be a string. It gets sha512 hashed to determine the file on disk.
-- The value must be a Buffer, so that it can be written to a file and read from it without having to convert anything.
+- The key type must be a string. It gets sha512 hashed to determine
+  the file on disk.
+- The value must be a Buffer, so that it can be written to a file and
+  read from it without having to convert anything.

--- a/src/dep-id/README.md
+++ b/src/dep-id/README.md
@@ -2,11 +2,10 @@
 
 # @vltpkg/dep-id
 
-A library for serializing dependencies into terse string identifiers, and turning those serialized identifiers back into `Spec` objects.
+A library for serializing dependencies into terse string identifiers,
+and turning those serialized identifiers back into `Spec` objects.
 
-**[Usage](#usage)**
-·
-**[Note](#note)**
+**[Usage](#usage)** · **[Note](#note)**
 
 ## Usage
 
@@ -50,12 +49,12 @@ const spec = hydrate('git;github:a/b;branch', 'x') // x@github:a/b#branch
 
 ### Note
 
-multiple different spec/manifest combinations _can_ result
-in the same identifier. For example, the specifiers
-`x@npm:y@latest` and `asdf@npm:y@1.x` might both ultimately
-resolve to the same package, so they only need to appear in the
-store once.
+multiple different spec/manifest combinations _can_ result in the same
+identifier. For example, the specifiers `x@npm:y@latest` and
+`asdf@npm:y@1.x` might both ultimately resolve to the same package, so
+they only need to appear in the store once.
 
 ## BROWSER API
 
-An isomorphic API `@vltpkg/dep-id/browser` is provided for use in the browser.
+An isomorphic API `@vltpkg/dep-id/browser` is provided for use in the
+browser.

--- a/src/dot-prop/README.md
+++ b/src/dot-prop/README.md
@@ -2,7 +2,9 @@
 
 # @vltpkg/dot-prop
 
-A library that allows you to easily access, set, delete, and check deeply nested properties in objects and arrays using string-based paths.
+A library that allows you to easily access, set, delete, and check
+deeply nested properties in objects and arrays using string-based
+paths.
 
 ## Usage
 

--- a/src/error-cause/README.md
+++ b/src/error-cause/README.md
@@ -2,25 +2,22 @@
 
 # @vltpkg/error-cause
 
-Utility functions for `Error` creation to help enforce vlt's `Error.cause` conventions.
+Utility functions for `Error` creation to help enforce vlt's
+`Error.cause` conventions.
 
-**[Usage](#usage)**
-·
-**[Error Reporting](#challenges-of-error-reporting)**
-·
-**[Conventions](#conventions)**
-·
-**[Error Types](#error-types)**
+**[Usage](#usage)** ·
+**[Error Reporting](#challenges-of-error-reporting)** ·
+**[Conventions](#conventions)** · **[Error Types](#error-types)**
 
 ## Why
 
-Most node programs have a mishmash of error codes and various
-`Error` subtypes, all in different shapes, making error handling
-and reporting more difficult at the top level. This negatively
-impacts debugging and user experience.
+Most node programs have a mishmash of error codes and various `Error`
+subtypes, all in different shapes, making error handling and reporting
+more difficult at the top level. This negatively impacts debugging and
+user experience.
 
-The JavaScript `Error` constructor has a [`cause`
-option](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/cause)
+The JavaScript `Error` constructor has a
+[`cause` option](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/cause)
 which is supported since Node 16.9. We should use it!
 
 This module makes that easy.
@@ -68,62 +65,60 @@ const checkBar = () => {
 }
 ```
 
-The functions will create an error object with a `cause` property
-if set, and the type checks will ensure that the `cause` object
-matches vlt's conventions.
+The functions will create an error object with a `cause` property if
+set, and the type checks will ensure that the `cause` object matches
+vlt's conventions.
 
 ## Challenges of Error Reporting
 
 - Provide enough information to be useful. On full inspection, we
-  should ideally always get back to not just the initial error
-  that was thrown, but also all locations where the error might
-  have been caught and handled in some way.
+  should ideally always get back to not just the initial error that
+  was thrown, but also all locations where the error might have been
+  caught and handled in some way.
 - Do not provide more information than is useful. Eg,
-  `console.error(er)` should not fill the entire scrollback
-  buffer.
-- New modules and libraries should have minimal friction in
-  creating a new style of error when needed. This means, minimize
-  the amount that any module needs to know about the errors
-  raised by any other module, including especially top-level
-  error handling.
-- _Some_ information about the error must be known to our
-  top-level error handler, so that it can usefully report errors
-  and suggest corrections.
+  `console.error(er)` should not fill the entire scrollback buffer.
+- New modules and libraries should have minimal friction in creating a
+  new style of error when needed. This means, minimize the amount that
+  any module needs to know about the errors raised by any other
+  module, including especially top-level error handling.
+- _Some_ information about the error must be known to our top-level
+  error handler, so that it can usefully report errors and suggest
+  corrections.
 
 ## Solution
 
 - A strictly upheld convention of Error object creation using the
   `cause` property.
-- Top level error handler can have special logic where necessary
-  for known error codes, but will still be able to do something
-  more useful when an Error object follows our conventions, even
-  if it's not a code that it knows.
+- Top level error handler can have special logic where necessary for
+  known error codes, but will still be able to do something more
+  useful when an Error object follows our conventions, even if it's
+  not a code that it knows.
 
 ## Conventions
 
-The following conventions should be followed for all `Error`
-creation and handling throughout the vlt codebase.
+The following conventions should be followed for all `Error` creation
+and handling throughout the vlt codebase.
 
 - **If you can't help, get out of the way.** Just let throws pass
   through to the top when nothing can be done to assist.
 - **Add information by using thrown error as `cause`.** Use a
   previously-thrown error as the `cause` option.
-- **Add even more info with a double-`cause`.** If more info can
-  be added to a prior throw, nest the `cause` properties like
+- **Add even more info with a double-`cause`.** If more info can be
+  added to a prior throw, nest the `cause` properties like
   `{ some, other, info, cause: priorError }`.
 - **Always set `cause`, even if no prior error.** Use a plain-old
   JavaScript object following our field conventions.
 - **Rare exception: synthetic ErrnoException style errors.** If we are
   doing something that is similar to a system operation, it's
   sometimes ok to mimic node's pattern.
-- **Do not subclass `Error`.** Just create a plain old Error, and
-  set the `cause` with additional information.
+- **Do not subclass `Error`.** Just create a plain old Error, and set
+  the `cause` with additional information.
 
 ### If you can't help, don't get in the way.
 
-Whenever possible, if no remediation or extra information can
-usefully be added, it's best to just not handle errors and let
-them be raised at the higher level. For example, instead of this:
+Whenever possible, if no remediation or extra information can usefully
+be added, it's best to just not handle errors and let them be raised
+at the higher level. For example, instead of this:
 
 ```
 let data
@@ -142,9 +137,9 @@ const data = await readFile(someFile)
 
 ### Add information by using thrown error as `cause`.
 
-If we can add information or do something else useful for the
-user in understanding the problem, do so by creating a new
-`Error` and setting the original thrown error as the `cause`.
+If we can add information or do something else useful for the user in
+understanding the problem, do so by creating a new `Error` and setting
+the original thrown error as the `cause`.
 
 ```js
 let data
@@ -158,9 +153,9 @@ try {
 
 ### Add even more info with a double-`cause`.
 
-If we can add even more information, that should ideally _not_ be
-put on the Error we throw, but on a `cause` object. Because
-`cause` objects can nest, we can do something like this:
+If we can add even more information, that should ideally _not_ be put
+on the Error we throw, but on a `cause` object. Because `cause`
+objects can nest, we can do something like this:
 
 ```js
 let data
@@ -204,27 +199,25 @@ throw error('could not resolve', {
 })
 ```
 
-This makes any big objects easily skipped if we want to just
-output the error with `console.error()` or something, but still
-preserves any debugging information that might be useful all the
-way down the chain.
+This makes any big objects easily skipped if we want to just output
+the error with `console.error()` or something, but still preserves any
+debugging information that might be useful all the way down the chain.
 
 ### Rare exception: synthetic ErrnoException style errors.
 
-In some rare low-level cases, there are operations we perform
-that are very similar to a node filesystem operation.
+In some rare low-level cases, there are operations we perform that are
+very similar to a node filesystem operation.
 
 For example, the `@vltpkg/which` module raises an error that is
-intentionally similar to node's filesystem `ENOENT` errors,
-because that is semantically sensible.
+intentionally similar to node's filesystem `ENOENT` errors, because
+that is semantically sensible.
 
-In those cases, the error _must_ follow node's conventions as
-close as possible. If we feel the need to add additional
-information beyond a known system error code, string path, etc.,
-or if the message isn't one that is typically raised by the
-underlying system, then it's a good sign that we ought to be
-creating an `Error` with a `cause` so that it can be reported
-more usefully.
+In those cases, the error _must_ follow node's conventions as close as
+possible. If we feel the need to add additional information beyond a
+known system error code, string path, etc., or if the message isn't
+one that is typically raised by the underlying system, then it's a
+good sign that we ought to be creating an `Error` with a `cause` so
+that it can be reported more usefully.
 
 In such cases, this is fine:
 
@@ -246,11 +239,11 @@ throw Object.assign(new Error('could not resolve'), {
 })
 ```
 
-**Do not** copy properties from a lower-level error or cause onto
-the new cause object. That is unnecessary, and obscures the
-origin of problems. Instead, just include the lower-level error
-as the `cause` property. If you already have a low-level error,
-you don't need to invent a synthetic one!
+**Do not** copy properties from a lower-level error or cause onto the
+new cause object. That is unnecessary, and obscures the origin of
+problems. Instead, just include the lower-level error as the `cause`
+property. If you already have a low-level error, you don't need to
+invent a synthetic one!
 
 For example, do not do this:
 
@@ -280,8 +273,8 @@ try {
 ### Do not subclass `Error`.
 
 Just use the `Error` classes defined in the language. Additional
-information about error causes should be on the `cause` property,
-not implicit in the constructor type.
+information about error causes should be on the `cause` property, not
+implicit in the constructor type.
 
 I.e. do not do this:
 
@@ -308,33 +301,33 @@ throw error('Could not version', { version })
 All of these are optional. Additional fields may be used where
 appropriate, and should be added to this list over time.
 
-- `cause` - The `cause` field within a `cause` object should
-  always be an `Error` object that was previously thrown. Note
-  that the `cause` on an Error itself might _also_ be a
-  previously thrown error, if no additional information could be
-  usefully added beyond improving the message.
+- `cause` - The `cause` field within a `cause` object should always be
+  an `Error` object that was previously thrown. Note that the `cause`
+  on an Error itself might _also_ be a previously thrown error, if no
+  additional information could be usefully added beyond improving the
+  message.
 - `name` - String. The name of something.
 - `offset` - Number. The offset in a Buffer or file where we are
   trying to read or write.
 - `registry` - String or URL. A package registry.
-- `code` - This must be a string if set, and should
-  only be present if it's one of our creation, not a code raised
-  on a system error. Eg, `ERESOLVE`, not `ENOENT`.
+- `code` - This must be a string if set, and should only be present if
+  it's one of our creation, not a code raised on a system error. Eg,
+  `ERESOLVE`, not `ENOENT`.
 - `path` - The target of a file system operation.
 - `target` - path on disk that is being written or extracted to
-- `spec` - a `@vltpkg/spec.Spec` object relevant to the operation
-  that failed.
-- `from` - string. The file path origin of a resolution that
-  failed, for example in the case of relative `file:` specifiers.
-- `status` - Number or null. Either the exit code of a process or
-  an HTTP response status code.
-- `signal` - `NodeJS.Signals` string or null, indicating the
-  signal that terminated a process.
+- `spec` - a `@vltpkg/spec.Spec` object relevant to the operation that
+  failed.
+- `from` - string. The file path origin of a resolution that failed,
+  for example in the case of relative `file:` specifiers.
+- `status` - Number or null. Either the exit code of a process or an
+  HTTP response status code.
+- `signal` - `NodeJS.Signals` string or null, indicating the signal
+  that terminated a process.
 - `validOptions` - Array of valid options when something is not a
   valid option. (For use in `did you mean X?` output.)
-- `todo` - String message indicating what bit of work this might
-  be a part of, what feature needs to be implemented, etc. Eg, `{
-todo: 'nested workspace support' }`.
+- `todo` - String message indicating what bit of work this might be a
+  part of, what feature needs to be implemented, etc. Eg,
+  `{ todo: 'nested workspace support' }`.
 - `wanted` - A desired value that was not found, or a regular
   expression or other pattern describing it.
 - `found` - The actual value, which was not wanted.
@@ -354,9 +347,9 @@ todo: 'nested workspace support' }`.
 
 - If there is a _type_ problem with an argument, for example a
   `string` was expected and a `number` was provided, throw a
-  `TypeError`. **Do not** use it for a value that is the correct
-  type but otherwise invalid, such as a `string` argument that is
-  actually a `string` but does not match an expected pattern.
+  `TypeError`. **Do not** use it for a value that is the correct type
+  but otherwise invalid, such as a `string` argument that is actually
+  a `string` but does not match an expected pattern.
 - If the type is fine, but a parsed string is invalid and not
   parseable, use `SyntaxError`.
 - In all other cases, use `Error`.

--- a/src/fast-split/README.md
+++ b/src/fast-split/README.md
@@ -2,17 +2,21 @@
 
 # @vltpkg/fast-split
 
-This is a very fast alternative to `String.split()`, which can be used to quickly parse a small-to-medium sized string by a given delimiter.
+This is a very fast alternative to `String.split()`, which can be used
+to quickly parse a small-to-medium sized string by a given delimiter.
 
-**[It's fast](#how-fast-is-it)**
-·
-**[Usage](#usage)**
+**[It's fast](#how-fast-is-it)** · **[Usage](#usage)**
 
 ## How Fast Is It!?
 
-This is about 10% faster for splitting short strings by a short delimiter. When we have to walk the resulting list for any reason, or limit the number of items returned, it's an even bigger difference.
+This is about 10% faster for splitting short strings by a short
+delimiter. When we have to walk the resulting list for any reason, or
+limit the number of items returned, it's an even bigger difference.
 
-2024 M1 macbook pro, using node 20.11.0, v8 version 11.3.244.8-node.17 Counts are operations per ms, splitting the string '1.2.3-asdf+foo' by the delimiter '.', transforms calling part.toUpperCase(), and limits at 2 items
+2024 M1 macbook pro, using node 20.11.0, v8 version 11.3.244.8-node.17
+Counts are operations per ms, splitting the string '1.2.3-asdf+foo' by
+the delimiter '.', transforms calling part.toUpperCase(), and limits
+at 2 items
 
 ```
               split 10385.779

--- a/src/git-scp-url/README.md
+++ b/src/git-scp-url/README.md
@@ -2,7 +2,8 @@
 
 # @vltpkg/git-scp-url
 
-Utility function for parsing git "scp-style" URLs, like `git:git@github.com:user/repo` or `git+ssh://github.com:user/repo`.
+Utility function for parsing git "scp-style" URLs, like
+`git:git@github.com:user/repo` or `git+ssh://github.com:user/repo`.
 
 ## Usage
 

--- a/src/git/README.md
+++ b/src/git/README.md
@@ -4,11 +4,7 @@
 
 A utility for spawning git from npm CLI contexts.
 
-**[Usage](#usage)**
-·
-**[API](#api)**
-·
-**[Options](#options)**
+**[Usage](#usage)** · **[API](#api)** · **[Options](#options)**
 
 ## Overview
 
@@ -49,23 +45,23 @@ All the other functions call this one at some point.
 Processes are launched using
 [`@vltpkg/promise-spawn`](http://npm.im/@vltpkg/promise-spawn).
 
-Return value is a `SpawnPromise` that resolves to a result object
-with `{cmd, args, code, signal, stdout, stderr}` members, or
-rejects with an error with the same fields, passed back from
+Return value is a `SpawnPromise` that resolves to a result object with
+`{cmd, args, code, signal, stdout, stderr}` members, or rejects with
+an error with the same fields, passed back from
 [`@vltpkg/promise-spawn`](http://npm.im/@vltpkg/promise-spawn).
 
 ### `clone(repo, ref = 'HEAD', target = null, opts = {})` -> `Promise<sha string>`
 
-Clone the repository into `target` path (or the default path for the name
-of the repository), checking out `ref`.
+Clone the repository into `target` path (or the default path for the
+name of the repository), checking out `ref`.
 
 Return value is the sha of the current HEAD in the locally cloned
 repository.
 
-In lieu of a specific `ref`, you may also pass in a `spec` option, which is
-a [`npm-package-arg`](http://npm.im/npm-package-arg) object for a `git`
-package dependency reference. In this way, you can select SemVer tags
-within a range, or any git committish value. For example:
+In lieu of a specific `ref`, you may also pass in a `spec` option,
+which is a [`npm-package-arg`](http://npm.im/npm-package-arg) object
+for a `git` package dependency reference. In this way, you can select
+SemVer tags within a range, or any git committish value. For example:
 
 ```js
 import { Spec } from '@vltpkg/spec'
@@ -75,17 +71,16 @@ clone('git@github.com:npm/git.git', '', null, {
 })
 ```
 
-This will automatically do a shallow `--depth=1` clone on any hosts that
-are known to support it. To force a shallow or deep clone, you can set the
-`gitShallow` option to `true` or `false` respectively.
+This will automatically do a shallow `--depth=1` clone on any hosts
+that are known to support it. To force a shallow or deep clone, you
+can set the `gitShallow` option to `true` or `false` respectively.
 
 ### `revs(repo, opts = {})` -> `Promise<rev doc Object>`
 
 Fetch a representation of all of the named references in a given
 repository. The resulting doc is intentionally somewhat
-packument-like, so that git semver ranges can be applied using
-the same
-[`@vltpkg/pick-manifest`](http://npm.im/@vltpkg/pick-manifest)
+packument-like, so that git semver ranges can be applied using the
+same [`@vltpkg/pick-manifest`](http://npm.im/@vltpkg/pick-manifest)
 logic.
 
 The resulting object looks like:
@@ -131,30 +126,30 @@ revs = {
 Resolve to `true` if the `cwd` option refers to the root of a git
 repository.
 
-It does this by looking for a file or folder at `${path}/.git`,
-which is not an airtight indicator, but usually pretty reliable.
+It does this by looking for a file or folder at `${path}/.git`, which
+is not an airtight indicator, but usually pretty reliable.
 
 ### `git.find(opts)` -> `Promise<string | undefined>`
 
-Given a path, walk up the file system tree until a git repo
-working directory is found. Since this calls `stat` a bunch of
-times, it's probably best to only call it if you're reasonably
-sure you're likely to be in a git project somewhere. Pass in
-`opts.root` to stop checking at that directory.
+Given a path, walk up the file system tree until a git repo working
+directory is found. Since this calls `stat` a bunch of times, it's
+probably best to only call it if you're reasonably sure you're likely
+to be in a git project somewhere. Pass in `opts.root` to stop checking
+at that directory.
 
 Resolves to `undefined` if not in a git project.
 
 ### `isClean(opts = {})` -> `Promise<boolean>`
 
-Return true if in a git dir, and that git dir is free of changes.
-This will resolve `true` if the git working dir is clean, or
-`false` if not, and reject if the path is not within a git
-directory or some other error occurs.
+Return true if in a git dir, and that git dir is free of changes. This
+will resolve `true` if the git working dir is clean, or `false` if
+not, and reject if the path is not within a git directory or some
+other error occurs.
 
 ### `getUser(opts = {})` -> `Promise<{name, email} | undefined>`
 
-Returns the user.name and user.email from the git config if found.
-If no value is found, it will return `undefined`.
+Returns the user.name and user.email from the git config if found. If
+no value is found, it will return `undefined`.
 
 ## Options
 
@@ -164,15 +159,15 @@ If no value is found, it will return `undefined`.
   - `factor`: Defaults to `opts.fetchRetryFactor` or 10
   - `maxTimeout`: Defaults to `opts.fetchRetryMaxtimeout` or 60000
   - `minTimeout`: Defaults to `opts.fetchRetryMintimeout` or 1000
-- `git` Path to the `git` binary to use. Will look up the first `git` in
-  the `PATH` if not specified.
-- `spec` The [`@vltpkg/spec`](http://npm.im/@vltpkg/spec)
-  specifier object for the thing being fetched (if relevant).
-- `fakePlatform` set to a fake value of `process.platform` to use. (Just
-  for testing `win32` behavior on Unix, and vice versa.)
+- `git` Path to the `git` binary to use. Will look up the first `git`
+  in the `PATH` if not specified.
+- `spec` The [`@vltpkg/spec`](http://npm.im/@vltpkg/spec) specifier
+  object for the thing being fetched (if relevant).
+- `fakePlatform` set to a fake value of `process.platform` to use.
+  (Just for testing `win32` behavior on Unix, and vice versa.)
 - `cwd` The current working dir for the git command. Particularly for
-  `find` and `is` and `isClean`, it's good to know that this defaults to
-  `process.cwd()`, as one might expect.
+  `find` and `is` and `isClean`, it's good to know that this defaults
+  to `process.cwd()`, as one might expect.
 - Any other options that can be passed to
   [`@vltpkg/promise-spawn`](http://npm.im/@vltpkg/promise-spawn), or
   `child_process.spawn()`.

--- a/src/graph/README.md
+++ b/src/graph/README.md
@@ -2,24 +2,25 @@
 
 # @vltpkg/graph
 
-This is the graph library responsible for representing the packages that are involved in a given install.
+This is the graph library responsible for representing the packages
+that are involved in a given install.
 
-**[API](#api)**
-·
-**[Usage](#usage)**
+**[API](#api)** · **[Usage](#usage)**
 
 ## API
 
 ### `actual.load({ projectRoot: string }): Graph`
 
-Recursively loads the `node_modules` folder found at `projectRoot` in order to
-create a graph representation of the current installed packages.
+Recursively loads the `node_modules` folder found at `projectRoot` in
+order to create a graph representation of the current installed
+packages.
 
 ### `async ideal.build({ projectRoot: string }): Promise<Graph>`
 
-This method returns a new `Graph` object, reading from the `package.json`
-file located at `projectRoot` dir and building up the graph representation
-of nodes and edges from the files read from the local file system.
+This method returns a new `Graph` object, reading from the
+`package.json` file located at `projectRoot` dir and building up the
+graph representation of nodes and edges from the files read from the
+local file system.
 
 ### `lockfile.load({ mainManifest: Manifest, projectRoot: string }): Graph`
 
@@ -27,9 +28,9 @@ Loads the lockfile file found at `projectRoot` and returns the graph.
 
 ## Usage
 
-Here's a quick example of how to use the `@vltpkg/graph.ideal.build` method to
-build a graph representation of the install defined at the `projectRoot`
-directory.
+Here's a quick example of how to use the `@vltpkg/graph.ideal.build`
+method to build a graph representation of the install defined at the
+`projectRoot` directory.
 
 ```
 import { ideal } from '@vltpkg/graph'

--- a/src/graph/src/lockfile/README.md
+++ b/src/graph/src/lockfile/README.md
@@ -1,7 +1,8 @@
 # @vltpkg/graph.lockfile
 
-A library that stores `@vltpkg/graph.Graph` information into a lockfile and
-reads information from stored lockfiles to rebuild a virtual `Graph`.
+A library that stores `@vltpkg/graph.Graph` information into a
+lockfile and reads information from stored lockfiles to rebuild a
+virtual `Graph`.
 
 ## USAGE
 

--- a/src/init/README.md
+++ b/src/init/README.md
@@ -6,8 +6,8 @@ Project initialization logic for `vlt`.
 
 ## Overview
 
-This is a tool that provides the project initialization logic
-used by the vlt cli and gui.
+This is a tool that provides the project initialization logic used by
+the vlt cli and gui.
 
 ## Usage
 

--- a/src/pick-manifest/README.md
+++ b/src/pick-manifest/README.md
@@ -2,4 +2,5 @@
 
 # @vltpkg/pick-manifest
 
-Selects the most appropriate version of a package’s manifest from a packument.
+Selects the most appropriate version of a package’s manifest from a
+packument.

--- a/src/promise-spawn/README.md
+++ b/src/promise-spawn/README.md
@@ -2,27 +2,26 @@
 
 # @vltpkg/promise-spawn
 
-Spawn a process and return a promise that resolves when the process closes. Fork of [`@npmcli/promise-spawn`](http://npm.im/@npmcli/promise-spawn).
+Spawn a process and return a promise that resolves when the process
+closes. Fork of
+[`@npmcli/promise-spawn`](http://npm.im/@npmcli/promise-spawn).
 
-**[Usage](#usage)**
-·
-**[API](#api)**
-·
+**[Usage](#usage)** · **[API](#api)** ·
 **[Caveats](#typescript-inference-caveats)**
 
 ## Differences from `@npmcli/promise-spawn`
 
-- A `SpawnPromise(cmd, args, options)` class is added that
-  handles most of the functionality.
+- A `SpawnPromise(cmd, args, options)` class is added that handles
+  most of the functionality.
 - `promiseSpawn.open()` is removed
-- When run as root, it just runs the command as root, it doesn't
-  try to infer the uid/gid based on the owner of the cwd..
+- When run as root, it just runs the command as root, it doesn't try
+  to infer the uid/gid based on the owner of the cwd..
 - No special handling for `shell: true` processes, and thus, no
-  escaping of arguments in that case. (It's just passed through
-  to Node's `spawn()` method.)
-- Fully type-aware, even down to inferring the presence and type
-  of `stdout` and `stderr` properties, as well as the properties
-  added via the optional `extra` argument.
+  escaping of arguments in that case. (It's just passed through to
+  Node's `spawn()` method.)
+- Fully type-aware, even down to inferring the presence and type of
+  `stdout` and `stderr` properties, as well as the properties added
+  via the optional `extra` argument.
 
 ## Usage
 
@@ -65,39 +64,38 @@ Result or error will be decorated with the properties in the `extra`
 object. You can use this to attach some helpful info about _why_ the
 command is being run, if it makes sense for your use case.
 
-If `stdio` is set to anything other than `'inherit'`, then the result/error
-will be decorated with `stdout` and `stderr` values. If `stdioString` is
-set to `true`, these will be strings. Otherwise they will be Buffer
-objects.
+If `stdio` is set to anything other than `'inherit'`, then the
+result/error will be decorated with `stdout` and `stderr` values. If
+`stdioString` is set to `true`, these will be strings. Otherwise they
+will be Buffer objects.
 
-Returned promise is decorated with the `stdin` stream if the process is set
-to pipe from `stdin`. Writing to this stream writes to the `stdin` of the
-spawned process.
+Returned promise is decorated with the `stdin` stream if the process
+is set to pipe from `stdin`. Writing to this stream writes to the
+`stdin` of the spawned process.
 
 #### Options
 
-- `stdioString` Boolean, default `true`. Return stdout/stderr
-  output as trimmed strings rather than buffers.
-- `acceptFail` Boolean, default `false`. If true, then a process
-  that closes with `status` other than 0, or `signal` other than
-  `null`, will reject the promise. If true, then failure exits
-  resolve the promise normally. This is useful when you need to
-  run a process where an exit status of `>0` is informative, to
-  avoid creating an Error object for it.
-- Any other options for `child_process.spawn` can be passed as
-  well.
+- `stdioString` Boolean, default `true`. Return stdout/stderr output
+  as trimmed strings rather than buffers.
+- `acceptFail` Boolean, default `false`. If true, then a process that
+  closes with `status` other than 0, or `signal` other than `null`,
+  will reject the promise. If true, then failure exits resolve the
+  promise normally. This is useful when you need to run a process
+  where an exit status of `>0` is informative, to avoid creating an
+  Error object for it.
+- Any other options for `child_process.spawn` can be passed as well.
 
 ## TypeScript Inference Caveats
 
 _Workaround:_
 
-If you provide a complex stdio option like `['pipe', 'inherit']`,
-then this will of course mean that `stdin` is set to a writable
-stream, `stderr` is set to a readable stream (because that's the
-default), but `stdout` is set to `null`.
+If you provide a complex stdio option like `['pipe', 'inherit']`, then
+this will of course mean that `stdin` is set to a writable stream,
+`stderr` is set to a readable stream (because that's the default), but
+`stdout` is set to `null`.
 
-The types will accurately infer this from the type of the
-argument. However, observe this incorrect result:
+The types will accurately infer this from the type of the argument.
+However, observe this incorrect result:
 
 ```
 const result = await promiseSpawn(cmd, args, {
@@ -109,13 +107,13 @@ result.stderr
 //     ^? string
 ```
 
-TS will infer the `options.stdio` property to be `('pipe' |
-'inherit')[]`. Since the second item of such an array _might_ be
-set to `'pipe'` at some point, TS will infer the return value to
-include `{ stdout: string }`.
+TS will infer the `options.stdio` property to be
+`('pipe' | 'inherit')[]`. Since the second item of such an array
+_might_ be set to `'pipe'` at some point, TS will infer the return
+value to include `{ stdout: string }`.
 
-To get around this, typecast the field to its literal value. This
-is a bit noisy, but works fine:
+To get around this, typecast the field to its literal value. This is a
+bit noisy, but works fine:
 
 ```js
 const result = await promiseSpawn(cmd, args, {

--- a/src/query/README.md
+++ b/src/query/README.md
@@ -4,10 +4,7 @@
 
 The **vlt** query syntax engine.
 
-**[Usage](#usage)**
-·
-**[Examples](#examples)**
-·
+**[Usage](#usage)** · **[Examples](#examples)** ·
 **[Supported Syntax Reference](#supported-syntax-reference)**
 
 ## Usage
@@ -34,73 +31,132 @@ query.search(':root > *')
 
 ## Supported Syntax Reference
 
-The vlt query syntax enable usage of css-selector-like strings to filter
-packages.
+The vlt query syntax enable usage of css-selector-like strings to
+filter packages.
 
-Many of the common elements of the CSS language are available, notably:
+Many of the common elements of the CSS language are available,
+notably:
 
 - `*` Universal selector, matches all selected items.
 - `&` Nesting selector, allows for nesting selectors.
 - `{}` Curly braces, when querying can be used to nest selectors.
 
-Split by group of selectors below is the complete reference to supported
-elements.
+Split by group of selectors below is the complete reference to
+supported elements.
 
 ### Attribute selectors
 
-Attribute selectors are used to match a value found in the `package.json`
-metadata for each of the nodes being queried to a arbitrary value you choose.
+Attribute selectors are used to match a value found in the
+`package.json` metadata for each of the nodes being queried to a
+arbitrary value you choose.
 
-- `[attr]` Matches elements with an `attr` property in its `package.json`.
-- `[attr=value]` Matches elements with a property `attr` whose value is exactly `value`.
-- `[attr^=value]` Matches elements with a property `attr` whose value starts with `value`.
-- `[attr$=value]` Matches elements with a property `attr` whose value ends with `value`.
-- `[attr~=value]` Matches elements with a property `attr` whose value is a whitespace-separated list of words, one of which is exactly `value`.
-- `[attr|=value]` Matches elements with a property `attr` whose value is either `value` or starts with `value-`.
+- `[attr]` Matches elements with an `attr` property in its
+  `package.json`.
+- `[attr=value]` Matches elements with a property `attr` whose value
+  is exactly `value`.
+- `[attr^=value]` Matches elements with a property `attr` whose value
+  starts with `value`.
+- `[attr$=value]` Matches elements with a property `attr` whose value
+  ends with `value`.
+- `[attr~=value]` Matches elements with a property `attr` whose value
+  is a whitespace-separated list of words, one of which is exactly
+  `value`.
+- `[attr|=value]` Matches elements with a property `attr` whose value
+  is either `value` or starts with `value-`.
 - `[attr*=value]` Matches elements with a property `attr`.
-- `[attr=value i]` Case-insensitive flag, setting it will cause any comparison to be case-insensitive.
-- `[attr=value s]` Case-sensitive flag, setting it will cause comparisons to be case-sensitive, this is the default behavior.
+- `[attr=value i]` Case-insensitive flag, setting it will cause any
+  comparison to be case-insensitive.
+- `[attr=value s]` Case-sensitive flag, setting it will cause
+  comparisons to be case-sensitive, this is the default behavior.
 
 ### Class selectors
 
 - `.prod` Matches prod dependencies to your current project.
-- `.dev` Matches packages that are only used as dev dependencies in your current project.
-- `.optional` Matches packages that are optional to your current project.
+- `.dev` Matches packages that are only used as dev dependencies in
+  your current project.
+- `.optional` Matches packages that are optional to your current
+  project.
 - `.peer` Matches peer dependencies to your current project.
-- `.workspace` Matches the current project worksacpes (listed in your `vlt-workspaces.json` file).
+- `.workspace` Matches the current project worksacpes (listed in your
+  `vlt-workspaces.json` file).
 
 ### Combinators
 
-- `>` Child combinator, matches packages that are direct dependencies of the previously selected nodes.
-- ` ` Descendant combinator, matches all packages that are direct & transitive dependencies of the previously selected nodes.
-- `~` Sibling combinator, matches packages that are direct dependencies of all dependents of the previously selected nodes.
+- `>` Child combinator, matches packages that are direct dependencies
+  of the previously selected nodes.
+- ` ` Descendant combinator, matches all packages that are direct &
+  transitive dependencies of the previously selected nodes.
+- `~` Sibling combinator, matches packages that are direct
+  dependencies of all dependents of the previously selected nodes.
 
 ### ID Selectors
 
-Identifiers are a shortcut to retrieving packages by name, unfortunately this shortcut only works for unscoped packages, with that in mind it's advised to rely on using **Attribute selectors** (showed above) instead.
+Identifiers are a shortcut to retrieving packages by name,
+unfortunately this shortcut only works for unscoped packages, with
+that in mind it's advised to rely on using **Attribute selectors**
+(showed above) instead.
 
 e.g: `#foo` is the same as `[name=foo]`
 
 ### Pseudo class selectors
 
-- `:attr(key, [attr=value])` The attribute pseudo-class allows for selecting packages based on nested properties of its `package.json` metadata. As an example, here is a query that filters only packages that declares an optional peer dependency named `foo`: `:attr(peerDependenciesMeta, foo, [optional=true])`
+- `:attr(key, [attr=value])` The attribute pseudo-class allows for
+  selecting packages based on nested properties of its `package.json`
+  metadata. As an example, here is a query that filters only packages
+  that declares an optional peer dependency named `foo`:
+  `:attr(peerDependenciesMeta, foo, [optional=true])`
 - `:empty` Matches packages that have no dependencies installed.
-- `:has(<selector-list>)` Matches only packages that have valid results for the selector expression used. As an example, here is a query that matches all packages that have a peer dependency on `react`: `:has(.peer[name=react])`
-- `:is(<forgiving-selector-list>)` Useful for writing large selectors in a more compact form, the `:is()` pseudo-class takes a selector list as its arguments and selects any element that can be selected by one of the selectors in that list. As an example, let's say I want to select packages named `a` & `b` that are direct dependencies of my project root: `:root > [name=a], :root > [name=b]` using the `:is()` pseudo-class, that same expression can be shortened to: `:root > :is([name=a], [name=b])`. Similar to the css pseudo-class of the same name, this selector has a forgiving behavior regarding its nested selector list ignoring any usage of non-existing ids, classes, combinators, operators and pseudo-selectors.
-- `:not(<selector-list>)` Negation pseudo-class, select packages that do not match a list of selectors.
-- `:outdated(<type>)` Matches packages that are outdated, the type parameter is optional and can be one of the following:
-  - `any` (default) a version exists that is greater than the current one
-  - `in-range` a version exists that is greater than the current one, and satisfies at least one if its parent's dependencies
-  - `out-of-range` a version exists that is greater than the current one, does not satisfy at least one of its parent's dependencies
-  - `major` a version exists that is a semver major greater than the current one
-  - `minor` a version exists that is a semver minor greater than the current one
-  - `patch` a version exists that is a semver patch greater than the current one
-- `:private` Matches packages that have the property `private` set on their `package.json` file.
-- `:semver(<value>, <function>, <custom-attribute-selector>)` Matches packages based on a semver value, e.g, to retrieve all packages that have a `version` satisfied by the semver value `^1.0.0`: `:semver(^1.0.0)`. It's also possible to define the type of semver comparison function to use by defining a second parameter, e.g: `:semver(^1.0.0, eq)` for an exact match, valid comparison types are: `eq`, `neq`, `gt`, `gte`, `lt`, `lte`, `satisfies` (default). A third parameter allows for specifying a different `package.json` property to use for the comparison, e.g: `:semver(^22, satisfies, :attr(engines, [node]))` for comparing the value of `engines.node`.
-- `:type(registry|file|git|remote|workspace)` Matches packages based on their type, e.g, to retrieve all git dependencies: `:type(git)`.
+- `:has(<selector-list>)` Matches only packages that have valid
+  results for the selector expression used. As an example, here is a
+  query that matches all packages that have a peer dependency on
+  `react`: `:has(.peer[name=react])`
+- `:is(<forgiving-selector-list>)` Useful for writing large selectors
+  in a more compact form, the `:is()` pseudo-class takes a selector
+  list as its arguments and selects any element that can be selected
+  by one of the selectors in that list. As an example, let's say I
+  want to select packages named `a` & `b` that are direct dependencies
+  of my project root: `:root > [name=a], :root > [name=b]` using the
+  `:is()` pseudo-class, that same expression can be shortened to:
+  `:root > :is([name=a], [name=b])`. Similar to the css pseudo-class
+  of the same name, this selector has a forgiving behavior regarding
+  its nested selector list ignoring any usage of non-existing ids,
+  classes, combinators, operators and pseudo-selectors.
+- `:not(<selector-list>)` Negation pseudo-class, select packages that
+  do not match a list of selectors.
+- `:outdated(<type>)` Matches packages that are outdated, the type
+  parameter is optional and can be one of the following:
+  - `any` (default) a version exists that is greater than the current
+    one
+  - `in-range` a version exists that is greater than the current one,
+    and satisfies at least one if its parent's dependencies
+  - `out-of-range` a version exists that is greater than the current
+    one, does not satisfy at least one of its parent's dependencies
+  - `major` a version exists that is a semver major greater than the
+    current one
+  - `minor` a version exists that is a semver minor greater than the
+    current one
+  - `patch` a version exists that is a semver patch greater than the
+    current one
+- `:private` Matches packages that have the property `private` set on
+  their `package.json` file.
+- `:semver(<value>, <function>, <custom-attribute-selector>)` Matches
+  packages based on a semver value, e.g, to retrieve all packages that
+  have a `version` satisfied by the semver value `^1.0.0`:
+  `:semver(^1.0.0)`. It's also possible to define the type of semver
+  comparison function to use by defining a second parameter, e.g:
+  `:semver(^1.0.0, eq)` for an exact match, valid comparison types
+  are: `eq`, `neq`, `gt`, `gte`, `lt`, `lte`, `satisfies` (default). A
+  third parameter allows for specifying a different `package.json`
+  property to use for the comparison, e.g:
+  `:semver(^22, satisfies, :attr(engines, [node]))` for comparing the
+  value of `engines.node`.
+- `:type(registry|file|git|remote|workspace)` Matches packages based
+  on their type, e.g, to retrieve all git dependencies: `:type(git)`.
 
 ### Pseudo Elements
 
-- `:project` Returns both the root node (as defined below) along with any workspace declared in your project.
-- `:root` Returns the root node, that represents the package defined at the top-level `package.json` of your project folder.
+- `:project` Returns both the root node (as defined below) along with
+  any workspace declared in your project.
+- `:root` Returns the root node, that represents the package defined
+  at the top-level `package.json` of your project folder.
 - `:scope` Returns the current scope of a given selector

--- a/src/registry-client/README.md
+++ b/src/registry-client/README.md
@@ -2,76 +2,73 @@
 
 # @vltpkg/registry-client
 
-This is a very light wrapper around undici, optimized for interfacing with an npm registry.
+This is a very light wrapper around undici, optimized for interfacing
+with an npm registry.
 
-**[Cache Unzipped](#cache-unzipped)**
-·
-**[Integrity Options](#integrity-options)**
-·
-**[Usage](#usage)**
+**[Cache Unzipped](#cache-unzipped)** ·
+**[Integrity Options](#integrity-options)** · **[Usage](#usage)**
 
 ## Overview
 
-Any response with `immutable` in the `cache-control` header, or with a `content-type` of `application/octet-stream` or a path ending in `.tgz`, will be cached forever and never requested again as long as the cache survives.
+Any response with `immutable` in the `cache-control` header, or with a
+`content-type` of `application/octet-stream` or a path ending in
+`.tgz`, will be cached forever and never requested again as long as
+the cache survives.
 
 If the request has a cached response:
 
-- Cached responses with `immutable` in the `cache-control`
-  header will be returned from cache without a network request,
-  no matter what.
-- Cached responses with a `content-type` of
-  `application/octet-stream` will be returned from cache without
-  a network request, no matter what, because tarballs are
-  immutable.
+- Cached responses with `immutable` in the `cache-control` header will
+  be returned from cache without a network request, no matter what.
+- Cached responses with a `content-type` of `application/octet-stream`
+  will be returned from cache without a network request, no matter
+  what, because tarballs are immutable.
 - Cached responses with `max-age=<n>` or `s-max-age=<n>` will be
-  served from cache without a network request if it's less than
-  `<n>` seconds old.
+  served from cache without a network request if it's less than `<n>`
+  seconds old.
 - Otherwise, a network request to the registry will be made
-  - if an `etag` is present in the cached response, it will be
-    used as the `if-none-match` header.
-  - If a `last-modified` header is in the response, that will
-    be used as the `if-modified-since` request header.
-  - If there is no `last-modified` header, then use the `mtime`
-    of the cache file as the `if-modified-since` header.
+  - if an `etag` is present in the cached response, it will be used as
+    the `if-none-match` header.
+  - If a `last-modified` header is in the response, that will be used
+    as the `if-modified-since` request header.
+  - If there is no `last-modified` header, then use the `mtime` of the
+    cache file as the `if-modified-since` header.
 
 This is the extent of the cache control logic. It is not a
-full-featured spec-compliant caching HTTP client, because that is
-not needed for this use case. Every response will be cached, even
-if the registry headers don't technically allow it.
+full-featured spec-compliant caching HTTP client, because that is not
+needed for this use case. Every response will be cached, even if the
+registry headers don't technically allow it.
 
 ## Cache Unzipped
 
-Client always sends `accept-encoding: gzip;q=1.0, *;q=0.5`
-header when making requests, to save time on the wire.
+Client always sends `accept-encoding: gzip;q=1.0, *;q=0.5` header when
+making requests, to save time on the wire.
 
-If response has `content-encoding: gzip`, then we swap out the
-body for the unzipped response body in the cache, as if it was
-not gzipped in the first place. This _must_ be done before
-returning the response, because you can't `JSON.parse()` a
-gzipped response anyway.
+If response has `content-encoding: gzip`, then we swap out the body
+for the unzipped response body in the cache, as if it was not gzipped
+in the first place. This _must_ be done before returning the response,
+because you can't `JSON.parse()` a gzipped response anyway.
 
-If the response is `content-type: application/octet-stream` and
-starts with the gzip header, then we return the raw body as we
-received it, but as a best-effort background job, unzip it and
-update the cache entry to be an unzipped response body. This is
-done in the `@vltpkg/cache-unzip` worker.
+If the response is `content-type: application/octet-stream` and starts
+with the gzip header, then we return the raw body as we received it,
+but as a best-effort background job, unzip it and update the cache
+entry to be an unzipped response body. This is done in the
+`@vltpkg/cache-unzip` worker.
 
 So,
 
-- json responses will always be un-zipped, in the response and in
-  the cache.
-- artifact responses _may_ be gzipped (and thus, have to be
-  unzipped by the unpack operation), but will eventually be
-  cached as unzipped tarballs.
+- json responses will always be un-zipped, in the response and in the
+  cache.
+- artifact responses _may_ be gzipped (and thus, have to be unzipped
+  by the unpack operation), but will eventually be cached as unzipped
+  tarballs.
 
-Thus, the `content-length` response header will _usually_ not
-match the actual byte length of the response body.
+Thus, the `content-length` response header will _usually_ not match
+the actual byte length of the response body.
 
 ## Integrity Options
 
-An `integrity` option may be specified in a
-`fetchOptions.context` object, or in the options provided to
-`cache.set()`. For example:
+An `integrity` option may be specified in a `fetchOptions.context`
+object, or in the options provided to `cache.set()`. For example:
 
 ```js
 const integrity = `sha512-${base64hash}`
@@ -86,16 +83,16 @@ cache.set(key, value, { integrity })
 const value = await cache.fetch(key, { context: { integrity } })
 ```
 
-If the integrity provided is obviously not a valid sha512
-`Integrity` string, then it is ignored.
+If the integrity provided is obviously not a valid sha512 `Integrity`
+string, then it is ignored.
 
-Integrity values are not calculated or verified. The caller must do this
-check, if desired.
+Integrity values are not calculated or verified. The caller must do
+this check, if desired.
 
 Note that the integrity provided to `cache.fetch()` or `cache.set()`
 does _not_ typically match the calculated integrity of the object
-being cached. Typically, the integrity is related to the body of
-the response that a `@vltpkg/registry-client.CacheEntry` object
+being cached. Typically, the integrity is related to the body of the
+response that a `@vltpkg/registry-client.CacheEntry` object
 represents.
 
 ## Usage

--- a/src/rollback-remove/README.md
+++ b/src/rollback-remove/README.md
@@ -2,13 +2,14 @@
 
 # @vltpkg/rollback-remove
 
-A utility for removing stuff, in such a way that the removal can be rolled back on failure, or confirmed and executed in a detached background process.
+A utility for removing stuff, in such a way that the removal can be
+rolled back on failure, or confirmed and executed in a detached
+background process.
 
 ## Usage
 
-The best way to use this is to _not_ catch errors, but detect
-failure in a `finally` block and either confirm or roll back
-appropriately.
+The best way to use this is to _not_ catch errors, but detect failure
+in a `finally` block and either confirm or roll back appropriately.
 
 ```js
 import { RollbackRemove } from '@vltpkg/rollback-remove'

--- a/src/run/README.md
+++ b/src/run/README.md
@@ -2,7 +2,9 @@
 
 # @vltpkg/run
 
-Run a script defined in a `package.json` file (eg, `vlt run` and lifecycle scripts), or an arbitrary command as if it was (eg, `vlt exec`).
+Run a script defined in a `package.json` file (eg, `vlt run` and
+lifecycle scripts), or an arbitrary command as if it was (eg,
+`vlt exec`).
 
 ## Usage
 

--- a/src/satisfies/README.md
+++ b/src/satisfies/README.md
@@ -2,7 +2,8 @@
 
 # @vltpkg/satisfies
 
-Give it a DepID and a Spec, and it'll tell you whether that dep satisfies the spec.
+Give it a DepID and a Spec, and it'll tell you whether that dep
+satisfies the spec.
 
 ## Usage
 

--- a/src/semver/README.md
+++ b/src/semver/README.md
@@ -2,12 +2,10 @@
 
 # @vltpkg/semver
 
-A library for parsing, validating & comparing Semantic Versions used by `vlt`.
+A library for parsing, validating & comparing Semantic Versions used
+by `vlt`.
 
-**[Usage](#usage)**
-·
-**[Functions](#functions)**
-·
+**[Usage](#usage)** · **[Functions](#functions)** ·
 **[Differences from node-semver](#differences)**
 
 ## Usage
@@ -46,26 +44,26 @@ import {
 - `parse(v)`: Attempt to parse a string as a semantic version,
   returning either a `Version` object or `undefined`.
 - `valid(v)`: Return true if the version is valid
-- `increment(v, type, [identifier])` Increment the specified part
-  of the version, and return the resulting object. If a Version
-  object is provided, it will be modified in-place.
+- `increment(v, type, [identifier])` Increment the specified part of
+  the version, and return the resulting object. If a Version object is
+  provided, it will be modified in-place.
 - `major(v)`: Return the major version number.
 - `minor(v)`: Return the minor version number.
 - `patch(v)`: Return the patch version number.
 - `prerelease(v)`: Returns an array of prerelease components, or
-  `undefined` if none exist. Example: `prerelease('1.2.3-alpha.1') ->
-['alpha', 1]`
-- `build(v)`: Returns an array of build components, or
-  `undefined` if none exist. Example: `prerelease('1.2.3+linux.33') ->
-['linux', '33']`
+  `undefined` if none exist. Example:
+  `prerelease('1.2.3-alpha.1') -> ['alpha', 1]`
+- `build(v)`: Returns an array of build components, or `undefined` if
+  none exist. Example:
+  `prerelease('1.2.3+linux.33') -> ['linux', '33']`
 - `stable(v)`: Returns an array of releases that are considered
   "stable" (ie. no prereleases), or an empty array if non exist.
 
 ### Comparison
 
-These functions all compare version strings or objects
-by their SemVer precedence. (Note that build metadata is not
-considered, as per the SemVer 2.0 specification.)
+These functions all compare version strings or objects by their SemVer
+precedence. (Note that build metadata is not considered, as per the
+SemVer 2.0 specification.)
 
 Unless otherwise noted, they throw an error on invalid versions.
 
@@ -73,83 +71,82 @@ Unless otherwise noted, they throw an error on invalid versions.
 - `gte(v1, v2)`: `v1 >= v2`
 - `lt(v1, v2)`: `v1 < v2`
 - `lte(v1, v2)`: `v1 <= v2`
-- `eq(v1, v2)`: `v1 == v2` This is true even if they're not the
-  exact same string. You already know how to compare strings.
+- `eq(v1, v2)`: `v1 == v2` This is true even if they're not the exact
+  same string. You already know how to compare strings.
 - `neq(v1, v2)`: `v1 != v2` The opposite of `eq`.
-- `compare(v1, v2)`: Return `0` if `v1 == v2`, or `1` if `v1` is greater, or `-1` if
-  `v2` is greater. Sorts in ascending order if passed to `Array.sort()`.
-- `sortMethod(v1, v2)`: The same as `compare`, except that
-  invalid versions are sorted to the end of the list rather than
-  throwing an error.
+- `compare(v1, v2)`: Return `0` if `v1 == v2`, or `1` if `v1` is
+  greater, or `-1` if `v2` is greater. Sorts in ascending order if
+  passed to `Array.sort()`.
+- `sortMethod(v1, v2)`: The same as `compare`, except that invalid
+  versions are sorted to the end of the list rather than throwing an
+  error.
 - `rcompare(v1, v2)`: Inverse of `compare`
-- `rsortMethod(v1, v2)`: Inverse of `sortMethod`. (Invalid
-  versions are still sorted to the end of the list.)
+- `rsortMethod(v1, v2)`: Inverse of `sortMethod`. (Invalid versions
+  are still sorted to the end of the list.)
 
 ### Ranges
 
-- `validRange(range)`: Return the valid range or null if it's not valid
-- `satisfies(version, range)`: Return true if the version satisfies the
-  range.
+- `validRange(range)`: Return the valid range or null if it's not
+  valid
+- `satisfies(version, range)`: Return true if the version satisfies
+  the range.
 - `highest(versions, range)`: Return the highest version in the list
   that satisfies the range, or `null` if none of them do.
-- `sortedHighest(versions, range)`: Optimized form of `highest`,
-  if the version list is known to be sorted in ascending SemVer
-  precedence order. If the list is not sorted already, may return
-  an incorrect result.
-- `rsortedHighest(versions, range)`: Optimized form of `highest`,
-  if the version list is known to be sorted in descending SemVer
-  precedence order. If the list is not sorted already, may return
-  an incorrect result.
+- `sortedHighest(versions, range)`: Optimized form of `highest`, if
+  the version list is known to be sorted in ascending SemVer
+  precedence order. If the list is not sorted already, may return an
+  incorrect result.
+- `rsortedHighest(versions, range)`: Optimized form of `highest`, if
+  the version list is known to be sorted in descending SemVer
+  precedence order. If the list is not sorted already, may return an
+  incorrect result.
 - `lowest(versions, range)`: Return the lowest version in the list
   that satisfies the range, or `null` if none of them do.
-- `sortedLowest(versions, range)`: Optimized form of `lowest`,
-  if the version list is known to be sorted in ascending SemVer
-  precedence order. If the list is not sorted already, may return
-  an incorrect result.
-- `rsortedLowest(versions, range)`: Optimized form of `lowest`,
-  if the version list is known to be sorted in descending SemVer
-  precedence order. If the list is not sorted already, may return
-  an incorrect result.
+- `sortedLowest(versions, range)`: Optimized form of `lowest`, if the
+  version list is known to be sorted in ascending SemVer precedence
+  order. If the list is not sorted already, may return an incorrect
+  result.
+- `rsortedLowest(versions, range)`: Optimized form of `lowest`, if the
+  version list is known to be sorted in descending SemVer precedence
+  order. If the list is not sorted already, may return an incorrect
+  result.
 
 ### Classes
 
-- `Version` Object representation of a SemVer version. Create
-  from a string with `Version.parse(versionString)`.
+- `Version` Object representation of a SemVer version. Create from a
+  string with `Version.parse(versionString)`.
 - `Range` Representation of a version range.
-- `Comparator` The representation of a single part of a Range,
-  which does most of the heavy lifting for parsing and testing
-  versions. This is an internal class, and should usually not be
-  used directly.
+- `Comparator` The representation of a single part of a Range, which
+  does most of the heavy lifting for parsing and testing versions.
+  This is an internal class, and should usually not be used directly.
 
 ## Differences
 
 ### Differences from `node-semver` (the one used by `npm`)
 
-- The API is slightly different. Most notably, `@vltpkg/semver`
-  lacks range intersection and other methods that are not needed
-  by `vlt`. Of course, these may be added eventually if we find a
-  need for them.
+- The API is slightly different. Most notably, `@vltpkg/semver` lacks
+  range intersection and other methods that are not needed by `vlt`.
+  Of course, these may be added eventually if we find a need for them.
 
-- Build metadata is preserved on `Version` objects and in
-  `toString()` values.
+- Build metadata is preserved on `Version` objects and in `toString()`
+  values.
 
-- It's significantly faster. About 40-50% faster at parsing
-  versions, 15-20% faster at parsing ranges, and 60-70% faster at
-  testing versions against ranges, which results in the
-  `highest()` method being around 2-3 times as fast as
-  node-semver's `maxSatisfying`.
+- It's significantly faster. About 40-50% faster at parsing versions,
+  15-20% faster at parsing ranges, and 60-70% faster at testing
+  versions against ranges, which results in the `highest()` method
+  being around 2-3 times as fast as node-semver's `maxSatisfying`.
 
-  Of course, if you're not writing a package manager or some
-  other program that does millions of version comparisons in
-  the course of its operations, this is likely not relevant.)
+  Of course, if you're not writing a package manager or some other
+  program that does millions of version comparisons in the course of
+  its operations, this is likely not relevant.)
 
-- There's no switch for `loose` vs `strict` mode. It just always
-  works the same way.
+- There's no switch for `loose` vs `strict` mode. It just always works
+  the same way.
 
   - A leading `v` or `=` on a version is always allowed
   - Prereleases _must_ be prefixed by a `-`.
-  - Excessively large numbers in prerelease identifiers are
-    treated as strings, rather than throwing an error.
+  - Excessively large numbers in prerelease identifiers are treated as
+    strings, rather than throwing an error.
 
   For example, `v1.2.3` will be parsed, but `1.2.3foo` will be
   considered invalid. `toString()` values are always the strict

--- a/src/spec/README.md
+++ b/src/spec/README.md
@@ -4,12 +4,8 @@
 
 This is a library for parsing **package specifiers**.
 
-**[Namings](#named-vs-unnamed)**
-·
-**[Specifiers](#types-of-specifiers)**
-·
-**[Usage](#usage)**
-·
+**[Namings](#named-vs-unnamed)** ·
+**[Specifiers](#types-of-specifiers)** · **[Usage](#usage)** ·
 **[Properties](#properties)**
 
 ## Overview
@@ -17,86 +13,83 @@ This is a library for parsing **package specifiers**.
 Specifiers are primarily used in the following cases:
 
 - On the command line, like `vlt add foo@1.x`
-- In manifests (such as `package.json`) where dependencies are
-  listed, like `"dependencies": { "foo": "1.x" }`
+- In manifests (such as `package.json`) where dependencies are listed,
+  like `"dependencies": { "foo": "1.x" }`
 - Internally within vlt, such as lockfiles and so on.
 
 ## Named vs Unnamed
 
-A "named" specifier is one with the full name included, separated
-from the specifier by a `@` character, such as
-`foo@1.x` or `@vltpkg/spec@1.0.0`. The `name` in these cases
-would be `foo` and `@vltpkg/spec`, respectively.
+A "named" specifier is one with the full name included, separated from
+the specifier by a `@` character, such as `foo@1.x` or
+`@vltpkg/spec@1.0.0`. The `name` in these cases would be `foo` and
+`@vltpkg/spec`, respectively.
 
 Note that it does _not_ always correspond to the `"name"` in the
-manifest of the resolved package! For example,
-`foo@npm:react@latest` would resolve to the latest version of
-`react`, but would be named `foo` in the dependency graph, and
-loaded as `import('foo')`.
+manifest of the resolved package! For example, `foo@npm:react@latest`
+would resolve to the latest version of `react`, but would be named
+`foo` in the dependency graph, and loaded as `import('foo')`.
 
 ## Types of Specifiers
 
 The following specifier types are supported:
 
-- `workspace:...` - Provide a semver range, or one of `~`, `*`,
-  or `^` to match against a dependency that exists in a workspace
-  project of a monorepo. The package name _must_ exist as a
-  workspace project in the monorepo. If a semver range is
-  provided, then it must match the referenced workspace package
-  version. Otherwise:
+- `workspace:...` - Provide a semver range, or one of `~`, `*`, or `^`
+  to match against a dependency that exists in a workspace project of
+  a monorepo. The package name _must_ exist as a workspace project in
+  the monorepo. If a semver range is provided, then it must match the
+  referenced workspace package version. Otherwise:
 
-  - `*` - Fill in whatever version is in the workspace, without
-    any prefix. So, if `./packages/foo` depends on
-    `bar@workspace*`, and `bar` is version `1.2.3`, then `foo`
-    will be published with `{ "dependencies": { "bar": "1.2.3" }}`
-  - `~` or `^` - Publish with the version found in the
-    monorepo, prefixed by the character. So in the example
-    above, it'd be `bar@~1.2.3` or `bar@^1.2.3`, respectively.
+  - `*` - Fill in whatever version is in the workspace, without any
+    prefix. So, if `./packages/foo` depends on `bar@workspace*`, and
+    `bar` is version `1.2.3`, then `foo` will be published with
+    `{ "dependencies": { "bar": "1.2.3" }}`
+  - `~` or `^` - Publish with the version found in the monorepo,
+    prefixed by the character. So in the example above, it'd be
+    `bar@~1.2.3` or `bar@^1.2.3`, respectively.
 
-- `semver range` - A valid semver range (including the empty
-  string or a single semver version). This is resolved against
-  the default registry. If the spec is a valid semver range, then
-  no further parsing is done.
+- `semver range` - A valid semver range (including the empty string or
+  a single semver version). This is resolved against the default
+  registry. If the spec is a valid semver range, then no further
+  parsing is done.
 
-- `git+ssh://<url>[selector]` or `git+https://<url>[selector]` -
-  A `git+ssh` or `git+https` url will be checked out by git. If
-  no 'git selector' is provided, then it will attempt to install
-  from the default version. The git selector can be:
+- `git+ssh://<url>[selector]` or `git+https://<url>[selector]` - A
+  `git+ssh` or `git+https` url will be checked out by git. If no 'git
+  selector' is provided, then it will attempt to install from the
+  default version. The git selector can be:
 
-  - `#committish` Any valid `committish` value will be checked
-    out. So, shasum, branch, tag, etc., would all work.
-  - `#semver:<range>` If a semver range is provided, it will
-    select over all the tags that are valid semver versions, and
-    pick the highest version number that satisfies the range.
-  - Additional fields can be specified by a `::`-separated series
-    of `key:value` pairs. Currently only `path:<path in repo>` is
-    supported, for referencing packages living below the root of
-    the repository, as in a monorepo. For example,
+  - `#committish` Any valid `committish` value will be checked out.
+    So, shasum, branch, tag, etc., would all work.
+  - `#semver:<range>` If a semver range is provided, it will select
+    over all the tags that are valid semver versions, and pick the
+    highest version number that satisfies the range.
+  - Additional fields can be specified by a `::`-separated series of
+    `key:value` pairs. Currently only `path:<path in repo>` is
+    supported, for referencing packages living below the root of the
+    repository, as in a monorepo. For example,
     `tcompare@github:tapjs/tapjs#bf457f24::path:src/tcompare`
 
-- `https://some-host.com/path/to/file.tgz` - An https or http URL
-  to a tarball will resolve to itself.
+- `https://some-host.com/path/to/file.tgz` - An https or http URL to a
+  tarball will resolve to itself.
 
-- `file:///path/to/file` - A file URL will resolve to itself. If
-  it is a directory, it will be reified as a symbolic link to the
-  folder specified. If it is a file, it will be treated as a
-  tarball that gets unpacked into place. Relative paths are
-  resolved from the package with the dependency.
+- `file:///path/to/file` - A file URL will resolve to itself. If it is
+  a directory, it will be reified as a symbolic link to the folder
+  specified. If it is a file, it will be treated as a tarball that
+  gets unpacked into place. Relative paths are resolved from the
+  package with the dependency.
 
-- `registry:<registry url>#<name>[@version range or dist-tag]` -
-  This will use the specified registry url, and look up the name
-  and version on that registry.
+- `registry:<registry url>#<name>[@version range or dist-tag]` - This
+  will use the specified registry url, and look up the name and
+  version on that registry.
 
-- If a registry shorthand is defined in the options, then you can
-  use it as an alias for that registry. Currently, the only
-  shorthand that is enabled by default is
-  `npm:<name>[@version-range]` as a shorthand for
-  `registry:https://registry.npmjs.org/#<name>[@version-range]`.
+- If a registry shorthand is defined in the options, then you can use
+  it as an alias for that registry. Currently, the only shorthand that
+  is enabled by default is `npm:<name>[@version-range]` as a shorthand
+  for `registry:https://registry.npmjs.org/#<name>[@version-range]`.
 
-- If a git repository shorthand is defined in the options, then
-  you can use that shorthand prefix as an alias for that git
-  host. Currently, `github:`, `bitbucket:`, `gitlab:`, and
-  `gist:` are supported by default.
+- If a git repository shorthand is defined in the options, then you
+  can use that shorthand prefix as an alias for that git host.
+  Currently, `github:`, `bitbucket:`, `gitlab:`, and `gist:` are
+  supported by default.
 
 - Anything else will be treated as a `dist-tag` in the registry
   packument. For example, `foo@latest` or `blah@legacy-v2`
@@ -141,8 +134,8 @@ const fooFromAcmeReg = Spec.parse(
 
 ## Properties
 
-- type - the type of spec that this is. One of `'registry'`,
-  `'git'`, `'file'`, or `'remote'`.
+- type - the type of spec that this is. One of `'registry'`, `'git'`,
+  `'file'`, or `'remote'`.
 - spec - the full named specifier passed to the constructor
 - options - options passed to the constructor, plus defaults
 - name - the name portion, so `foo` in `foo@1.x`
@@ -150,8 +143,7 @@ const fooFromAcmeReg = Spec.parse(
 - when `type` === `'git'`:
   - gitRemote - git remote url
   - gitSelector - the `::`-separated set of `key:value` fields
-  - gitSelectorParsed - the `gitSelector` parsed into a Record
-    object
+  - gitSelectorParsed - the `gitSelector` parsed into a Record object
   - gitCommittish - the commit sha, branch, or tag
   - namedGitHost - `github`, `gitlab`, `bitbucket`, etc.
   - remoteURL - when using a named git host with an archive url
@@ -161,15 +153,14 @@ const fooFromAcmeReg = Spec.parse(
   - range - the parsed semver range, if valid
 - when `type` === `'registry'`:
   - registry - the registry to look up data from
-  - namedRegistry - in the case of alias specs, the named
-    registry
+  - namedRegistry - in the case of alias specs, the named registry
   - registrySpec - the semver range or dist-tag
   - semver - the semver range, if valid
   - range - the parsed semver range, if valid
   - distTag - the registrySpec when it is not a semver range
-  - subspec - the parsed spec to to be resolved against the
-    registry in question, if the spec is a named registry like
-    `npm:x@2.x` or an explicit registry url like
+  - subspec - the parsed spec to to be resolved against the registry
+    in question, if the spec is a named registry like `npm:x@2.x` or
+    an explicit registry url like
     `registry:https://registry.npmjs.org#x@2.x`.
 - when `type` === `'file'`:
   - file - the path on disk to find the package

--- a/src/tar/README.md
+++ b/src/tar/README.md
@@ -2,26 +2,27 @@
 
 # @vltpkg/tar
 
-A library for unpacking JavaScript package tarballs (gzip-compressed or raw) into a specified folder.
+A library for unpacking JavaScript package tarballs (gzip-compressed
+or raw) into a specified folder.
 
-**[Usage](#usage)**
-·
-**[Caveats](#caveats)**
+**[Usage](#usage)** · **[Caveats](#caveats)**
 
 ## Overview
 
-If you are unpacking anything other than npm packages, in precisely the way that [vlt](https://vlt.sh) does, then this is
-probably not what you're looking for.
+If you are unpacking anything other than npm packages, in precisely
+the way that [vlt](https://vlt.sh) does, then this is probably not
+what you're looking for.
 
-For a very complete and battle-tested generic tar implementation in JavaScript, see [node-tar](http://npm.im/tar).
+For a very complete and battle-tested generic tar implementation in
+JavaScript, see [node-tar](http://npm.im/tar).
 
 ## Usage
 
 ### unpack(tarData, targetFolder)
 
 Pass your gzip-compressed or raw uncompressed JavaScript package
-tarball in a Buffer (or Uint8Array, or ArrayBuffer slice) into
-the function, along with the folder you want to drop it in.
+tarball in a Buffer (or Uint8Array, or ArrayBuffer slice) into the
+function, along with the folder you want to drop it in.
 
 It will unpack as fast as possible, using synchronous I/O.
 
@@ -38,14 +39,13 @@ unpack(unzipped, 'node_modules/target')
 
 ### `class Pool`
 
-Create a pool of worker threads which will service unpack
-requests in parallel.
+Create a pool of worker threads which will service unpack requests in
+parallel.
 
 New requests that get added will be assigned to workers as those
-workers become available. When a worker completes its task, and
-there are no more tasks to assign, it is terminated. If not
-enough workers are available to service requests, then new ones
-will be spawned.
+workers become available. When a worker completes its task, and there
+are no more tasks to assign, it is terminated. If not enough workers
+are available to service requests, then new ones will be spawned.
 
 #### `pool.jobs`
 
@@ -66,29 +66,27 @@ completed.
 
 #### `pool.unpack(tarData: Buffer, target: string) => Promise<void>`
 
-Unpack the supplied Buffer of data into the target folder,
-using synchronous I/O in a worker thread.
+Unpack the supplied Buffer of data into the target folder, using
+synchronous I/O in a worker thread.
 
 Promise resolves when this unpack request has been completed.
 
 ## Caveats
 
-As stated above, **this is not a general purpose tar
-implementation**. It does not handle symbolic links at all (those
-aren't allowed in JavaScript packages). It does not respect
-uid/gid ownership flags. All files are with a mode of `0o644` (or
-`0o666` on Windows - technically it's `0o666` xor'ed with the
-system umask, so that'll often be `0o664` on linux systems). All
-directories are created with a mode of `0o755` by default (with
-the same windows/umask caveats as files, so maybe that's `0o775`
-or some such.) All ctime/mtime/atime/birthtime values will just
-be left as the current time.
+As stated above, **this is not a general purpose tar implementation**.
+It does not handle symbolic links at all (those aren't allowed in
+JavaScript packages). It does not respect uid/gid ownership flags. All
+files are with a mode of `0o644` (or `0o666` on Windows - technically
+it's `0o666` xor'ed with the system umask, so that'll often be `0o664`
+on linux systems). All directories are created with a mode of `0o755`
+by default (with the same windows/umask caveats as files, so maybe
+that's `0o775` or some such.) All ctime/mtime/atime/birthtime values
+will just be left as the current time.
 
-It does not do any of the binary linking or other stuff that a
-package manager will need to do. It _just_ does the unpack, as
-ruthlessly fast as possible, and that's all.
+It does not do any of the binary linking or other stuff that a package
+manager will need to do. It _just_ does the unpack, as ruthlessly fast
+as possible, and that's all.
 
-Synchronous IO is used because that's faster and requires less
-CPU utilization. The `Pool` class manages multiple worker threads
-doing this work, so faster sync IO for the whole thing is much
-more optimal.
+Synchronous IO is used because that's faster and requires less CPU
+utilization. The `Pool` class manages multiple worker threads doing
+this work, so faster sync IO for the whole thing is much more optimal.

--- a/src/types/README.md
+++ b/src/types/README.md
@@ -2,7 +2,8 @@
 
 # @vltpkg/types
 
-A module for a handful of core types that are used throughout vlt extensively, and don't belong to any one particular implementation.
+A module for a handful of core types that are used throughout vlt
+extensively, and don't belong to any one particular implementation.
 
 ## Usage
 

--- a/src/vlt/CONTRIBUTING.md
+++ b/src/vlt/CONTRIBUTING.md
@@ -2,39 +2,39 @@
 
 (Or: "What goes in this workspace?")
 
-There is always a tendency, when adding features to a CLI
-project, to say, "This is just a small little feature, I'll just
-put it in here for now while we figure out how it works".
+There is always a tendency, when adding features to a CLI project, to
+say, "This is just a small little feature, I'll just put it in here
+for now while we figure out how it works".
 
-This is an ok impulse! Sometimes an experiment is just easiest to
-do in one place!
+This is an ok impulse! Sometimes an experiment is just easiest to do
+in one place!
 
-But it must come along with ruthless repeated refactoring.
-Whenever possible, certainly before considering a feature "done",
-create a new workspace or add the functionality to an existing
-`@vltpkg/*` library in this project.
+But it must come along with ruthless repeated refactoring. Whenever
+possible, certainly before considering a feature "done", create a new
+workspace or add the functionality to an existing `@vltpkg/*` library
+in this project.
 
-_Only_ the following sorts of functionality belong here in the
-cli project directly:
+_Only_ the following sorts of functionality belong here in the cli
+project directly:
 
 - Configuration definitions and loading logic. (This is kind of a
-  stretch, but it's always annoying to _not_ have config
-  definition live with argument parsing.)
-- Argument parsing (ie, turning "stuff a user typed" into "list
-  of things to do").
+  stretch, but it's always annoying to _not_ have config definition
+  live with argument parsing.)
+- Argument parsing (ie, turning "stuff a user typed" into "list of
+  things to do").
 - Minimal command functions that pass user arguments to
   library-provided implementation methods.
-- View implementations that take the result of an action and
-  present it in various ways.
+- View implementations that take the result of an action and present
+  it in various ways.
 - Ergonomic presentations of various common error messages.
 
 In software design pattern terms, this is a "View Controller". It
 parses the user's intent, passes functionality off to some other
-module, and then presents the result in the appropriate format.
-It does _not_ implement that functionality or contain other
-opinions unrelated to "what is the user asking for" and "how to
-present the result".
+module, and then presents the result in the appropriate format. It
+does _not_ implement that functionality or contain other opinions
+unrelated to "what is the user asking for" and "how to present the
+result".
 
-Basically, if it's not "parse user intent" or "print the result",
-then it belongs elsewhere! You can spike it out here, but it
-_must_ find a home in another project.
+Basically, if it's not "parse user intent" or "print the result", then
+it belongs elsewhere! You can spike it out here, but it _must_ find a
+home in another project.

--- a/src/vlt/README.md
+++ b/src/vlt/README.md
@@ -18,3 +18,6 @@ process.chdir('/some/vlt/project')
 process.argv.splice(2, 0, 'install')
 await vlt()
 ```
+
+Visit [docs.vlt.sh](https://docs.vlt.sh) to see the full
+documentation.

--- a/src/vlt/src/config/README.md
+++ b/src/vlt/src/config/README.md
@@ -25,40 +25,38 @@ console.log(config.jack.usageMarkdown())
 
 ## Config Files
 
-This module will walk up from the current working directory
-seeking a project root. This is indicated by the following
-algorithm:
+This module will walk up from the current working directory seeking a
+project root. This is indicated by the following algorithm:
 
-- If a `node_modules` or `package.json` file is found, record
-  this path as the "likely root", but keep searching.
-- If the current directory is `$HOME` or the XDG config home,
-  stop searching.
+- If a `node_modules` or `package.json` file is found, record this
+  path as the "likely root", but keep searching.
+- If the current directory is `$HOME` or the XDG config home, stop
+  searching.
 - If a `.git` or `vlt-workspaces.json` file is found, use this
   directory as the project root and stop searching.
 - If a `vlt.json` file is found and successfully loaded, use this
   directory as the project root and stop searching.
 - If continuing to search, restart in the parent directory.
-- If the search was ended without a definitive root, but a likely
-  root was found, use that.
-- If the search was ended without a definitive root or a likely
-  root, then use the current working directory.
+- If the search was ended without a definitive root, but a likely root
+  was found, use that.
+- If the search was ended without a definitive root or a likely root,
+  then use the current working directory.
 
-The project root `vlt.json` file will override values that are
-found in the XDG config home `vlt/vlt.json` file.
+The project root `vlt.json` file will override values that are found
+in the XDG config home `vlt/vlt.json` file.
 
-These are further overridden by any matching `VLT_*` fields in
-the environment, or options specified on the command line.
+These are further overridden by any matching `VLT_*` fields in the
+environment, or options specified on the command line.
 
 ## Configuration Definitions and Patterns
 
-All configuration options are defined in `./definition.ts`.
-See [jackspeak docs](http://npm.im/jackspeak) for a full
-description of the format.
+All configuration options are defined in `./definition.ts`. See
+[jackspeak docs](http://npm.im/jackspeak) for a full description of
+the format.
 
-`{ type: 'string', multiple: true }` options can be interpreted
-as a set of `key=value` pairs, and will be saved back to a config
-file in this shape. For example, you could put this in a
-`vlt.json` file:
+`{ type: 'string', multiple: true }` options can be interpreted as a
+set of `key=value` pairs, and will be saved back to a config file in
+this shape. For example, you could put this in a `vlt.json` file:
 
 ```json
 {
@@ -70,10 +68,9 @@ file in this shape. For example, you could put this in a
 }
 ```
 
-However, in the environment and on the command line, where all
-values _must_ be strings, these are expressed as a set of
-`key=value` pairs. So these would be equivalent to the above
-example:
+However, in the environment and on the command line, where all values
+_must_ be strings, these are expressed as a set of `key=value` pairs.
+So these would be equivalent to the above example:
 
 ```bash
 $ vlt \
@@ -91,13 +88,13 @@ parsed as `{ [key]: '' }` in the resulting Record.
 
 ## Passing to Other `@vltpkg` Modules
 
-After loading and parsing the config files, environment, and
-command line, `config.options` will be a flattened object
-representing the effective current configuration.
+After loading and parsing the config files, environment, and command
+line, `config.options` will be a flattened object representing the
+effective current configuration.
 
-All `@vltpkg` modules must register their user-configurable
-options in the definitions provided here, such that they can be
-called with `config.options` as an options argument.
+All `@vltpkg` modules must register their user-configurable options in
+the definitions provided here, such that they can be called with
+`config.options` as an options argument.
 
 Example:
 

--- a/src/which/README.md
+++ b/src/which/README.md
@@ -4,15 +4,16 @@
 
 Like the unix `which` utility.
 
-**[Usage](#usage)**
-·
-**[Options](#options)**
+**[Usage](#usage)** · **[Options](#options)**
 
 ## Overview
 
-Finds the first instance of a specified executable in the PATH environment variable. Does not cache the results, so `hash -r` is not needed when the PATH changes.
+Finds the first instance of a specified executable in the PATH
+environment variable. Does not cache the results, so `hash -r` is not
+needed when the PATH changes.
 
-Port of the [`which`](http://npm.im/which) to a TypeScript hybrid module.
+Port of the [`which`](http://npm.im/which) to a TypeScript hybrid
+module.
 
 ## Usage
 

--- a/src/workspaces/README.md
+++ b/src/workspaces/README.md
@@ -4,9 +4,7 @@
 
 Utilities for working with vlt workspaces.
 
-**[Usage](#usage)**
-·
-**[Run Order](#run-order)**
+**[Usage](#usage)** · **[Run Order](#run-order)**
 
 ## Usage
 
@@ -71,9 +69,8 @@ for (const path of m.paths()) {
 }
 ```
 
-Configuration is stored in the project root at
-`vlt-workspaces.json`. The type of the object in the file must
-be:
+Configuration is stored in the project root at `vlt-workspaces.json`.
+The type of the object in the file must be:
 
 ```ts
 type WorkspaceConfiguration =
@@ -82,17 +79,16 @@ type WorkspaceConfiguration =
   | { [group: string]: string | string[] }
 ```
 
-If it's an object, each key is a group name, and each value is a
-path, glob, or array of paths and globs, which specify the
-location of the workspace projects. Glob matches are only
-considered if they are a directory containing a `package.json`
-file.
+If it's an object, each key is a group name, and each value is a path,
+glob, or array of paths and globs, which specify the location of the
+workspace projects. Glob matches are only considered if they are a
+directory containing a `package.json` file.
 
 A `string` or `string[]` in the file is interpreted as
 `{"packages": <value>}`. Ie, the default group is `packages`.
 
-Workspaces are allowed to be in multiple groups, so something
-like this is fine:
+Workspaces are allowed to be in multiple groups, so something like
+this is fine:
 
 ```json
 {
@@ -102,14 +98,13 @@ like this is fine:
 }
 ```
 
-If the glob patterns result in a situation where one workspace
-folder is contained within another workspace folder, an error
-will be raised.
+If the glob patterns result in a situation where one workspace folder
+is contained within another workspace folder, an error will be raised.
 
 ## Run Order
 
-The `monorepo.run` method can run an async function for each
-workspace in the project, visiting each exactly once.
+The `monorepo.run` method can run an async function for each workspace
+in the project, visiting each exactly once.
 
 When workspaces depend on one another, it will walk dependencies
 before dependents, _unless_ there is a cycle, as that would be

--- a/src/xdg/README.md
+++ b/src/xdg/README.md
@@ -2,7 +2,9 @@
 
 # @vltpkg/xdg
 
-Get appropriate data, cache, and config directories following the [XDG spec](https://wiki.archlinux.org/title/XDG_Base_Directory), namespaced to a specific app-name subfolder.
+Get appropriate data, cache, and config directories following the
+[XDG spec](https://wiki.archlinux.org/title/XDG_Base_Directory),
+namespaced to a specific app-name subfolder.
 
 ## Usage
 

--- a/www/docs/src/content/docs/cli/auth.mdx
+++ b/www/docs/src/content/docs/cli/auth.mdx
@@ -7,20 +7,19 @@ sidebar:
 
 import { Code } from '@astrojs/starlight/components'
 
-The vlt client supports logging into multiple different
-registries.
+The vlt client supports logging into multiple different registries.
 
 ## npm Web Login
 
-To log into a registry that supports the npm web login, such as
-the public npm registry, use the `vlt login` command.
+To log into a registry that supports the npm web login, such as the
+public npm registry, use the `vlt login` command.
 
 For example, to log into the default registry:
 
 <Code code="$ vlt login" title="Terminal" lang="bash" />
 
-To log into a custom registry that supports npm web login, run
-the same command, specifying the registry to log into:
+To log into a custom registry that supports npm web login, run the
+same command, specifying the registry to log into:
 
 <Code
   code="$ vlt login --registry=https://my-custom-registry.mycompany.local/"
@@ -28,26 +27,24 @@ the same command, specifying the registry to log into:
   lang="bash"
 />
 
-To remove your authorization to a given registry, including
-attempting to destroy the token on the server side, use the `vlt
-logout` command.
+To remove your authorization to a given registry, including attempting
+to destroy the token on the server side, use the `vlt logout` command.
 
 ## Other Registries
 
-If your registry provides a bearer token that should be presented
-for authentication, it can be added using the `vlt token add`
-command.
+If your registry provides a bearer token that should be presented for
+authentication, it can be added using the `vlt token add` command.
 
 This will prompt you to paste in the token.
 
-To remove a token from vlt's keychain, use the `vlt token rm`
-command. Note that this will _not_ delete the token from the
-server; it only removes it from the local keychain store.
+To remove a token from vlt's keychain, use the `vlt token rm` command.
+Note that this will _not_ delete the token from the server; it only
+removes it from the local keychain store.
 
 ## CI (and Other Headless Environments)
 
-A token for the default registry can be provided in the
-`VLT_TOKEN` environment variable.
+A token for the default registry can be provided in the `VLT_TOKEN`
+environment variable.
 
 For example:
 
@@ -55,9 +52,9 @@ For example:
 VLT_TOKEN="helloworldtokendeadbeef" vlt install
 ```
 
-To provide a token for other registries, replace all
-non-alphanumeric characters in the registry URL with `_`, and set
-the appropriate `VLT_TOKEN_{...}` variable.
+To provide a token for other registries, replace all non-alphanumeric
+characters in the registry URL with `_`, and set the appropriate
+`VLT_TOKEN_{...}` variable.
 
 ```
 VLT_TOKEN_https_my_custom_registry_mycompany_local="helloworldtokendeadbeef" vlt install
@@ -66,43 +63,39 @@ VLT_TOKEN_https_my_custom_registry_mycompany_local="helloworldtokendeadbeef" vlt
 ## OTP
 
 One-time password (OTP) and MFA is supported for non-headless
-environments by opening a web browser or prompting on the command
-line for a OTP from your authenticator app, when the registry
-prompts for multifactor auth.
+environments by opening a web browser or prompting on the command line
+for a OTP from your authenticator app, when the registry prompts for
+multifactor auth.
 
 For headless environments, an OTP token may be provided in the
 `VLT_OTP` environment variable.
 
 ## Why Environment Variables and Not Config
 
-The vlt client is designed to make it less likely that passwords
-are leaked in configuration files that might be checked into
-source control, which is a surprisingly common security failure
-mode.
+The vlt client is designed to make it less likely that passwords are
+leaked in configuration files that might be checked into source
+control, which is a surprisingly common security failure mode.
 
-With vlt, sensitive information is _only_ kept in a tightly
-restricted keychain file, or in the environment. Of course,
-perfect security is often impossible, but it is nevertheless
-important to do our best to make it less likely that passwords
-can be leaked by accident.
+With vlt, sensitive information is _only_ kept in a tightly restricted
+keychain file, or in the environment. Of course, perfect security is
+often impossible, but it is nevertheless important to do our best to
+make it less likely that passwords can be leaked by accident.
 
 ## Credential Management
 
-Each "identity" in vlt is a set of authentication tokens for
-known registries.
+Each "identity" in vlt is a set of authentication tokens for known
+registries.
 
-For example, you could have a `corp` identity with the
-credentials that you use for the work on corporate projects, and
-a `personal` account with your own personal npm registry login
-credentials.
+For example, you could have a `corp` identity with the credentials
+that you use for the work on corporate projects, and a `personal`
+account with your own personal npm registry login credentials.
 
-Running `vlt config set identity=corp` will switch into `corp`
-mode. `vlt config set identity=personal` will switch into
-`personal` mode.
+Running `vlt config set identity=corp` will switch into `corp` mode.
+`vlt config set identity=personal` will switch into `personal` mode.
 
-This can also be set in a project root with a `vlt.json` config
-file, to make it easier to set per project. For example, you
-could have this in your `vlt.json` in the project root:
+This can also be set in a project root with a `vlt.json` config file,
+to make it easier to set per project. For example, you could have this
+in your `vlt.json` in the project root:
 
 ```json
 {

--- a/www/docs/src/content/docs/cli/commands/config.mdx
+++ b/www/docs/src/content/docs/cli/commands/config.mdx
@@ -42,7 +42,9 @@ Print all configuration settings currently in effect
 
 ### set
 
-Set config values. By default, these are written to the project config file, `vlt.json` in the root of the project. To set things for all projects, run with `--config=user`
+Set config values. By default, these are written to the project config
+file, `vlt.json` in the root of the project. To set things for all
+projects, run with `--config=user`
 
 <Code
   code="$ vlt config set <key>=<value> [<key>=<value> ...] [--config=<user | project>]"
@@ -52,7 +54,10 @@ Set config values. By default, these are written to the project config file, `vl
 
 ### del
 
-Delete the named config fields. If no values remain in the config file, delete the file as well. By default, operates on the `vlt.json` file in the root of the current project. To delete a config field from the user config file, specify `--config=user`.
+Delete the named config fields. If no values remain in the config
+file, delete the file as well. By default, operates on the `vlt.json`
+file in the root of the current project. To delete a config field from
+the user config file, specify `--config=user`.
 
 <Code
   code="$ vlt config del <key> [<key> ...] [--config=<user | project>]"
@@ -72,7 +77,8 @@ Edit the configuration file
 
 ### help
 
-Get information about a config field, or show a list of known config field names.
+Get information about a config field, or show a list of known config
+field names.
 
 <Code
   code="$ vlt config help [field ...]"

--- a/www/docs/src/content/docs/cli/commands/exec.mdx
+++ b/www/docs/src/content/docs/cli/commands/exec.mdx
@@ -10,11 +10,16 @@ Usage:
 
 <Code code="$ vlt exec [command]" title="Terminal" lang="bash" />
 
-Run an arbitrary command, with the local installed packages first in the PATH. Ie, this will run your locally installed package bins.
+Run an arbitrary command, with the local installed packages first in
+the PATH. Ie, this will run your locally installed package bins.
 
-If no command is provided, then a shell is spawned in the current working directory, with the locally installed package bins first in the PATH.
+If no command is provided, then a shell is spawned in the current
+working directory, with the locally installed package bins first in
+the PATH.
 
-Note that any vlt configs must be specified _before_ the command, as the remainder of the command line options are provided to the exec process.
+Note that any vlt configs must be specified _before_ the command, as
+the remainder of the command line options are provided to the exec
+process.
 
 ## Aliases
 

--- a/www/docs/src/content/docs/cli/commands/install.mdx
+++ b/www/docs/src/content/docs/cli/commands/install.mdx
@@ -14,7 +14,8 @@ Usage:
   lang="bash"
 />
 
-Install the specified packages, updating package.json and vlt-lock.json appropriately.
+Install the specified packages, updating package.json and
+vlt-lock.json appropriately.
 
 ## Aliases
 

--- a/www/docs/src/content/docs/cli/commands/list.mdx
+++ b/www/docs/src/content/docs/cli/commands/list.mdx
@@ -15,7 +15,8 @@ $ vlt ls <query> --view=[human | json | mermaid | gui]"
   lang="bash"
 />
 
-List installed dependencies matching the provided query. Defaults to listing direct dependencies of a project and any configured workspace.
+List installed dependencies matching the provided query. Defaults to
+listing direct dependencies of a project and any configured workspace.
 
 ## Examples
 

--- a/www/docs/src/content/docs/cli/commands/login.mdx
+++ b/www/docs/src/content/docs/cli/commands/login.mdx
@@ -10,4 +10,5 @@ Usage:
 
 <Code code="$ vlt login" title="Terminal" lang="bash" />
 
-Authenticate against a registry, and store the token in the appropriate config file for later use.
+Authenticate against a registry, and store the token in the
+appropriate config file for later use.

--- a/www/docs/src/content/docs/cli/commands/logout.mdx
+++ b/www/docs/src/content/docs/cli/commands/logout.mdx
@@ -10,4 +10,5 @@ Usage:
 
 <Code code="$ vlt logout" title="Terminal" lang="bash" />
 
-Log out of the default registry, deleting the token from the local keychain, as well as destroying it on the server.
+Log out of the default registry, deleting the token from the local
+keychain, as well as destroying it on the server.

--- a/www/docs/src/content/docs/cli/commands/run-exec.mdx
+++ b/www/docs/src/content/docs/cli/commands/run-exec.mdx
@@ -14,7 +14,8 @@ Usage:
   lang="bash"
 />
 
-If the first argument is a defined script in package.json, then this is equivalent to `vlt run`.
+If the first argument is a defined script in package.json, then this
+is equivalent to `vlt run`.
 
 If not, then this is equivalent to `vlt exec`.
 

--- a/www/docs/src/content/docs/cli/commands/run.mdx
+++ b/www/docs/src/content/docs/cli/commands/run.mdx
@@ -14,7 +14,10 @@ Usage:
   lang="bash"
 />
 
-Run a script defined in 'package.json', passing along any extra arguments. Note that vlt config values must be specified _before_ the script name, because everything after that is handed off to the script process.
+Run a script defined in 'package.json', passing along any extra
+arguments. Note that vlt config values must be specified _before_ the
+script name, because everything after that is handed off to the script
+process.
 
 ## Aliases
 

--- a/www/docs/src/content/docs/cli/commands/uninstall.mdx
+++ b/www/docs/src/content/docs/cli/commands/uninstall.mdx
@@ -14,7 +14,8 @@ Usage:
   lang="bash"
 />
 
-The opposite of `vlt install`. Removes deps and updates vlt-lock.json and package.json appropriately.
+The opposite of `vlt install`. Removes deps and updates vlt-lock.json
+and package.json appropriately.
 
 ## Aliases
 

--- a/www/docs/src/content/docs/cli/commands/whoami.mdx
+++ b/www/docs/src/content/docs/cli/commands/whoami.mdx
@@ -10,4 +10,5 @@ Usage:
 
 <Code code="$ vlt whoami" title="Terminal" lang="bash" />
 
-Look up the username for the currently active token, when logged into a registry.
+Look up the username for the currently active token, when logged into
+a registry.

--- a/www/docs/src/content/docs/cli/configuring.mdx
+++ b/www/docs/src/content/docs/cli/configuring.mdx
@@ -15,7 +15,8 @@ Usage:
   lang="bash"
 />
 
-More documentation available at [https://docs.vlt.sh](https://docs.vlt.sh)
+More documentation available at
+[https://docs.vlt.sh](https://docs.vlt.sh)
 
 ## Subcommands
 
@@ -27,13 +28,17 @@ Run `vlt <cmd> --help` for more information about a specific command
 
 ## Configuration
 
-If a `vlt.json` file is present in the root of the current project, then that will be used as a source of configuration information.
+If a `vlt.json` file is present in the root of the current project,
+then that will be used as a source of configuration information.
 
-Next, the `vlt.json` file in the XDG specified config directory will be checked, and loaded for any fields not set in the local project.
+Next, the `vlt.json` file in the XDG specified config directory will
+be checked, and loaded for any fields not set in the local project.
 
-Object type values will be merged together. Set a field to `null` in the JSON configuration to explicitly remove it.
+Object type values will be merged together. Set a field to `null` in
+the JSON configuration to explicitly remove it.
 
-Command-specific fields may be set in a nested `command` object that overrides any options defined at the top level.
+Command-specific fields may be set in a nested `command` object that
+overrides any options defined at the top level.
 
 ### `-c --color`
 
@@ -45,15 +50,21 @@ Do not use colors (Default for non-TTY)
 
 ### `--registry=<url>`
 
-Sets the registry for fetching packages, when no registry is explicitly set on a specifier.
+Sets the registry for fetching packages, when no registry is
+explicitly set on a specifier.
 
-For example, `express@latest` will be resolved by looking up the metadata from this registry.
+For example, `express@latest` will be resolved by looking up the
+metadata from this registry.
 
-Note that alias specifiers starting with `npm:` will still map to `https://registry.npmjs.org/` if this is changed, unless the a new mapping is created via the `--registries` option.
+Note that alias specifiers starting with `npm:` will still map to
+`https://registry.npmjs.org/` if this is changed, unless the a new
+mapping is created via the `--registries` option.
 
 ### `--registries=<name=url>`
 
-Specify named registry hosts by their prefix. To set the default registry used for non-namespaced specifiers, use the `--registry` option.
+Specify named registry hosts by their prefix. To set the default
+registry used for non-namespaced specifiers, use the `--registry`
+option.
 
 Prefixes can be used as a package alias. For example:
 
@@ -63,7 +74,8 @@ Prefixes can be used as a package alias. For example:
   lang="bash"
 />
 
-By default, the public npm registry is registered to the `npm:` prefix. It is not recommended to change this mapping in most cases.
+By default, the public npm registry is registered to the `npm:`
+prefix. It is not recommended to change this mapping in most cases.
 
 Can be set multiple times
 
@@ -71,13 +83,23 @@ Can be set multiple times
 
 Map package name scopes to registry URLs.
 
-For example, `--scope-registries @acme=https://registry.acme/` would tell vlt to fetch any packages named `@acme/...` from the `https://registry.acme/` registry.
+For example, `--scope-registries @acme=https://registry.acme/` would
+tell vlt to fetch any packages named `@acme/...` from the
+`https://registry.acme/` registry.
 
-Note: this way of specifying registries is more ambiguous, compared with using the `--registries` field and explicit prefixes, because instead of failing when the configuration is absent, it will instead attempt to fetch from the default registry.
+Note: this way of specifying registries is more ambiguous, compared
+with using the `--registries` field and explicit prefixes, because
+instead of failing when the configuration is absent, it will instead
+attempt to fetch from the default registry.
 
-By comparison, using `--registries acme=https://registry.acme/` and then specifying dependencies such as `"foo": "acme:foo@1.x"` means that regardless of the name, the package will be fetched from the explicitly named registry, or fail if no registry is defined with that name.
+By comparison, using `--registries acme=https://registry.acme/` and
+then specifying dependencies such as `"foo": "acme:foo@1.x"` means
+that regardless of the name, the package will be fetched from the
+explicitly named registry, or fail if no registry is defined with that
+name.
 
-However, custom registry aliases are not supported by other package managers.
+However, custom registry aliases are not supported by other package
+managers.
 
 Can be set multiple times
 
@@ -85,23 +107,32 @@ Can be set multiple times
 
 Map a shorthand name to a git remote URL template.
 
-The `template` may contain placeholders, which will be swapped with the relevant values.
+The `template` may contain placeholders, which will be swapped with
+the relevant values.
 
-`$1`, `$2`, etc. are replaced with the appropriate n-th path portion. For example, `github:user/project` would replace the `$1` in the template with `user`, and `$2` with `project`.
+`$1`, `$2`, etc. are replaced with the appropriate n-th path portion.
+For example, `github:user/project` would replace the `$1` in the
+template with `user`, and `$2` with `project`.
 
 Can be set multiple times
 
 ### `-A<name=template> --git-host-archives=<name=template>`
 
-Similar to the `--git-host <name>=<template>` option, this option can define a template string that will be expanded to provide the URL to download a pre-built tarball of the git repository.
+Similar to the `--git-host <name>=<template>` option, this option can
+define a template string that will be expanded to provide the URL to
+download a pre-built tarball of the git repository.
 
-In addition to the n-th path portion expansions performed by `--git-host`, this field will also expand the string `$committish` in the template, replacing it with the resolved git committish value to be fetched.
+In addition to the n-th path portion expansions performed by
+`--git-host`, this field will also expand the string `$committish` in
+the template, replacing it with the resolved git committish value to
+be fetched.
 
 Can be set multiple times
 
 ### `--cache=<path>`
 
-Location of the vlt on-disk cache. Defaults to the platform-specific directory recommended by the XDG specification.
+Location of the vlt on-disk cache. Defaults to the platform-specific
+directory recommended by the XDG specification.
 
 ### `--tag=<tag>`
 
@@ -113,29 +144,36 @@ Do not install any packages published after this date
 
 ### `--os=<os>`
 
-The operating system to use as the selector when choosing packages based on their `os` value.
+The operating system to use as the selector when choosing packages
+based on their `os` value.
 
 ### `--arch=<arch>`
 
-CPU architecture to use as the selector when choosing packages based on their `cpu` value.
+CPU architecture to use as the selector when choosing packages based
+on their `cpu` value.
 
 ### `--node-version=<version>`
 
-Node version to use when choosing packages based on their `engines.node` value.
+Node version to use when choosing packages based on their
+`engines.node` value.
 
 ### `--git-shallow`
 
-Set to force `--depth=1` on all git clone actions. When set explicitly to false with --no-git-shallow, then `--depth=1` will not be used.
+Set to force `--depth=1` on all git clone actions. When set explicitly
+to false with --no-git-shallow, then `--depth=1` will not be used.
 
-When not set explicitly, `--depth=1` will be used for git hosts known to support this behavior.
+When not set explicitly, `--depth=1` will be used for git hosts known
+to support this behavior.
 
 ### `--fetch-retries=<n>`
 
-Number of retries to perform when encountering network errors or likely-transient errors from git hosts.
+Number of retries to perform when encountering network errors or
+likely-transient errors from git hosts.
 
 ### `--fetch-retry-factor=<n>`
 
-The exponential backoff factor to use when retrying requests due to network issues.
+The exponential backoff factor to use when retrying requests due to
+network issues.
 
 ### `--fetch-retry-mintimeout=<n>`
 
@@ -147,11 +185,14 @@ Maximum number of milliseconds between two retries
 
 ### `-i<name> --identity=<name>`
 
-Provide a string to define an identity for storing auth information when logging into registries.
+Provide a string to define an identity for storing auth information
+when logging into registries.
 
-Authentication tokens will be stored in the XDG data directory, in `vlt/auth/${identity}/keychain.json`.
+Authentication tokens will be stored in the XDG data directory, in
+`vlt/auth/${identity}/keychain.json`.
 
-If no identity is provided, then the default `''` will be used, storing the file at `vlt/auth/keychain.json`.
+If no identity is provided, then the default `''` will be used,
+storing the file at `vlt/auth/keychain.json`.
 
 May only contain lowercase alphanumeric characters.
 
@@ -167,7 +208,8 @@ Can be set multiple times
 
 ### `-g<workspace-group> --workspace-group=<workspace-group>`
 
-Specify named workspace group names to load and operate on when doing recursive operations on workspaces.
+Specify named workspace group names to load and operate on when doing
+recursive operations on workspaces.
 
 Can be set multiple times
 
@@ -177,39 +219,49 @@ Run an operation across multiple workspaces.
 
 No effect when used in non-monorepo projects.
 
-Implied by setting --workspace or --workspace-group. If not set, then the action is run on the project root.
+Implied by setting --workspace or --workspace-group. If not set, then
+the action is run on the project root.
 
 ### `-b --bail`
 
-When running scripts across multiple workspaces, stop on the first failure.
+When running scripts across multiple workspaces, stop on the first
+failure.
 
 ### `-B --no-bail`
 
-When running scripts across multiple workspaces, continue on failure, running the script for all workspaces.
+When running scripts across multiple workspaces, continue on failure,
+running the script for all workspaces.
 
 ### `--config=<user | project>`
 
-Specify whether to operate on user-level or project-level configuration files when running `vlt config` commands.
+Specify whether to operate on user-level or project-level
+configuration files when running `vlt config` commands.
 
 Valid options: "user", "project"
 
 ### `--editor=<program>`
 
-The blocking editor to use for `vlt config edit` and any other cases where a file should be opened for editing.
+The blocking editor to use for `vlt config edit` and any other cases
+where a file should be opened for editing.
 
-Defaults to the `EDITOR` or `VISUAL` env if set, or `notepad.exe` on Windows, or `vi` elsewhere.
+Defaults to the `EDITOR` or `VISUAL` env if set, or `notepad.exe` on
+Windows, or `vi` elsewhere.
 
 ### `--script-shell=<program>`
 
-The shell to use when executing `package.json#scripts` (either as lifecycle scripts or explicitly with `vlt run`) and `vlt exec`.
+The shell to use when executing `package.json#scripts` (either as
+lifecycle scripts or explicitly with `vlt run`) and `vlt exec`.
 
-If not set, defaults to `/bin/sh` on POSIX systems, and `cmd.exe` on Windows.
+If not set, defaults to `/bin/sh` on POSIX systems, and `cmd.exe` on
+Windows.
 
-When no argument is provided to `vlt exec`, the `SHELL` environment variable takes precedence if set.
+When no argument is provided to `vlt exec`, the `SHELL` environment
+variable takes precedence if set.
 
 ### `--fallback-command=<command>`
 
-The command to run when the first argument doesn't match any known commands.
+The command to run when the first argument doesn't match any known
+commands.
 
 For pnpm-style behavior, set this to 'run-exec'. e.g:
 
@@ -227,15 +279,20 @@ Valid options:
 
 ### `--package=<p>`
 
-When running `vlt install-exec`, this allows you to explicitly set the package to search for bins. If not provided, then vlt will interpret the first argument as the package, and attempt to run the default executable.
+When running `vlt install-exec`, this allows you to explicitly set the
+package to search for bins. If not provided, then vlt will interpret
+the first argument as the package, and attempt to run the default
+executable.
 
 ### `--view=<output>`
 
-Configures the output format for commands. Valid options: "human", "json", "mermaid", "gui"
+Configures the output format for commands. Valid options: "human",
+"json", "mermaid", "gui"
 
 ### `--dashboard-root=<path>`
 
-The root directory to use for the dashboard GUI. If not set, the user home directory is used.
+The root directory to use for the dashboard GUI. If not set, the user
+home directory is used.
 
 Can be set multiple times
 
@@ -253,7 +310,10 @@ Save installed packages to a package.json file as peerDependencies
 
 ### `-P --save-prod`
 
-Save installed packages into dependencies specifically. This is useful if a package already exists in devDependencies or optionalDependencies, but you want to move it to be a non-optional production dependency.
+Save installed packages into dependencies specifically. This is useful
+if a package already exists in devDependencies or
+optionalDependencies, but you want to move it to be a non-optional
+production dependency.
 
 ### `-v --version`
 

--- a/www/docs/src/content/docs/cli/selectors.mdx
+++ b/www/docs/src/content/docs/cli/selectors.mdx
@@ -7,73 +7,132 @@ sidebar:
 
 ## Supported Syntax Reference
 
-The vlt query syntax enable usage of css-selector-like strings to filter
-packages.
+The vlt query syntax enable usage of css-selector-like strings to
+filter packages.
 
-Many of the common elements of the CSS language are available, notably:
+Many of the common elements of the CSS language are available,
+notably:
 
 - `*` Universal selector, matches all selected items.
 - `&` Nesting selector, allows for nesting selectors.
 - `{}` Curly braces, when querying can be used to nest selectors.
 
-Split by group of selectors below is the complete reference to supported
-elements.
+Split by group of selectors below is the complete reference to
+supported elements.
 
 ### Attribute selectors
 
-Attribute selectors are used to match a value found in the `package.json`
-metadata for each of the nodes being queried to a arbitrary value you choose.
+Attribute selectors are used to match a value found in the
+`package.json` metadata for each of the nodes being queried to a
+arbitrary value you choose.
 
-- `[attr]` Matches elements with an `attr` property in its `package.json`.
-- `[attr=value]` Matches elements with a property `attr` whose value is exactly `value`.
-- `[attr^=value]` Matches elements with a property `attr` whose value starts with `value`.
-- `[attr$=value]` Matches elements with a property `attr` whose value ends with `value`.
-- `[attr~=value]` Matches elements with a property `attr` whose value is a whitespace-separated list of words, one of which is exactly `value`.
-- `[attr|=value]` Matches elements with a property `attr` whose value is either `value` or starts with `value-`.
+- `[attr]` Matches elements with an `attr` property in its
+  `package.json`.
+- `[attr=value]` Matches elements with a property `attr` whose value
+  is exactly `value`.
+- `[attr^=value]` Matches elements with a property `attr` whose value
+  starts with `value`.
+- `[attr$=value]` Matches elements with a property `attr` whose value
+  ends with `value`.
+- `[attr~=value]` Matches elements with a property `attr` whose value
+  is a whitespace-separated list of words, one of which is exactly
+  `value`.
+- `[attr|=value]` Matches elements with a property `attr` whose value
+  is either `value` or starts with `value-`.
 - `[attr*=value]` Matches elements with a property `attr`.
-- `[attr=value i]` Case-insensitive flag, setting it will cause any comparison to be case-insensitive.
-- `[attr=value s]` Case-sensitive flag, setting it will cause comparisons to be case-sensitive, this is the default behavior.
+- `[attr=value i]` Case-insensitive flag, setting it will cause any
+  comparison to be case-insensitive.
+- `[attr=value s]` Case-sensitive flag, setting it will cause
+  comparisons to be case-sensitive, this is the default behavior.
 
 ### Class selectors
 
 - `.prod` Matches prod dependencies to your current project.
-- `.dev` Matches packages that are only used as dev dependencies in your current project.
-- `.optional` Matches packages that are optional to your current project.
+- `.dev` Matches packages that are only used as dev dependencies in
+  your current project.
+- `.optional` Matches packages that are optional to your current
+  project.
 - `.peer` Matches peer dependencies to your current project.
-- `.workspace` Matches the current project worksacpes (listed in your `vlt-workspaces.json` file).
+- `.workspace` Matches the current project worksacpes (listed in your
+  `vlt-workspaces.json` file).
 
 ### Combinators
 
-- `>` Child combinator, matches packages that are direct dependencies of the previously selected nodes.
-- ` ` Descendant combinator, matches all packages that are direct & transitive dependencies of the previously selected nodes.
-- `~` Sibling combinator, matches packages that are direct dependencies of all dependents of the previously selected nodes.
+- `>` Child combinator, matches packages that are direct dependencies
+  of the previously selected nodes.
+- ` ` Descendant combinator, matches all packages that are direct &
+  transitive dependencies of the previously selected nodes.
+- `~` Sibling combinator, matches packages that are direct
+  dependencies of all dependents of the previously selected nodes.
 
 ### ID Selectors
 
-Identifiers are a shortcut to retrieving packages by name, unfortunately this shortcut only works for unscoped packages, with that in mind it's advised to rely on using **Attribute selectors** (showed above) instead.
+Identifiers are a shortcut to retrieving packages by name,
+unfortunately this shortcut only works for unscoped packages, with
+that in mind it's advised to rely on using **Attribute selectors**
+(showed above) instead.
 
 e.g: `#foo` is the same as `[name=foo]`
 
 ### Pseudo class selectors
 
-- `:attr(key, [attr=value])` The attribute pseudo-class allows for selecting packages based on nested properties of its `package.json` metadata. As an example, here is a query that filters only packages that declares an optional peer dependency named `foo`: `:attr(peerDependenciesMeta, foo, [optional=true])`
+- `:attr(key, [attr=value])` The attribute pseudo-class allows for
+  selecting packages based on nested properties of its `package.json`
+  metadata. As an example, here is a query that filters only packages
+  that declares an optional peer dependency named `foo`:
+  `:attr(peerDependenciesMeta, foo, [optional=true])`
 - `:empty` Matches packages that have no dependencies installed.
-- `:has(<selector-list>)` Matches only packages that have valid results for the selector expression used. As an example, here is a query that matches all packages that have a peer dependency on `react`: `:has(.peer[name=react])`
-- `:is(<forgiving-selector-list>)` Useful for writing large selectors in a more compact form, the `:is()` pseudo-class takes a selector list as its arguments and selects any element that can be selected by one of the selectors in that list. As an example, let's say I want to select packages named `a` & `b` that are direct dependencies of my project root: `:root > [name=a], :root > [name=b]` using the `:is()` pseudo-class, that same expression can be shortened to: `:root > :is([name=a], [name=b])`. Similar to the css pseudo-class of the same name, this selector has a forgiving behavior regarding its nested selector list ignoring any usage of non-existing ids, classes, combinators, operators and pseudo-selectors.
-- `:not(<selector-list>)` Negation pseudo-class, select packages that do not match a list of selectors.
-- `:outdated(<type>)` Matches packages that are outdated, the type parameter is optional and can be one of the following:
-  - `any` (default) a version exists that is greater than the current one
-  - `in-range` a version exists that is greater than the current one, and satisfies at least one if its parent's dependencies
-  - `out-of-range` a version exists that is greater than the current one, does not satisfy at least one of its parent's dependencies
-  - `major` a version exists that is a semver major greater than the current one
-  - `minor` a version exists that is a semver minor greater than the current one
-  - `patch` a version exists that is a semver patch greater than the current one
-- `:private` Matches packages that have the property `private` set on their `package.json` file.
-- `:semver(<value>, <function>, <custom-attribute-selector>)` Matches packages based on a semver value, e.g, to retrieve all packages that have a `version` satisfied by the semver value `^1.0.0`: `:semver(^1.0.0)`. It's also possible to define the type of semver comparison function to use by defining a second parameter, e.g: `:semver(^1.0.0, eq)` for an exact match, valid comparison types are: `eq`, `neq`, `gt`, `gte`, `lt`, `lte`, `satisfies` (default). A third parameter allows for specifying a different `package.json` property to use for the comparison, e.g: `:semver(^22, satisfies, :attr(engines, [node]))` for comparing the value of `engines.node`.
-- `:type(registry|file|git|remote|workspace)` Matches packages based on their type, e.g, to retrieve all git dependencies: `:type(git)`.
+- `:has(<selector-list>)` Matches only packages that have valid
+  results for the selector expression used. As an example, here is a
+  query that matches all packages that have a peer dependency on
+  `react`: `:has(.peer[name=react])`
+- `:is(<forgiving-selector-list>)` Useful for writing large selectors
+  in a more compact form, the `:is()` pseudo-class takes a selector
+  list as its arguments and selects any element that can be selected
+  by one of the selectors in that list. As an example, let's say I
+  want to select packages named `a` & `b` that are direct dependencies
+  of my project root: `:root > [name=a], :root > [name=b]` using the
+  `:is()` pseudo-class, that same expression can be shortened to:
+  `:root > :is([name=a], [name=b])`. Similar to the css pseudo-class
+  of the same name, this selector has a forgiving behavior regarding
+  its nested selector list ignoring any usage of non-existing ids,
+  classes, combinators, operators and pseudo-selectors.
+- `:not(<selector-list>)` Negation pseudo-class, select packages that
+  do not match a list of selectors.
+- `:outdated(<type>)` Matches packages that are outdated, the type
+  parameter is optional and can be one of the following:
+  - `any` (default) a version exists that is greater than the current
+    one
+  - `in-range` a version exists that is greater than the current one,
+    and satisfies at least one if its parent's dependencies
+  - `out-of-range` a version exists that is greater than the current
+    one, does not satisfy at least one of its parent's dependencies
+  - `major` a version exists that is a semver major greater than the
+    current one
+  - `minor` a version exists that is a semver minor greater than the
+    current one
+  - `patch` a version exists that is a semver patch greater than the
+    current one
+- `:private` Matches packages that have the property `private` set on
+  their `package.json` file.
+- `:semver(<value>, <function>, <custom-attribute-selector>)` Matches
+  packages based on a semver value, e.g, to retrieve all packages that
+  have a `version` satisfied by the semver value `^1.0.0`:
+  `:semver(^1.0.0)`. It's also possible to define the type of semver
+  comparison function to use by defining a second parameter, e.g:
+  `:semver(^1.0.0, eq)` for an exact match, valid comparison types
+  are: `eq`, `neq`, `gt`, `gte`, `lt`, `lte`, `satisfies` (default). A
+  third parameter allows for specifying a different `package.json`
+  property to use for the comparison, e.g:
+  `:semver(^22, satisfies, :attr(engines, [node]))` for comparing the
+  value of `engines.node`.
+- `:type(registry|file|git|remote|workspace)` Matches packages based
+  on their type, e.g, to retrieve all git dependencies: `:type(git)`.
 
 ### Pseudo Elements
 
-- `:project` Returns both the root node (as defined below) along with any workspace declared in your project.
-- `:root` Returns the root node, that represents the package defined at the top-level `package.json` of your project folder.
+- `:project` Returns both the root node (as defined below) along with
+  any workspace declared in your project.
+- `:root` Returns the root node, that represents the package defined
+  at the top-level `package.json` of your project folder.
 - `:scope` Returns the current scope of a given selector

--- a/www/docs/src/content/docs/cli/using-with-vsr.mdx
+++ b/www/docs/src/content/docs/cli/using-with-vsr.mdx
@@ -41,34 +41,35 @@ It's possible to configure the vlt client to install packages from a
 vsr instance.
 
 There are two possible ways to configure a vsr instance. For direct
-dependencies we recommend configuring private registries using a custom
-registry protocol that allows for fine grained and explicit control of
-registry sources per package. The other possible method is to configure your
-vsr instance as the default registry.
+dependencies we recommend configuring private registries using a
+custom registry protocol that allows for fine grained and explicit
+control of registry sources per package. The other possible method is
+to configure your vsr instance as the default registry.
 
-This guide will show you how to set up a VSR instance using both methods.
-You'll need to choose which method serves your specific workflow best and
-depending on the choice you may only setup that specific method and ignore
-the other one.
+This guide will show you how to set up a VSR instance using both
+methods. You'll need to choose which method serves your specific
+workflow best and depending on the choice you may only setup that
+specific method and ignore the other one.
 
 ### Getting started with VSR
 
-For this example we're going to use a local-running vsr instance. Here's how
-to start one:
+For this example we're going to use a local-running vsr instance.
+Here's how to start one:
 
 <Code code="$ npx -y vltpkg/vsr" title="Terminal" lang="bash" />
 
-You can consult the [VSR Quickstart](https://github.com/vltpkg/vsr?tab=readme-ov-file#quick-starts)
+You can consult the
+[VSR Quickstart](https://github.com/vltpkg/vsr?tab=readme-ov-file#quick-starts)
 for more information on how to get started.
 
 Please note, in the rest of this guide you may need to replace
-`http://localhost:1337` with the correct url in case you decide to use your
-VSR instance from an environment other than local-run.
+`http://localhost:1337` with the correct url in case you decide to use
+your VSR instance from an environment other than local-run.
 
-Log in to your VSR instance. In case you already have a custom user token
-configured than you should just use that. If you're just getting started and
-want to test using the default `admin` profile you may just use the default
-token: `xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx`.
+Log in to your VSR instance. In case you already have a custom user
+token configured than you should just use that. If you're just getting
+started and want to test using the default `admin` profile you may
+just use the default token: `xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx`.
 
 <Code
   code="$ vlt token --registry=http://localhost:1337 add"
@@ -76,22 +77,23 @@ token: `xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx`.
   lang="bash"
 />
 
-The `token` subcommand is going to open a prompt allowing you to input the
-user token.
+The `token` subcommand is going to open a prompt allowing you to input
+the user token.
 
-Please note that the default admin token is not suitable for regular usage,
-do not use it outside of just a simple experimental test setup.
+Please note that the default admin token is not suitable for regular
+usage, do not use it outside of just a simple experimental test setup.
 
 ### Set up a VSR instance using a custom registry protocol
 
-Edit your config file to set the local VSR instance as a valid custom registry
-protocol:
+Edit your config file to set the local VSR instance as a valid custom
+registry protocol:
 
 <Code code={customProtocolJsonExample} title="vlt.json" lang="json" />
 
-It's now possible to install specific packages from your VSR instance using
-`vsr:` as a package alias. In the following example we're going to install a
-package named `foo` that was published to our custom VSR instance:
+It's now possible to install specific packages from your VSR instance
+using `vsr:` as a package alias. In the following example we're going
+to install a package named `foo` that was published to our custom VSR
+instance:
 
 <Code
   code="$ vlt install foo@vsr:foo@latest"
@@ -121,5 +123,5 @@ Alternatively, you can also edit your config file:
   lang="json"
 />
 
-Using the default registry setup, each `vlt install <pkg>` will fetch assets
-from your VSR instance.
+Using the default registry setup, each `vlt install <pkg>` will fetch
+assets from your VSR instance.

--- a/www/docs/src/content/docs/index.mdx
+++ b/www/docs/src/content/docs/index.mdx
@@ -11,7 +11,9 @@ import { CardGrid, CardGridLink } from '@/components/cards/cards.tsx'
 
 # Documentation
 
-VLT delivers the tools and infrastructure developers need to streamline package management, scale efficiently, and secure a faster, more tailored web experience.
+VLT delivers the tools and infrastructure developers need to
+streamline package management, scale efficiently, and secure a faster,
+more tailored web experience.
 
 ## Getting Started
 
@@ -30,7 +32,8 @@ Learn how to get the VLT client set up in your project.
 
 ## Explore
 
-Discover the full range of commands and options available in the VLT CLI.
+Discover the full range of commands and options available in the VLT
+CLI.
 
 <CardGrid>
   <CardGridLink


### PR DESCRIPTION
This PR turns on prettier's `proseWrap: always` setting only for `.md` and `.mdx` files. We were already attempting to hard wrap our markdown, so this change codifies it and makes it fixable with `prettier --write` (or `pnpm fix`).