### PR TITLE
cli: ensure published package.json has bins set

### DIFF
--- a/infra/build/src/prepack.ts
+++ b/infra/build/src/prepack.ts
@@ -11,6 +11,7 @@ import assert from 'node:assert'
 import { resolve } from 'node:path'
 import { bundle } from './bundle.ts'
 import { compile } from './compile.ts'
+import { BINS } from './bins.ts'
 
 const { __VLT_INTERNAL_LOCAL_OPTIONAL_DEPS } = process.env
 
@@ -79,7 +80,17 @@ const main = async () => {
   // The default CLI
   if (pkg.name === 'vlt') {
     await bundle({ outdir })
-    writeFiles({ outdir, pkg })
+    writeFiles({
+      outdir,
+      pkg,
+      pkgExtra: {
+        bin: BINS.reduce<Record<string, string>>((acc, bin) => {
+          acc[bin] = `./${bin}.js`
+          return acc
+        }, {}),
+      },
+    })
+
     return
   }
 

--- a/infra/build/test/prepack.ts
+++ b/infra/build/test/prepack.ts
@@ -97,6 +97,13 @@ t.test('default vlt CLI', async t => {
     keywords: ['hi'],
     type: 'module',
     license: 'MIT',
+    bin: {
+      vlix: './vlix.js',
+      vlr: './vlr.js',
+      vlrx: './vlrx.js',
+      vlt: './vlt.js',
+      vlx: './vlx.js',
+    },
   })
   t.strictSame(
     readOutdir(dir),


### PR DESCRIPTION
I broke the published `vlt` package in #481 by accidentally removing the `package.json#bin`. This adds them back.