### PR TITLE
gui: error view button bugfix

### DIFF
--- a/src/gui/src/app/error-found.tsx
+++ b/src/gui/src/app/error-found.tsx
@@ -1,17 +1,14 @@
-import { useNavigate } from 'react-router'
+import { useLocation, NavLink, useNavigate } from 'react-router'
 import type { MouseEvent } from 'react'
 import { useGraphStore } from '@/state/index.js'
 import { Button } from '@/components/ui/button.jsx'
 import { ArrowRight, TriangleAlert } from 'lucide-react'
+import { cn } from '@/lib/utils.js'
 
 export const ErrorFound = () => {
   const navigate = useNavigate()
+  const { pathname } = useLocation()
   const errorCause = useGraphStore(state => state.errorCause)
-
-  const onDashboardButtonClick = (e: MouseEvent) => {
-    e.preventDefault()
-    void navigate('/dashboard')
-  }
 
   const onBackButtonClick = (e: MouseEvent) => {
     e.preventDefault()
@@ -19,7 +16,11 @@ export const ErrorFound = () => {
   }
 
   return (
-    <section className="flex h-full flex-col items-center justify-center rounded-lg border-[1px] bg-white dark:bg-black">
+    <section
+      className={cn(
+        'flex flex-col items-center justify-center rounded-lg border-[1px] bg-white dark:bg-black',
+        pathname === '/error' ? 'h-full' : 'h-screen',
+      )}>
       <div className="relative -mt-32 flex flex-col items-center justify-center">
         <div className="relative flex flex-col gap-8">
           <div className="absolute inset-0 z-[2] bg-gradient-radial from-white/0 via-transparent to-white dark:from-black/0 dark:to-black" />
@@ -51,9 +52,11 @@ export const ErrorFound = () => {
             <Button variant="outline" onClick={onBackButtonClick}>
               Back
             </Button>
-            <Button onClick={onDashboardButtonClick}>
-              <span>Dashboard</span>
-              <ArrowRight />
+            <Button asChild>
+              <NavLink to="/">
+                <span>Dashboard</span>
+                <ArrowRight />
+              </NavLink>
             </Button>
           </div>
         </div>

--- a/src/gui/test/app/__snapshots__/error-found.tsx.snap
+++ b/src/gui/test/app/__snapshots__/error-found.tsx.snap
@@ -3,7 +3,7 @@
 exports[`error-found has a cause 1`] = `
 
 <div>
-  <section class="flex h-full flex-col items-center justify-center rounded-lg border-[1px] bg-white dark:bg-black">
+  <section class="flex flex-col items-center justify-center rounded-lg border-[1px] bg-white dark:bg-black h-full">
     <div class="relative -mt-32 flex flex-col items-center justify-center">
       <div class="relative flex flex-col gap-8">
         <div class="absolute inset-0 z-[2] bg-gradient-radial from-white/0 via-transparent to-white dark:from-black/0 dark:to-black">
@@ -391,12 +391,14 @@ exports[`error-found has a cause 1`] = `
           <gui-button variant="outline">
             Back
           </gui-button>
-          <gui-button>
-            <span>
-              Dashboard
-            </span>
-            <gui-arrow-right-icon>
-            </gui-arrow-right-icon>
+          <gui-button aschild="true">
+            <gui-nav-link to="/">
+              <span>
+                Dashboard
+              </span>
+              <gui-arrow-right-icon>
+              </gui-arrow-right-icon>
+            </gui-nav-link>
           </gui-button>
         </div>
       </div>
@@ -411,7 +413,7 @@ exports[`error-found has a cause 1`] = `
 exports[`render default 1`] = `
 
 <div>
-  <section class="flex h-full flex-col items-center justify-center rounded-lg border-[1px] bg-white dark:bg-black">
+  <section class="flex flex-col items-center justify-center rounded-lg border-[1px] bg-white dark:bg-black h-full">
     <div class="relative -mt-32 flex flex-col items-center justify-center">
       <div class="relative flex flex-col gap-8">
         <div class="absolute inset-0 z-[2] bg-gradient-radial from-white/0 via-transparent to-white dark:from-black/0 dark:to-black">
@@ -799,12 +801,14 @@ exports[`render default 1`] = `
           <gui-button variant="outline">
             Back
           </gui-button>
-          <gui-button>
-            <span>
-              Dashboard
-            </span>
-            <gui-arrow-right-icon>
-            </gui-arrow-right-icon>
+          <gui-button aschild="true">
+            <gui-nav-link to="/">
+              <span>
+                Dashboard
+              </span>
+              <gui-arrow-right-icon>
+              </gui-arrow-right-icon>
+            </gui-nav-link>
           </gui-button>
         </div>
       </div>

--- a/src/gui/test/app/error-found.tsx
+++ b/src/gui/test/app/error-found.tsx
@@ -6,6 +6,8 @@ import { ErrorFound } from '@/app/error-found.jsx'
 
 vi.mock('react-router', () => ({
   useNavigate: vi.fn(),
+  useLocation: vi.fn(() => ({ pathname: '/error' })),
+  NavLink: 'gui-nav-link',
 }))
 vi.mock('@/components/ui/button.jsx', () => ({
   Button: 'gui-button',


### PR DESCRIPTION
- correctly sets the navigation destination on the `dashboard` button
- updates the height of the view if the `pathname` is not `/error`, this
  is to support a global errorBoundary view
