### PR TITLE
security-archive: add a security db & cache system

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,6 +33,27 @@ catalogs:
     eslint:
       specifier: ^9.20.0
       version: 9.20.0
+    graph-run:
+      specifier: ^1.0.4
+      version: 1.0.4
+    lru-cache:
+      specifier: ^11.0.2
+      version: 11.0.2
+    p-retry:
+      specifier: ^6.2.1
+      version: 6.2.1
+    package-json-from-dist:
+      specifier: ^1.0.0
+      version: 1.0.1
+    pacote:
+      specifier: ^18.0.6
+      version: 18.0.6
+    path-scurry:
+      specifier: ^2.0.0
+      version: 2.0.0
+    polite-json:
+      specifier: ^5.0.0
+      version: 5.0.0
     prettier:
       specifier: ^3.4.2
       version: 3.4.2
@@ -1476,6 +1497,67 @@ importers:
       '@vltpkg/workspaces':
         specifier: workspace:*
         version: link:../workspaces
+    devDependencies:
+      '@eslint/js':
+        specifier: 'catalog:'
+        version: 9.20.0
+      '@types/eslint__js':
+        specifier: 'catalog:'
+        version: 8.42.3
+      '@types/node':
+        specifier: 'catalog:'
+        version: 22.13.1
+      eslint:
+        specifier: 'catalog:'
+        version: 9.20.0(jiti@1.21.6)
+      prettier:
+        specifier: 'catalog:'
+        version: 3.4.2
+      tap:
+        specifier: 'catalog:'
+        version: 21.1.0(@types/node@22.13.1)(@types/react@18.3.18)(react-devtools-core@4.28.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.7.3)
+      tshy:
+        specifier: 'catalog:'
+        version: 3.0.2(patch_hash=nn5gj4wshdx7c2chh4frit2bve)
+      typedoc:
+        specifier: 'catalog:'
+        version: 0.27.6(typescript@5.7.3)
+      typescript:
+        specifier: 'catalog:'
+        version: 5.7.3
+      typescript-eslint:
+        specifier: 'catalog:'
+        version: 8.23.0(eslint@9.20.0(jiti@1.21.6))(typescript@5.7.3)
+
+  src/security-archive:
+    dependencies:
+      '@vltpkg/dep-id':
+        specifier: workspace:*
+        version: link:../dep-id
+      '@vltpkg/error-cause':
+        specifier: workspace:*
+        version: link:../error-cause
+      '@vltpkg/graph':
+        specifier: workspace:*
+        version: link:../graph
+      '@vltpkg/spec':
+        specifier: workspace:*
+        version: link:../spec
+      '@vltpkg/types':
+        specifier: workspace:*
+        version: link:../types
+      '@vltpkg/xdg':
+        specifier: workspace:*
+        version: link:../xdg
+      lru-cache:
+        specifier: 'catalog:'
+        version: 11.0.2
+      p-retry:
+        specifier: 'catalog:'
+        version: 6.2.1
+      package-json-from-dist:
+        specifier: 'catalog:'
+        version: 1.0.1
     devDependencies:
       '@eslint/js':
         specifier: 'catalog:'
@@ -4448,6 +4530,9 @@ packages:
   '@types/react@18.3.18':
     resolution: {integrity: sha512-t4yC+vtgnkYjNSKlFx1jkAhH8LgTo2N/7Qvi83kdEaUtMDiwpbLAktKDaAMlRcJ5eSxZkH74eEGt1ky31d7kfQ==}
 
+  '@types/retry@0.12.2':
+    resolution: {integrity: sha512-XISRgDJ2Tc5q4TRqvgJtzsRkFYNJzZrhTdtMoGVBttwzzQJkPnS3WWTFc7kuDRoPtPakl+T+OfdEUjYJj7Jbow==}
+
   '@types/retry@0.12.5':
     resolution: {integrity: sha512-3xSjTp3v03X/lSQLkczaN9UIEwJMoMCA1+Nb5HfbJEQWogdeQIyVtTvxPXDQjZ5zws8rFQfVfRdz03ARihPJgw==}
 
@@ -6096,6 +6181,10 @@ packages:
     resolution: {integrity: sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw==}
     engines: {node: '>= 0.4'}
 
+  is-network-error@1.1.0:
+    resolution: {integrity: sha512-tUdRRAnhT+OtCZR/LxZelH/C7QtjtFrTu5tXCA8pl55eTUElUHT+GPYV8MBMBvea/j+NxQqVt3LbWMRir7Gx9g==}
+    engines: {node: '>=16'}
+
   is-node-process@1.2.0:
     resolution: {integrity: sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==}
 
@@ -6869,6 +6958,10 @@ packages:
   p-queue@8.0.1:
     resolution: {integrity: sha512-NXzu9aQJTAzbBqOt2hwsR63ea7yvxJc0PwN/zobNAudYfb1B7R08SzB4TsLeSbUCuG467NhnoT0oO6w1qRO+BA==}
     engines: {node: '>=18'}
+
+  p-retry@6.2.1:
+    resolution: {integrity: sha512-hEt02O4hUct5wtwg4H4KcWgDdm+l1bOaEy/hWzd8xtXB9BqxTWBBhb+2ImAtH4Cv4rPjV76xN3Zumqk3k3AhhQ==}
+    engines: {node: '>=16.17'}
 
   p-timeout@6.1.3:
     resolution: {integrity: sha512-UJUyfKbwvr/uZSV6btANfb+0t/mOhKV/KXcCUTp8FcQI+v/0d+wXqH4htrW0E4rR6WiEO/EPvUFiV9D5OI4vlw==}
@@ -11215,6 +11308,8 @@ snapshots:
       '@types/prop-types': 15.7.13
       csstype: 3.1.3
 
+  '@types/retry@0.12.2': {}
+
   '@types/retry@0.12.5': {}
 
   '@types/sax@1.2.7':
@@ -13291,6 +13386,8 @@ snapshots:
 
   is-negative-zero@2.0.3: {}
 
+  is-network-error@1.1.0: {}
+
   is-node-process@1.2.0: {}
 
   is-number-object@1.0.7:
@@ -14368,6 +14465,12 @@ snapshots:
     dependencies:
       eventemitter3: 5.0.1
       p-timeout: 6.1.3
