### PR TITLE
gui: integrate react router

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,24 +33,6 @@ catalogs:
     eslint:
       specifier: ^9.20.0
       version: 9.20.0
-    graph-run:
-      specifier: ^1.0.4
-      version: 1.0.4
-    lru-cache:
-      specifier: ^11.0.2
-      version: 11.0.2
-    package-json-from-dist:
-      specifier: ^1.0.0
-      version: 1.0.1
-    pacote:
-      specifier: ^18.0.6
-      version: 18.0.6
-    path-scurry:
-      specifier: ^2.0.0
-      version: 2.0.0
-    polite-json:
-      specifier: ^5.0.0
-      version: 5.0.0
     prettier:
       specifier: ^3.4.2
       version: 3.4.2
@@ -87,9 +69,6 @@ catalogs:
     typescript-eslint:
       specifier: ^8.23.0
       version: 8.23.0
-    walk-up-path:
-      specifier: ^4.0.0
-      version: 4.0.0
 
 patchedDependencies:
   tshy:
@@ -832,6 +811,9 @@ importers:
       react-dom:
         specifier: ^18.3.1
         version: 18.3.1(react@18.3.1)
+      react-router:
+        specifier: ^7.3.0
+        version: 7.3.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       recharts:
         specifier: ^2.15.1
         version: 2.15.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -5083,6 +5065,10 @@ packages:
     resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
     engines: {node: '>= 0.6'}
 
+  cookie@1.0.2:
+    resolution: {integrity: sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==}
+    engines: {node: '>=18'}
+
   cross-spawn@7.0.3:
     resolution: {integrity: sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==}
     engines: {node: '>= 8'}
@@ -7256,6 +7242,16 @@ packages:
       '@types/react':
         optional: true
 
