### PR TITLE
gui: update directory select logic

### DIFF
--- a/src/gui/src/app/queries.tsx
+++ b/src/gui/src/app/queries.tsx
@@ -15,6 +15,7 @@ import { Checkbox } from '@/components/ui/checkbox.jsx'
 import { QueriesEmptyState } from '@/components/queries/queries-empty-state.jsx'
 import { CreateQuery } from '@/components/queries/create-query.jsx'
 import { AnimatePresence, LayoutGroup, motion } from 'framer-motion'
+import { startDashboardData } from '@/lib/start-dashboard-data.js'
 
 const Queries = () => {
   const savedQueries = useGraphStore(state => state.savedQueries)
@@ -28,6 +29,17 @@ const Queries = () => {
   >([])
   const savedLabels = useGraphStore(state => state.savedQueryLabels)
   const [isCreating, setIsCreating] = useState<boolean>(false)
+  const dashboard = useGraphStore(state => state.dashboard)
+  const updateActiveRoute = useGraphStore(
+    state => state.updateActiveRoute,
+  )
+  const updateDashboard = useGraphStore(
+    state => state.updateDashboard,
+  )
+  const updateErrorCause = useGraphStore(
+    state => state.updateErrorCause,
+  )
+  const stamp = useGraphStore(state => state.stamp)
 
   const handleSelectQuery = (selectedQuery: SavedQuery) => {
     setSelectedQueries(prev => {
@@ -47,6 +59,22 @@ const Queries = () => {
       setSelectedQueries(filteredQueries)
     }
   }
+
+  useEffect(() => {
+    startDashboardData({
+      updateActiveRoute,
+      updateDashboard,
+      updateErrorCause,
+      stamp,
+    })
+
+    history.pushState(
+      { query: '', route: '/queries' },
+      '',
+      '/queries',
+    )
+    window.scrollTo(0, 0)
+  }, [stamp])
 
   useEffect(() => {
     if (savedQueries) {
@@ -119,7 +147,10 @@ const Queries = () => {
                 }}
                 exit={{ height: 0, opacity: 0, scale: 0.8 }}
                 className="mt-6">
-                <CreateQuery onClose={() => setIsCreating(false)} />
+                <CreateQuery
+                  dashboard={dashboard}
+                  onClose={() => setIsCreating(false)}
+                />
               </motion.div>
             )}
           </AnimatePresence>
@@ -169,6 +200,7 @@ const Queries = () => {
                     checked={selectedQueries.some(
                       selected => selected.id === query.id,
                     )}
+                    dashboard={dashboard}
                     handleSelect={handleSelectQuery}
                     key={query.id}
                     item={query}
@@ -179,7 +211,9 @@ const Queries = () => {
         </LayoutGroup>
       </div>
 
-      {!savedQueries?.length && <QueriesEmptyState />}
+      {!savedQueries?.length && (
+        <QueriesEmptyState dashboard={dashboard} />
+      )}
     </section>
   )
 }

--- a/src/gui/src/components/create-new-project/index.tsx
+++ b/src/gui/src/components/create-new-project/index.tsx
@@ -5,25 +5,11 @@ import { Input } from '@/components/ui/input.jsx'
 import { Button } from '@/components/ui/button.jsx'
 import { Label } from '@/components/ui/form-label.jsx'
 import { requestRouteTransition } from '@/lib/request-route-transition.js'
-import {
-  Command,
-  CommandEmpty,
-  CommandGroup,
-  CommandInput,
-  CommandItem,
-  CommandList,
-} from '@/components/ui/command.jsx'
-import { ChevronDown, Check } from 'lucide-react'
-import {
-  Popover,
-  PopoverContent,
-  PopoverTrigger,
-} from '@/components/ui/popover.jsx'
 import { motion, AnimatePresence } from 'framer-motion'
-import { cn } from '@/lib/utils.js'
 import { Grid, System, Cell } from '@/components/grid/grid.jsx'
 import { Next, Vercel, Nuxt, Node } from '@/components/icons/index.js'
 import { AnimatedBeam } from '@/components/animated-beam.jsx'
+import { DirectorySelect } from '@/components/directory-select.jsx'
 
 export type NewProjectItem = {
   path: string
@@ -156,48 +142,12 @@ export const CreateNewProjectContent = ({
           className="flex flex-col gap-6">
           <div className="flex flex-col gap-2 px-8">
             <Label htmlFor="location">Location *</Label>
-            <Popover>
-              <PopoverTrigger asChild>
-                <Button className="group flex h-[40px] w-full items-center justify-between border-[1px] border-muted bg-white text-muted-foreground shadow-none hover:bg-accent dark:bg-muted-foreground/5 dark:hover:bg-muted-foreground/10">
-                  {pathName || '~'}
-                  <ChevronDown className="text-foreground opacity-50 duration-300 group-data-[state=open]:-rotate-180" />
-                </Button>
-              </PopoverTrigger>
-              <PopoverContent className="max-h-[--radix-popover-content-available-height] w-[--radix-popover-trigger-width] p-0">
-                <Command>
-                  <CommandInput placeholder="Select location" />
-                  <CommandList>
-                    <CommandEmpty>Location not found.</CommandEmpty>
-                    <CommandGroup>
-                      {dashboard?.dashboardProjectLocations.map(
-                        location => (
-                          <CommandItem
-                            key={location.path}
-                            value={location.path}
-                            onSelect={currentValue => {
-                              setPathName(
-                                currentValue === pathName ? '' : (
-                                  currentValue
-                                ),
-                              )
-                            }}>
-                            <Check
-                              className={cn(
-                                'mr-2 size-4',
-                                pathName === location.path ?
-                                  'opacity-100'
-                                : 'opacity-0',
-                              )}
-                            />
-                            {location.readablePath}
-                          </CommandItem>
-                        ),
-                      )}
-                    </CommandGroup>
-                  </CommandList>
-                </Command>
-              </PopoverContent>
-            </Popover>
+            <DirectorySelect
+              acceptsGlobal={false}
+              dashboard={dashboard}
+              setDirectory={setPathName}
+              directory={pathName}
+            />
           </div>
 
           <div className="flex flex-col gap-2 px-8">

--- a/src/gui/src/components/directory-select.tsx
+++ b/src/gui/src/components/directory-select.tsx
@@ -1,0 +1,103 @@
+import { useState } from 'react'
+import {
+  Popover,
+  PopoverTrigger,
+  PopoverContent,
+} from '@/components/ui/popover.jsx'
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from '@/components/ui/command.jsx'
+import { Button } from '@/components/ui/button.jsx'
+import { ChevronDown, Check } from 'lucide-react'
+import { cn } from '@/lib/utils.js'
+import type { DashboardData } from '@/state/types.js'
+
+interface DirectorySelectProps {
+  directory: string
+  setDirectory: (directory: string) => void
+  dashboard?: DashboardData
+  acceptsGlobal?: boolean
+}
+
+export const DirectorySelect = ({
+  directory,
+  setDirectory,
+  dashboard,
+  acceptsGlobal = true,
+}: DirectorySelectProps) => {
+  const [displayPath, setDisplayPath] = useState<string>(
+    acceptsGlobal ? 'Global' : '',
+  )
+
+  return (
+    <Popover>
+      <PopoverTrigger asChild>
+        <Button className="group flex h-[40px] w-full items-center justify-between border-[1px] border-muted bg-white text-muted-foreground shadow-none hover:bg-accent dark:bg-muted-foreground/5 dark:hover:bg-muted-foreground/10">
+          {displayPath || 'Select a directory'}
+          <ChevronDown className="text-foreground opacity-50 duration-300 group-data-[state=open]:-rotate-180" />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent className="max-h-[--radix-popover-content-available-height] w-[--radix-popover-trigger-width] p-0">
+        <Command defaultValue={acceptsGlobal ? '' : undefined}>
+          <CommandInput placeholder="Directory" />
+          <CommandList>
+            <CommandEmpty>Directory not found.</CommandEmpty>
+            <CommandGroup>
+              {dashboard?.dashboardProjectLocations.map(location =>
+                location.readablePath === '~' && acceptsGlobal ?
+                  <CommandItem
+                    key={location.path}
+                    value=""
+                    className="hover:bg-accent"
+                    onSelect={currentValue => {
+                      setDirectory(currentValue === '' ? '' : '')
+                      setDisplayPath('Global')
+                    }}>
+                    <Check
+                      className={cn(
+                        'mr-2 size-4',
+                        directory === '' ? 'opacity-100' : (
+                          'opacity-0'
+                        ),
+                      )}
+                    />
+                    Global
+                  </CommandItem>
+                : <CommandItem
+                    key={location.path}
+                    value={location.path}
+                    onSelect={currentValue => {
+                      setDirectory(
+                        currentValue === directory ? '' : (
+                          currentValue
+                        ),
+                      )
+                      setDisplayPath(
+                        acceptsGlobal && currentValue === directory ?
+                          'Global'
+                        : location.readablePath,
+                      )
+                    }}>
+                    <Check
+                      className={cn(
+                        'mr-2 size-4',
+                        directory === location.path ?
+                          'opacity-100'
+                        : 'opacity-0',
+                      )}
+                    />
+                    {location.readablePath}
+                  </CommandItem>,
+              )}
+            </CommandGroup>
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
+  )
+}

--- a/src/gui/src/components/queries/create-query.tsx
+++ b/src/gui/src/components/queries/create-query.tsx
@@ -3,7 +3,7 @@ import { Button } from '@/components/ui/button.jsx'
 import { Input } from '@/components/ui/input.jsx'
 import { useGraphStore } from '@/state/index.js'
 import { v4 as uuidv4 } from 'uuid'
-import type { QueryLabel } from '@/state/types.js'
+import type { QueryLabel, DashboardData } from '@/state/types.js'
 import { LabelSelect } from '@/components/labels/label-select.jsx'
 import { LabelBadge } from '@/components/labels/label-badge.jsx'
 import { useToast } from '@/components/hooks/use-toast.js'
@@ -13,17 +13,26 @@ import {
   PopoverTrigger,
   PopoverContent,
 } from '@/components/ui/popover.jsx'
-import { ChevronsUpDown } from 'lucide-react'
+import {
+  Tooltip,
+  TooltipProvider,
+  TooltipTrigger,
+  TooltipContent,
+} from '@/components/ui/tooltip.jsx'
+import { ChevronsUpDown, CircleHelp } from 'lucide-react'
 import { cn } from '@/lib/utils.js'
+import { DirectorySelect } from '@/components/directory-select.jsx'
 
 interface CreateQueryProps {
   onClose: () => void
   className?: string
+  dashboard?: DashboardData
 }
 
 export const CreateQuery = ({
   className,
   onClose,
+  dashboard,
 }: CreateQueryProps) => {
   const [queryName, setQueryName] = useState<string>('')
   const [query, setQuery] = useState<string>('')
@@ -111,19 +120,32 @@ export const CreateQuery = ({
             />
           </div>
 
-          <div className="flex grow flex-col gap-2">
-            <Label className="border-none text-sm font-medium">
-              Directory
-            </Label>
-            <Input
-              type="text"
-              value={directory}
-              onChange={e => setDirectory(e.target.value)}
-              placeholder="Directory (optional)"
+          <div className="flex w-[300px] flex-col gap-2">
+            <TooltipProvider>
+              <Tooltip>
+                <TooltipTrigger className="inline-flex cursor-default items-center">
+                  <Label className="border-none text-sm font-medium">
+                    Directory (optional)
+                  </Label>
+                  <CircleHelp
+                    className="text-muted-foreground"
+                    size={18}
+                  />
+                </TooltipTrigger>
+                <TooltipContent>
+                  Set directory to 'Global' to reuse across all
+                  projects.
+                </TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
+            <DirectorySelect
+              directory={directory}
+              setDirectory={setDirectory}
+              dashboard={dashboard}
             />
           </div>
 
-          <div className="flex grow flex-col gap-2">
+          <div className="flex w-[175px] flex-col gap-2">
             <Label className="border-none text-sm font-medium">
               Labels
             </Label>

--- a/src/gui/src/components/queries/queries-empty-state.tsx
+++ b/src/gui/src/components/queries/queries-empty-state.tsx
@@ -3,8 +3,13 @@ import { Button } from '@/components/ui/button.jsx'
 import { Command, Plus, Star } from 'lucide-react'
 import { AnimatePresence, motion, useAnimate } from 'framer-motion'
 import { CreateQuery } from '@/components/queries/create-query.jsx'
+import type { DashboardData } from '@/state/types.js'
 
-const QueriesEmptyState = () => {
+interface QueriesEmptyStateProps {
+  dashboard?: DashboardData
+}
+
+const QueriesEmptyState = ({ dashboard }: QueriesEmptyStateProps) => {
   const [starScope, starAnimate] = useAnimate<HTMLDivElement>()
   const [cursorScope, cursorAnimate] = useAnimate<HTMLDivElement>()
   const [isCreating, setIsCreating] = useState<boolean>(false)
@@ -230,7 +235,8 @@ const QueriesEmptyState = () => {
             initial={{ opacity: 0, y: 10 }}
             animate={{ opacity: 1, y: 0 }}>
             <CreateQuery
-              className="relative mx-auto w-3/5"
+              dashboard={dashboard}
+              className="relative mx-auto w-full max-w-6xl"
               onClose={() => setIsCreating(false)}
             />
           </motion.div>

--- a/src/gui/src/components/queries/saved-item.tsx
+++ b/src/gui/src/components/queries/saved-item.tsx
@@ -1,5 +1,10 @@
 import { useEffect, useState } from 'react'
-import type { SavedQuery, Action, QueryLabel } from '@/state/types.js'
+import type {
+  SavedQuery,
+  Action,
+  QueryLabel,
+  DashboardData,
+} from '@/state/types.js'
 import { useGraphStore } from '@/state/index.js'
 import { Input } from '@/components/ui/input.jsx'
 import { Button } from '@/components/ui/button.jsx'
@@ -7,7 +12,7 @@ import { useToast } from '@/components/hooks/use-toast.js'
 import { Checkbox } from '@/components/ui/checkbox.jsx'
 import { Label } from '@/components/ui/label.jsx'
 import { LabelBadge } from '@/components/labels/label-badge.jsx'
-import { ArrowRight, ChevronsUpDown } from 'lucide-react'
+import { CircleHelp, ArrowRight, ChevronsUpDown } from 'lucide-react'
 import { LabelSelect } from '@/components/labels/label-select.jsx'
 import {
   Popover,
@@ -20,6 +25,7 @@ import {
   TooltipTrigger,
   TooltipContent,
 } from '@/components/ui/tooltip.jsx'
+import { DirectorySelect } from '@/components/directory-select.jsx'
 
 type SelectQueryOptions = {
   updateActiveRoute: Action['updateActiveRoute']
@@ -80,10 +86,12 @@ const SavedQueryItem = ({
   item,
   handleSelect,
   checked,
+  dashboard,
 }: {
   item: SavedQuery
   handleSelect: (item: SavedQuery) => void
   checked: boolean
+  dashboard?: DashboardData
 }) => {
   const { toast } = useToast()
   const [isExpanded, setIsExpanded] = useState<boolean>(false)
@@ -243,14 +251,27 @@ const SavedQueryItem = ({
               />
             </div>
             <div className="flex grow flex-col gap-2">
-              <Label className="border-none text-sm font-medium">
-                Directory
-              </Label>
-              <Input
-                type="text"
-                value={editContext}
-                onChange={e => setEditContext(e.target.value)}
-                placeholder="Directory (optional)"
+              <TooltipProvider>
+                <Tooltip>
+                  <TooltipTrigger className="inline-flex cursor-default items-center">
+                    <Label className="border-none text-sm font-medium">
+                      Directory (optional)
+                    </Label>
+                    <CircleHelp
+                      className="text-muted-foreground"
+                      size={18}
+                    />
+                  </TooltipTrigger>
+                  <TooltipContent>
+                    Set directory to 'Global' to reuse across all
+                    projects.
+                  </TooltipContent>
+                </Tooltip>
+              </TooltipProvider>
+              <DirectorySelect
+                dashboard={dashboard}
+                setDirectory={setEditContext}
+                directory={editContext}
               />
             </div>
             <div className="flex grow flex-col gap-2">

--- a/src/gui/test/app/__snapshots__/queries.tsx.snap
+++ b/src/gui/test/app/__snapshots__/queries.tsx.snap
@@ -1,6 +1,6 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`labels view > labels render default 1`] = `
+exports[`queries view > queries render default 1`] = `
 
 <section class="flex h-full max-h-[calc(100svh-65px-16px)] w-full grow flex-col overflow-y-scroll rounded-b-lg border-[1px] px-8">
   <div class="flex w-full max-w-8xl flex-col">

--- a/src/gui/test/app/queries.tsx
+++ b/src/gui/test/app/queries.tsx
@@ -57,8 +57,8 @@ afterEach(() => {
   cleanup()
 })
 
-describe('labels view', () => {
-  it('labels render default', () => {
+describe('queries view', () => {
+  it('queries render default', () => {
     const Container = () => {
       return <Queries />
     }

--- a/src/gui/test/components/__snapshots__/directory-select.tsx.snap
+++ b/src/gui/test/components/__snapshots__/directory-select.tsx.snap
@@ -1,0 +1,36 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`directory select > renders correctly 1`] = `
+
+<gui-popover>
+  <gui-popover-trigger aschild="true">
+    <gui-button classname="group flex h-[40px] w-full items-center justify-between border-[1px] border-muted bg-white text-muted-foreground shadow-none hover:bg-accent dark:bg-muted-foreground/5 dark:hover:bg-muted-foreground/10">
+      Global
+      <gui-chevron-down-icon classname="text-foreground opacity-50 duration-300 group-data-[state=open]:-rotate-180">
+      </gui-chevron-down-icon>
+    </gui-button>
+  </gui-popover-trigger>
+  <gui-popover-content classname="max-h-[--radix-popover-content-available-height] w-[--radix-popover-trigger-width] p-0">
+    <gui-command>
+      <gui-command-input placeholder="Directory">
+      </gui-command-input>
+      <gui-command-list>
+        <gui-command-empty>
+          Directory not found.
+        </gui-command-empty>
+        <gui-command-group>
+          <gui-command-item
+            value
+            classname="hover:bg-accent"
+          >
+            <gui-check-icon classname="mr-2 size-4 opacity-100">
+            </gui-check-icon>
+            Global
+          </gui-command-item>
+        </gui-command-group>
+      </gui-command-list>
+    </gui-command>
+  </gui-popover-content>
+</gui-popover>
+
+`;

--- a/src/gui/test/components/create-new-project/__snapshots__/index.tsx.snap
+++ b/src/gui/test/components/create-new-project/__snapshots__/index.tsx.snap
@@ -33,28 +33,11 @@ exports[`create-new-project-content render default 1`] = `
           <gui-label htmlfor="location">
             Location *
           </gui-label>
-          <gui-popover>
-            <gui-popover-trigger aschild="true">
-              <gui-button classname="group flex h-[40px] w-full items-center justify-between border-[1px] border-muted bg-white text-muted-foreground shadow-none hover:bg-accent dark:bg-muted-foreground/5 dark:hover:bg-muted-foreground/10">
-                ~
-                <gui-chevron-down-icon classname="text-foreground opacity-50 duration-300 group-data-[state=open]:-rotate-180">
-                </gui-chevron-down-icon>
-              </gui-button>
-            </gui-popover-trigger>
-            <gui-popover-content classname="max-h-[--radix-popover-content-available-height] w-[--radix-popover-trigger-width] p-0">
-              <gui-command>
-                <gui-command-input placeholder="Select location">
-                </gui-command-input>
-                <gui-command-list>
-                  <gui-command-empty>
-                    Location not found.
-                  </gui-command-empty>
-                  <gui-command-group>
-                  </gui-command-group>
-                </gui-command-list>
-              </gui-command>
-            </gui-popover-content>
-          </gui-popover>
+          <gui-directory-select
+            acceptsglobal="false"
+            directory
+          >
+          </gui-directory-select>
         </div>
         <div class="flex flex-col gap-2 px-8">
           <gui-label htmlfor="author">
@@ -226,33 +209,12 @@ exports[`create-new-project-content with results 1`] = `
           <gui-label htmlfor="location">
             Location *
           </gui-label>
-          <gui-popover>
-            <gui-popover-trigger aschild="true">
-              <gui-button classname="group flex h-[40px] w-full items-center justify-between border-[1px] border-muted bg-white text-muted-foreground shadow-none hover:bg-accent dark:bg-muted-foreground/5 dark:hover:bg-muted-foreground/10">
-                ~
-                <gui-chevron-down-icon classname="text-foreground opacity-50 duration-300 group-data-[state=open]:-rotate-180">
-                </gui-chevron-down-icon>
-              </gui-button>
-            </gui-popover-trigger>
-            <gui-popover-content classname="max-h-[--radix-popover-content-available-height] w-[--radix-popover-trigger-width] p-0">
-              <gui-command>
-                <gui-command-input placeholder="Select location">
-                </gui-command-input>
-                <gui-command-list>
-                  <gui-command-empty>
-                    Location not found.
-                  </gui-command-empty>
-                  <gui-command-group>
-                    <gui-command-item value="/home/user">
-                      <gui-check-icon classname="mr-2 size-4 opacity-0">
-                      </gui-check-icon>
-                      ~
-                    </gui-command-item>
-                  </gui-command-group>
-                </gui-command-list>
-              </gui-command>
-            </gui-popover-content>
-          </gui-popover>
+          <gui-directory-select
+            acceptsglobal="false"
+            dashboard="[object Object]"
+            directory
+          >
+          </gui-directory-select>
         </div>
         <div class="flex flex-col gap-2 px-8">
           <gui-label htmlfor="author">

--- a/src/gui/test/components/create-new-project/index.tsx
+++ b/src/gui/test/components/create-new-project/index.tsx
@@ -16,26 +16,6 @@ vi.mock('@/components/ui/form-label.jsx', () => ({
   Label: 'gui-label',
 }))
 
-vi.mock('@/components/ui/command.jsx', () => ({
-  Command: 'gui-command',
-  CommandEmpty: 'gui-command-empty',
-  CommandGroup: 'gui-command-group',
-  CommandInput: 'gui-command-input',
-  CommandItem: 'gui-command-item',
-  CommandList: 'gui-command-list',
-}))
-
-vi.mock('lucide-react', () => ({
-  ChevronDown: 'gui-chevron-down-icon',
-  Check: 'gui-check-icon',
-}))
-
-vi.mock('@/components/ui/popover.jsx', () => ({
-  Popover: 'gui-popover',
-  PopoverContent: 'gui-popover-content',
-  PopoverTrigger: 'gui-popover-trigger',
-}))
-
 vi.mock('@/components/grid/grid.jsx', () => ({
   Grid: 'gui-grid',
   System: 'gui-grid-system',
@@ -51,6 +31,10 @@ vi.mock('@/components/icons/index.js', () => ({
 
 vi.mock('@/components/animated-beam.jsx', () => ({
   AnimatedBeam: 'gui-animated-beam',
+}))
+
+vi.mock('@/components/directory-select.jsx', () => ({
+  DirectorySelect: 'gui-directory-select',
 }))
 
 expect.addSnapshotSerializer({

--- a/src/gui/test/components/directory-select.tsx
+++ b/src/gui/test/components/directory-select.tsx
@@ -1,0 +1,88 @@
+import { vi, expect, afterEach, describe, it } from 'vitest'
+import { cleanup, render } from '@testing-library/react'
+import html from 'diffable-html'
+import { useGraphStore as useStore } from '@/state/index.js'
+import { DirectorySelect } from '@/components/directory-select.jsx'
+import type { DashboardData } from '@/state/types.js'
+
+vi.mock('@/components/ui/popover.jsx', () => ({
+  Popover: 'gui-popover',
+  PopoverTrigger: 'gui-popover-trigger',
+  PopoverContent: 'gui-popover-content',
+}))
+
+vi.mock('@/components/ui/command.jsx', () => ({
+  Command: 'gui-command',
+  CommandEmpty: 'gui-command-empty',
+  CommandGroup: 'gui-command-group',
+  CommandInput: 'gui-command-input',
+  CommandItem: 'gui-command-item',
+  CommandList: 'gui-command-list',
+}))
+
+vi.mock('@/components/ui/button.jsx', () => ({
+  Button: 'gui-button',
+}))
+
+vi.mock('lucide-react', () => ({
+  ChevronDown: 'gui-chevron-down-icon',
+  Check: 'gui-check-icon',
+}))
+
+expect.addSnapshotSerializer({
+  serialize: v => html(v),
+  test: () => true,
+})
+
+afterEach(() => {
+  const CleanUp = () => (useStore(state => state.reset)(), '')
+  render(<CleanUp />)
+  cleanup()
+})
+
+describe('directory select', () => {
+  it('renders correctly', () => {
+    const mockSetDirectory = vi.fn()
+    const mockDirectory = ''
+
+    const mockDashboard = {
+      buildVersion: '1.0.0',
+      cwd: '/home/user',
+      defaultAuthor: 'Ruy Adorno',
+      dashboardProjectLocations: [
+        { path: '/home/user', readablePath: '~' },
+      ],
+      projects: [
+        {
+          name: 'project-foo',
+          readablePath: '~/project-foo',
+          path: '/home/user/project-foo',
+          manifest: { name: 'project-foo', version: '1.0.0' },
+          tools: ['node', 'vlt'],
+          mtime: 1730498483044,
+        },
+        {
+          name: 'project-bar',
+          readablePath: '~/project-foo',
+          path: '/home/user/project-bar',
+          manifest: { name: 'project-bar', version: '1.0.0' },
+          tools: ['node', 'vlt'],
+          mtime: 1730498491029,
+        },
+      ],
+    } satisfies DashboardData
+
+    const Container = () => {
+      return (
+        <DirectorySelect
+          directory={mockDirectory}
+          setDirectory={mockSetDirectory}
+          dashboard={mockDashboard}
+        />
+      )
+    }
+
+    const { container } = render(<Container />)
+    expect(container.innerHTML).toMatchSnapshot()
+  })
+})

--- a/src/gui/test/components/queries/__snapshots__/create-query.tsx.snap
+++ b/src/gui/test/components/queries/__snapshots__/create-query.tsx.snap
@@ -34,18 +34,28 @@ exports[`create-query > should render correctly 1`] = `
         >
         </gui-input>
       </div>
-      <div class="flex grow flex-col gap-2">
-        <gui-label classname="border-none text-sm font-medium">
-          Directory
-        </gui-label>
-        <gui-input
-          type="text"
-          value
-          placeholder="Directory (optional)"
-        >
-        </gui-input>
+      <div class="flex w-[300px] flex-col gap-2">
+        <gui-tooltip-provider>
+          <gui-tooltip>
+            <gui-tooltip-trigger classname="inline-flex cursor-default items-center">
+              <gui-label classname="border-none text-sm font-medium">
+                Directory (optional)
+              </gui-label>
+              <gui-circle-help-icon
+                classname="text-muted-foreground"
+                size="18"
+              >
+              </gui-circle-help-icon>
+            </gui-tooltip-trigger>
+            <gui-tooltip-content>
+              Set directory to 'Global' to reuse across all projects.
+            </gui-tooltip-content>
+          </gui-tooltip>
+        </gui-tooltip-provider>
+        <gui-directory-select directory>
+        </gui-directory-select>
       </div>
-      <div class="flex grow flex-col gap-2">
+      <div class="flex w-[175px] flex-col gap-2">
         <gui-label classname="border-none text-sm font-medium">
           Labels
         </gui-label>

--- a/src/gui/test/components/queries/create-query.tsx
+++ b/src/gui/test/components/queries/create-query.tsx
@@ -31,8 +31,20 @@ vi.mock('@/components/ui/popover.jsx', () => ({
   PopoverTrigger: 'gui-popover-trigger',
 }))
 
+vi.mock('@/components/ui/tooltip.jsx', () => ({
+  Tooltip: 'gui-tooltip',
+  TooltipContent: 'gui-tooltip-content',
+  TooltipProvider: 'gui-tooltip-provider',
+  TooltipTrigger: 'gui-tooltip-trigger',
+}))
+
 vi.mock('lucide-react', () => ({
   ChevronsUpDown: 'gui-chevron-icon',
+  CircleHelp: 'gui-circle-help-icon',
+}))
+
+vi.mock('@/components/directory-select.jsx', () => ({
+  DirectorySelect: 'gui-directory-select',
 }))
 
 expect.addSnapshotSerializer({

--- a/src/gui/test/components/queries/saved-item.tsx
+++ b/src/gui/test/components/queries/saved-item.tsx
@@ -26,6 +26,7 @@ vi.mock('@/components/labels/label-badge.jsx', () => ({
 }))
 
 vi.mock('lucide-react', () => ({
+  CircleHelp: 'gui-circle-help-icon',
   ArrowRight: 'gui-arrow-right-icon',
   ChevronsUpDown: 'gui-chevrons-up-down-icon',
 }))
@@ -45,6 +46,10 @@ vi.mock('@/components/ui/tooltip.jsx', () => ({
   TooltipProvider: 'gui-tooltip-provider',
   TooltipTrigger: 'gui-tooltip-trigger',
   TooltipContent: 'gui-tooltip-content',
+}))
+
+vi.mock('@/components/directory-select.jsx', () => ({
+  DirectorySelect: 'gui-directory-select',
 }))
 
 expect.addSnapshotSerializer({


### PR DESCRIPTION
Replaces the old directory select logic, which was previous just an input field with a command/combobox that allows a user to select the directory from a list.

This PR creates a new `directory-select` component to reuse whenever the UI requires it.

Closes vltpkg/statusboard#84

### Before
<img width="1332" alt="Screenshot 2025-03-07 at 15 30 54" src="https://github.com/user-attachments/assets/89d483b4-138d-4806-af70-264d19a8f13f" />

### After
<img width="1306" alt="Screenshot 2025-03-14 at 12 51 52" src="https://github.com/user-attachments/assets/d69ee237-f198-47b7-bc86-705eb2ecc07d" />

<img width="463" alt="Screenshot 2025-03-14 at 12 52 00" src="https://github.com/user-attachments/assets/6562bda4-57f9-4341-b029-27185adcb80c" />

- **feat**: creates `directory-select` component

- removes old path select, replaces with directory-select component
- updates queries saved-item with new `directory-select` comp
- updates `queries` view to fetch dashboard data
- updates directory select logic for new `directory-select` comp
- fetches dashboardData to pass into `create-query` comp
- chore: lint & format