+
+  p-retry@6.2.1:
+    dependencies:
+      '@types/retry': 0.12.2
+      is-network-error: 1.1.0
+      retry: 0.13.1
 
   p-timeout@6.1.3: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -14,6 +14,7 @@ catalog:
   eslint: ^9.20.0
   graph-run: ^1.0.4
   lru-cache: ^11.0.2
+  p-retry: ^6.2.1
   package-json-from-dist: ^1.0.0
   pacote: ^18.0.6
   path-scurry: ^2.0.0

--- a/src/security-archive/LICENSE
+++ b/src/security-archive/LICENSE
@@ -1,0 +1,15 @@
+Copyright (c) vlt technology, Inc.
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+   Subject to the terms and conditions of this license, each copyright holder and contributor hereby grants to those receiving rights under this license a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable (except for failure to satisfy the conditions of this license) patent license to make, have made, use, offer to sell, sell, import, and otherwise transfer this software, where such license applies only to those patent claims, already acquired or hereafter acquired, licensable by such copyright holder or contributor that are necessarily infringed by:
+
+(a) their Contribution(s) (the licensed copyrights of copyright holders and non-copyrightable additions of contributors, in source or binary form) alone; or
+(b) combination of their Contribution(s) with the work of authorship to which such Contribution(s) was added by such copyright holder or contributor, if, at the time the Contribution is added, such addition causes such combination to be necessarily infringed. The patent license shall not apply to any other combinations which include the Contribution.
+Except as expressly stated above, no rights or licenses from any copyright holder or contributor is granted under this license, whether expressly, by implication, estoppel or otherwise.
+
+DISCLAIMER
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/src/security-archive/README.md
+++ b/src/security-archive/README.md
@@ -1,0 +1,38 @@
+# @vltpkg/security-archive
+
+A key/value storage that holds security data for unique package
+versions that are coming from a public registry.
+
+This package serves as the backend for `@vltpkg/query` when using
+pseudo-selectors that rely on security data.
+
+Security data is provided in partnership with
+[Socket](https://socket.dev/).
+
+## Usage
+
+```
+import { actual } from '@vltpkg/graph'
+import { SecurityArchive } from '@vltpkg/security-archive'
+
+const specOptions = {
+  registry: 'https://registry.npmjs.org/',
+}
+const graph = actual.load({
+  ...specOptions,
+  projectRoot: process.cwd(),
+})
+
+const archive = await SecurityArchive.start({ graph, specOptions })
+
+if (archive.ok) {
+  for (const node of graph.nodes.values()) {
+    const securityData = archive.get(node.id)
+    if (securityData) {
+      console.log('securityData', securityData)
+    }
+  }
+} else {
+  console.warn('Failed to start the SecurityArchive')
+}
+```

--- a/src/security-archive/package.json
+++ b/src/security-archive/package.json
@@ -1,0 +1,76 @@
+{
+  "name": "@vltpkg/security-archive",
+  "description": "A database of security information of packages",
+  "version": "0.0.0-3",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/vltpkg/vltpkg.git",
+    "directory": "src/security-archive"
+  },
+  "tshy": {
+    "selfLink": false,
+    "liveDev": true,
+    "dialects": [
+      "esm"
+    ],
+    "exports": {
+      "./package.json": "./package.json",
+      ".": "./src/index.ts"
+    }
+  },
+  "dependencies": {
+    "@vltpkg/dep-id": "workspace:*",
+    "@vltpkg/error-cause": "workspace:*",
+    "@vltpkg/graph": "workspace:*",
+    "@vltpkg/spec": "workspace:*",
+    "@vltpkg/types": "workspace:*",
+    "@vltpkg/xdg": "workspace:*",
+    "lru-cache": "catalog:",
+    "p-retry": "catalog:",
+    "package-json-from-dist": "catalog:"
+  },
+  "devDependencies": {
+    "@eslint/js": "catalog:",
+    "@types/eslint__js": "catalog:",
+    "@types/node": "catalog:",
+    "eslint": "catalog:",
+    "prettier": "catalog:",
+    "tap": "catalog:",
+    "tshy": "catalog:",
+    "typedoc": "catalog:",
+    "typescript": "catalog:",
+    "typescript-eslint": "catalog:"
+  },
+  "license": "BSD-2-Clause-Patent",
+  "engines": {
+    "node": ">=22"
+  },
+  "scripts": {
+    "format": "prettier --write . --log-level warn --ignore-path ../../.prettierignore --cache",
+    "format:check": "prettier --check . --ignore-path ../../.prettierignore --cache",
+    "lint": "eslint . --fix",
+    "lint:check": "eslint .",
+    "prepack": "tshy",
+    "snap": "tap",
+    "test": "tap",
+    "posttest": "tsc --noEmit",
+    "typecheck": "tsc --noEmit"
+  },
+  "tap": {
+    "extends": "../../tap-config.yaml"
+  },
+  "prettier": "../../.prettierrc.js",
+  "module": "./src/index.ts",
+  "type": "module",
+  "exports": {
+    "./package.json": "./package.json",
+    ".": {
+      "import": {
+        "default": "./src/index.ts"
+      }
+    }
+  },
+  "files": [
+    "dist"
+  ]
+}

--- a/src/security-archive/src/browser.ts
+++ b/src/security-archive/src/browser.ts
@@ -1,0 +1,51 @@
+import { asDepID } from '@vltpkg/dep-id/browser'
+import { error } from '@vltpkg/error-cause'
+import { asPackageReportData } from './types.ts'
+import type { JSONField } from '@vltpkg/types'
+import type {
+  PackageReportData,
+  SecurityArchiveLike,
+} from './types.ts'
+import type { DepID } from '@vltpkg/dep-id'
+
+export type * from './types.ts'
+
+const isObj = (o: unknown): o is Record<string, unknown> =>
+  !!o && typeof o === 'object'
+
+const isSecurityArchiveJSON = (
+  json: unknown,
+): json is Record<string, JSONField> =>
+  isObj(json) &&
+  Object.entries(json).every(
+    ([key, value]) => typeof key === 'string' && isObj(value),
+  )
+
+const asSecurityArchiveJSON = (
+  json: unknown,
+): Record<string, JSONField> => {
+  if (!isSecurityArchiveJSON(json)) {
+    throw error('Invalid security archive JSON', { found: json })
+  }
+  return json
+}
+
+/**
+ * A database of security information for given packages in a graph.
+ */
+export class SecurityArchive
+  extends Map<DepID, PackageReportData>
+  implements SecurityArchiveLike
+{
+  /**
+   * Loads a security archive from a valid JSON dump.
+   */
+  static load(dump: unknown) {
+    const archive = new SecurityArchive()
+    const json = asSecurityArchiveJSON(dump)
+    for (const [key, value] of Object.entries(json)) {
+      archive.set(asDepID(key), asPackageReportData(value))
+    }
+    return archive
+  }
+}