+  react-router@7.3.0:
+    resolution: {integrity: sha512-466f2W7HIWaNXTKM5nHTqNxLrHTyXybm7R0eBlVSt0k/u55tTCDO194OIx/NrYD4TS5SXKTNekXfT37kMKUjgw==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      react: '>=18'
+      react-dom: '>=18'
+    peerDependenciesMeta:
+      react-dom:
+        optional: true
+
   react-smooth@4.0.4:
     resolution: {integrity: sha512-gnGKTpYwqL0Iii09gHobNolvX4Kiq4PKx6eWBCYYix+8cdw+cGo3do906l1NBPKkSWx1DghC1dlWG9L2uGd61Q==}
     peerDependencies:
@@ -7521,6 +7517,9 @@ packages:
 
   serve-handler@6.1.6:
     resolution: {integrity: sha512-x5RL9Y2p5+Sh3D38Fh9i/iQ5ZK+e4xuXRd/pGbM4D13tgo/MGwbttUk8emytcr1YYzBYs+apnUngBDFYfpjPuQ==}
+
+  set-cookie-parser@2.7.1:
+    resolution: {integrity: sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==}
 
   set-function-length@1.2.2:
     resolution: {integrity: sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==}
@@ -7931,6 +7930,9 @@ packages:
   tuf-js@2.2.1:
     resolution: {integrity: sha512-GwIJau9XaA8nLVbUXsN3IlFi7WmQ48gBUrl3FTkkL/XLu/POhBzfmX9hd33FNMX1qAsfl6ozO1iMmW9NC8YniA==}
     engines: {node: ^16.14.0 || >=18.0.0}
+
+  turbo-stream@2.4.0:
+    resolution: {integrity: sha512-FHncC10WpBd2eOmGwpmQsWLDoK4cqsA/UT/GqNoaKOQnT8uzhtCbg3EoUDMvqpOSAI0S26mr0rkjzbOO6S3v1g==}
 
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
@@ -11984,6 +11986,8 @@ snapshots:
 
   cookie@0.7.2: {}
 
+  cookie@1.0.2: {}
+
   cross-spawn@7.0.3:
     dependencies:
       path-key: 3.1.1
@@ -14719,6 +14723,16 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.18
 
+  react-router@7.3.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      '@types/cookie': 0.6.0
+      cookie: 1.0.2
+      react: 18.3.1
+      set-cookie-parser: 2.7.1
+      turbo-stream: 2.4.0
+    optionalDependencies:
+      react-dom: 18.3.1(react@18.3.1)
+
   react-smooth@4.0.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
       fast-equals: 5.2.2
@@ -15112,6 +15126,8 @@ snapshots:
       path-is-inside: 1.0.2
       path-to-regexp: 3.3.0
       range-parser: 1.2.0
+
+  set-cookie-parser@2.7.1: {}
 
   set-function-length@1.2.2:
     dependencies:
@@ -15683,6 +15699,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  turbo-stream@2.4.0: {}
+
   type-check@0.4.0:
     dependencies:
       prelude-ls: 1.2.1
@@ -15863,7 +15881,7 @@ snapshots:
     dependencies:
       browserslist: 4.24.0
       escalade: 3.2.0
-      picocolors: 1.1.0
+      picocolors: 1.1.1
 
   uri-js@4.4.1:
     dependencies:

--- a/src/gui/package.json
+++ b/src/gui/package.json
@@ -38,6 +38,7 @@
     "lucide-react": "^0.453.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
+    "react-router": "^7.3.0",
     "recharts": "^2.15.1",
     "shiki": "^1.22.2",
     "tailwind-merge": "^2.5.2",

--- a/src/gui/src/app/create-new-project.tsx
+++ b/src/gui/src/app/create-new-project.tsx
@@ -1,3 +1,4 @@
+import { useNavigate } from 'react-router'
 import { useState, useEffect } from 'react'
 import { useGraphStore } from '@/state/index.js'
 import { CreateNewProjectContent } from '@/components/create-new-project/index.jsx'
@@ -6,9 +7,7 @@ import { InlineCode } from '@/components/ui/inline-code.jsx'
 import { LoadingSpinner } from '@/components/ui/loading-spinner.jsx'
 
 export const CreateNewProject = () => {
-  const updateActiveRoute = useGraphStore(
-    state => state.updateActiveRoute,
-  )
+  const navigate = useNavigate()
   const updateDashboard = useGraphStore(
     state => state.updateDashboard,
   )
@@ -21,18 +20,11 @@ export const CreateNewProject = () => {
 
   useEffect(() => {
     startDashboardData({
-      updateActiveRoute,
+      navigate,
       updateDashboard,
       updateErrorCause,
       stamp,
     })
-
-    history.pushState(
-      { query: '', route: '/new-project' },
-      '',
-      '/new-project',
-    )
-    window.scrollTo(0, 0)
   }, [stamp])
 
   if (inProgress)

--- a/src/gui/src/app/dashboard.tsx
+++ b/src/gui/src/app/dashboard.tsx
@@ -1,3 +1,4 @@
+import { useNavigate } from 'react-router'
 import { useEffect } from 'react'
 import { DashboardGrid } from '@/components/dashboard-grid/index.jsx'
 import { useGraphStore } from '@/state/index.js'
@@ -5,9 +6,7 @@ import { startDashboardData } from '@/lib/start-dashboard-data.js'
 
 export const Dashboard = () => {
   const dashboard = useGraphStore(state => state.dashboard)
-  const updateActiveRoute = useGraphStore(
-    state => state.updateActiveRoute,
-  )
+  const navigate = useNavigate()
   const updateDashboard = useGraphStore(
     state => state.updateDashboard,
   )
@@ -18,19 +17,11 @@ export const Dashboard = () => {
 
   useEffect(() => {
     startDashboardData({
-      updateActiveRoute,
+      navigate,
       updateErrorCause,
       updateDashboard,
       stamp,
     })
-
-    history.pushState(
-      { query: '', route: '/dashboard' },
-      '',
-      '/dashboard',
-    )
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-    window.scrollTo?.(0, 0)
   }, [stamp])
 
   return (

--- a/src/gui/src/app/error-found.tsx
+++ b/src/gui/src/app/error-found.tsx
@@ -1,29 +1,21 @@
-import { useEffect } from 'react'
+import { useNavigate } from 'react-router'
 import type { MouseEvent } from 'react'
 import { useGraphStore } from '@/state/index.js'
 import { Button } from '@/components/ui/button.jsx'
 import { ArrowRight, TriangleAlert } from 'lucide-react'
 
 export const ErrorFound = () => {
-  const updateActiveRoute = useGraphStore(
-    state => state.updateActiveRoute,
-  )
-  const previousRoute = useGraphStore(state => state.previousRoute)
+  const navigate = useNavigate()
   const errorCause = useGraphStore(state => state.errorCause)
-
-  useEffect(() => {
-    history.pushState({ query: '', route: '/error' }, '', '/error')
-    window.scrollTo(0, 0)
-  })
 
   const onDashboardButtonClick = (e: MouseEvent) => {
     e.preventDefault()
-    updateActiveRoute('/dashboard')
+    void navigate('/dashboard')
   }
 
   const onBackButtonClick = (e: MouseEvent) => {
     e.preventDefault()
-    updateActiveRoute(previousRoute)
+    void navigate(-1)
   }
 
   return (

--- a/src/gui/src/app/explorer.tsx
+++ b/src/gui/src/app/explorer.tsx
@@ -1,3 +1,4 @@
+import { useNavigate } from 'react-router'
 import { useEffect, useRef } from 'react'
 import { Query } from '@vltpkg/query'
 import { SearchBar } from '@/components/search-bar.jsx'
@@ -48,9 +49,7 @@ const startGraphData = async ({
 }
 
 export const Explorer = () => {
-  const updateActiveRoute = useGraphStore(
-    state => state.updateActiveRoute,
-  )
+  const navigate = useNavigate()
   const updateErrorCause = useGraphStore(
     state => state.updateErrorCause,
   )
@@ -79,7 +78,7 @@ export const Explorer = () => {
       stamp,
     }).catch((err: unknown) => {
       console.error(err)
-      updateActiveRoute('/error')
+      void navigate('/error')
       updateErrorCause('Failed to initialize explorer.')
     })
   }, [stamp])

--- a/src/gui/src/app/queries.tsx
+++ b/src/gui/src/app/queries.tsx
@@ -1,3 +1,4 @@
+import { useNavigate, NavLink } from 'react-router'
 import { useEffect, useState } from 'react'
 import { useGraphStore } from '@/state/index.js'
 import type { SavedQuery } from '@/state/types.js'
@@ -18,6 +19,7 @@ import { AnimatePresence, LayoutGroup, motion } from 'framer-motion'
 import { startDashboardData } from '@/lib/start-dashboard-data.js'
 
 const Queries = () => {
+  const navigate = useNavigate()
   const savedQueries = useGraphStore(state => state.savedQueries)
   const [filteredQueries, setFilteredQueries] = useState<
     SavedQuery[]
@@ -30,9 +32,6 @@ const Queries = () => {
   const savedLabels = useGraphStore(state => state.savedQueryLabels)
   const [isCreating, setIsCreating] = useState<boolean>(false)
   const dashboard = useGraphStore(state => state.dashboard)
-  const updateActiveRoute = useGraphStore(
-    state => state.updateActiveRoute,
-  )
   const updateDashboard = useGraphStore(
     state => state.updateDashboard,
   )
@@ -62,18 +61,11 @@ const Queries = () => {
 
   useEffect(() => {
     startDashboardData({
-      updateActiveRoute,
+      navigate,
       updateDashboard,
       updateErrorCause,
       stamp,
     })
-
-    history.pushState(
-      { query: '', route: '/queries' },
-      '',
-      '/queries',
-    )
-    window.scrollTo(0, 0)
   }, [stamp])
 
   useEffect(() => {
@@ -122,13 +114,13 @@ const Queries = () => {
               </Button>
             )}
             <Button asChild variant="outline">
-              <a href="/labels">
+              <NavLink to="/labels">
                 <Tag />
                 <span>Labels</span>
                 <Badge variant="secondary">
                   {savedLabels?.length}
                 </Badge>
-              </a>
+              </NavLink>
             </Button>
           </div>
         </div>

--- a/src/gui/src/components/create-new-project/index.tsx
+++ b/src/gui/src/components/create-new-project/index.tsx
@@ -1,3 +1,4 @@
+import { useNavigate } from 'react-router'
 import { useState, useRef } from 'react'
 import type { SyntheticEvent } from 'react'
 import { useGraphStore } from '@/state/index.js'
@@ -26,10 +27,8 @@ export const CreateNewProjectContent = ({
   inProgress,
   setInProgress,
 }: CreateNewProjectContentProps) => {
+  const navigate = useNavigate()
   const dashboard = useGraphStore(state => state.dashboard)
-  const updateActiveRoute = useGraphStore(
-    state => state.updateActiveRoute,
-  )
   const updateErrorCause = useGraphStore(
     state => state.updateErrorCause,
   )
@@ -75,7 +74,7 @@ export const CreateNewProjectContent = ({
     if (inProgress) return
     setInProgress(true)
     void requestRouteTransition<NewProjectItem>({
-      updateActiveRoute,
+      navigate,
       updateErrorCause,
       updateQuery,
       updateStamp,

--- a/src/gui/src/components/dashboard-grid/index.tsx
+++ b/src/gui/src/components/dashboard-grid/index.tsx
@@ -1,4 +1,5 @@
 import { motion, AnimatePresence } from 'framer-motion'
+import { useNavigate, NavLink } from 'react-router'
 import { useEffect, useState } from 'react'
 import type { MouseEvent } from 'react'
 import type { DashboardDataProject } from '@/state/types.js'
@@ -43,8 +44,8 @@ export const DashboardItem = ({
   }
 
   return (
-    <a
-      href="#"
+    <div
+      role="link"
       className="group relative w-full cursor-default"
       onClick={onDashboardItemClick}>
       {/* top */}
@@ -84,15 +85,13 @@ export const DashboardItem = ({
           </Tooltip>
         </TooltipProvider>
       </div>
-    </a>
+    </div>
   )
 }
 
 export const DashboardGrid = () => {
+  const navigate = useNavigate()
   const dashboard = useGraphStore(state => state.dashboard)
-  const updateActiveRoute = useGraphStore(
-    state => state.updateActiveRoute,
-  )
   const updateErrorCause = useGraphStore(
     state => state.updateErrorCause,
   )
@@ -118,7 +117,7 @@ export const DashboardGrid = () => {
     setInProgress(true)
 
     void requestRouteTransition<{ path: string }>({
-      updateActiveRoute,
+      navigate,
       updateErrorCause,
       updateQuery,
       updateStamp,
@@ -140,10 +139,6 @@ export const DashboardGrid = () => {
       )
     }
   }, [dashboard])
-
-  const onCreateNewProjectClick = () => {
-    updateActiveRoute('/new-project')
-  }
 
   if (inProgress) {
     return (
@@ -199,11 +194,11 @@ export const DashboardGrid = () => {
               />
             </motion.div>
           }
-          <Button
-            onClick={onCreateNewProjectClick}
-            className="ml-auto">
-            <Plus size={24} />
-            Create New Project
+          <Button asChild className="ml-auto">
+            <NavLink to="/create-new-project">
+              <Plus size={24} />
+              Create New Project
+            </NavLink>
           </Button>
         </div>
       </div>

--- a/src/gui/src/components/explorer-grid/dependency-side-bar.tsx
+++ b/src/gui/src/components/explorer-grid/dependency-side-bar.tsx
@@ -1,3 +1,4 @@
+import { useNavigate } from 'react-router'
 import { useEffect, useState } from 'react'
 import { Plus } from 'lucide-react'
 import type { DepID } from '@vltpkg/dep-id/browser'
@@ -120,12 +121,10 @@ export const DependencySideBar = ({
   onDependencyClick,
   uninstalledDependencies,
 }: DependencySideBarProps) => {
+  const navigate = useNavigate()
   const [scope, animate] = useAnimate()
   const { toast } = useToast()
   const updateStamp = useGraphStore(state => state.updateStamp)
-  const updateActiveRoute = useGraphStore(
-    state => state.updateActiveRoute,
-  )
   const updateErrorCause = useGraphStore(
     state => state.updateErrorCause,
   )
@@ -185,7 +184,7 @@ export const DependencySideBar = ({
       onSuccessful: onSuccessfulInstall,
     }).catch((err: unknown) => {
       console.error(err)
-      updateActiveRoute('/error')
+      void navigate('/error')
       updateErrorCause(
         'Unexpected error trying to install dependency.',
       )
@@ -208,7 +207,7 @@ export const DependencySideBar = ({
       onSuccessful: onSuccessfulUninstall,
     }).catch((err: unknown) => {
       console.error(err)
-      updateActiveRoute('/error')
+      void navigate('/error')
       updateErrorCause(
         'Unexpected error trying to uninstall dependency.',
       )

--- a/src/gui/src/components/explorer-grid/empty-results-state.tsx
+++ b/src/gui/src/components/explorer-grid/empty-results-state.tsx
@@ -1,15 +1,14 @@
+import { useNavigate } from 'react-router'
 import { Button } from '@/components/ui/button.jsx'
 import { ArrowRight } from 'lucide-react'
 import { useGraphStore } from '@/state/index.js'
 
 const EmptyResultsState = () => {
-  const updateActiveRoute = useGraphStore(
-    state => state.updateActiveRoute,
-  )
+  const navigate = useNavigate()
   const updateQuery = useGraphStore(state => state.updateQuery)
 
   const navigateToRoot = () => {
-    updateActiveRoute('/explore')
+    void navigate('/explore')
     updateQuery(':root')
   }
 

--- a/src/gui/src/components/explorer-grid/query-matches.tsx
+++ b/src/gui/src/components/explorer-grid/query-matches.tsx
@@ -1,3 +1,4 @@
+import { NavLink, useNavigate } from 'react-router'
 import type { SavedQuery } from '@/state/types.js'
 import { useEffect, useState } from 'react'
 import { useGraphStore } from '@/state/index.js'
@@ -51,15 +52,10 @@ const LabelTags = ({
   queries: SavedQuery[]
   className?: string
 }) => {
-  const updateRoute = useGraphStore(state => state.updateActiveRoute)
+  const navigate = useNavigate()
 
   const navigateToLabel = (labelName: string) => {
-    updateRoute('/labels')
-    history.pushState(
-      { route: '/labels' },
-      '',
-      `/labels?name=${encodeURIComponent(labelName)}`,
-    )
+    void navigate(`/labels?name=${encodeURIComponent(labelName)}`)
   }
 
   return (
@@ -122,11 +118,11 @@ const Notification = ({
   query: string
 }) => {
   return (
-    <a
-      href={`/queries?query=${encodeURIComponent(query)}`}
+    <NavLink
+      to={`/queries?query=${encodeURIComponent(query)}`}
       className={`flex h-[1.5rem] cursor-pointer items-center justify-center rounded-sm border border-muted-foreground/20 bg-muted px-2 py-1 text-[10px] transition-all ${className}`}>
       Matches {numberOfQueries} Queries
-    </a>
+    </NavLink>
   )
 }
 

--- a/src/gui/src/components/explorer-grid/root-button.tsx
+++ b/src/gui/src/components/explorer-grid/root-button.tsx
@@ -1,3 +1,4 @@
+import { useNavigate } from 'react-router'
 import { Button } from '@/components/ui/button.jsx'
 import { House } from 'lucide-react'
 import {
@@ -9,14 +10,12 @@ import {
 import { DEFAULT_QUERY, useGraphStore } from '@/state/index.js'
 
 const RootButton = () => {
-  const updateActiveRoute = useGraphStore(
-    state => state.updateActiveRoute,
-  )
+  const navigate = useNavigate()
   const updateQuery = useGraphStore(state => state.updateQuery)
   const query = useGraphStore(state => state.query)
 
   const onClick = () => {
-    updateActiveRoute('/explore')
+    void navigate('/explore')
     updateQuery(':root')
   }
 

--- a/src/gui/src/components/explorer-grid/setup-project.tsx
+++ b/src/gui/src/components/explorer-grid/setup-project.tsx
@@ -1,3 +1,4 @@
+import { useNavigate } from 'react-router'
 import { useState } from 'react'
 import type { SyntheticEvent } from 'react'
 import { useGraphStore } from '@/state/index.js'
@@ -7,9 +8,7 @@ import { LoadingSpinner } from '@/components/ui/loading-spinner.jsx'
 import { InlineCode } from '@/components/ui/inline-code.jsx'
 
 export const SetupProject = () => {
-  const updateActiveRoute = useGraphStore(
-    state => state.updateActiveRoute,
-  )
+  const navigate = useNavigate()
   const updateErrorCause = useGraphStore(
     state => state.updateErrorCause,
   )
@@ -19,7 +18,7 @@ export const SetupProject = () => {
 
   const onDashboardClick = (e: SyntheticEvent) => {
     e.preventDefault()
-    updateActiveRoute('/')
+    void navigate('/')
   }
 
   const onInstallClick = (e: SyntheticEvent) => {
@@ -27,7 +26,7 @@ export const SetupProject = () => {
     e.preventDefault()
     setInProgress(true)
     void requestRouteTransition<{ add: Record<string, string>[] }>({
-      updateActiveRoute,
+      navigate,
       updateErrorCause,
       updateQuery,
       updateStamp,

--- a/src/gui/src/components/labels/label.tsx
+++ b/src/gui/src/components/labels/label.tsx
@@ -1,3 +1,4 @@
+import { useNavigate } from 'react-router'
 import { useEffect, useState } from 'react'
 import { Checkbox } from '@/components/ui/checkbox.jsx'
 import { Button } from '@/components/ui/button.jsx'
@@ -25,6 +26,7 @@ interface LabelProps {
 }
 
 const Label = ({ queryLabel, checked, handleSelect }: LabelProps) => {
+  const navigate = useNavigate()
   const [isExpanded, setIsExpanded] = useState<boolean>(false)
   const [editDescription, setEditDescription] = useState<string>('')
   const [editName, setEditName] = useState<string>('')
@@ -36,7 +38,6 @@ const Label = ({ queryLabel, checked, handleSelect }: LabelProps) => {
   const [queriesReferenced, setQueriesReferenced] =
     useState<number>(0)
   const savedQueries = useGraphStore(state => state.savedQueries)
-  const updateRoute = useGraphStore(state => state.updateActiveRoute)
 
   const handleEdit = () => {
     setIsExpanded(!isExpanded)
@@ -57,12 +58,7 @@ const Label = ({ queryLabel, checked, handleSelect }: LabelProps) => {
   }
 
   const navigateToRef = () => {
-    updateRoute('/queries')
-    history.pushState(
-      { route: '/queries' },
-      '',
-      `/queries?label=${encodeURIComponent(editName)}`,
-    )
+    void navigate(`/queries?label=${encodeURIComponent(editName)}`)
   }
 
   useEffect(() => {

--- a/src/gui/src/components/navigation/header.tsx
+++ b/src/gui/src/components/navigation/header.tsx
@@ -1,3 +1,4 @@
+import { useLocation } from 'react-router'
 import { useEffect, useState } from 'react'
 import { useGraphStore } from '@/state/index.js'
 
@@ -5,31 +6,29 @@ const routeNames = new Map<string, string>([
   ['/', 'Dashboard'],
   ['/error', 'Error'],
   ['/explore', 'Explore'],
-  ['/dashboard', 'Dashboard'],
-  ['/new-project', 'New Project'],
   ['/queries', 'Queries'],
   ['/labels', 'Labels'],
 ])
 
 const Header = () => {
   const [routeName, setRouteName] = useState<string>('')
-  const route = useGraphStore(state => state.activeRoute)
+  const { pathname } = useLocation()
   const projectInfo = useGraphStore(state => state.projectInfo)
 
   useEffect(() => {
     /**
      * Set a clean route on the state for display
      */
-    const mappedName = routeNames.get(route)
+    const mappedName = routeNames.get(pathname)
     if (mappedName) {
       setRouteName(mappedName)
     } else {
       setRouteName('VLT /vōlt/')
     }
-  }, [route])
+  }, [pathname])
 
-  if (route.includes('error')) return null
-  if (route === '/new-project') return null
+  if (pathname.includes('error')) return null
+  if (pathname === '/create-new-project') return null
 
   if (projectInfo.vltInstalled === false) return null
 

--- a/src/gui/src/components/navigation/sidebar/menu.ts
+++ b/src/gui/src/components/navigation/sidebar/menu.ts
@@ -17,7 +17,7 @@ export interface MenuItem {
 const menuItems: MenuItem[] = [
   {
     title: 'Dashboard',
-    url: '/dashboard',
+    url: '/',
     icon: LayoutDashboard,
   },
 ]

--- a/src/gui/src/components/navigation/sidebar/nav-main.tsx
+++ b/src/gui/src/components/navigation/sidebar/nav-main.tsx
@@ -1,3 +1,4 @@
+import { useLocation, NavLink } from 'react-router'
 import menuItems from './menu.js'
 import type { MenuItem } from './menu.js'
 import {
@@ -12,13 +13,9 @@ import {
   CollapsibleTrigger,
 } from '@/components/ui/collapsible.jsx'
 import { ChevronDown, ChevronRight } from 'lucide-react'
-import { useGraphStore } from '@/state/index.js'
 
 const SidebarMainNav = () => {
-  const activeRoute = useGraphStore(state => state.activeRoute)
-  const updateActiveRoute = useGraphStore(
-    state => state.updateActiveRoute,
-  )
+  const { pathname } = useLocation()
 
   const renderItems = (items: MenuItem[]) => {
     return items.map(item => {
@@ -33,18 +30,20 @@ const SidebarMainNav = () => {
           <SidebarMenuItem>
             <CollapsibleTrigger asChild>
               <SidebarMenuButton
-                isActive={activeRoute === item.url}
-                onClick={() => updateActiveRoute(item.url)}
-                className="whitespace-nowrap data-[active=true]:bg-neutral-200 data-[active=true]:text-foreground data-[active=true]:dark:bg-neutral-800 data-[active=true]:dark:text-foreground"
+                asChild
+                isActive={pathname === item.url}
+                className="whitespace-nowrap data-[active=true]:bg-neutral-200/80 data-[active=true]:text-foreground data-[active=true]:dark:bg-neutral-700/80 data-[active=true]:dark:text-foreground"
                 tooltip={item.title}>
-                {item.icon && <item.icon />}
-                <span>{item.title}</span>
-                {hasSubItems && (
-                  <>
-                    <ChevronRight className="ml-auto transition-transform duration-200 group-data-[state=open]/collapsible:hidden" />
-                    <ChevronDown className="ml-auto transition-transform duration-200 group-data-[state=closed]/collapsible:hidden" />
-                  </>
-                )}
+                <NavLink to={item.url}>
+                  {item.icon && <item.icon />}
+                  <span>{item.title}</span>
+                  {hasSubItems && (
+                    <>
+                      <ChevronRight className="ml-auto transition-transform duration-200 group-data-[state=open]/collapsible:hidden" />
+                      <ChevronDown className="ml-auto transition-transform duration-200 group-data-[state=closed]/collapsible:hidden" />
+                    </>
+                  )}
+                </NavLink>
               </SidebarMenuButton>
             </CollapsibleTrigger>
             {item.items && hasSubItems && (

--- a/src/gui/src/components/navigation/sidebar/nav-project-queries.tsx
+++ b/src/gui/src/components/navigation/sidebar/nav-project-queries.tsx
@@ -1,3 +1,4 @@
+import { useNavigate } from 'react-router'
 import { useEffect, useState } from 'react'
 import {
   SidebarMenuSub,
@@ -26,6 +27,7 @@ import {
 import { selectQuery } from '@/components/queries/saved-item.jsx'
 
 const SidebarQueryProjectNav = () => {
+  const navigate = useNavigate()
   const savedQueries = useGraphStore(state => state.savedQueries)
   const [projectQueries, setProjectQueries] = useState<SavedQuery[]>(
     [],
@@ -36,9 +38,6 @@ const SidebarQueryProjectNav = () => {
     useState<boolean>(false)
   const [globalQueriesOpen, setGlobalQueriesOpen] =
     useState<boolean>(false)
-  const updateActiveRoute = useGraphStore(
-    state => state.updateActiveRoute,
-  )
   const updateErrorCause = useGraphStore(
     state => state.updateErrorCause,
   )
@@ -65,7 +64,7 @@ const SidebarQueryProjectNav = () => {
 
   const runQuery = async (item: SavedQuery): Promise<void> => {
     await selectQuery({
-      updateActiveRoute,
+      navigate,
       updateErrorCause,
       updateQuery,
       updateStamp,
@@ -76,7 +75,7 @@ const SidebarQueryProjectNav = () => {
 
   const runGlobalQuery = async (item: SavedQuery): Promise<void> => {
     await selectQuery({
-      updateActiveRoute,
+      navigate,
       updateErrorCause,
       updateQuery,
       updateStamp,

--- a/src/gui/src/components/navigation/sidebar/nav-queries.tsx
+++ b/src/gui/src/components/navigation/sidebar/nav-queries.tsx
@@ -1,3 +1,4 @@
+import { useLocation, NavLink } from 'react-router'
 import { useEffect, useState } from 'react'
 import {
   SidebarMenu,
@@ -9,7 +10,7 @@ import { Star } from 'lucide-react'
 import { useGraphStore } from '@/state/index.js'
 
 const SidebarQueryNav = () => {
-  const activeRoute = useGraphStore(state => state.activeRoute)
+  const { pathname } = useLocation()
   const savedQueries = useGraphStore(state => state.savedQueries)
   const [queryCount, setQueryCount] = useState<number>(0)
 
@@ -25,19 +26,19 @@ const SidebarQueryNav = () => {
     <SidebarMenu>
       <SidebarMenuItem>
         <SidebarMenuButton
-          isActive={activeRoute === '/queries'}
+          isActive={pathname === '/queries'}
           asChild
           tooltip="Saved queries"
-          className="cursor-default whitespace-nowrap data-[active=true]:bg-neutral-200/80 data-[active=true]:text-foreground data-[active=true]:dark:bg-neutral-800 data-[active=true]:dark:text-foreground">
-          <a
-            href="/queries"
-            className={`text-foreground ${activeRoute === '/queries' ? '' : ''}`}>
+          className="cursor-default whitespace-nowrap data-[active=true]:bg-neutral-200/80 data-[active=true]:text-foreground data-[active=true]:dark:bg-neutral-700/80 data-[active=true]:dark:text-foreground">
+          <NavLink
+            to="/queries"
+            className={`text-foreground ${pathname === '/queries' ? '' : ''}`}>
             <Star />
             <span>Queries</span>
             <SidebarMenuBadge>
               {queryCount !== 0 ? queryCount : undefined}
             </SidebarMenuBadge>
-          </a>
+          </NavLink>
         </SidebarMenuButton>
       </SidebarMenuItem>
     </SidebarMenu>

--- a/src/gui/src/components/queries/queries-empty-state.tsx
+++ b/src/gui/src/components/queries/queries-empty-state.tsx
@@ -1,3 +1,4 @@
+import { NavLink } from 'react-router'
 import { useState, useEffect } from 'react'
 import { Button } from '@/components/ui/button.jsx'
 import { Command, Plus, Star } from 'lucide-react'
@@ -215,7 +216,7 @@ const QueriesEmptyState = ({ dashboard }: QueriesEmptyStateProps) => {
               </p>
               <div className="z-[2] flex items-center justify-center gap-3 text-center">
                 <Button asChild variant="outline">
-                  <a href="/">Explore Projects</a>
+                  <NavLink to="/">Explore Projects</NavLink>
                 </Button>
                 <Button onClick={() => setIsCreating(true)}>
                   <span>New Query</span>

--- a/src/gui/src/components/queries/saved-item.tsx
+++ b/src/gui/src/components/queries/saved-item.tsx
@@ -1,3 +1,4 @@
+import { useNavigate } from 'react-router'
 import { useEffect, useState } from 'react'
 import type {
   SavedQuery,
@@ -28,7 +29,7 @@ import {
 import { DirectorySelect } from '@/components/directory-select.jsx'
 
 type SelectQueryOptions = {
-  updateActiveRoute: Action['updateActiveRoute']
+  navigate: (route: string) => void
   updateErrorCause: Action['updateErrorCause']
   updateQuery: Action['updateQuery']
   updateStamp: Action['updateStamp']
@@ -39,7 +40,7 @@ type SelectQueryOptions = {
 // TODO: should reuse / share the project select logic from:
 // src/gui/src/components/dashboard-grid/index.tsx
 export const selectQuery = async ({
-  updateActiveRoute,
+  navigate,
   updateErrorCause,
   updateQuery,
   updateStamp,
@@ -59,7 +60,7 @@ export const selectQuery = async ({
     })
   } catch (err) {
     console.error(err)
-    updateActiveRoute('/error')
+    navigate('/error')
     updateErrorCause('Failed to request project selection.')
     return
   }
@@ -74,10 +75,10 @@ export const selectQuery = async ({
   if (projectSelected) {
     window.scrollTo(0, 0)
     updateQuery(item.query)
-    updateActiveRoute('/explore')
+    navigate('/explore')
     updateStamp()
   } else {
-    updateActiveRoute('/error')
+    navigate('/error')
     updateErrorCause('Failed to select project.')
   }
 }
@@ -93,6 +94,7 @@ const SavedQueryItem = ({
   checked: boolean
   dashboard?: DashboardData
 }) => {
+  const navigate = useNavigate()
   const { toast } = useToast()
   const [isExpanded, setIsExpanded] = useState<boolean>(false)
   const [editName, setEditName] = useState<string>('')
@@ -107,9 +109,6 @@ const SavedQueryItem = ({
   const [isValid, setIsValid] = useState<boolean>(false)
   const updateSavedQuery = useGraphStore(
     state => state.updateSavedQuery,
-  )
-  const updateActiveRoute = useGraphStore(
-    state => state.updateActiveRoute,
   )
   const updateErrorCause = useGraphStore(
     state => state.updateErrorCause,
@@ -154,7 +153,7 @@ const SavedQueryItem = ({
 
   const runQuery = async (): Promise<void> => {
     await selectQuery({
-      updateActiveRoute,
+      navigate,
       updateErrorCause,
       updateQuery,
       updateStamp,

--- a/src/gui/src/components/ui/filter-search.tsx
+++ b/src/gui/src/components/ui/filter-search.tsx
@@ -1,4 +1,5 @@
 import type { SavedQuery } from '@/state/types.js'
+import { useSearchParams } from 'react-router'
 import { useEffect, useRef, useState } from 'react'
 import { Input } from '@/components/ui/input.jsx'
 import { Kbd } from '@/components/ui/kbd.jsx'
@@ -20,6 +21,7 @@ const FilterSearch = <T,>({
   const [filterText, setFilterText] = useState<string>('')
   const inputRef = useRef<HTMLInputElement>(null)
   const isInitialMount = useRef(true)
+  const [searchParams, setSearchParams] = useSearchParams()
 
   /**
    * Update URL params based on `filterText` after initial load.
@@ -27,7 +29,7 @@ const FilterSearch = <T,>({
   useEffect(() => {
     if (isInitialMount.current) return
 
-    const params = new URLSearchParams(window.location.search)
+    const params = new URLSearchParams(searchParams)
     const itemKeys = items ? Object.keys(items[0] ?? {}) : []
 
     if (!filterText.trim()) {
@@ -56,15 +58,14 @@ const FilterSearch = <T,>({
       }
     }
 
-    const newUrl = `${window.location.pathname}?${params.toString()}`
-    window.history.replaceState({}, '', newUrl)
+    setSearchParams(params)
   }, [filterText])
 
   /**
    * Sync URL params with filtered items on initial load.
    */
   useEffect(() => {
-    const params = new URLSearchParams(window.location.search)
+    const params = new URLSearchParams(searchParams)
     const itemKeys = items ? Object.keys(items[0] ?? {}) : []
 
     const paramKeys = Array.from(params.keys())
@@ -91,7 +92,7 @@ const FilterSearch = <T,>({
       return
     }
 
-    const params = new URLSearchParams(window.location.search)
+    const params = new URLSearchParams(searchParams)
     const selectors: { key: string; value: string }[] = []
 
     for (const [key, value] of params.entries()) {
@@ -122,7 +123,7 @@ const FilterSearch = <T,>({
     )
 
     setFilteredItems(filteredItems)
-  }, [items, window.location.search, filterText])
+  }, [items, searchParams, filterText])
 
   /**
    * Handle keyboard shortcuts.

--- a/src/gui/src/index.tsx
+++ b/src/gui/src/index.tsx
@@ -1,9 +1,9 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import { ThemeProvider } from '@/components/ui/theme-provider.jsx'
-import Layout from './layout.jsx'
+import { Router } from '@/routes.jsx'
 
-const App = () => <Layout />
+const App = () => <Router />
 
 const rootElement = document.getElementById('app')
 if (rootElement) {

--- a/src/gui/src/layout.tsx
+++ b/src/gui/src/layout.tsx
@@ -1,4 +1,4 @@
-// navigation
+import { Outlet } from 'react-router'
 import { Header } from '@/components/navigation/header.jsx'
 import {
   defaultOpen,
@@ -8,43 +8,15 @@ import {
   SidebarProvider,
   SidebarInset,
 } from '@/components/ui/sidebar.jsx'
-
-// routes
-import { CreateNewProject } from '@/app/create-new-project.jsx'
-import { Explorer } from '@/app/explorer.jsx'
-import { ErrorFound } from '@/app/error-found.jsx'
-import { Dashboard } from '@/app/dashboard.jsx'
-import { Queries } from '@/app/queries.jsx'
-import { Labels } from '@/app/labels.jsx'
-
-import { useGraphStore } from '@/state/index.js'
 import { Toaster } from '@/components/ui/toaster.jsx'
 
-const routeMap: Record<string, React.ReactElement> = {
-  '/dashboard': <Dashboard />,
-  '/error': <ErrorFound />,
-  '/explore': <Explorer />,
-  '/queries': <Queries />,
-  '/labels': <Labels />,
-  '/new-project': <CreateNewProject />,
-}
-
 const Layout = () => {
-  const route = useGraphStore(state => state.activeRoute)
-
-  const defaultComponent = <Dashboard />
-  const matchedComponent = Object.keys(routeMap).find(key =>
-    route.startsWith(key),
-  )
-
   return (
     <SidebarProvider defaultOpen={defaultOpen}>
       <AppSidebar />
       <SidebarInset>
         <Header />
-        {matchedComponent ?
-          routeMap[matchedComponent]
-        : defaultComponent}
+        <Outlet />
       </SidebarInset>
       <Toaster />
     </SidebarProvider>

--- a/src/gui/src/lib/request-route-transition.ts
+++ b/src/gui/src/lib/request-route-transition.ts
@@ -2,7 +2,7 @@ import type { Action } from '@/state/types.js'
 import { DEFAULT_QUERY } from '@/state/index.js'
 
 export type RequestRouteTransitionOptions<T> = {
-  updateActiveRoute: Action['updateActiveRoute']
+  navigate: (route: string) => void
   updateErrorCause: Action['updateErrorCause']
   updateQuery: Action['updateQuery']
   updateStamp: Action['updateStamp']
@@ -13,7 +13,7 @@ export type RequestRouteTransitionOptions<T> = {
 }
 
 export const requestRouteTransition = async <T>({
-  updateActiveRoute,
+  navigate,
   updateErrorCause,
   updateQuery,
   updateStamp,
@@ -34,7 +34,7 @@ export const requestRouteTransition = async <T>({
   } catch (err) {
     // eslint-disable-next-line no-console
     console.error(err)
-    updateActiveRoute('/error')
+    navigate('/error')
     updateErrorCause('Failed to submit request.')
     return
   }
@@ -50,10 +50,10 @@ export const requestRouteTransition = async <T>({
   if (projectSelected) {
     window.scrollTo(0, 0)
     updateQuery(DEFAULT_QUERY)
-    updateActiveRoute(destinationRoute)
+    navigate(destinationRoute)
     updateStamp()
   } else {
-    updateActiveRoute('/error')
+    navigate('/error')
     updateErrorCause(errorMessage)
   }
 }

--- a/src/gui/src/lib/start-dashboard-data.ts
+++ b/src/gui/src/lib/start-dashboard-data.ts
@@ -5,7 +5,7 @@ export type RequestDashboardDataOptions = {
 }
 
 export type StartDashboardDataOptions = {
-  updateActiveRoute: Action['updateActiveRoute']
+  navigate: (route: string) => void
   updateDashboard: Action['updateDashboard']
   updateErrorCause: Action['updateErrorCause']
   stamp: State['stamp']
@@ -20,7 +20,7 @@ export const requestDashboardData = async ({
 }
 
 export const startDashboardData = ({
-  updateActiveRoute,
+  navigate,
   updateDashboard,
   updateErrorCause,
   stamp,
@@ -35,7 +35,7 @@ export const startDashboardData = ({
   void _startDashboard().catch((err: unknown) => {
     // eslint-disable-next-line no-console
     console.error(err)
-    updateActiveRoute('/error')
+    navigate('/error')
     updateErrorCause('Failed to initialize dashboard.')
   })
 }

--- a/src/gui/src/routes.tsx
+++ b/src/gui/src/routes.tsx
@@ -1,0 +1,51 @@
+import { createBrowserRouter, RouterProvider } from 'react-router'
+import type { RouteObject } from 'react-router'
+
+import Layout from '@/layout.jsx'
+
+import { CreateNewProject } from '@/app/create-new-project.jsx'
+import { Dashboard } from '@/app/dashboard.jsx'
+import { ErrorFound } from '@/app/error-found.jsx'
+import { Explorer } from '@/app/explorer.jsx'
+import { Labels } from '@/app/labels.jsx'
+import { Queries } from '@/app/queries.jsx'
+
+export const routes: RouteObject[] = [
+  {
+    path: '/',
+    element: <Layout />,
+    errorElement: <ErrorFound />,
+    children: [
+      {
+        index: true,
+        element: <Dashboard />,
+      },
+      {
+        path: 'create-new-project',
+        element: <CreateNewProject />,
+      },
+      {
+        path: 'error',
+        element: <ErrorFound />,
+      },
+      {
+        path: 'explore',
+        element: <Explorer />,
+      },
+      {
+        path: 'labels',
+        element: <Labels />,
+      },
+      {
+        path: 'queries',
+        element: <Queries />,
+      },
+    ],
+  },
+]
+
+const router = createBrowserRouter(routes)
+
+export const Router = () => {
+  return <RouterProvider router={router} />
+}

--- a/src/gui/src/state/index.ts
+++ b/src/gui/src/state/index.ts
@@ -32,8 +32,6 @@ const DEFAULT_QUERY_LABELS: QueryLabel[] = [
 const newStamp = () => String(Math.random()).slice(2)
 
 const initialState: State = {
-  activeRoute: location.pathname,
-  previousRoute: '',
   dashboard: undefined,
   graph: undefined,
   edges: [],
@@ -82,14 +80,6 @@ const initialState: State = {
 export const useGraphStore = create<Action & State>((set, get) => {
   const store = {
     ...initialState,
-    updateActiveRoute: (activeRoute: State['activeRoute']) =>
-      set(state => ({
-        previousRoute: state.activeRoute,
-        activeRoute,
-        stamp: String(Math.random()).slice(2),
-      })),
-    updatePreviousRoute: (previousRoute: State['activeRoute']) =>
-      set(() => ({ previousRoute })),
     updateDashboard: (dashboard: State['dashboard']) =>
       set(() => ({ dashboard })),
     updateGraph: (graph: State['graph']) => set(() => ({ graph })),
@@ -258,20 +248,5 @@ export const useGraphStore = create<Action & State>((set, get) => {
     },
   }
 
-  // updates internal state anytime the browser URL changes
-  window.addEventListener('popstate', (e: PopStateEvent): void => {
-    if (!e.state) return
-    const { query, route } = e.state as {
-      query?: string
-      route?: string
-    }
-    if (query != null) {
-      store.updateQuery(query)
-    }
-    if (route) {
-      store.updatePreviousRoute(store.activeRoute)
-      store.updateActiveRoute(route)
-    }
-  })
   return store
 })

--- a/src/gui/src/state/types.ts
+++ b/src/gui/src/state/types.ts
@@ -9,8 +9,6 @@ import type { SpecOptionsFilled } from '@vltpkg/spec/browser'
 import type { Integrity, Manifest } from '@vltpkg/types'
 
 export type Action = {
-  updateActiveRoute: (route: State['activeRoute']) => void
-  updatePreviousRoute: (route: State['activeRoute']) => void
   updateDashboard: (dashboard: State['dashboard']) => void
   updateGraph: (graph: State['graph']) => void
   updateQ: (q: State['q']) => void
@@ -76,14 +74,6 @@ export type RawNode = {
  * The main state object for the graph explorer.
  */
 export type State = {
-  /**
-   * The current location.pathname (e.g. route) in the app.
-   */
-  activeRoute: string
-  /**
-   * The last route in the app.
-   */
-  previousRoute: string
   /**
    * List of projects to be displayed in the dashboard.
    */

--- a/src/gui/test/__snapshots__/layout.tsx.snap
+++ b/src/gui/test/__snapshots__/layout.tsx.snap
@@ -1,6 +1,6 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`renders Layout for the "/dashboard" view 1`] = `
+exports[`renders Layout with an outlet 1`] = `
 
 <gui-sidebar-provider defaultopen="true">
   <gui-app-sidebar>
@@ -8,93 +8,8 @@ exports[`renders Layout for the "/dashboard" view 1`] = `
   <gui-sidebar-inset>
     <gui-nav-header>
     </gui-nav-header>
-    <gui-dashboard>
-    </gui-dashboard>
-  </gui-sidebar-inset>
-  <gui-toaster>
-  </gui-toaster>
-</gui-sidebar-provider>
-
-`;
-
-exports[`renders Layout for the "/error" view 1`] = `
-
-<gui-sidebar-provider defaultopen="true">
-  <gui-app-sidebar>
-  </gui-app-sidebar>
-  <gui-sidebar-inset>
-    <gui-nav-header>
-    </gui-nav-header>
-    <gui-error-found>
-    </gui-error-found>
-  </gui-sidebar-inset>
-  <gui-toaster>
-  </gui-toaster>
-</gui-sidebar-provider>
-
-`;
-
-exports[`renders Layout for the "/explore" view 1`] = `
-
-<gui-sidebar-provider defaultopen="true">
-  <gui-app-sidebar>
-  </gui-app-sidebar>
-  <gui-sidebar-inset>
-    <gui-nav-header>
-    </gui-nav-header>
-    <gui-explorer>
-    </gui-explorer>
-  </gui-sidebar-inset>
-  <gui-toaster>
-  </gui-toaster>
-</gui-sidebar-provider>
-
-`;
-
-exports[`renders Layout for the "/labels" view 1`] = `
-
-<gui-sidebar-provider defaultopen="true">
-  <gui-app-sidebar>
-  </gui-app-sidebar>
-  <gui-sidebar-inset>
-    <gui-nav-header>
-    </gui-nav-header>
-    <gui-labels>
-    </gui-labels>
-  </gui-sidebar-inset>
-  <gui-toaster>
-  </gui-toaster>
-</gui-sidebar-provider>
-
-`;
-
-exports[`renders Layout for the "/new-project" view 1`] = `
-
-<gui-sidebar-provider defaultopen="true">
-  <gui-app-sidebar>
-  </gui-app-sidebar>
-  <gui-sidebar-inset>
-    <gui-nav-header>
-    </gui-nav-header>
-    <gui-create-new-project>
-    </gui-create-new-project>
-  </gui-sidebar-inset>
-  <gui-toaster>
-  </gui-toaster>
-</gui-sidebar-provider>
-
-`;
-
-exports[`renders Layout for the "/queries" view 1`] = `
-
-<gui-sidebar-provider defaultopen="true">
-  <gui-app-sidebar>
-  </gui-app-sidebar>
-  <gui-sidebar-inset>
-    <gui-nav-header>
-    </gui-nav-header>
-    <gui-queries>
-    </gui-queries>
+    <gui-router-outlet>
+    </gui-router-outlet>
   </gui-sidebar-inset>
   <gui-toaster>
   </gui-toaster>

--- a/src/gui/test/__snapshots__/routes.tsx.snap
+++ b/src/gui/test/__snapshots__/routes.tsx.snap
@@ -1,0 +1,115 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`renders Layout for the "/" view 1`] = `
+
+<gui-layout>
+  <gui-sidebar-provider defaultopen="true">
+    <gui-app-sidebar>
+    </gui-app-sidebar>
+    <gui-sidebar-inset>
+      <gui-header>
+      </gui-header>
+      <gui-dashboard>
+      </gui-dashboard>
+    </gui-sidebar-inset>
+    <gui-toaster>
+    </gui-toaster>
+  </gui-sidebar-provider>
+</gui-layout>
+
+`;
+
+exports[`renders Layout for the "/create-new-project" view 1`] = `
+
+<gui-layout>
+  <gui-sidebar-provider defaultopen="true">
+    <gui-app-sidebar>
+    </gui-app-sidebar>
+    <gui-sidebar-inset>
+      <gui-header>
+      </gui-header>
+      <gui-create-new-project>
+      </gui-create-new-project>
+    </gui-sidebar-inset>
+    <gui-toaster>
+    </gui-toaster>
+  </gui-sidebar-provider>
+</gui-layout>
+
+`;
+
+exports[`renders Layout for the "/error" view 1`] = `
+
+<gui-layout>
+  <gui-sidebar-provider defaultopen="true">
+    <gui-app-sidebar>
+    </gui-app-sidebar>
+    <gui-sidebar-inset>
+      <gui-header>
+      </gui-header>
+      <gui-error-found>
+      </gui-error-found>
+    </gui-sidebar-inset>
+    <gui-toaster>
+    </gui-toaster>
+  </gui-sidebar-provider>
+</gui-layout>
+
+`;
+
+exports[`renders Layout for the "/explore" view 1`] = `
+
+<gui-layout>
+  <gui-sidebar-provider defaultopen="true">
+    <gui-app-sidebar>
+    </gui-app-sidebar>
+    <gui-sidebar-inset>
+      <gui-header>
+      </gui-header>
+      <gui-explorer>
+      </gui-explorer>
+    </gui-sidebar-inset>
+    <gui-toaster>
+    </gui-toaster>
+  </gui-sidebar-provider>
+</gui-layout>
+
+`;
+
+exports[`renders Layout for the "/labels" view 1`] = `
+
+<gui-layout>
+  <gui-sidebar-provider defaultopen="true">
+    <gui-app-sidebar>
+    </gui-app-sidebar>
+    <gui-sidebar-inset>
+      <gui-header>
+      </gui-header>
+      <gui-labels>
+      </gui-labels>
+    </gui-sidebar-inset>
+    <gui-toaster>
+    </gui-toaster>
+  </gui-sidebar-provider>
+</gui-layout>
+
+`;
+
+exports[`renders Layout for the "/queries" view 1`] = `
+
+<gui-layout>
+  <gui-sidebar-provider defaultopen="true">
+    <gui-app-sidebar>
+    </gui-app-sidebar>
+    <gui-sidebar-inset>
+      <gui-header>
+      </gui-header>
+      <gui-queries>
+      </gui-queries>
+    </gui-sidebar-inset>
+    <gui-toaster>
+    </gui-toaster>
+  </gui-sidebar-provider>
+</gui-layout>
+
+`;

--- a/src/gui/test/app/__snapshots__/create-new-project.tsx.snap
+++ b/src/gui/test/app/__snapshots__/create-new-project.tsx.snap
@@ -2,33 +2,31 @@
 
 exports[`render default 1`] = `
 
-<div>
-  <section class="flex h-full w-full flex-col rounded-lg border-[1px]">
-    <div class="h-1/5 rounded-t-lg border-b-[1px] border-border">
-      <div class="mx-auto flex h-full max-w-8xl flex-col justify-end gap-2 px-16 py-8">
-        <h4 class="text-2xl font-medium">
-          Create a new Project
-        </h4>
-        <p class="text-pretty text-sm text-muted-foreground">
-          A Project is a scaffolded through the
-          <gui-inline-code>
-            vlt init
-          </gui-inline-code>
-          command, and creates a folder that contains a
-          <gui-inline-code>
-            package.json
-          </gui-inline-code>
-          file.
-        </p>
-      </div>
+<section class="flex h-full w-full flex-col rounded-lg border-[1px]">
+  <div class="h-1/5 rounded-t-lg border-b-[1px] border-border">
+    <div class="mx-auto flex h-full max-w-8xl flex-col justify-end gap-2 px-16 py-8">
+      <h4 class="text-2xl font-medium">
+        Create a new Project
+      </h4>
+      <p class="text-pretty text-sm text-muted-foreground">
+        A Project is a scaffolded through the
+        <gui-inline-code>
+          vlt init
+        </gui-inline-code>
+        command, and creates a folder that contains a
+        <gui-inline-code>
+          package.json
+        </gui-inline-code>
+        file.
+      </p>
     </div>
-    <div class="relative mx-auto flex h-full w-full max-w-8xl items-center justify-center px-16 py-8">
-      <div class="absolute inset-0 z-[1] bg-[linear-gradient(to_right,#80808012_1px,transparent_1px),linear-gradient(to_bottom,#80808012_1px,transparent_1px)] bg-[size:32px_32px] [mask-image:radial-gradient(ellipse_50%_50%_at_50%_50%,#fff_70%,transparent_100%)] dark:[mask-image:radial-gradient(ellipse_50%_50%_at_50%_50%,#000_60%,transparent_100%)]">
-      </div>
-      <gui-create-new-project-content inprogress="false">
-      </gui-create-new-project-content>
+  </div>
+  <div class="relative mx-auto flex h-full w-full max-w-8xl items-center justify-center px-16 py-8">
+    <div class="absolute inset-0 z-[1] bg-[linear-gradient(to_right,#80808012_1px,transparent_1px),linear-gradient(to_bottom,#80808012_1px,transparent_1px)] bg-[size:32px_32px] [mask-image:radial-gradient(ellipse_50%_50%_at_50%_50%,#fff_70%,transparent_100%)] dark:[mask-image:radial-gradient(ellipse_50%_50%_at_50%_50%,#000_60%,transparent_100%)]">
     </div>
-  </section>
-</div>
+    <gui-create-new-project-content inprogress="false">
+    </gui-create-new-project-content>
+  </div>
+</section>
 
 `;

--- a/src/gui/test/app/__snapshots__/queries.tsx.snap
+++ b/src/gui/test/app/__snapshots__/queries.tsx.snap
@@ -32,7 +32,7 @@ exports[`queries view > queries render default 1`] = `
           aschild="true"
           variant="outline"
         >
-          <a href="/labels">
+          <gui-nav-link to="/labels">
             <gui-tag-icon>
             </gui-tag-icon>
             <span>
@@ -41,7 +41,7 @@ exports[`queries view > queries render default 1`] = `
             <gui-badge variant="secondary">
               3
             </gui-badge>
-          </a>
+          </gui-nav-link>
         </gui-button>
       </div>
     </div>

--- a/src/gui/test/app/create-new-project.tsx
+++ b/src/gui/test/app/create-new-project.tsx
@@ -4,6 +4,10 @@ import html from 'diffable-html'
 import { useGraphStore as useStore } from '@/state/index.js'
 import { CreateNewProject } from '@/app/create-new-project.jsx'
 
+vi.mock('react-router', () => ({
+  useNavigate: vi.fn(),
+}))
+
 vi.mock('@/components/create-new-project/index.jsx', () => ({
   CreateNewProjectContent: 'gui-create-new-project-content',
 }))
@@ -32,6 +36,6 @@ afterEach(() => {
 })
 
 test('render default', async () => {
-  render(<CreateNewProject />)
-  expect(window.document.body.innerHTML).toMatchSnapshot()
+  const { container } = render(<CreateNewProject />)
+  expect(container.innerHTML).toMatchSnapshot()
 })

--- a/src/gui/test/app/dashboard.tsx
+++ b/src/gui/test/app/dashboard.tsx
@@ -13,14 +13,8 @@ import html from 'diffable-html'
 import { useGraphStore as useStore } from '@/state/index.js'
 import { Dashboard } from '@/app/dashboard.jsx'
 
-vi.mock('@/components/ui/logo.jsx', () => ({
-  Logo: 'gui-logo',
-}))
-vi.mock('@/components/ui/title.jsx', () => ({
-  Title: 'gui-title',
-}))
-vi.mock('@/components/ui/theme-switcher.jsx', () => ({
-  ThemeSwitcher: 'gui-theme-switcher',
+vi.mock('react-router', () => ({
+  useNavigate: vi.fn(),
 }))
 vi.mock('@/components/dashboard-grid/index.jsx', () => ({
   DashboardGrid: 'gui-dashboard-grid',

--- a/src/gui/test/app/error-found.tsx
+++ b/src/gui/test/app/error-found.tsx
@@ -4,6 +4,9 @@ import html from 'diffable-html'
 import { useGraphStore as useStore } from '@/state/index.js'
 import { ErrorFound } from '@/app/error-found.jsx'
 
+vi.mock('react-router', () => ({
+  useNavigate: vi.fn(),
+}))
 vi.mock('@/components/ui/button.jsx', () => ({
   Button: 'gui-button',
 }))

--- a/src/gui/test/app/explorer.tsx
+++ b/src/gui/test/app/explorer.tsx
@@ -17,6 +17,10 @@ import { useGraphStore as useStore } from '@/state/index.js'
 import { Explorer } from '@/app/explorer.jsx'
 import { joinDepIDTuple } from '@vltpkg/dep-id/browser'
 
+vi.mock('react-router', () => ({
+  useNavigate: vi.fn(),
+}))
+
 vi.mock('@/components/search-bar.jsx', () => ({
   SearchBar: 'gui-search-bar',
 }))

--- a/src/gui/test/app/queries.tsx
+++ b/src/gui/test/app/queries.tsx
@@ -4,6 +4,15 @@ import html from 'diffable-html'
 import { useGraphStore as useStore } from '@/state/index.js'
 import { Queries } from '@/app/queries.jsx'
 
+vi.mock('@/lib/start-dashboard-data.js', () => ({
+  startDashboardData: vi.fn(),
+}))
+
+vi.mock('react-router', () => ({
+  NavLink: 'gui-nav-link',
+  useNavigate: vi.fn(),
+}))
+
 vi.mock('@/components/queries/saved-item.jsx', () => ({
   SavedQueryItem: 'gui-saved-query-item',
 }))

--- a/src/gui/test/components/create-new-project/index.tsx
+++ b/src/gui/test/components/create-new-project/index.tsx
@@ -4,6 +4,10 @@ import html from 'diffable-html'
 import { useGraphStore as useStore } from '@/state/index.js'
 import { CreateNewProjectContent } from '@/components/create-new-project/index.jsx'
 
+vi.mock('react-router', () => ({
+  useNavigate: vi.fn(),
+}))
+
 vi.mock('@/components/ui/input.jsx', () => ({
   Input: 'gui-input',
 }))

--- a/src/gui/test/components/dashboard-grid/__snapshots__/index.tsx.snap
+++ b/src/gui/test/components/dashboard-grid/__snapshots__/index.tsx.snap
@@ -21,10 +21,15 @@ exports[`dashboard-grid render default 1`] = `
           >
           </gui-sort-dropdown>
         </div>
-        <gui-button classname="ml-auto">
-          <gui-plus-icon size="24">
-          </gui-plus-icon>
-          Create New Project
+        <gui-button
+          aschild="true"
+          classname="ml-auto"
+        >
+          <gui-nav-link to="/create-new-project">
+            <gui-plus-icon size="24">
+            </gui-plus-icon>
+            Create New Project
+          </gui-nav-link>
         </gui-button>
       </div>
     </div>
@@ -67,10 +72,15 @@ exports[`dashboard-grid with results 1`] = `
           >
           </gui-sort-dropdown>
         </div>
-        <gui-button classname="ml-auto">
-          <gui-plus-icon size="24">
-          </gui-plus-icon>
-          Create New Project
+        <gui-button
+          aschild="true"
+          classname="ml-auto"
+        >
+          <gui-nav-link to="/create-new-project">
+            <gui-plus-icon size="24">
+            </gui-plus-icon>
+            Create New Project
+          </gui-nav-link>
         </gui-button>
       </div>
     </div>
@@ -82,8 +92,8 @@ exports[`dashboard-grid with results 1`] = `
         Projects
       </p>
       <div class="grid grid-cols-1 gap-x-6 gap-y-6 sm:grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
-        <a
-          href="#"
+        <div
+          role="link"
           class="group relative w-full cursor-default"
         >
           <div class="relative flex h-24 items-center overflow-hidden rounded-t-lg border-x-[1px] border-t-[1px] border-muted bg-card transition-all group-hover:bg-card-accent">
@@ -114,9 +124,9 @@ exports[`dashboard-grid with results 1`] = `
               </gui-tooltip>
             </gui-tooltip-provider>
           </div>
-        </a>
-        <a
-          href="#"
+        </div>
+        <div
+          role="link"
           class="group relative w-full cursor-default"
         >
           <div class="relative flex h-24 items-center overflow-hidden rounded-t-lg border-x-[1px] border-t-[1px] border-muted bg-card transition-all group-hover:bg-card-accent">
@@ -149,7 +159,7 @@ exports[`dashboard-grid with results 1`] = `
               </gui-tooltip>
             </gui-tooltip-provider>
           </div>
-        </a>
+        </div>
       </div>
     </div>
   </div>

--- a/src/gui/test/components/dashboard-grid/index.tsx
+++ b/src/gui/test/components/dashboard-grid/index.tsx
@@ -5,6 +5,11 @@ import { useGraphStore as useStore } from '@/state/index.js'
 import { DashboardGrid } from '@/components/dashboard-grid/index.jsx'
 import type { DashboardTools } from '@/state/types.js'
 
+vi.mock('react-router', () => ({
+  useNavigate: vi.fn(),
+  NavLink: 'gui-nav-link',
+}))
+
 vi.mock('@/utils/dashboard-tools.jsx', () => ({
   getIconSet: vi.fn((tools: DashboardTools[]) => {
     const mockRuntimes: Partial<Record<DashboardTools, string>> = {

--- a/src/gui/test/components/explorer-grid/dependency-side-bar.tsx
+++ b/src/gui/test/components/explorer-grid/dependency-side-bar.tsx
@@ -5,6 +5,10 @@ import { useGraphStore as useStore } from '@/state/index.js'
 import { DependencySideBar } from '@/components/explorer-grid/dependency-side-bar.jsx'
 import type { GridItemData } from '@/components/explorer-grid/types.js'
 
+vi.mock('react-router', () => ({
+  useNavigate: vi.fn(),
+}))
+
 vi.mock('lucide-react', () => ({
   Plus: 'gui-plus-icon',
 }))

--- a/src/gui/test/components/explorer-grid/empty-results-state.tsx
+++ b/src/gui/test/components/explorer-grid/empty-results-state.tsx
@@ -4,6 +4,10 @@ import html from 'diffable-html'
 import { useGraphStore as useStore } from '@/state/index.js'
 import { EmptyResultsState } from '@/components/explorer-grid/empty-results-state.jsx'
 
+vi.mock('react-router', () => ({
+  useNavigate: vi.fn(),
+}))
+
 vi.mock('@/components/ui/button.jsx', () => ({
   Button: 'gui-button',
 }))

--- a/src/gui/test/components/explorer-grid/query-matches.tsx
+++ b/src/gui/test/components/explorer-grid/query-matches.tsx
@@ -5,6 +5,11 @@ import html from 'diffable-html'
 import { useGraphStore as useStore } from '@/state/index.js'
 import { QueryMatches } from '@/components/explorer-grid/query-matches.jsx'
 
+vi.mock('react-router', () => ({
+  NavLink: 'gui-nav-link',
+  useNavigate: vi.fn(),
+}))
+
 vi.mock('@/components/ui/popover.jsx', () => ({
   Popover: 'gui-popover',
   PopoverContent: 'gui-popover-content',

--- a/src/gui/test/components/explorer-grid/root-button.tsx
+++ b/src/gui/test/components/explorer-grid/root-button.tsx
@@ -4,6 +4,10 @@ import html from 'diffable-html'
 import { useGraphStore as useStore } from '@/state/index.js'
 import { RootButton } from '@/components/explorer-grid/root-button.jsx'
 
+vi.mock('react-router', () => ({
+  useNavigate: vi.fn(),
+}))
+
 vi.mock('@/components/ui/button.jsx', () => ({
   Button: 'gui-button',
 }))

--- a/src/gui/test/components/explorer-grid/setup-project.tsx
+++ b/src/gui/test/components/explorer-grid/setup-project.tsx
@@ -5,6 +5,10 @@ import html from 'diffable-html'
 import { useGraphStore as useStore } from '@/state/index.js'
 import { SetupProject } from '@/components/explorer-grid/setup-project.jsx'
 
+vi.mock('react-router', () => ({
+  useNavigate: vi.fn(),
+}))
+
 vi.mock('@/components/ui/button.jsx', () => ({
   Button: 'gui-button',
 }))

--- a/src/gui/test/components/labels/label.tsx
+++ b/src/gui/test/components/labels/label.tsx
@@ -4,6 +4,10 @@ import html from 'diffable-html'
 import type { QueryLabel } from '@/state/types.js'
 import { Label } from '@/components/labels/label.jsx'
 
+vi.mock('react-router', () => ({
+  useNavigate: vi.fn(),
+}))
+
 vi.mock('@/components/ui/checkbox.jsx', () => ({
   Checkbox: 'gui-checkbox',
 }))

--- a/src/gui/test/components/navigation/__snapshots__/header.tsx.snap
+++ b/src/gui/test/components/navigation/__snapshots__/header.tsx.snap
@@ -12,15 +12,8 @@ exports[`renders Header for route / with expected name Dashboard 1`] = `
 
 `;
 
-exports[`renders Header for route /dashboard with expected name Dashboard 1`] = `
+exports[`renders Header for route /create-new-project with expected name null 1`] = `
 
-<div class="flex h-[65px] w-full items-center rounded-t-lg border-x-[1px] border-t-[1px] px-8 py-3">
-  <div class="flex w-full max-w-8xl items-center">
-    <h3 class="mt-1 text-lg font-medium">
-      Dashboard
-    </h3>
-  </div>
-</div>
 
 `;
 

--- a/src/gui/test/components/navigation/sidebar/__snapshots__/nav-main.tsx.snap
+++ b/src/gui/test/components/navigation/sidebar/__snapshots__/nav-main.tsx.snap
@@ -10,15 +10,18 @@ exports[`AppSidebar main nav > renders correctly 1`] = `
     <gui-sidebar-menu-item>
       <gui-collapsible-trigger aschild="true">
         <gui-sidebar-menu-button
+          aschild="true"
           isactive="false"
-          classname="whitespace-nowrap data-[active=true]:bg-neutral-200 data-[active=true]:text-foreground data-[active=true]:dark:bg-neutral-800 data-[active=true]:dark:text-foreground"
+          classname="whitespace-nowrap data-[active=true]:bg-neutral-200/80 data-[active=true]:text-foreground data-[active=true]:dark:bg-neutral-700/80 data-[active=true]:dark:text-foreground"
           tooltip="Dashboard"
         >
-          <gui-layout-dashboard-icon>
-          </gui-layout-dashboard-icon>
-          <span>
-            Dashboard
-          </span>
+          <gui-nav-link to="/">
+            <gui-layout-dashboard-icon>
+            </gui-layout-dashboard-icon>
+            <span>
+              Dashboard
+            </span>
+          </gui-nav-link>
         </gui-sidebar-menu-button>
       </gui-collapsible-trigger>
     </gui-sidebar-menu-item>

--- a/src/gui/test/components/navigation/sidebar/__snapshots__/nav-queries.tsx.snap
+++ b/src/gui/test/components/navigation/sidebar/__snapshots__/nav-queries.tsx.snap
@@ -8,11 +8,11 @@ exports[`AppSidebar query nav > renders correctly 1`] = `
       isactive="false"
       aschild="true"
       tooltip="Saved queries"
-      classname="cursor-default whitespace-nowrap data-[active=true]:bg-neutral-200/80 data-[active=true]:text-foreground data-[active=true]:dark:bg-neutral-800 data-[active=true]:dark:text-foreground"
+      classname="cursor-default whitespace-nowrap data-[active=true]:bg-neutral-200/80 data-[active=true]:text-foreground data-[active=true]:dark:bg-neutral-700/80 data-[active=true]:dark:text-foreground"
     >
-      <a
-        href="/queries"
-        class="text-foreground "
+      <gui-nav-link
+        to="/queries"
+        classname="text-foreground "
       >
         <gui-star-icon>
         </gui-star-icon>
@@ -21,7 +21,7 @@ exports[`AppSidebar query nav > renders correctly 1`] = `
         </span>
         <gui-sidebar-menu-badge>
         </gui-sidebar-menu-badge>
-      </a>
+      </gui-nav-link>
     </gui-sidebar-menu-button>
   </gui-sidebar-menu-item>
 </gui-sidebar-menu>

--- a/src/gui/test/components/navigation/sidebar/nav-main.tsx
+++ b/src/gui/test/components/navigation/sidebar/nav-main.tsx
@@ -4,6 +4,11 @@ import html from 'diffable-html'
 import { SidebarMainNav } from '@/components/navigation/sidebar/nav-main.jsx'
 import { useGraphStore as useStore } from '@/state/index.js'
 
+vi.mock('react-router', () => ({
+  useLocation: vi.fn().mockReturnValue({ pathname: '/dashboard' }),
+  NavLink: 'gui-nav-link',
+}))
+
 vi.mock('@/components/ui/sidebar.jsx', () => ({
   SidebarMenuSub: 'gui-sidebar-menu-sub',
   SidebarMenu: 'gui-sidebar-menu',

--- a/src/gui/test/components/navigation/sidebar/nav-queries.tsx
+++ b/src/gui/test/components/navigation/sidebar/nav-queries.tsx
@@ -4,6 +4,11 @@ import html from 'diffable-html'
 import { SidebarQueryNav } from '@/components/navigation/sidebar/nav-queries.jsx'
 import { useGraphStore as useStore } from '@/state/index.js'
 
+vi.mock('react-router', () => ({
+  useLocation: vi.fn().mockReturnValue({ pathname: '/dashboard' }),
+  NavLink: 'gui-nav-link',
+}))
+
 vi.mock('@/components/ui/sidebar.jsx', () => ({
   SidebarMenu: 'gui-sidebar-menu',
   SidebarMenuButton: 'gui-sidebar-menu-button',

--- a/src/gui/test/components/queries/__snapshots__/queries-empty-state.tsx.snap
+++ b/src/gui/test/components/queries/__snapshots__/queries-empty-state.tsx.snap
@@ -86,9 +86,9 @@ exports[`queries-empty-state > labels render default 1`] = `
           aschild="true"
           variant="outline"
         >
-          <a href="/">
+          <gui-nav-link to="/">
             Explore Projects
-          </a>
+          </gui-nav-link>
         </gui-button>
         <gui-button>
           <span>

--- a/src/gui/test/components/queries/queries-empty-state.tsx
+++ b/src/gui/test/components/queries/queries-empty-state.tsx
@@ -4,6 +4,10 @@ import html from 'diffable-html'
 import { useGraphStore as useStore } from '@/state/index.js'
 import { QueriesEmptyState } from '@/components/queries/queries-empty-state.jsx'
 
+vi.mock('react-router', () => ({
+  NavLink: 'gui-nav-link',
+}))
+
 vi.mock('@/components/ui/button.jsx', () => ({
   Button: 'gui-button',
 }))

--- a/src/gui/test/components/queries/saved-item.tsx
+++ b/src/gui/test/components/queries/saved-item.tsx
@@ -5,6 +5,10 @@ import { useGraphStore as useStore } from '@/state/index.js'
 import type { SavedQuery } from '@/state/types.js'
 import { SavedQueryItem } from '@/components/queries/saved-item.jsx'
 
+vi.mock('react-router', () => ({
+  useNavigate: vi.fn(),
+}))
+
 vi.mock('@/components/ui/input.jsx', () => ({
   Input: 'gui-label',
 }))

--- a/src/gui/test/components/ui/filter-search.tsx
+++ b/src/gui/test/components/ui/filter-search.tsx
@@ -4,6 +4,10 @@ import { cleanup, render } from '@testing-library/react'
 import html from 'diffable-html'
 import { FilterSearch } from '@/components/ui/filter-search.jsx'
 
+vi.mock('react-router', () => ({
+  useSearchParams: vi.fn().mockReturnValue(['', vi.fn()]),
+}))
+
 vi.mock('@/components/ui/input.jsx', () => ({
   Input: 'gui-input',
 }))

--- a/src/gui/test/layout.tsx
+++ b/src/gui/test/layout.tsx
@@ -4,6 +4,10 @@ import html from 'diffable-html'
 import { useGraphStore as useStore } from '@/state/index.js'
 import Layout from '@/layout.jsx'
 
+vi.mock('react-router', () => ({
+  Outlet: 'gui-router-outlet',
+}))
+
 vi.mock('@/components/navigation/header.jsx', () => ({
   Header: 'gui-nav-header',
 }))
@@ -15,26 +19,6 @@ vi.mock('@/components/ui/sidebar.jsx', () => ({
   SidebarProvider: 'gui-sidebar-provider',
   SidebarInset: 'gui-sidebar-inset',
 }))
-
-vi.mock('@/app/create-new-project.jsx', () => ({
-  CreateNewProject: 'gui-create-new-project',
-}))
-vi.mock('@/app/explorer.jsx', () => ({
-  Explorer: 'gui-explorer',
-}))
-vi.mock('@/app/error-found.jsx', () => ({
-  ErrorFound: 'gui-error-found',
-}))
-vi.mock('@/app/dashboard.jsx', () => ({
-  Dashboard: 'gui-dashboard',
-}))
-vi.mock('@/app/queries.jsx', () => ({
-  Queries: 'gui-queries',
-}))
-vi.mock('@/app/labels.jsx', () => ({
-  Labels: 'gui-labels',
-}))
-
 vi.mock('@/components/ui/toaster.jsx', () => ({
   Toaster: 'gui-toaster',
 }))
@@ -50,68 +34,7 @@ afterEach(() => {
   cleanup()
 })
 
-test('renders Layout for the "/new-project" view', () => {
-  const Container = () => {
-    const setRoute = useStore(state => state.updateActiveRoute)
-    setRoute('/new-project')
-    return <Layout />
-  }
-
-  const { container } = render(<Container />)
-  expect(container.innerHTML).toMatchSnapshot()
-})
-
-test('renders Layout for the "/dashboard" view', () => {
-  const Container = () => {
-    const setRoute = useStore(state => state.updateActiveRoute)
-    setRoute('/dashboard')
-    return <Layout />
-  }
-
-  const { container } = render(<Container />)
-  expect(container.innerHTML).toMatchSnapshot()
-})
-
-test('renders Layout for the "/explore" view', () => {
-  const Container = () => {
-    const setRoute = useStore(state => state.updateActiveRoute)
-    setRoute('/explore')
-    return <Layout />
-  }
-
-  const { container } = render(<Container />)
-  expect(container.innerHTML).toMatchSnapshot()
-})
-
-test('renders Layout for the "/queries" view', () => {
-  const Container = () => {
-    const setRoute = useStore(state => state.updateActiveRoute)
-    setRoute('/queries')
-    return <Layout />
-  }
-
-  const { container } = render(<Container />)
-  expect(container.innerHTML).toMatchSnapshot()
-})
-
-test('renders Layout for the "/labels" view', () => {
-  const Container = () => {
-    const setRoute = useStore(state => state.updateActiveRoute)
-    setRoute('/labels')
-    return <Layout />
-  }
-
-  const { container } = render(<Container />)
-  expect(container.innerHTML).toMatchSnapshot()
-})
-
-test('renders Layout for the "/error" view', () => {
-  const Container = () => {
-    const setRoute = useStore(state => state.updateActiveRoute)
-    setRoute('/error')
-    return <Layout />
-  }
-
-  const { container } = render(<Container />)
+test('renders Layout with an outlet', () => {
+  const { container } = render(<Layout />)
   expect(container.innerHTML).toMatchSnapshot()
 })

--- a/src/gui/test/lib/request-route-transition.ts
+++ b/src/gui/test/lib/request-route-transition.ts
@@ -36,12 +36,12 @@ beforeEach(() => {
 })
 
 test('requestRouteTransition success', async () => {
-  const updateActiveRoute = vi.fn()
+  const navigate = vi.fn()
   const updateErrorCause = vi.fn()
   const updateQuery = vi.fn()
   const updateStamp = vi.fn()
   await requestRouteTransition({
-    updateActiveRoute,
+    navigate,
     updateErrorCause,
     updateQuery,
     updateStamp,
@@ -51,17 +51,17 @@ test('requestRouteTransition success', async () => {
     errorMessage: 'Unexpected error.',
   })
   expect(updateErrorCause).not.toHaveBeenCalled()
-  expect(updateActiveRoute).toHaveBeenCalledWith('/next-route')
+  expect(navigate).toHaveBeenCalledWith('/next-route')
   expect(updateStamp).toHaveBeenCalled()
 })
 
 test('requestRouteTransition failure', async () => {
-  const updateActiveRoute = vi.fn()
+  const navigate = vi.fn()
   const updateErrorCause = vi.fn()
   const updateQuery = vi.fn()
   const updateStamp = vi.fn()
   await requestRouteTransition({
-    updateActiveRoute,
+    navigate,
     updateErrorCause,
     updateQuery,
     updateStamp,
@@ -70,19 +70,19 @@ test('requestRouteTransition failure', async () => {
     destinationRoute: '/next-route',
     errorMessage: 'Failed.',
   })
-  expect(updateActiveRoute).toHaveBeenCalledWith('/error')
+  expect(navigate).toHaveBeenCalledWith('/error')
   expect(updateErrorCause).toHaveBeenCalledWith('Failed.')
   expect(updateStamp).not.toHaveBeenCalled()
 })
 
 test('requestRouteTransition 404', async () => {
   console.error = vi.fn()
-  const updateActiveRoute = vi.fn()
+  const navigate = vi.fn()
   const updateErrorCause = vi.fn()
   const updateQuery = vi.fn()
   const updateStamp = vi.fn()
   await requestRouteTransition({
-    updateActiveRoute,
+    navigate,
     updateErrorCause,
     updateQuery,
     updateStamp,
@@ -92,19 +92,19 @@ test('requestRouteTransition 404', async () => {
     errorMessage: 'Failed.',
   })
   expect(console.error).toHaveBeenCalled()
-  expect(updateActiveRoute).toHaveBeenCalledWith('/error')
+  expect(navigate).toHaveBeenCalledWith('/error')
   expect(updateErrorCause).toHaveBeenCalledWith('Failed.')
   expect(updateStamp).not.toHaveBeenCalled()
 })
 
 test('requestRouteTransition throw', async () => {
   console.error = vi.fn()
-  const updateActiveRoute = vi.fn()
+  const navigate = vi.fn()
   const updateErrorCause = vi.fn()
   const updateQuery = vi.fn()
   const updateStamp = vi.fn()
   await requestRouteTransition({
-    updateActiveRoute,
+    navigate,
     updateErrorCause,
     updateQuery,
     updateStamp,
@@ -114,7 +114,7 @@ test('requestRouteTransition throw', async () => {
     errorMessage: 'Failed.',
   })
   expect(console.error).toHaveBeenCalled()
-  expect(updateActiveRoute).toHaveBeenCalledWith('/error')
+  expect(navigate).toHaveBeenCalledWith('/error')
   expect(updateErrorCause).toHaveBeenCalledWith(
     'Failed to submit request.',
   )

--- a/src/gui/test/lib/start-dashboard-data.ts
+++ b/src/gui/test/lib/start-dashboard-data.ts
@@ -48,7 +48,7 @@ test('standard dashboard response', async () => {
   await new Promise<void>((res, rej) => {
     try {
       startDashboardData({
-        updateActiveRoute: vi.fn(),
+        navigate: vi.fn(),
         updateDashboard: dashboardData => {
           expect(dashboardData).toMatchSnapshot(
             'should return standard dashboard data',
@@ -69,7 +69,7 @@ test('missing dashboard response', async () => {
   await new Promise<void>((res, rej) => {
     try {
       startDashboardData({
-        updateActiveRoute: route => {
+        navigate: route => {
           expect(route).toBe('/error')
           res()
         },

--- a/src/gui/test/routes.tsx
+++ b/src/gui/test/routes.tsx
@@ -1,0 +1,135 @@
+import React from 'react'
+import { beforeAll, afterEach, test, vi, expect } from 'vitest'
+import { render, cleanup } from '@testing-library/react'
+import { createMemoryRouter, RouterProvider } from 'react-router'
+import html from 'diffable-html'
+import { useGraphStore as useStore } from '@/state/index.js'
+import { routes } from '@/routes.jsx'
+
+vi.mock('react-router', async () => {
+  const actual = await import('react-router')
+  return {
+    ...actual,
+    createBrowserRouter: vi.fn(),
+  }
+})
+
+vi.mock('@/components/navigation/header.jsx', () => ({
+  Header: 'gui-header',
+}))
+vi.mock('@/components/navigation/footer.jsx', () => ({
+  Footer: 'gui-footer',
+}))
+vi.mock('@/components/navigation/sidebar/index.jsx', () => ({
+  defaultOpen: true,
+  AppSidebar: 'gui-app-sidebar',
+}))
+vi.mock('@/components/ui/sidebar.jsx', () => ({
+  SidebarProvider: 'gui-sidebar-provider',
+  SidebarInset: 'gui-sidebar-inset',
+}))
+vi.mock('@/components/ui/toaster.jsx', () => ({
+  Toaster: 'gui-toaster',
+}))
+
+vi.mock('@/layout.jsx', async importOriginal => {
+  const actual =
+    (await importOriginal()) as typeof import('@/layout.jsx') // eslint-disable-line @typescript-eslint/no-unnecessary-type-assertion
+
+  return {
+    default: ({
+      children,
+      ...props
+    }: {
+      children?: React.ReactNode
+    }) =>
+      React.createElement(
+        'gui-layout' as 'div',
+        null,
+        <actual.default {...props} />,
+      ),
+  }
+})
+
+vi.mock('@/app/create-new-project.jsx', () => ({
+  CreateNewProject: 'gui-create-new-project',
+}))
+vi.mock('@/app/dashboard.jsx', () => ({
+  Dashboard: 'gui-dashboard',
+}))
+vi.mock('@/app/error-found.jsx', () => ({
+  ErrorFound: 'gui-error-found',
+}))
+vi.mock('@/app/explorer.jsx', () => ({
+  Explorer: 'gui-explorer',
+}))
+vi.mock('@/app/labels.jsx', () => ({
+  Labels: 'gui-labels',
+}))
+vi.mock('@/app/queries.jsx', () => ({
+  Queries: 'gui-queries',
+}))
+
+expect.addSnapshotSerializer({
+  serialize: v => html(v),
+  test: () => true,
+})
+
+beforeAll(() => {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: vi.fn().mockImplementation(query => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  })
+})
+
+afterEach(() => {
+  const CleanUp = () => (useStore(state => state.reset)(), '')
+  render(<CleanUp />)
+  cleanup()
+})
+
+const renderWithRouter = (initialRoute: string) => {
+  const router = createMemoryRouter(routes, {
+    initialEntries: [initialRoute],
+  })
+  return render(<RouterProvider router={router} />)
+}
+
+test('renders Layout for the "/" view', () => {
+  const { container } = renderWithRouter('/')
+  expect(container.innerHTML).toMatchSnapshot()
+})
+
+test('renders Layout for the "/create-new-project" view', () => {
+  const { container } = renderWithRouter('/create-new-project')
+  expect(container.innerHTML).toMatchSnapshot()
+})
+
+test('renders Layout for the "/explore" view', () => {
+  const { container } = renderWithRouter('/explore')
+  expect(container.innerHTML).toMatchSnapshot()
+})
+
+test('renders Layout for the "/queries" view', () => {
+  const { container } = renderWithRouter('/queries')
+  expect(container.innerHTML).toMatchSnapshot()
+})
+
+test('renders Layout for the "/labels" view', () => {
+  const { container } = renderWithRouter('/labels')
+  expect(container.innerHTML).toMatchSnapshot()
+})
+
+test('renders Layout for the "/error" view', () => {
+  const { container } = renderWithRouter('/error')
+  expect(container.innerHTML).toMatchSnapshot()
+})

--- a/src/server/src/handle-static.ts
+++ b/src/server/src/handle-static.ts
@@ -25,15 +25,7 @@ export const handleStatic = async (
   const opts = {
     cleanUrls: true,
     public: publicDir,
-    rewrites: [
-      { source: '/', destination: '/index.html' },
-      { source: '/error', destination: '/index.html' },
-      { source: '/explore', destination: '/index.html' },
-      { source: '/dashboard', destination: '/index.html' },
-      { source: '/queries', destination: '/index.html' },
-      { source: '/labels', destination: '/index.html' },
-      { source: '/new-project', destination: '/index.html' },
-    ],
+    rewrites: [{ source: '**', destination: '/index.html' }],
   }
 
   const handle = () =>

--- a/src/server/test/handle-static.ts
+++ b/src/server/test/handle-static.ts
@@ -91,15 +91,7 @@ t.test('/handle-it', async t => {
       t.strictSame(opts, {
         cleanUrls: true,
         public: context.options.publicDir,
-        rewrites: [
-          { source: '/', destination: '/index.html' },
-          { source: '/error', destination: '/index.html' },
-          { source: '/explore', destination: '/index.html' },
-          { source: '/dashboard', destination: '/index.html' },
-          { source: '/queries', destination: '/index.html' },
-          { source: '/labels', destination: '/index.html' },
-          { source: '/new-project', destination: '/index.html' },
-        ],
+        rewrites: [{ source: '**', destination: '/index.html' }],
       })
     },
   })
@@ -126,15 +118,7 @@ t.test('/handle-it not proxied', async t => {
       t.strictSame(opts, {
         cleanUrls: true,
         public: context.options.publicDir,
-        rewrites: [
-          { source: '/', destination: '/index.html' },
-          { source: '/error', destination: '/index.html' },
-          { source: '/explore', destination: '/index.html' },
-          { source: '/dashboard', destination: '/index.html' },
-          { source: '/queries', destination: '/index.html' },
-          { source: '/labels', destination: '/index.html' },
-          { source: '/new-project', destination: '/index.html' },
-        ],
+        rewrites: [{ source: '**', destination: '/index.html' }],
       })
     },
   })
@@ -194,15 +178,7 @@ t.test('/esbuild is proxied', async t => {
       t.strictSame(opts, {
         cleanUrls: true,
         public: context.options.publicDir,
-        rewrites: [
-          { source: '/', destination: '/index.html' },
-          { source: '/error', destination: '/index.html' },
-          { source: '/explore', destination: '/index.html' },
-          { source: '/dashboard', destination: '/index.html' },
-          { source: '/queries', destination: '/index.html' },
-          { source: '/labels', destination: '/index.html' },
-          { source: '/new-project', destination: '/index.html' },
-        ],
+        rewrites: [{ source: '**', destination: '/index.html' }],
       })
     },
   })
@@ -278,15 +254,7 @@ t.test('/handle-it is proxied, has an error', async t => {
       t.strictSame(opts, {
         cleanUrls: true,
         public: context.options.publicDir,
-        rewrites: [
-          { source: '/', destination: '/index.html' },
-          { source: '/error', destination: '/index.html' },
-          { source: '/explore', destination: '/index.html' },
-          { source: '/dashboard', destination: '/index.html' },
-          { source: '/queries', destination: '/index.html' },
-          { source: '/labels', destination: '/index.html' },
-          { source: '/new-project', destination: '/index.html' },
-        ],
+        rewrites: [{ source: '**', destination: '/index.html' }],
       })
     },
   })
@@ -374,15 +342,7 @@ t.test(
         t.strictSame(opts, {
           cleanUrls: true,
           public: context.options.publicDir,
-          rewrites: [
-            { source: '/', destination: '/index.html' },
-            { source: '/error', destination: '/index.html' },
-            { source: '/explore', destination: '/index.html' },
-            { source: '/dashboard', destination: '/index.html' },
-            { source: '/queries', destination: '/index.html' },
-            { source: '/labels', destination: '/index.html' },
-            { source: '/new-project', destination: '/index.html' },
-          ],
+          rewrites: [{ source: '**', destination: '/index.html' }],
         })
       },
     })
@@ -465,15 +425,7 @@ t.test('/esbuild has an ECONNREFUSED error', async t => {
       t.strictSame(opts, {
         cleanUrls: true,
         public: context.options.publicDir,
-        rewrites: [
-          { source: '/', destination: '/index.html' },
-          { source: '/error', destination: '/index.html' },
-          { source: '/explore', destination: '/index.html' },
-          { source: '/dashboard', destination: '/index.html' },
-          { source: '/queries', destination: '/index.html' },
-          { source: '/labels', destination: '/index.html' },
-          { source: '/new-project', destination: '/index.html' },
-        ],
+        rewrites: [{ source: '**', destination: '/index.html' }],
       })
     },
   })

--- a/src/vlt/src/start-gui.ts
+++ b/src/vlt/src/start-gui.ts
@@ -15,7 +15,7 @@ export const getDefaultStartingRoute = async (options: {
   const stat = await scurry.lstat(`${projectRoot}/package.json`)
   return stat?.isFile() && !stat.isSymbolicLink() ?
       `/explore?query=${encodeURIComponent(':root')}`
-    : '/dashboard'
+    : '/'
 }
 
 export const startGUI = async (

--- a/src/vlt/test/start-gui.ts
+++ b/src/vlt/test/start-gui.ts
@@ -28,14 +28,14 @@ t.test('getDefaultStartingRoute', async t => {
       scurry,
       projectRoot: resolve(dir, 'linky'),
     }),
-    `/dashboard`,
+    `/`,
   )
   t.equal(
     await getDefaultStartingRoute({
       scurry,
       projectRoot: dir,
     }),
-    `/dashboard`,
+    `/`,
   )
   t.equal(
     await getDefaultStartingRoute({
@@ -96,7 +96,7 @@ t.test('startGUI()', async t => {
     '@vltpkg/url-open': {
       urlOpen: (url: string) => {
         urlOpened = true
-        t.equal(url, 'server-address/dashboard')
+        t.equal(url, 'server-address/')
       },
     },
   })


### PR DESCRIPTION
Replaces previous route setting using zustand with [react router v7](https://reactrouter.com/)

Closes vltpkg/statusboard#66

### Features
- Creates a browser router and provider in `src/routes.tsx`,
- Replaces `layout.tsx` app wrapper in `src/index.tsx` with the RouterProvider `Router`
- Removes zustand `updateActiveRoute` and `activeRoute` in `state/index.ts`

- Replaces all `<a />` elements with `<NavLink />` component from `react-router`
- Replaces all instances of `updateActiveRoute` with the `useNavigate` hook from `react-router`
- Replaces all instances of `activeRoute` with the `useLocation` hook from `react-router`

- Updates rewrites in `vlt/src/start-gui.ts` to be usable as an SPA

### Tests
- updates tests and snapshots