--- a/src/security-archive/src/index.ts
+++ b/src/security-archive/src/index.ts
@@ -1,0 +1,385 @@
+// eslint-disable-next-line import/no-unresolved
+import { DatabaseSync } from 'node:sqlite'
+import { LRUCache } from 'lru-cache'
+import pRetry, { AbortError } from 'p-retry'
+import { loadPackageJson } from 'package-json-from-dist'
+import { asDepID, splitDepID, joinDepIDTuple } from '@vltpkg/dep-id'
+import { error } from '@vltpkg/error-cause'
+import { XDG } from '@vltpkg/xdg'
+import { asPackageReportData } from './types.ts'
+import type { DepID } from '@vltpkg/dep-id'
+import type { GraphLike } from '@vltpkg/graph'
+import type { SpecOptions } from '@vltpkg/spec'
+import type {
+  PackageReportData,
+  SecurityArchiveLike,
+  SecurityArchiveRefreshOptions,
+} from './types.ts'
+
+export type * from './types.ts'
+
+const SOCKET_API_V0_URL = 'https://api.socket.dev/v0/purl?alerts=true'
+const SOCKET_PUBLIC_API_TOKEN =
+  'sktsec_t_--RAN5U4ivauy4w37-6aoKyYPDt5ZbaT5JBVMqiwKo_api'
+
+export const targetSecurityRegisty = 'https://registry.npmjs.org/'
+
+export type JSONItemResponse = {
+  namespace?: `@{string}`
+  name: string
+  version: string
+}
+
+export type DBReadEntry = {
+  depID: string
+  report: string
+  start: number
+  ttl: number
+}
+
+export type DBWriteEntry = [string, string, number, number]
+
+export type SecurityArchiveOptions = LRUCache.OptionsBase<
+  DepID,
+  PackageReportData,
+  unknown
+> & {
+  /**
+   * Security archive does not supports a fetch-on-demand model.
+   */
+  fetchMethod?: undefined
+  /**
+   * An optional value for the path in which to store the sqlite db.
+   */
+  path?: string
+  /**
+   * Number of retries attempts to reach the remote security API.
+   */
+  retries?: number
+}
+
+/**
+ * Only the public npm registry has information available in the
+ * socket.dev API. This function checks if a given depID is pointing
+ * to the public npm registry and returns `true` if it does.
+ */
+const usesTargetRegistry = (
+  depID: DepID,
+  specOptions: SpecOptions,
+): boolean => {
+  const [nodeType, nodeRegistry] = splitDepID(depID)
+
+  if (nodeType !== 'registry') {
+    return false
+  }
+
+  const reg =
+    nodeRegistry === '' ?
+      specOptions.registry
+    : specOptions.registries?.[nodeRegistry]
+  return reg === targetSecurityRegisty
+}
+
+// Loads the version number to be used in the User-Agent header
+export const { version } = loadPackageJson(
+  import.meta.filename,
+  process.env.__VLT_INTERNAL_CLI_PACKAGE_JSON,
+) as {
+  version: string
+}
+
+/**
+ * A database of security information for given packages in a graph.
+ *
+ * Using the SecurityArchive.refresh() method will update the local cache
+ * with information from the socket.dev APIs or load from the local storage
+ * if available. Information about package security is then available
+ * using the SecurityArchive.get() method.
+ */
+export class SecurityArchive
+  extends LRUCache<DepID, PackageReportData>
+  implements SecurityArchiveLike
+{
+  #fetchedDepIDs = new Set<DepID>()
+  #path: string
+  #retries: number
+
+  /**
+   * True if the refresh process was successful and report data
+   * is available for all public registry packages in the graph.
+   */
+  ok = false
+
+  /**
+   * Creates a new security archive instance and starts the refresh process.
+   */
+  static async start(
+    options: SecurityArchiveOptions & SecurityArchiveRefreshOptions,
+  ) {
+    const archive = new SecurityArchive(options)
+    await archive.refresh(options)
+    return archive
+  }
+
+  /**
+   * By default, limits to 100K entries in the in-memory archive.
+   */
+  static get defaultMax() {
+    return 100_000
+  }
+
+  /**
+   * By default, entries are cached for 3 hours.
+   */
+  static get defaultTtl() {
+    return 1000 * 60 * 60 * 3
+  }
+
+  constructor(options: SecurityArchiveOptions = {}) {
+    super({
+      max: SecurityArchive.defaultMax,
+      ttl: SecurityArchive.defaultTtl,
+      ...options,
+    })
+
+    this.#path =
+      options.path ?? new XDG('vlt').cache('security-archive.db')
+    this.#retries = options.retries ?? 3
+  }
+
+  /**
+   * Opens a connection to the database at the given path.
+   */
+  #openDatabase(): DatabaseSync {
+    const db = new DatabaseSync(this.#path)
+    db.exec(
+      'CREATE TABLE IF NOT EXISTS cache ' +
+        '(depID TEXT PRIMARY KEY, report TEXT, ttl INTEGER, start INTEGER) ' +
+        // WITHOUT ROWID models a key=value storage,
+        // enforcing depID must be unique and not null
+        // while using less space and more efficient lookups
+        // https://www.sqlite.org/withoutrowid.html
+        'WITHOUT ROWID',
+    )
+    db.exec('PRAGMA journal_mode = TRUNCATE')
+    db.exec('PRAGMA synchronous = NORMAL')
+    return db
+  }
+
+  /**
+   * Loads all valid items found in the database into the in-memory cache.
+   */
+  #loadItemsFromDatabase(db: DatabaseSync, graph: GraphLike): void {
+    const depIDs: string[] = []
+    for (const node of graph.nodes.values()) {
+      depIDs.push(`'${node.id}'`)
+    }
+    // retrieves from the db packages using their dep-id reference
+    // and only include entries that have a valid TTL value
+    const dbRead = db.prepare(
+      'SELECT depID, report, start, ttl, ' +
+        `(SELECT UNIXEPOCH('subsecond')) as now ` +
+        'FROM cache ' +
+        `WHERE depID IN (${depIDs.join(',')}) ` +
+        'GROUP BY depID HAVING SUM(start + ttl) > now',
+    )
+    for (const entry of dbRead.all() as DBReadEntry[]) {
+      const { depID, report, start, ttl } = entry
+      try {
+        this.set(
+          asDepID(depID),
+          asPackageReportData(JSON.parse(report)),
+          {
+            ttl,
+            start,
+          },
+        )
+      } catch {
+        // prune any invalid entries from the database
+        db.prepare('DELETE FROM cache WHERE depID = ?').run(depID)
+      }
+    }
+  }
+
+  /**
+   * Queues up all required packages that are missing from the archive.
+   */
+  #queueUpRequiredPackages(
+    graph: GraphLike,
+    specOptions: SpecOptions,
+  ): Set<Record<'purl', string>> {
+    const queue = new Set<Record<'purl', string>>()
+    const nodes = graph.nodes.values()
+    for (const node of nodes) {
+      // only queue up valid public registry
+      // references that are missing from the archive
+      if (
+        usesTargetRegistry(node.id, specOptions) &&
+        !this.has(node.id)
+      ) {
+        const purl = `pkg:npm/${node.name}@${node.version}`
+        queue.add({ purl })
+      }
+    }
+    return queue
+  }
+
+  /**
+   * Fetches security information from the socket.dev API.
+   * Returns a string of NDJSON data.
+   */
+  async #retrieveRemoteData(
+    queue: Set<Record<'purl', string>>,
+  ): Promise<string> {
+    // fetch information from the socket.dev API
+    const req = await fetch(SOCKET_API_V0_URL, {
+      method: 'POST',
+      headers: {
+        Authorization: `Basic ${Buffer.from(`${SOCKET_PUBLIC_API_TOKEN}:`).toString('base64url')}`,
+        'User-Agent': `@vltpkg/security-archive/${version}`,
+      },
+      body: JSON.stringify({
+        components: Array.from(queue),
+      }),
+    })
+    // on missing valid auth or API, it should abort the retry logic
+    if (req.status === 404) {
+      throw new AbortError('Missing API')
+    }
+    // on any other error throws an error that will trigger retry
+    if (!req.ok || !(req.status >= 200 && req.status <= 299)) {
+      throw error('Failed to fetch security data', { response: req })
+    }
+
+    const str = await req.text()
+    return str.trim() + '\n'
+  }
+
+  /**
+   * Parses and load NDJSON data into the in-memory cache.
+   */
+  #loadFromNDJSON(str: string, graph: GraphLike): void {
+    const json = str.split('}\n')
+    for (const line of json) {
+      if (!line.trim()) continue
+      const data = JSON.parse(line + '}') as JSONItemResponse
+      const scope = data.namespace ? `${data.namespace}/` : ''
+      const depID = joinDepIDTuple([
+        'registry',
+        '',
+        `${scope}${data.name}@${data.version}`,
+      ])
+      const aliasedDepID = joinDepIDTuple([
+        'registry',
+        'npm',
+        `${scope}${data.name}@${data.version}`,
+      ])
+      const node =
+        graph.nodes.get(depID) ?? graph.nodes.get(aliasedDepID)
+      if (node) {
+        this.#fetchedDepIDs.add(node.id)
+        this.set(node.id, asPackageReportData(data))
+      } else {
+        // eslint-disable-next-line no-console
+        console.warn(
+          `security-archive: failed to find node for ${scope}${data.name}@${data.version} found in the response.`,
+        )
+      }
+    }
+  }
+
+  /**
+   * Store new in-memory items to the database.
+   */
+  #storeNewItemsToDatabase(db: DatabaseSync): void {
+    const insertData: DBWriteEntry[] = []
+    for (const depID of this.#fetchedDepIDs) {
+      const entry = this.info(depID)
+      if (entry?.start && entry.ttl) {
+        insertData.push([
+          depID,
+          JSON.stringify(entry.value),
+          entry.start,
+          entry.ttl,
+        ])
+      }
+    }
+    const dbWrite = db.prepare(
+      'INSERT OR REPLACE INTO cache (depID, report, start, ttl) ' +
+        'VALUES (?, ?, ?, ?)',
+    )
+    for (const data of insertData) {
+      dbWrite.run(...data)
+    }
+  }
+
+  /**
+   * Validates that all public-registry packages in the graph
+   * have a valid report data in the current in-memory cache.
+   */
+  #validateReportData(graph: GraphLike, specOptions: SpecOptions) {
+    for (const node of graph.nodes.values()) {
+      if (usesTargetRegistry(node.id, specOptions)) {
+        if (!this.has(node.id)) {
+          this.ok = false
+          return
+        }
+      }
+    }
+    this.ok = true
+  }
+
+  /**
+   * Starts the security archive by providing a {@link GraphLike} instance,
+   * its registry-based nodes are going to be used as valid potential entries.
+   *
+   * Any entry that is missing from the persisted cached values are going
+   * to be requested in a batch-request to the remote socket.dev API.
+   */
+  async refresh({
+    graph,
+    specOptions,
+  }: SecurityArchiveRefreshOptions) {
+    // should start by clearing the current in-memory cache
+    this.clear()
+
+    const db = this.#openDatabase()
+
+    try {
+      this.#loadItemsFromDatabase(db, graph)
+
+      const queue = this.#queueUpRequiredPackages(graph, specOptions)
+      // only reach for the remote API if there are packages queued up
+      if (queue.size > 0) {
+        // Parse the response data
+        const res = await pRetry(
+          () => this.#retrieveRemoteData(queue),
+          { retries: this.#retries },
+        )
+        this.#loadFromNDJSON(res, graph)
+        this.#storeNewItemsToDatabase(db)
+      }
+
+      // validates the refresh process was successful
+      this.#validateReportData(graph, specOptions)
+    } finally {
+      db.exec('PRAGMA optimize')
+      db.close()
+      // TODO: at this point we could spawn a deref process to
+      // remove entries with expired ttl values and vaccum the db
+    }
+  }
+
+  /**
+   * Outputs the current in-memory cache as a JSON object.
+   */
+  toJSON() {
+    if (!this.ok) return undefined
+
+    const obj: Record<DepID, PackageReportData> = {}
+    for (const [key, value] of this.dump()) {
+      obj[key] = value.value
+    }
+    return obj
+  }
+}

--- a/src/security-archive/src/types.ts
+++ b/src/security-archive/src/types.ts
@@ -1,0 +1,84 @@
+import { error } from '@vltpkg/error-cause'
+import type { DepID } from '@vltpkg/dep-id'
+import type { GraphLike } from '@vltpkg/graph'
+import type { SpecOptions } from '@vltpkg/spec'
+
+/**
+ * Parameter options for initializing a security archive.
+ */
+export type SecurityArchiveRefreshOptions = {
+  /**
+   * A @link{GraphLike} instance to find what packages the
+   * security archive should have.
+   */
+  graph: GraphLike
+  /**
+   * A @link{SpecOptions} instance to use for resolving dependencies.
+   */
+  specOptions: SpecOptions
+}
+
+/**
+ * An interface for interacting with a security archive.
+ */
+export interface SecurityArchiveLike {
+  get: (depId: DepID) => PackageReportData | undefined
+  set: (depId: DepID, data: PackageReportData) => void
+  delete: (depId: DepID) => void
+  has: (depId: DepID) => boolean
+  clear: () => void
+}
+
+/**
+ * Package alert extra information.
+ */
+export type PackageAlertProps = {
+  lastPublish: string
+}
+
+/**
+ * A known alert for a given package.
+ */
+export type PackageAlert = {
+  key: string
+  type: string
+  severity: 'low' | 'middle' | 'high' | 'critical'
+  category: string
+  props: PackageAlertProps
+}
+
+/**
+ * The report data for a given package.
+ */
+export type PackageReportData = {
+  id: string
+  author: string[]
+  size: number
+  type: 'npm'
+  namespace?: `@${string}`
+  name: string
+  version: string
+  license: string
+  alerts: PackageAlert[]
+}
+
+export const isPackageReportData = (
+  o: unknown,
+): o is PackageReportData =>
+  typeof o === 'object' &&
+  o != null &&
+  'id' in o &&
+  'type' in o &&
+  'name' in o &&
+  'version' in o &&
+  'alerts' in o &&
+  o.type === 'npm'
+
+export const asPackageReportData = (
+  o: unknown,
+): PackageReportData => {
+  if (!isPackageReportData(o)) {
+    throw error('Invalid package report data', { found: o })
+  }
+  return o
+}

--- a/src/security-archive/tap-snapshots/test/index.ts.test.cjs
+++ b/src/security-archive/tap-snapshots/test/index.ts.test.cjs
@@ -1,0 +1,208 @@
+/* IMPORTANT
+ * This snapshot file is auto-generated, but designed for humans.
+ * It should be checked into source control and tracked carefully.
+ * Re-generate by setting TAP_SNAPSHOT=1 and running tests.
+ * Make sure to inspect the output below.  Do not ignore changes!
+ */
+'use strict'
+exports[`test/index.ts > TAP > SecurityArchive.refresh > should have persisted the API response into the database 1`] = `
+Object {
+  "··@ruyadorno§foo@1.0.0": Object {
+    "alerts": Array [],
+    "author": Array [
+      "ruyadorno",
+    ],
+    "batchIndex": 1,
+    "id": "99923218962",
+    "license": "MIT",
+    "licenseDetails": Array [],
+    "name": "foo",
+    "namespace": "@ruyadorno",
+    "score": Object {
+      "license": 1,
+      "maintenance": 0.84,
+      "overall": 0.83,
+      "quality": 0.83,
+      "supplyChain": 0.99,
+      "vulnerability": 1,
+    },
+    "size": 13003,
+    "type": "npm",
+    "version": "1.0.0",
+  },
+  "··english-days@1.0.0": Object {
+    "alerts": Array [
+      Object {
+        "category": "maintenance",
+        "key": "QG35N0uHm_B_BG4Bc_OlJW3rR2XiTPlFZMNZjm-G1Ufg",
+        "props": Object {
+          "lastPublish": "2016-02-17T02:52:33.918Z",
+        },
+        "severity": "low",
+        "type": "unmaintained",
+      },
+      Object {
+        "category": "supplyChainRisk",
+        "key": "Q2JOM20TNSY962_q6c1goNPMN46sXiFfk0X_8YrIplsU",
+        "props": Object {
+          "linesOfCode": 9,
+        },
+        "severity": "middle",
+        "type": "trivialPackage",
+      },
+      Object {
+        "category": "quality",
+        "key": "Q1hdrp66HKyFF0sBwU7tGypHUBcwpNViZKOQHEKyvIMo",
+        "severity": "middle",
+        "type": "unpopularPackage",
+      },
+    ],
+    "author": Array [
+      "wesleytodd",
+    ],
+    "batchIndex": 0,
+    "id": "15713076833",
+    "license": "ISC",
+    "licenseDetails": Array [],
+    "name": "english-days",
+    "score": Object {
+      "license": 1,
+      "maintenance": 0.75,
+      "overall": 0.55,
+      "quality": 0.55,
+      "supplyChain": 0.6,
+      "vulnerability": 1,
+    },
+    "size": 1632,
+    "type": "npm",
+    "version": "1.0.0",
+  },
+}
+`
+
+exports[`test/index.ts > TAP > SecurityArchive.refresh > should have removed the borked entry from the database 1`] = `
+Object {
+  "··english-days@1.0.0": Object {
+    "alerts": Array [
+      Object {
+        "category": "maintenance",
+        "key": "QG35N0uHm_B_BG4Bc_OlJW3rR2XiTPlFZMNZjm-G1Ufg",
+        "props": Object {
+          "lastPublish": "2016-02-17T02:52:33.918Z",
+        },
+        "severity": "low",
+        "type": "unmaintained",
+      },
+      Object {
+        "category": "supplyChainRisk",
+        "key": "Q2JOM20TNSY962_q6c1goNPMN46sXiFfk0X_8YrIplsU",
+        "props": Object {
+          "linesOfCode": 9,
+        },
+        "severity": "middle",
+        "type": "trivialPackage",
+      },
+      Object {
+        "category": "quality",
+        "key": "Q1hdrp66HKyFF0sBwU7tGypHUBcwpNViZKOQHEKyvIMo",
+        "severity": "middle",
+        "type": "unpopularPackage",
+      },
+    ],
+    "author": Array [
+      "wesleytodd",
+    ],
+    "batchIndex": 0,
+    "id": "15713076833",
+    "license": "ISC",
+    "licenseDetails": Array [],
+    "name": "english-days",
+    "score": Object {
+      "license": 1,
+      "maintenance": 0.75,
+      "overall": 0.55,
+      "quality": 0.55,
+      "supplyChain": 0.6,
+      "vulnerability": 1,
+    },
+    "size": 1632,
+    "type": "npm",
+    "version": "1.0.0",
+  },
+}
+`
+
+exports[`test/index.ts > TAP > SecurityArchive.refresh > should output a JSON representation of the current archive 1`] = `
+Object {
+  "··@ruyadorno§foo@1.0.0": Object {
+    "alerts": Array [],
+    "author": Array [
+      "ruyadorno",
+    ],
+    "batchIndex": 1,
+    "id": "99923218962",
+    "license": "MIT",
+    "licenseDetails": Array [],
+    "name": "foo",
+    "namespace": "@ruyadorno",
+    "score": Object {
+      "license": 1,
+      "maintenance": 0.84,
+      "overall": 0.83,
+      "quality": 0.83,
+      "supplyChain": 0.99,
+      "vulnerability": 1,
+    },
+    "size": 13003,
+    "type": "npm",
+    "version": "1.0.0",
+  },
+  "··english-days@1.0.0": Object {
+    "alerts": Array [
+      Object {
+        "category": "maintenance",
+        "key": "QG35N0uHm_B_BG4Bc_OlJW3rR2XiTPlFZMNZjm-G1Ufg",
+        "props": Object {
+          "lastPublish": "2016-02-17T02:52:33.918Z",
+        },
+        "severity": "low",
+        "type": "unmaintained",
+      },
+      Object {
+        "category": "supplyChainRisk",
+        "key": "Q2JOM20TNSY962_q6c1goNPMN46sXiFfk0X_8YrIplsU",
+        "props": Object {
+          "linesOfCode": 9,
+        },
+        "severity": "middle",
+        "type": "trivialPackage",
+      },
+      Object {
+        "category": "quality",
+        "key": "Q1hdrp66HKyFF0sBwU7tGypHUBcwpNViZKOQHEKyvIMo",
+        "severity": "middle",
+        "type": "unpopularPackage",
+      },
+    ],
+    "author": Array [
+      "wesleytodd",
+    ],
+    "batchIndex": 0,
+    "id": "15713076833",
+    "license": "ISC",
+    "licenseDetails": Array [],
+    "name": "english-days",
+    "score": Object {
+      "license": 1,
+      "maintenance": 0.75,
+      "overall": 0.55,
+      "quality": 0.55,
+      "supplyChain": 0.6,
+      "vulnerability": 1,
+    },
+    "size": 1632,
+    "type": "npm",
+    "version": "1.0.0",
+  },
+}
+`

--- a/src/security-archive/test/browser.ts
+++ b/src/security-archive/test/browser.ts
@@ -1,0 +1,102 @@
+import t from 'tap'
+import { joinDepIDTuple } from '@vltpkg/dep-id/browser'
+import { SecurityArchive } from '../src/browser.ts'
+
+const json = {
+  '··english-days@1.0.0': {
+    id: '15713076833',
+    author: ['wesleytodd'],
+    size: 1632,
+    type: 'npm',
+    name: 'english-days',
+    version: '1.0.0',
+    license: 'ISC',
+    licenseDetails: [],
+    score: {
+      license: 1,
+      maintenance: 0.75,
+      overall: 0.55,
+      quality: 0.55,
+      supplyChain: 0.6,
+      vulnerability: 1,
+    },
+    alerts: [
+      {
+        key: 'QG35N0uHm_B_BG4Bc_OlJW3rR2XiTPlFZMNZjm-G1Ufg',
+        type: 'unmaintained',
+        severity: 'low',
+        category: 'maintenance',
+        props: {
+          lastPublish: '2016-02-17T02:52:33.918Z',
+        },
+      },
+      {
+        key: 'Q2JOM20TNSY962_q6c1goNPMN46sXiFfk0X_8YrIplsU',
+        type: 'trivialPackage',
+        severity: 'middle',
+        category: 'supplyChainRisk',
+        props: {
+          linesOfCode: 9,
+        },
+      },
+      {
+        key: 'Q1hdrp66HKyFF0sBwU7tGypHUBcwpNViZKOQHEKyvIMo',
+        type: 'unpopularPackage',
+        severity: 'middle',
+        category: 'quality',
+      },
+    ],
+    batchIndex: 0,
+  },
+  '··@ruyadorno§foo@1.0.0': {
+    id: '99923218962',
+    author: ['ruyadorno'],
+    size: 13003,
+    type: 'npm',
+    namespace: '@ruyadorno',
+    name: 'foo',
+    version: '1.0.0',
+    license: 'MIT',
+    licenseDetails: [],
+    score: {
+      license: 1,
+      maintenance: 0.84,
+      overall: 0.83,
+      quality: 0.83,
+      supplyChain: 0.99,
+      vulnerability: 1,
+    },
+    alerts: [],
+    batchIndex: 1,
+  },
+}
+
+t.test('SecurityArchive.load', async t => {
+  const archive = SecurityArchive.load(json)
+  t.strictSame(
+    archive.get(
+      joinDepIDTuple(['registry', '', 'english-days@1.0.0']),
+    )!.name,
+    'english-days',
+    'should load have loaded security data',
+  )
+
+  await t.test('empty archive', async t => {
+    const archive = SecurityArchive.load({})
+    t.strictSame(archive.size, 0, 'should have an empty archive')
+  })
+})
+
+t.test('load bad data', async t => {
+  t.throws(
+    () => SecurityArchive.load('borked data'),
+    /Invalid security archive JSON/,
+    'should throw on invalid data',
+  )
+
+  t.throws(
+    () => SecurityArchive.load({ also: 'borked data' }),
+    /Invalid security archive JSON/,
+    'should throw on invalid data obj',
+  )
+})

--- a/src/security-archive/test/fixtures/graph.ts
+++ b/src/security-archive/test/fixtures/graph.ts
@@ -1,0 +1,98 @@
+import { joinDepIDTuple } from '@vltpkg/dep-id'
+import { Spec } from '@vltpkg/spec'
+import type { GraphLike, NodeLike } from '@vltpkg/graph'
+import type { SpecLike, SpecOptions } from '@vltpkg/spec/browser'
+import type { DependencyTypeShort } from '@vltpkg/types'
+
+export const specOptions = {
+  registry: 'https://registry.npmjs.org/',
+  registries: {
+    custom: 'http://example.com',
+  },
+} satisfies SpecOptions
+
+const projectRoot = '.'
+// NOTE: name is the only property that is being tracked in these fixture
+export const newGraph = (rootName: string): GraphLike => {
+  const graph = {} as GraphLike
+  const addNode = newNode(graph)
+  const mainImporter = addNode(rootName)
+  mainImporter.id = joinDepIDTuple(['file', '.'])
+  mainImporter.mainImporter = true
+  mainImporter.importer = true
+  mainImporter.graph = graph
+  graph.importers = new Set([mainImporter])
+  graph.mainImporter = mainImporter
+  graph.nodes = new Map([[mainImporter.id, mainImporter]])
+  graph.edges = new Set()
+
+  return graph
+}
+export const newNode =
+  (graph: GraphLike) =>
+  (name: string, version = '1.0.0', registry?: string): NodeLike => ({
+    projectRoot,
+    edgesIn: new Set(),
+    edgesOut: new Map(),
+    importer: false,
+    mainImporter: false,
+    graph,
+    id: joinDepIDTuple([
+      'registry',
+      registry ?? '',
+      `${name}@${version}`,
+    ]),
+    name,
+    version,
+    location:
+      'node_modules/.vlt/·${registry}·${name}@${version}/node_modules/${name}',
+    manifest: { name, version },
+    integrity: 'sha512-deadbeef',
+    resolved: undefined,
+    dev: false,
+    optional: false,
+    setResolved() {},
+  })
+const newEdge = (
+  from: NodeLike,
+  spec: SpecLike<Spec>,
+  type: DependencyTypeShort,
+  to?: NodeLike,
+) => {
+  const edge = { name: spec.name, from, to, spec, type }
+  from.edgesOut.set(spec.name, edge)
+  if (to) {
+    to.edgesIn.add(edge)
+  }
+  from.graph.edges.add(edge)
+}
+
+export const getSimpleReportGraph = (): GraphLike => {
+  const graph = newGraph('my-project')
+  const addNode = newNode(graph)
+  const foo = addNode('@ruyadorno/foo')
+  const englishDays = addNode('english-days')
+  const customRegistry = addNode('registry', '1.0.1', 'custom')
+  graph.nodes.set(foo.id, foo)
+  graph.nodes.set(englishDays.id, englishDays)
+  graph.nodes.set(customRegistry.id, customRegistry)
+  newEdge(
+    graph.mainImporter,
+    Spec.parse('@ruyadorno/foo', '^1.0.0', specOptions),
+    'prod',
+    foo,
+  )
+  newEdge(
+    graph.mainImporter,
+    Spec.parse('english-days', '^1.0.0', specOptions),
+    'dev',
+    englishDays,
+  )
+  newEdge(
+    graph.mainImporter,
+    Spec.parse('registry', 'custom:registry@^1.0.0', specOptions),
+    'dev',
+    customRegistry,
+  )
+  return graph
+}

--- a/src/security-archive/test/index.ts
+++ b/src/security-archive/test/index.ts
@@ -1,0 +1,293 @@
+import { resolve } from 'node:path'
+// eslint-disable-next-line import/no-unresolved
+import { DatabaseSync } from 'node:sqlite'
+import t from 'tap'
+import { joinDepIDTuple } from '@vltpkg/dep-id'
+import { SecurityArchive } from '../src/index.ts'
+import {
+  specOptions,
+  getSimpleReportGraph,
+} from './fixtures/graph.ts'
+import type { PackageReportData } from '../src/types.ts'
+
+const fooReport = {
+  id: '99923218962',
+  author: ['ruyadorno'],
+  size: 13003,
+  type: 'npm',
+  namespace: '@ruyadorno',
+  name: 'foo',
+  version: '1.0.0',
+  license: 'MIT',
+  licenseDetails: [],
+  score: {
+    license: 1,
+    maintenance: 0.84,
+    overall: 0.83,
+    quality: 0.83,
+    supplyChain: 0.99,
+    vulnerability: 1,
+  },
+  alerts: [],
+  batchIndex: 1,
+}
+
+const fooNewReport = {
+  id: '99923218963',
+  author: ['ruyadorno'],
+  size: 13013,
+  type: 'npm',
+  namespace: '@ruyadorno',
+  name: 'foo',
+  version: '1.0.1',
+  license: 'MIT',
+  licenseDetails: [],
+  score: {
+    license: 1,
+    maintenance: 0.94,
+    overall: 0.93,
+    quality: 0.93,
+    supplyChain: 0.99,
+    vulnerability: 1,
+  },
+  alerts: [],
+  batchIndex: 1,
+}
+
+const englishDaysReport = {
+  id: '15713076833',
+  author: ['wesleytodd'],
+  size: 1632,
+  type: 'npm',
+  name: 'english-days',
+  version: '1.0.0',
+  license: 'ISC',
+  licenseDetails: [],
+  score: {
+    license: 1,
+    maintenance: 0.75,
+    overall: 0.55,
+    quality: 0.55,
+    supplyChain: 0.6,
+    vulnerability: 1,
+  },
+  alerts: [
+    {
+      key: 'QG35N0uHm_B_BG4Bc_OlJW3rR2XiTPlFZMNZjm-G1Ufg',
+      type: 'unmaintained',
+      severity: 'low',
+      category: 'maintenance',
+      props: { lastPublish: '2016-02-17T02:52:33.918Z' },
+    },
+    {
+      key: 'Q2JOM20TNSY962_q6c1goNPMN46sXiFfk0X_8YrIplsU',
+      type: 'trivialPackage',
+      severity: 'middle',
+      category: 'supplyChainRisk',
+      props: { linesOfCode: 9 },
+    },
+    {
+      key: 'Q1hdrp66HKyFF0sBwU7tGypHUBcwpNViZKOQHEKyvIMo',
+      type: 'unpopularPackage',
+      severity: 'middle',
+      category: 'quality',
+    },
+  ],
+  batchIndex: 0,
+}
+
+t.test('map-like', async t => {
+  const archive = new SecurityArchive()
+  const id = joinDepIDTuple(['registry', '', 'bar'])
+  archive.set(id, { name: 'bar' } as PackageReportData)
+  t.strictSame(archive.has(id), true)
+  t.strictSame(archive.get(id), { name: 'bar' })
+  archive.delete(id)
+  t.strictSame(archive.get(id), undefined)
+})
+
+t.test('SecurityArchive.refresh', async t => {
+  const dir = t.testdir()
+  const graph = getSimpleReportGraph()
+  global.fetch = async () =>
+    ({
+      ok: true,
+      status: 200,
+      text: async () => `${JSON.stringify(fooReport)}
+${JSON.stringify(englishDaysReport)}
+`,
+    }) as unknown as Response
+  const path = resolve(dir, 'test.db')
+  const archive = await SecurityArchive.start({
+    graph,
+    path,
+    specOptions,
+  })
+
+  t.strictSame(
+    archive.get(
+      joinDepIDTuple(['registry', '', '@ruyadorno/foo@1.0.0']),
+    ),
+    fooReport,
+    'should have loaded API response into the in-memory archive',
+  )
+
+  const db = new DatabaseSync(path)
+  const dbRead = db.prepare('SELECT depID, report FROM cache')
+  const dbDump: Record<string, any> = {}
+  const readData = dbRead.all() as { depID: string; report: any }[]
+  for (const { depID, report } of readData) {
+    dbDump[depID] = JSON.parse(report)
+  }
+  t.matchSnapshot(
+    dbDump,
+    'should have persisted the API response into the database',
+  )
+
+  t.matchSnapshot(
+    archive.toJSON(),
+    'should output a JSON representation of the current archive',
+  )
+
+  // Updates the fetch mock to return a new version of foo
+  global.fetch = async () =>
+    ({
+      ok: true,
+      status: 200,
+      text: async () => `${JSON.stringify(fooNewReport)}
+${JSON.stringify(englishDaysReport)}
+`,
+    }) as unknown as Response
+
+  await archive.refresh({ graph, specOptions })
+
+  // here we test that retrieving data for foo still returns the old
+  // version, since that was loaded from the db instead and is still valid
+  t.strictSame(
+    archive.get(
+      joinDepIDTuple(['registry', '', '@ruyadorno/foo@1.0.0']),
+    ),
+    fooReport,
+    'should have loaded API response from db',
+  )
+
+  // check pruning bad entries from the db
+  global.fetch = async () =>
+    ({
+      ok: true,
+      status: 200,
+      text: async () => '',
+    }) as unknown as Response
+
+  const dbWrite = db.prepare(
+    'INSERT OR REPLACE INTO cache (depID, report, start, ttl) ' +
+      'VALUES (?, ?, ?, ?)',
+  )
+  dbWrite.run(
+    joinDepIDTuple(['registry', '', '@ruyadorno/foo@1.0.0']),
+    'borked data',
+    Date.now(),
+    SecurityArchive.defaultTtl,
+  )
+
+  await archive.refresh({ graph, specOptions })
+
+  const readBorked = db.prepare('SELECT depID, report FROM cache')
+  const dumpBorked: Record<string, any> = {}
+  const borkedData = readBorked.all() as {
+    depID: string
+    report: any
+  }[]
+  for (const { depID, report } of borkedData) {
+    dumpBorked[depID] = JSON.parse(report)
+  }
+  t.matchSnapshot(
+    dumpBorked,
+    'should have removed the borked entry from the database',
+  )
+
+  // check that the toJSON method returns undefined
+  // when the archive is in an invalid state (archive.ok=false)
+  t.strictSame(
+    archive.toJSON(),
+    undefined,
+    'should output undefined when the archive is in an invalid state',
+  )
+
+  db.close()
+
+  await t.test('extraneous package in API response', async t => {
+    const dir = t.testdir()
+    const path = resolve(dir, 'missing.db')
+
+    // fetch mock returns a response with an extraneous pkg report
+    global.fetch = async () =>
+      ({
+        ok: true,
+        status: 200,
+        text: async () => `${JSON.stringify(fooReport)}
+${JSON.stringify(englishDaysReport)}
+${JSON.stringify({
+  id: '99923218964',
+  type: 'npm',
+  name: 'extraneous',
+  version: '1.0.0',
+})}
+`,
+      }) as unknown as Response
+
+    const warn = t.capture(console, 'warn').args
+    const archive = new SecurityArchive({ path })
+    await archive.refresh({ graph, specOptions })
+
+    t.strictSame(
+      warn(),
+      [
+        [
+          'security-archive: failed to find node for extraneous@1.0.0 found in the response.',
+        ],
+      ],
+      'should warn about the extraneous package',
+    )
+  })
+
+  await t.test('bad api response', async t => {
+    const dir = t.testdir()
+    const path = resolve(dir, 'missing.db')
+
+    // Updates the fetch mock to return a new version of foo
+    global.fetch = async () =>
+      ({
+        ok: false,
+        status: 500,
+        text: async () => '',
+      }) as unknown as Response
+
+    const archive = new SecurityArchive({ path, retries: 0 })
+    await t.rejects(
+      archive.refresh({ graph, specOptions }),
+      /Failed to fetch security data/,
+      'should throw an error when the API response is invalid',
+    )
+  })
+
+  await t.test('missing api response', async t => {
+    const dir = t.testdir()
+    const path = resolve(dir, 'missing.db')
+
+    // Updates the fetch mock to return a new version of foo
+    global.fetch = async () =>
+      ({
+        ok: false,
+        status: 404,
+        text: async () => 'Missing API',
+      }) as unknown as Response
+
+    const archive = new SecurityArchive({ path })
+    await t.rejects(
+      archive.refresh({ graph, specOptions }),
+      /Missing API/,
+      'should abort retries',
+    )
+  })
+})

--- a/src/security-archive/tsconfig.json
+++ b/src/security-archive/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../tsconfig.json"
+}

--- a/src/security-archive/typedoc.mjs
+++ b/src/security-archive/typedoc.mjs
@@ -1,0 +1,2 @@
+import config from '../../www/docs/typedoc.workspace.mjs'
+export default config(import.meta.dirname)


### PR DESCRIPTION
Add a new package `@vltpkg/security-archive` that handles accessing, fetching remote data and persisting security report data on packages from a given graph.

## Usage

```js
import { actual } from '@vltpkg/graph'
import { SecurityArchive } from '@vltpkg/security-archive'
const specOptions = {
  registry: 'https://registry.npmjs.org/',
}
const graph = actual.load({
  ...specOptions,
  projectRoot: process.cwd(),
})
const archive = await SecurityArchive.start({ graph, specOptions })
if (archive.ok) {
  for (const node of graph.nodes.values()) {
    const securityData = archive.get(node.id)
    if (securityData) {
      console.log('securityData', securityData)
    }
  }
} else {
  console.warn('Failed to start the SecurityArchive')
}
```