### PR TITLE
Add query alert security selectors

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1283,6 +1283,9 @@ importers:
       '@vltpkg/graph':
         specifier: workspace:*
         version: link:../graph
+      '@vltpkg/security-archive':
+        specifier: workspace:*
+        version: link:../security-archive
       '@vltpkg/semver':
         specifier: workspace:*
         version: link:../semver

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1958,6 +1958,9 @@ importers:
       '@vltpkg/run':
         specifier: workspace:*
         version: link:../run
+      '@vltpkg/security-archive':
+        specifier: workspace:*
+        version: link:../security-archive
       '@vltpkg/server':
         specifier: workspace:*
         version: link:../server

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -805,6 +805,9 @@ importers:
       '@vltpkg/query':
         specifier: workspace:*
         version: link:../query
+      '@vltpkg/security-archive':
+        specifier: workspace:*
+        version: link:../security-archive
       '@vltpkg/spec':
         specifier: workspace:*
         version: link:../spec

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1677,6 +1677,9 @@ importers:
       '@vltpkg/package-json':
         specifier: workspace:*
         version: link:../package-json
+      '@vltpkg/security-archive':
+        specifier: workspace:*
+        version: link:../security-archive
       '@vltpkg/spec':
         specifier: workspace:*
         version: link:../spec
@@ -12589,7 +12592,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.0(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.7.0)(eslint@9.20.0(jiti@1.21.6)):
+  eslint-module-utils@2.12.0(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.7.0(eslint-plugin-import@2.31.0)(eslint@9.20.0(jiti@1.21.6)))(eslint@9.20.0(jiti@1.21.6)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
@@ -12610,7 +12613,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.20.0(jiti@1.21.6)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.0(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.7.0)(eslint@9.20.0(jiti@1.21.6))
+      eslint-module-utils: 2.12.0(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.7.0(eslint-plugin-import@2.31.0)(eslint@9.20.0(jiti@1.21.6)))(eslint@9.20.0(jiti@1.21.6))
       hasown: 2.0.2
       is-core-module: 2.15.1
       is-glob: 4.0.3

--- a/src/gui/package.json
+++ b/src/gui/package.json
@@ -28,6 +28,7 @@
     "@vltpkg/fast-split": "workspace:*",
     "@vltpkg/graph": "workspace:*",
     "@vltpkg/query": "workspace:*",
+    "@vltpkg/security-archive": "workspace:*",
     "@vltpkg/spec": "workspace:*",
     "@vltpkg/types": "workspace:*",
     "class-variance-authority": "^0.7.0",

--- a/src/gui/src/app/explorer.tsx
+++ b/src/gui/src/app/explorer.tsx
@@ -38,8 +38,8 @@ const startGraphData = async ({
   const data = (await res.json()) as TransferData & {
     hasDashboard: boolean
   }
-  const { graph, specOptions } = load(data)
-  const q = new Query({ graph, specOptions })
+  const { graph, specOptions, securityArchive } = load(data)
+  const q = new Query({ graph, specOptions, securityArchive })
 
   updateHasDashboard(data.hasDashboard)
   updateGraph(graph)

--- a/src/gui/src/state/load-graph.ts
+++ b/src/gui/src/state/load-graph.ts
@@ -1,12 +1,5 @@
-import type { Manifest, DependencyTypeShort } from '@vltpkg/types'
 import { lockfile } from '@vltpkg/graph/browser'
-import type { DepID } from '@vltpkg/dep-id/browser'
-import type {
-  EdgeLike,
-  LockfileData,
-  GraphLike,
-  NodeLike,
-} from '@vltpkg/graph'
+import { SecurityArchive } from '@vltpkg/security-archive/browser'
 import {
   defaultRegistry,
   defaultRegistries,
@@ -14,6 +7,14 @@ import {
   defaultGitHostArchives,
   defaultScopeRegistries,
 } from '@vltpkg/spec/browser'
+import type { Manifest, DependencyTypeShort } from '@vltpkg/types'
+import type { DepID } from '@vltpkg/dep-id/browser'
+import type {
+  EdgeLike,
+  LockfileData,
+  GraphLike,
+  NodeLike,
+} from '@vltpkg/graph'
 import type { SpecOptionsFilled, Spec } from '@vltpkg/spec/browser'
 import type { TransferData } from './types.ts'
 
@@ -57,6 +58,7 @@ type MaybeGraphLike = Pick<
 export type LoadResponse = {
   graph: GraphLike
   specOptions: SpecOptionsFilled
+  securityArchive: SecurityArchive | undefined
 }
 
 export const load = (transfered: TransferData): LoadResponse => {
@@ -148,9 +150,13 @@ export const load = (transfered: TransferData): LoadResponse => {
   lockfile.loadNodes(graph, transfered.lockfile.nodes)
   const specOptions = loadSpecOptions(transfered.lockfile)
   lockfile.loadEdges(graph, transfered.lockfile.edges, specOptions)
+  const securityArchive = SecurityArchive.load(
+    transfered.securityArchive,
+  )
 
   return {
     graph,
     specOptions,
+    securityArchive,
   }
 }

--- a/src/gui/src/state/types.ts
+++ b/src/gui/src/state/types.ts
@@ -48,12 +48,18 @@ export type ProjectInfo = {
 }
 
 /**
+ * Transfer data JSON object used to send security data from the backend.
+ */
+export type SecurityArchiveTransfer = Record<string, any> | undefined
+
+/**
  * Transfer data object used to send data from the cli.
  */
 export type TransferData = {
   importers: RawNode[]
   lockfile: LockfileData
   projectInfo: ProjectInfo
+  securityArchive: SecurityArchiveTransfer
 }
 
 export type RawNode = {

--- a/src/gui/test/components/explorer-grid/index.tsx
+++ b/src/gui/test/components/explorer-grid/index.tsx
@@ -201,8 +201,13 @@ test('explorer-grid renders workspace with edges in', async () => {
       tools: ['vlt'],
       vltInstalled: true,
     },
+    securityArchive: undefined,
   })
-  const q = new Query({ graph, specOptions: {} })
+  const q = new Query({
+    graph,
+    specOptions: {},
+    securityArchive: undefined,
+  })
   const result = await q.search(':project[name=b]')
 
   const Container = () => {

--- a/src/gui/test/state/__snapshots__/load-graph.ts.snap
+++ b/src/gui/test/state/__snapshots__/load-graph.ts.snap
@@ -274,6 +274,7 @@ exports[`load graph 1`] = `
       gitlab: 'https://gitlab.com/$1/$2/repository/archive.tar.gz?ref=$committish'
     },
     'scope-registries': {}
-  }
+  },
+  securityArchive: undefined
 }"
 `;

--- a/src/gui/test/state/load-graph.ts
+++ b/src/gui/test/state/load-graph.ts
@@ -86,6 +86,7 @@ const transferData: TransferData = {
     tools: ['vlt'],
     vltInstalled: true,
   },
+  securityArchive: undefined,
 }
 
 test('load graph', () => {

--- a/src/query/README.md
+++ b/src/query/README.md
@@ -169,5 +169,62 @@ going to require a network call to hydrate package report data. Keep
 in mind that this is going to slow down end-user query usage since the
 security data needs to be fetched prior to a `Query` instantiation.
 
+- `:abandoned` Matches packages that were published by an npm account
+  that no longer exists.
+- `:confused` Matches packages affected by manifest confusion. This
+  could be malicious or caused by an error when publishing the
+  package.
+- `:debug` Matches packages that use debug, reflection and dynamic
+  code execution features.
+- `:deprecated` Matches packages marked as deprecated. This could
+  indicate that a single version should not be used, or that the
+  package is no longer maintained and any new vulnerabilities will not
+  be fixed.
+- `:dynamic` Matches packages that uses dynamic imports.
+- `:entropic` Matches packages that contains high entropic strings.
+  This could be a sign of encrypted data, leaked secrets or obfuscated
+  code.
+- `:env` Matches packages that accesses environment variables, which
+  may be a sign of credential stuffing or data theft.
+- `:eval` Matches packages that use dynamic code execution (e.g.,
+  eval()), which is a dangerous practice. This can prevent the code
+  from running in certain environments and increases the risk that the
+  code may contain exploits or malicious behavior.
+- `:fs` Matches packages that accesses the file system, and could
+  potentially read sensitive data.
+- `:obfuscated` Matches packages that use obfuscated files,
+  intentionally packed to hide their behavior. This could be a sign of
+  malware.
+- `:minified` Matches packages that contain minified code. This may be
+  harmless in some cases where minified code is included in packaged
+  libraries.
+- `:native` Matches packages that contain native code (e.g., compiled
+  binaries or shared libraries). Including native code can obscure
+  malicious behavior.
+- `:network` Matches packages that access the network.
+- `:scripts` Matches packages that have scripts that are run when the
+  package is installed. The majority of malware in npm is hidden in
+  install scripts.
+- `:shell` Matches packages that accesses the system shell. Accessing
+  the system shell increases the risk of executing arbitrary code.
+- `:shrinkwrap` Matches packages that contains a shrinkwrap file. This
+  may allow the package to bypass normal install procedures.
+- `:suspicious` Matches packages that may have its GitHub repository
+  artificially inflated with stars (from bots, crowdsourcing, etc.).
+- `:tracker` Matches packages that contains telemetry which tracks how
+  it is used.
+- `:trivial` Matches packages that have less than 10 lines of code.
+  These packages are easily copied into your own project and may not
+  warrant the additional supply chain risk of an external dependency.
+- `:undesirable` Matches packages that are a joke, parody, or includes
+  undocumented or hidden behavior unrelated to its primary function.
+- `:unknown` Matches packages that have a new npm collaborator
+  publishing a version of the package for the first time. New
+  collaborators are usually benign additions to a project, but do
+  indicate a change to the security surface area of a package.
 - `:unmaintained` Matches packages that have not been updated in more
   than 5 years and may be unmaintained.
+- `:unpopular` Matches packages that are not very popular.
+- `:unstable` Matches packages with unstable ownership. This indicates
+  a new collaborator has begun publishing package versions. Package
+  stability and security risk may be elevated.

--- a/src/query/README.md
+++ b/src/query/README.md
@@ -166,6 +166,8 @@ e.g: `#foo` is the same as `[name=foo]`
 The following pseudo-selectors rely on security data provided by
 [Socket](https://socket.dev/), the usage of any of these selectors is
 going to require a network call to hydrate package report data. Keep
-in mind that this is going to slow down end-user query usage since
-the security data needs to be fetched prior to a `Query`
-instantiation.
+in mind that this is going to slow down end-user query usage since the
+security data needs to be fetched prior to a `Query` instantiation.
+
+- `:unmaintained` Matches packages that have not been updated in more
+  than 5 years and may be unmaintained.

--- a/src/query/README.md
+++ b/src/query/README.md
@@ -12,7 +12,7 @@ The **vlt** query syntax engine.
 ```js
 import { Query } from '@vltpkg/query'
 
-const query = new Query({ nodes })
+const query = new Query({ nodes, specOptions, securityArchive })
 query.search(':root > *')
 ```
 
@@ -160,3 +160,12 @@ e.g: `#foo` is the same as `[name=foo]`
 - `:root` Returns the root node, that represents the package defined
   at the top-level `package.json` of your project folder.
 - `:scope` Returns the current scope of a given selector
+
+### Security Selectors
+
+The following pseudo-selectors rely on security data provided by
+[Socket](https://socket.dev/), the usage of any of these selectors is
+going to require a network call to hydrate package report data. Keep
+in mind that this is going to slow down end-user query usage since
+the security data needs to be fetched prior to a `Query`
+instantiation.

--- a/src/query/package.json
+++ b/src/query/package.json
@@ -22,6 +22,7 @@
     "@vltpkg/dep-id": "workspace:*",
     "@vltpkg/error-cause": "workspace:*",
     "@vltpkg/graph": "workspace:*",
+    "@vltpkg/security-archive": "workspace:*",
     "@vltpkg/semver": "workspace:*",
     "@vltpkg/types": "workspace:*",
     "postcss-selector-parser": "^6.1.2"

--- a/src/query/src/index.ts
+++ b/src/query/src/index.ts
@@ -114,17 +114,24 @@ export type QueryOptions = {
   securityArchive: SecurityArchiveLike | undefined
 }
 
+const securitySelectors = new Set([':unmaintained'])
+
 export class Query {
   #cache: Map<string, QueryResponse>
   #graph: GraphLike
   #specOptions: SpecOptions
   #securityArchive: SecurityArchiveLike | undefined
 
-  constructor({
-    graph,
-    specOptions,
-    securityArchive
-  }: QueryOptions) {
+  static hasSecuritySelectors(query: string): boolean {
+    for (const selector of securitySelectors) {
+      if (query.includes(selector)) {
+        return true
+      }
+    }
+    return false
+  }
+
+  constructor({ graph, specOptions, securityArchive }: QueryOptions) {
     this.#cache = new Map()
     this.#graph = graph
     this.#specOptions = specOptions

--- a/src/query/src/index.ts
+++ b/src/query/src/index.ts
@@ -119,6 +119,7 @@ const securitySelectors = new Set([
   ':suspicious',
   ':trivial',
   ':undesirable',
+  ':unknown',
   ':unmaintained',
   ':unstable',
 ])

--- a/src/query/src/index.ts
+++ b/src/query/src/index.ts
@@ -121,6 +121,7 @@ const securitySelectors = new Set([
   ':eval',
   ':obfuscated',
   ':native',
+  ':network',
   ':scripts',
   ':shell',
   ':shrinkwrap',

--- a/src/query/src/index.ts
+++ b/src/query/src/index.ts
@@ -115,11 +115,12 @@ export type QueryOptions = {
 }
 
 const securitySelectors = new Set([
-  ':unmaintained',
-  ':unstable',
   ':abandoned',
   ':suspicious',
+  ':trivial',
   ':undesirable',
+  ':unmaintained',
+  ':unstable',
 ])
 
 export class Query {

--- a/src/query/src/index.ts
+++ b/src/query/src/index.ts
@@ -119,6 +119,7 @@ const securitySelectors = new Set([
   ':confused',
   ':debug',
   ':deprecated',
+  ':dynamic',
   ':eval',
   ':obfuscated',
   ':native',

--- a/src/query/src/index.ts
+++ b/src/query/src/index.ts
@@ -121,6 +121,7 @@ const securitySelectors = new Set([
   ':deprecated',
   ':dynamic',
   ':entropic',
+  ':env',
   ':eval',
   ':fs',
   ':obfuscated',

--- a/src/query/src/index.ts
+++ b/src/query/src/index.ts
@@ -120,6 +120,7 @@ const securitySelectors = new Set([
   ':obfuscated',
   ':shrinkwrap',
   ':suspicious',
+  ':tracker',
   ':trivial',
   ':undesirable',
   ':unknown',

--- a/src/query/src/index.ts
+++ b/src/query/src/index.ts
@@ -125,6 +125,7 @@ const securitySelectors = new Set([
   ':eval',
   ':fs',
   ':obfuscated',
+  ':minified',
   ':native',
   ':network',
   ':scripts',

--- a/src/query/src/index.ts
+++ b/src/query/src/index.ts
@@ -121,6 +121,7 @@ const securitySelectors = new Set([
   ':deprecated',
   ':dynamic',
   ':eval',
+  ':fs',
   ':obfuscated',
   ':native',
   ':network',

--- a/src/query/src/index.ts
+++ b/src/query/src/index.ts
@@ -120,6 +120,7 @@ const securitySelectors = new Set([
   ':eval',
   ':obfuscated',
   ':scripts',
+  ':shell',
   ':shrinkwrap',
   ':suspicious',
   ':tracker',

--- a/src/query/src/index.ts
+++ b/src/query/src/index.ts
@@ -116,6 +116,7 @@ export type QueryOptions = {
 
 const securitySelectors = new Set([
   ':abandoned',
+  ':deprecated',
   ':suspicious',
   ':trivial',
   ':undesirable',

--- a/src/query/src/index.ts
+++ b/src/query/src/index.ts
@@ -120,6 +120,7 @@ const securitySelectors = new Set([
   ':debug',
   ':deprecated',
   ':dynamic',
+  ':entropic',
   ':eval',
   ':fs',
   ':obfuscated',

--- a/src/query/src/index.ts
+++ b/src/query/src/index.ts
@@ -119,6 +119,7 @@ const securitySelectors = new Set([
   ':deprecated',
   ':eval',
   ':obfuscated',
+  ':scripts',
   ':shrinkwrap',
   ':suspicious',
   ':tracker',

--- a/src/query/src/index.ts
+++ b/src/query/src/index.ts
@@ -114,6 +114,8 @@ export type QueryOptions = {
   securityArchive: SecurityArchiveLike | undefined
 }
 
+// A list of known security selectors that rely on
+// data from the security-archive in order to work
 const securitySelectors = new Set([
   ':abandoned',
   ':confused',
@@ -147,6 +149,11 @@ export class Query {
   #specOptions: SpecOptions
   #securityArchive: SecurityArchiveLike | undefined
 
+  /**
+   * Helper method to determine if a given query string is using any of
+   * the known security selectors. This is useful so that operations can
+   * skip hydrating the security archive if it's not needed.
+   */
   static hasSecuritySelectors(query: string): boolean {
     for (const selector of securitySelectors) {
       if (query.includes(selector)) {
@@ -163,6 +170,9 @@ export class Query {
     this.#securityArchive = securityArchive
   }
 
+  /**
+   * Search the graph for nodes and edges that match the given query.
+   */
   async search(
     query: string,
     signal?: AbortSignal,

--- a/src/query/src/index.ts
+++ b/src/query/src/index.ts
@@ -117,6 +117,7 @@ export type QueryOptions = {
 const securitySelectors = new Set([
   ':abandoned',
   ':deprecated',
+  ':obfuscated',
   ':shrinkwrap',
   ':suspicious',
   ':trivial',

--- a/src/query/src/index.ts
+++ b/src/query/src/index.ts
@@ -117,6 +117,7 @@ export type QueryOptions = {
 const securitySelectors = new Set([
   ':abandoned',
   ':deprecated',
+  ':shrinkwrap',
   ':suspicious',
   ':trivial',
   ':undesirable',

--- a/src/query/src/index.ts
+++ b/src/query/src/index.ts
@@ -116,6 +116,7 @@ export type QueryOptions = {
 
 const securitySelectors = new Set([
   ':abandoned',
+  ':confused',
   ':deprecated',
   ':eval',
   ':obfuscated',

--- a/src/query/src/index.ts
+++ b/src/query/src/index.ts
@@ -117,6 +117,7 @@ export type QueryOptions = {
 const securitySelectors = new Set([
   ':abandoned',
   ':deprecated',
+  ':eval',
   ':obfuscated',
   ':shrinkwrap',
   ':suspicious',

--- a/src/query/src/index.ts
+++ b/src/query/src/index.ts
@@ -117,6 +117,7 @@ export type QueryOptions = {
 const securitySelectors = new Set([
   ':abandoned',
   ':confused',
+  ':debug',
   ':deprecated',
   ':eval',
   ':obfuscated',

--- a/src/query/src/index.ts
+++ b/src/query/src/index.ts
@@ -121,6 +121,7 @@ const securitySelectors = new Set([
   ':undesirable',
   ':unknown',
   ':unmaintained',
+  ':unpopular',
   ':unstable',
 ])
 

--- a/src/query/src/index.ts
+++ b/src/query/src/index.ts
@@ -114,7 +114,11 @@ export type QueryOptions = {
   securityArchive: SecurityArchiveLike | undefined
 }
 
-const securitySelectors = new Set([':unmaintained', ':suspicious'])
+const securitySelectors = new Set([
+  ':unmaintained',
+  ':suspicious',
+  ':undesirable',
+])
 
 export class Query {
   #cache: Map<string, QueryResponse>

--- a/src/query/src/index.ts
+++ b/src/query/src/index.ts
@@ -116,6 +116,7 @@ export type QueryOptions = {
 
 const securitySelectors = new Set([
   ':unmaintained',
+  ':unstable',
   ':suspicious',
   ':undesirable',
 ])

--- a/src/query/src/index.ts
+++ b/src/query/src/index.ts
@@ -117,6 +117,7 @@ export type QueryOptions = {
 const securitySelectors = new Set([
   ':unmaintained',
   ':unstable',
+  ':abandoned',
   ':suspicious',
   ':undesirable',
 ])

--- a/src/query/src/index.ts
+++ b/src/query/src/index.ts
@@ -119,6 +119,7 @@ const securitySelectors = new Set([
   ':deprecated',
   ':eval',
   ':obfuscated',
+  ':native',
   ':scripts',
   ':shell',
   ':shrinkwrap',

--- a/src/query/src/index.ts
+++ b/src/query/src/index.ts
@@ -114,7 +114,7 @@ export type QueryOptions = {
   securityArchive: SecurityArchiveLike | undefined
 }
 
-const securitySelectors = new Set([':unmaintained'])
+const securitySelectors = new Set([':unmaintained', ':suspicious'])
 
 export class Query {
   #cache: Map<string, QueryResponse>

--- a/src/query/src/index.ts
+++ b/src/query/src/index.ts
@@ -1,6 +1,7 @@
 import { error } from '@vltpkg/error-cause'
 import type { EdgeLike, GraphLike, NodeLike } from '@vltpkg/graph'
 import type { SpecOptions } from '@vltpkg/spec/browser'
+import type { SecurityArchiveLike } from '@vltpkg/security-archive'
 import postcssSelectorParser from 'postcss-selector-parser'
 import { attribute } from './attribute.ts'
 import { classFn } from './class.ts'
@@ -110,17 +111,24 @@ export const walk = async (
 export type QueryOptions = {
   graph: GraphLike
   specOptions: SpecOptions
+  securityArchive: SecurityArchiveLike | undefined
 }
 
 export class Query {
   #cache: Map<string, QueryResponse>
   #graph: GraphLike
   #specOptions: SpecOptions
+  #securityArchive: SecurityArchiveLike | undefined
 
-  constructor({ graph, specOptions }: QueryOptions) {
+  constructor({
+    graph,
+    specOptions,
+    securityArchive
+  }: QueryOptions) {
     this.#cache = new Map()
     this.#graph = graph
     this.#specOptions = specOptions
+    this.#securityArchive = securityArchive
   }
 
   async search(
@@ -165,6 +173,7 @@ export class Query {
       },
       partial: { nodes, edges },
       signal,
+      securityArchive: this.#securityArchive,
       specOptions: this.#specOptions,
       walk,
     })

--- a/src/query/src/pseudo.ts
+++ b/src/query/src/pseudo.ts
@@ -5,6 +5,7 @@ import { asManifest } from '@vltpkg/types'
 import { attr } from './pseudo/attr.ts'
 import { outdated } from './pseudo/outdated.ts'
 import { semverParser as semver } from './pseudo/semver.ts'
+import { suspicious } from './pseudo/suspicious.ts'
 import { unmaintained } from './pseudo/unmaintained.ts'
 import { removeDanglingEdges, removeNode } from './pseudo/helpers.ts'
 import {
@@ -330,6 +331,7 @@ const pseudoSelectors = new Map<string, ParserFn>(
     scope,
     type: typeFn,
     semver,
+    suspicious,
     unmaintained,
   }),
 )

--- a/src/query/src/pseudo.ts
+++ b/src/query/src/pseudo.ts
@@ -19,6 +19,7 @@ import { confused } from './pseudo/confused.ts'
 import { deprecated } from './pseudo/deprecated.ts'
 import { evalParser } from './pseudo/eval.ts'
 import { nativeParser } from './pseudo/native.ts'
+import { network } from './pseudo/network.ts'
 import { obfuscated } from './pseudo/obfuscated.ts'
 import { outdated } from './pseudo/outdated.ts'
 import { scripts } from './pseudo/scripts.ts'
@@ -345,6 +346,7 @@ const pseudoSelectors = new Map<string, ParserFn>(
     // TODO: link
     missing,
     native: nativeParser,
+    network,
     not,
     obfuscated,
     outdated,

--- a/src/query/src/pseudo.ts
+++ b/src/query/src/pseudo.ts
@@ -17,6 +17,7 @@ import { abandoned } from './pseudo/abandoned.ts'
 import { attr } from './pseudo/attr.ts'
 import { deprecated } from './pseudo/deprecated.ts'
 import { evalParser } from './pseudo/eval.ts'
+import { nativeParser } from './pseudo/native.ts'
 import { obfuscated } from './pseudo/obfuscated.ts'
 import { outdated } from './pseudo/outdated.ts'
 import { scripts } from './pseudo/scripts.ts'
@@ -341,6 +342,7 @@ const pseudoSelectors = new Map<string, ParserFn>(
     is,
     // TODO: link
     missing,
+    native: nativeParser,
     not,
     obfuscated,
     outdated,

--- a/src/query/src/pseudo.ts
+++ b/src/query/src/pseudo.ts
@@ -16,6 +16,7 @@ import type { ParserFn, ParserState } from './types.ts'
 import { abandoned } from './pseudo/abandoned.ts'
 import { attr } from './pseudo/attr.ts'
 import { confused } from './pseudo/confused.ts'
+import { debug } from './pseudo/debug.ts'
 import { deprecated } from './pseudo/deprecated.ts'
 import { evalParser } from './pseudo/eval.ts'
 import { nativeParser } from './pseudo/native.ts'
@@ -338,6 +339,7 @@ const pseudoSelectors = new Map<string, ParserFn>(
     abandoned,
     attr,
     confused,
+    debug,
     deprecated,
     eval: evalParser,
     empty,

--- a/src/query/src/pseudo.ts
+++ b/src/query/src/pseudo.ts
@@ -23,6 +23,7 @@ import { entropic } from './pseudo/entropic.ts'
 import { env } from './pseudo/env.ts'
 import { evalParser } from './pseudo/eval.ts'
 import { fs } from './pseudo/fs.ts'
+import { minified } from './pseudo/minified.ts'
 import { nativeParser } from './pseudo/native.ts'
 import { network } from './pseudo/network.ts'
 import { obfuscated } from './pseudo/obfuscated.ts'
@@ -354,6 +355,7 @@ const pseudoSelectors = new Map<string, ParserFn>(
     has,
     is,
     // TODO: link
+    minified,
     missing,
     native: nativeParser,
     network,

--- a/src/query/src/pseudo.ts
+++ b/src/query/src/pseudo.ts
@@ -16,6 +16,7 @@ import type { ParserFn, ParserState } from './types.ts'
 import { abandoned } from './pseudo/abandoned.ts'
 import { attr } from './pseudo/attr.ts'
 import { deprecated } from './pseudo/deprecated.ts'
+import { obfuscated } from './pseudo/obfuscated.ts'
 import { outdated } from './pseudo/outdated.ts'
 import { semverParser as semver } from './pseudo/semver.ts'
 import { shrinkwrap } from './pseudo/shrinkwrap.ts'
@@ -336,6 +337,7 @@ const pseudoSelectors = new Map<string, ParserFn>(
     // TODO: link
     missing,
     not,
+    obfuscated,
     outdated,
     // TODO: overridden
     private: privateFn,

--- a/src/query/src/pseudo.ts
+++ b/src/query/src/pseudo.ts
@@ -53,6 +53,7 @@ const has = async (state: ParserState) => {
           edges: new Set(state.partial.edges),
           nodes: new Set(state.partial.nodes),
         },
+        securityArchive: state.securityArchive,
         specOptions: state.specOptions,
       })
       for (const n of nestedState.collect.nodes) {
@@ -134,6 +135,7 @@ const is = async (state: ParserState) => {
           edges: new Set(state.partial.edges),
         },
         walk: state.walk,
+        securityArchive: state.securityArchive,
         specOptions: state.specOptions,
       })
       for (const n of nestedState.collect.nodes) {
@@ -186,6 +188,7 @@ const not = async (state: ParserState) => {
           edges: new Set(state.partial.edges),
         },
         walk: state.walk,
+        securityArchive: state.securityArchive,
         specOptions: state.specOptions,
       })
       for (const n of nestedState.collect.nodes) {

--- a/src/query/src/pseudo.ts
+++ b/src/query/src/pseudo.ts
@@ -18,6 +18,7 @@ import { attr } from './pseudo/attr.ts'
 import { confused } from './pseudo/confused.ts'
 import { debug } from './pseudo/debug.ts'
 import { deprecated } from './pseudo/deprecated.ts'
+import { dynamic } from './pseudo/dynamic.ts'
 import { evalParser } from './pseudo/eval.ts'
 import { nativeParser } from './pseudo/native.ts'
 import { network } from './pseudo/network.ts'
@@ -341,6 +342,7 @@ const pseudoSelectors = new Map<string, ParserFn>(
     confused,
     debug,
     deprecated,
+    dynamic,
     eval: evalParser,
     empty,
     has,

--- a/src/query/src/pseudo.ts
+++ b/src/query/src/pseudo.ts
@@ -18,6 +18,7 @@ import { attr } from './pseudo/attr.ts'
 import { deprecated } from './pseudo/deprecated.ts'
 import { outdated } from './pseudo/outdated.ts'
 import { semverParser as semver } from './pseudo/semver.ts'
+import { shrinkwrap } from './pseudo/shrinkwrap.ts'
 import { suspicious } from './pseudo/suspicious.ts'
 import { trivial } from './pseudo/trivial.ts'
 import { undesirable } from './pseudo/undesirable.ts'
@@ -342,6 +343,7 @@ const pseudoSelectors = new Map<string, ParserFn>(
     root,
     scope,
     semver,
+    shrinkwrap,
     suspicious,
     trivial,
     type: typeFn,

--- a/src/query/src/pseudo.ts
+++ b/src/query/src/pseudo.ts
@@ -21,6 +21,7 @@ import { outdated } from './pseudo/outdated.ts'
 import { semverParser as semver } from './pseudo/semver.ts'
 import { shrinkwrap } from './pseudo/shrinkwrap.ts'
 import { suspicious } from './pseudo/suspicious.ts'
+import { tracker } from './pseudo/tracker.ts'
 import { trivial } from './pseudo/trivial.ts'
 import { undesirable } from './pseudo/undesirable.ts'
 import { unknown } from './pseudo/unknown.ts'
@@ -347,6 +348,7 @@ const pseudoSelectors = new Map<string, ParserFn>(
     semver,
     shrinkwrap,
     suspicious,
+    tracker,
     trivial,
     type: typeFn,
     undesirable,

--- a/src/query/src/pseudo.ts
+++ b/src/query/src/pseudo.ts
@@ -6,6 +6,7 @@ import { attr } from './pseudo/attr.ts'
 import { outdated } from './pseudo/outdated.ts'
 import { semverParser as semver } from './pseudo/semver.ts'
 import { suspicious } from './pseudo/suspicious.ts'
+import { trivial } from './pseudo/trivial.ts'
 import { undesirable } from './pseudo/undesirable.ts'
 import { unmaintained } from './pseudo/unmaintained.ts'
 import { abandoned } from './pseudo/abandoned.ts'
@@ -319,6 +320,7 @@ const typeFn = async (state: ParserState) => {
 
 const pseudoSelectors = new Map<string, ParserFn>(
   Object.entries({
+    abandoned,
     attr,
     empty,
     has,
@@ -332,13 +334,13 @@ const pseudoSelectors = new Map<string, ParserFn>(
     project,
     root,
     scope,
-    type: typeFn,
     semver,
     suspicious,
+    trivial,
+    type: typeFn,
     undesirable,
-    abandoned,
-    unstable,
     unmaintained,
+    unstable,
   }),
 )
 

--- a/src/query/src/pseudo.ts
+++ b/src/query/src/pseudo.ts
@@ -6,6 +6,7 @@ import { attr } from './pseudo/attr.ts'
 import { outdated } from './pseudo/outdated.ts'
 import { semverParser as semver } from './pseudo/semver.ts'
 import { suspicious } from './pseudo/suspicious.ts'
+import { undesirable } from './pseudo/undesirable.ts'
 import { unmaintained } from './pseudo/unmaintained.ts'
 import { removeDanglingEdges, removeNode } from './pseudo/helpers.ts'
 import {
@@ -332,6 +333,7 @@ const pseudoSelectors = new Map<string, ParserFn>(
     type: typeFn,
     semver,
     suspicious,
+    undesirable,
     unmaintained,
   }),
 )

--- a/src/query/src/pseudo.ts
+++ b/src/query/src/pseudo.ts
@@ -19,6 +19,7 @@ import { deprecated } from './pseudo/deprecated.ts'
 import { evalParser } from './pseudo/eval.ts'
 import { obfuscated } from './pseudo/obfuscated.ts'
 import { outdated } from './pseudo/outdated.ts'
+import { scripts } from './pseudo/scripts.ts'
 import { semverParser as semver } from './pseudo/semver.ts'
 import { shrinkwrap } from './pseudo/shrinkwrap.ts'
 import { suspicious } from './pseudo/suspicious.ts'
@@ -347,6 +348,7 @@ const pseudoSelectors = new Map<string, ParserFn>(
     project,
     root,
     scope,
+    scripts,
     semver,
     shrinkwrap,
     suspicious,

--- a/src/query/src/pseudo.ts
+++ b/src/query/src/pseudo.ts
@@ -15,6 +15,7 @@ import type { ParserFn, ParserState } from './types.ts'
 // imported pseudo selectors
 import { abandoned } from './pseudo/abandoned.ts'
 import { attr } from './pseudo/attr.ts'
+import { deprecated } from './pseudo/deprecated.ts'
 import { outdated } from './pseudo/outdated.ts'
 import { semverParser as semver } from './pseudo/semver.ts'
 import { suspicious } from './pseudo/suspicious.ts'
@@ -327,6 +328,7 @@ const pseudoSelectors = new Map<string, ParserFn>(
   Object.entries({
     abandoned,
     attr,
+    deprecated,
     empty,
     has,
     is,

--- a/src/query/src/pseudo.ts
+++ b/src/query/src/pseudo.ts
@@ -8,6 +8,7 @@ import { semverParser as semver } from './pseudo/semver.ts'
 import { suspicious } from './pseudo/suspicious.ts'
 import { undesirable } from './pseudo/undesirable.ts'
 import { unmaintained } from './pseudo/unmaintained.ts'
+import { abandoned } from './pseudo/abandoned.ts'
 import { unstable } from './pseudo/unstable.ts'
 import { removeDanglingEdges, removeNode } from './pseudo/helpers.ts'
 import {
@@ -335,6 +336,7 @@ const pseudoSelectors = new Map<string, ParserFn>(
     semver,
     suspicious,
     undesirable,
+    abandoned,
     unstable,
     unmaintained,
   }),

--- a/src/query/src/pseudo.ts
+++ b/src/query/src/pseudo.ts
@@ -20,6 +20,7 @@ import { debug } from './pseudo/debug.ts'
 import { deprecated } from './pseudo/deprecated.ts'
 import { dynamic } from './pseudo/dynamic.ts'
 import { evalParser } from './pseudo/eval.ts'
+import { fs } from './pseudo/fs.ts'
 import { nativeParser } from './pseudo/native.ts'
 import { network } from './pseudo/network.ts'
 import { obfuscated } from './pseudo/obfuscated.ts'
@@ -345,6 +346,7 @@ const pseudoSelectors = new Map<string, ParserFn>(
     dynamic,
     eval: evalParser,
     empty,
+    fs,
     has,
     is,
     // TODO: link

--- a/src/query/src/pseudo.ts
+++ b/src/query/src/pseudo.ts
@@ -5,6 +5,7 @@ import { asManifest } from '@vltpkg/types'
 import { attr } from './pseudo/attr.ts'
 import { outdated } from './pseudo/outdated.ts'
 import { semverParser as semver } from './pseudo/semver.ts'
+import { unmaintained } from './pseudo/unmaintained.ts'
 import { removeDanglingEdges, removeNode } from './pseudo/helpers.ts'
 import {
   asPostcssNodeWithChildren,
@@ -321,6 +322,7 @@ const pseudoSelectors = new Map<string, ParserFn>(
     // TODO: link
     missing,
     not,
+    outdated,
     // TODO: overridden
     private: privateFn,
     project,
@@ -328,7 +330,7 @@ const pseudoSelectors = new Map<string, ParserFn>(
     scope,
     type: typeFn,
     semver,
-    outdated,
+    unmaintained,
   }),
 )
 

--- a/src/query/src/pseudo.ts
+++ b/src/query/src/pseudo.ts
@@ -8,6 +8,7 @@ import { semverParser as semver } from './pseudo/semver.ts'
 import { suspicious } from './pseudo/suspicious.ts'
 import { undesirable } from './pseudo/undesirable.ts'
 import { unmaintained } from './pseudo/unmaintained.ts'
+import { unstable } from './pseudo/unstable.ts'
 import { removeDanglingEdges, removeNode } from './pseudo/helpers.ts'
 import {
   asPostcssNodeWithChildren,
@@ -334,6 +335,7 @@ const pseudoSelectors = new Map<string, ParserFn>(
     semver,
     suspicious,
     undesirable,
+    unstable,
     unmaintained,
   }),
 )

--- a/src/query/src/pseudo.ts
+++ b/src/query/src/pseudo.ts
@@ -15,6 +15,7 @@ import type { ParserFn, ParserState } from './types.ts'
 // imported pseudo selectors
 import { abandoned } from './pseudo/abandoned.ts'
 import { attr } from './pseudo/attr.ts'
+import { confused } from './pseudo/confused.ts'
 import { deprecated } from './pseudo/deprecated.ts'
 import { evalParser } from './pseudo/eval.ts'
 import { nativeParser } from './pseudo/native.ts'
@@ -335,6 +336,7 @@ const pseudoSelectors = new Map<string, ParserFn>(
   Object.entries({
     abandoned,
     attr,
+    confused,
     deprecated,
     eval: evalParser,
     empty,

--- a/src/query/src/pseudo.ts
+++ b/src/query/src/pseudo.ts
@@ -16,6 +16,7 @@ import type { ParserFn, ParserState } from './types.ts'
 import { abandoned } from './pseudo/abandoned.ts'
 import { attr } from './pseudo/attr.ts'
 import { deprecated } from './pseudo/deprecated.ts'
+import { evalParser } from './pseudo/eval.ts'
 import { obfuscated } from './pseudo/obfuscated.ts'
 import { outdated } from './pseudo/outdated.ts'
 import { semverParser as semver } from './pseudo/semver.ts'
@@ -332,6 +333,7 @@ const pseudoSelectors = new Map<string, ParserFn>(
     abandoned,
     attr,
     deprecated,
+    eval: evalParser,
     empty,
     has,
     is,

--- a/src/query/src/pseudo.ts
+++ b/src/query/src/pseudo.ts
@@ -2,15 +2,7 @@ import { splitDepID } from '@vltpkg/dep-id/browser'
 import { error } from '@vltpkg/error-cause'
 import type { EdgeLike, NodeLike } from '@vltpkg/graph'
 import { asManifest } from '@vltpkg/types'
-import { attr } from './pseudo/attr.ts'
-import { outdated } from './pseudo/outdated.ts'
-import { semverParser as semver } from './pseudo/semver.ts'
-import { suspicious } from './pseudo/suspicious.ts'
-import { trivial } from './pseudo/trivial.ts'
-import { undesirable } from './pseudo/undesirable.ts'
-import { unmaintained } from './pseudo/unmaintained.ts'
-import { abandoned } from './pseudo/abandoned.ts'
-import { unstable } from './pseudo/unstable.ts'
+
 import { removeDanglingEdges, removeNode } from './pseudo/helpers.ts'
 import {
   asPostcssNodeWithChildren,
@@ -19,6 +11,18 @@ import {
   isSelectorNode,
 } from './types.ts'
 import type { ParserFn, ParserState } from './types.ts'
+
+// imported pseudo selectors
+import { abandoned } from './pseudo/abandoned.ts'
+import { attr } from './pseudo/attr.ts'
+import { outdated } from './pseudo/outdated.ts'
+import { semverParser as semver } from './pseudo/semver.ts'
+import { suspicious } from './pseudo/suspicious.ts'
+import { trivial } from './pseudo/trivial.ts'
+import { undesirable } from './pseudo/undesirable.ts'
+import { unknown } from './pseudo/unknown.ts'
+import { unmaintained } from './pseudo/unmaintained.ts'
+import { unstable } from './pseudo/unstable.ts'
 
 /**
  * :empty Pseudo-Selector, matches only nodes that have no children.
@@ -339,6 +343,7 @@ const pseudoSelectors = new Map<string, ParserFn>(
     trivial,
     type: typeFn,
     undesirable,
+    unknown,
     unmaintained,
     unstable,
   }),

--- a/src/query/src/pseudo.ts
+++ b/src/query/src/pseudo.ts
@@ -19,6 +19,7 @@ import { confused } from './pseudo/confused.ts'
 import { debug } from './pseudo/debug.ts'
 import { deprecated } from './pseudo/deprecated.ts'
 import { dynamic } from './pseudo/dynamic.ts'
+import { entropic } from './pseudo/entropic.ts'
 import { evalParser } from './pseudo/eval.ts'
 import { fs } from './pseudo/fs.ts'
 import { nativeParser } from './pseudo/native.ts'
@@ -346,6 +347,7 @@ const pseudoSelectors = new Map<string, ParserFn>(
     dynamic,
     eval: evalParser,
     empty,
+    entropic,
     fs,
     has,
     is,

--- a/src/query/src/pseudo.ts
+++ b/src/query/src/pseudo.ts
@@ -20,6 +20,7 @@ import { debug } from './pseudo/debug.ts'
 import { deprecated } from './pseudo/deprecated.ts'
 import { dynamic } from './pseudo/dynamic.ts'
 import { entropic } from './pseudo/entropic.ts'
+import { env } from './pseudo/env.ts'
 import { evalParser } from './pseudo/eval.ts'
 import { fs } from './pseudo/fs.ts'
 import { nativeParser } from './pseudo/native.ts'
@@ -348,6 +349,7 @@ const pseudoSelectors = new Map<string, ParserFn>(
     eval: evalParser,
     empty,
     entropic,
+    env,
     fs,
     has,
     is,

--- a/src/query/src/pseudo.ts
+++ b/src/query/src/pseudo.ts
@@ -20,6 +20,7 @@ import { evalParser } from './pseudo/eval.ts'
 import { obfuscated } from './pseudo/obfuscated.ts'
 import { outdated } from './pseudo/outdated.ts'
 import { scripts } from './pseudo/scripts.ts'
+import { shell } from './pseudo/shell.ts'
 import { semverParser as semver } from './pseudo/semver.ts'
 import { shrinkwrap } from './pseudo/shrinkwrap.ts'
 import { suspicious } from './pseudo/suspicious.ts'
@@ -350,6 +351,7 @@ const pseudoSelectors = new Map<string, ParserFn>(
     scope,
     scripts,
     semver,
+    shell,
     shrinkwrap,
     suspicious,
     tracker,

--- a/src/query/src/pseudo.ts
+++ b/src/query/src/pseudo.ts
@@ -22,6 +22,7 @@ import { trivial } from './pseudo/trivial.ts'
 import { undesirable } from './pseudo/undesirable.ts'
 import { unknown } from './pseudo/unknown.ts'
 import { unmaintained } from './pseudo/unmaintained.ts'
+import { unpopular } from './pseudo/unpopular.ts'
 import { unstable } from './pseudo/unstable.ts'
 
 /**
@@ -345,6 +346,7 @@ const pseudoSelectors = new Map<string, ParserFn>(
     undesirable,
     unknown,
     unmaintained,
+    unpopular,
     unstable,
   }),
 )

--- a/src/query/src/pseudo/abandoned.ts
+++ b/src/query/src/pseudo/abandoned.ts
@@ -1,0 +1,9 @@
+import { createSecuritySelectorFilter } from './helpers.ts'
+
+/**
+ * Filters out any node that does not have a **missingAuthor** report alert.
+ */
+export const abandoned = createSecuritySelectorFilter(
+  'abandoned',
+  'missingAuthor',
+)

--- a/src/query/src/pseudo/confused.ts
+++ b/src/query/src/pseudo/confused.ts
@@ -1,0 +1,9 @@
+import { createSecuritySelectorFilter } from './helpers.ts'
+
+/**
+ * Filters out any node that does not have a **manifestConfusion** report alert.
+ */
+export const confused = createSecuritySelectorFilter(
+  'confused',
+  'manifestConfusion',
+)

--- a/src/query/src/pseudo/debug.ts
+++ b/src/query/src/pseudo/debug.ts
@@ -1,0 +1,9 @@
+import { createSecuritySelectorFilter } from './helpers.ts'
+
+/**
+ * Filters out any node that does not have a **debugAccess** report alert.
+ */
+export const debug = createSecuritySelectorFilter(
+  'debug',
+  'debugAccess',
+)

--- a/src/query/src/pseudo/deprecated.ts
+++ b/src/query/src/pseudo/deprecated.ts
@@ -1,0 +1,9 @@
+import { createSecuritySelectorFilter } from './helpers.ts'
+
+/**
+ * Filters out any node that does not have a **deprecated** report alert.
+ */
+export const deprecated = createSecuritySelectorFilter(
+  'deprecated',
+  'deprecated',
+)

--- a/src/query/src/pseudo/dynamic.ts
+++ b/src/query/src/pseudo/dynamic.ts
@@ -1,0 +1,9 @@
+import { createSecuritySelectorFilter } from './helpers.ts'
+
+/**
+ * Filters out any node that does not have a **dynamicRequire** report alert.
+ */
+export const dynamic = createSecuritySelectorFilter(
+  'dynamic',
+  'dynamicRequire',
+)

--- a/src/query/src/pseudo/entropic.ts
+++ b/src/query/src/pseudo/entropic.ts
@@ -1,0 +1,9 @@
+import { createSecuritySelectorFilter } from './helpers.ts'
+
+/**
+ * Filters out any node that does not have a **highEntropyStrings** report alert.
+ */
+export const entropic = createSecuritySelectorFilter(
+  'entropic',
+  'highEntropyStrings',
+)

--- a/src/query/src/pseudo/env.ts
+++ b/src/query/src/pseudo/env.ts
@@ -1,0 +1,6 @@
+import { createSecuritySelectorFilter } from './helpers.ts'
+
+/**
+ * Filters out any node that does not have a **envVars** report alert.
+ */
+export const env = createSecuritySelectorFilter('env', 'envVars')

--- a/src/query/src/pseudo/eval.ts
+++ b/src/query/src/pseudo/eval.ts
@@ -1,0 +1,9 @@
+import { createSecuritySelectorFilter } from './helpers.ts'
+
+/**
+ * Filters out any node that does not have a **usesEval** report alert.
+ */
+export const evalParser = createSecuritySelectorFilter(
+  'eval',
+  'usesEval',
+)

--- a/src/query/src/pseudo/fs.ts
+++ b/src/query/src/pseudo/fs.ts
@@ -1,0 +1,9 @@
+import { createSecuritySelectorFilter } from './helpers.ts'
+
+/**
+ * Filters out any node that does not have a **filesystemAccess** report alert.
+ */
+export const fs = createSecuritySelectorFilter(
+  'fs',
+  'filesystemAccess',
+)

--- a/src/query/src/pseudo/helpers.ts
+++ b/src/query/src/pseudo/helpers.ts
@@ -27,3 +27,32 @@ export const removeDanglingEdges = (state: ParserState) => {
  */
 export const removeQuotes = (value: string) =>
   value.replace(/^"(.*?)"$/, '$1')
+
+/**
+ * Reusable security selector alert filter.
+ */
+export const createSecuritySelectorFilter = (
+  name: string,
+  type: string,
+) => {
+  return async (state: ParserState) => {
+    if (!state.securityArchive) {
+      throw new Error(
+        `Missing security archive while trying to parse the :${name} security selector`,
+      )
+    }
+
+    for (const node of state.partial.nodes) {
+      const report = state.securityArchive.get(node.id)
+      const exclude =
+        !report?.alerts.some(alert => alert.type === type)
+      if (exclude) {
+        removeNode(state, node)
+      }
+    }
+
+    removeDanglingEdges(state)
+
+    return state
+  }
+}

--- a/src/query/src/pseudo/helpers.ts
+++ b/src/query/src/pseudo/helpers.ts
@@ -44,8 +44,9 @@ export const createSecuritySelectorFilter = (
 
     for (const node of state.partial.nodes) {
       const report = state.securityArchive.get(node.id)
-      const exclude =
-        !report?.alerts.some(alert => alert.type === type)
+      const exclude = !report?.alerts.some(
+        alert => alert.type === type,
+      )
       if (exclude) {
         removeNode(state, node)
       }

--- a/src/query/src/pseudo/minified.ts
+++ b/src/query/src/pseudo/minified.ts
@@ -1,0 +1,9 @@
+import { createSecuritySelectorFilter } from './helpers.ts'
+
+/**
+ * Filters out any node that does not have a **minifiedFile** report alert.
+ */
+export const minified = createSecuritySelectorFilter(
+  'minified',
+  'minifiedFile',
+)

--- a/src/query/src/pseudo/native.ts
+++ b/src/query/src/pseudo/native.ts
@@ -1,0 +1,9 @@
+import { createSecuritySelectorFilter } from './helpers.ts'
+
+/**
+ * Filters out any node that does not have a **hasNativeCode** report alert.
+ */
+export const nativeParser = createSecuritySelectorFilter(
+  'native',
+  'hasNativeCode',
+)

--- a/src/query/src/pseudo/network.ts
+++ b/src/query/src/pseudo/network.ts
@@ -1,0 +1,9 @@
+import { createSecuritySelectorFilter } from './helpers.ts'
+
+/**
+ * Filters out any node that does not have a **networkAccess** report alert.
+ */
+export const network = createSecuritySelectorFilter(
+  'network',
+  'networkAccess',
+)

--- a/src/query/src/pseudo/obfuscated.ts
+++ b/src/query/src/pseudo/obfuscated.ts
@@ -1,0 +1,9 @@
+import { createSecuritySelectorFilter } from './helpers.ts'
+
+/**
+ * Filters out any node that does not have an **obfuscatedFile** report alert.
+ */
+export const obfuscated = createSecuritySelectorFilter(
+  'obfuscated',
+  'obfuscatedFile',
+)

--- a/src/query/src/pseudo/scripts.ts
+++ b/src/query/src/pseudo/scripts.ts
@@ -1,0 +1,9 @@
+import { createSecuritySelectorFilter } from './helpers.ts'
+
+/**
+ * Filters out any node that does not have an **installScripts** report alert.
+ */
+export const scripts = createSecuritySelectorFilter(
+  'scripts',
+  'installScripts',
+)

--- a/src/query/src/pseudo/shell.ts
+++ b/src/query/src/pseudo/shell.ts
@@ -1,0 +1,9 @@
+import { createSecuritySelectorFilter } from './helpers.ts'
+
+/**
+ * Filters out any node that does not have a **shellAccess** report alert.
+ */
+export const shell = createSecuritySelectorFilter(
+  'shell',
+  'shellAccess',
+)

--- a/src/query/src/pseudo/shrinkwrap.ts
+++ b/src/query/src/pseudo/shrinkwrap.ts
@@ -1,0 +1,9 @@
+import { createSecuritySelectorFilter } from './helpers.ts'
+
+/**
+ * Filters out any node that does not have a **shrinkwrap** report alert.
+ */
+export const shrinkwrap = createSecuritySelectorFilter(
+  'shrinkwrap',
+  'shrinkwrap',
+)

--- a/src/query/src/pseudo/suspicious.ts
+++ b/src/query/src/pseudo/suspicious.ts
@@ -1,0 +1,9 @@
+import { createSecuritySelectorFilter } from './helpers.ts'
+
+/**
+ * Filters out any node that does not have a **suspiciousStarActivity** report alert.
+ */
+export const suspicious = createSecuritySelectorFilter(
+  'suspicious',
+  'suspiciousStarActivity',
+)

--- a/src/query/src/pseudo/tracker.ts
+++ b/src/query/src/pseudo/tracker.ts
@@ -1,0 +1,9 @@
+import { createSecuritySelectorFilter } from './helpers.ts'
+
+/**
+ * Filters out any node that does not have a **telemetry** report alert.
+ */
+export const tracker = createSecuritySelectorFilter(
+  'tracker',
+  'telemetry',
+)

--- a/src/query/src/pseudo/trivial.ts
+++ b/src/query/src/pseudo/trivial.ts
@@ -1,0 +1,9 @@
+import { createSecuritySelectorFilter } from './helpers.ts'
+
+/**
+ * Filters out any node that does not have a **trivialPackage** report alert.
+ */
+export const trivial = createSecuritySelectorFilter(
+  'trivial',
+  'trivialPackage',
+)

--- a/src/query/src/pseudo/undesirable.ts
+++ b/src/query/src/pseudo/undesirable.ts
@@ -1,0 +1,9 @@
+import { createSecuritySelectorFilter } from './helpers.ts'
+
+/**
+ * Filters out any node that does not have a **troll** report alert.
+ */
+export const undesirable = createSecuritySelectorFilter(
+  'undesirable',
+  'troll',
+)

--- a/src/query/src/pseudo/unknown.ts
+++ b/src/query/src/pseudo/unknown.ts
@@ -1,0 +1,9 @@
+import { createSecuritySelectorFilter } from './helpers.ts'
+
+/**
+ * Filters out any node that does not have a **newAuthor** report alert.
+ */
+export const unknown = createSecuritySelectorFilter(
+  'unknown',
+  'newAuthor',
+)

--- a/src/query/src/pseudo/unmaintained.ts
+++ b/src/query/src/pseudo/unmaintained.ts
@@ -1,0 +1,9 @@
+import { createSecuritySelectorFilter } from './helpers.ts'
+
+/**
+ * Filters out any node that does not have a **unmaintained** report alert.
+ */
+export const unmaintained = createSecuritySelectorFilter(
+  'unmaintained',
+  'unmaintained',
+)

--- a/src/query/src/pseudo/unpopular.ts
+++ b/src/query/src/pseudo/unpopular.ts
@@ -1,0 +1,9 @@
+import { createSecuritySelectorFilter } from './helpers.ts'
+
+/**
+ * Filters out any node that does not have a **unpopularPackage** report alert.
+ */
+export const unpopular = createSecuritySelectorFilter(
+  'unpopular',
+  'unpopularPackage',
+)

--- a/src/query/src/pseudo/unstable.ts
+++ b/src/query/src/pseudo/unstable.ts
@@ -1,0 +1,9 @@
+import { createSecuritySelectorFilter } from './helpers.ts'
+
+/**
+ * Filters out any node that does not have a **unstableOwnership** report alert.
+ */
+export const unstable = createSecuritySelectorFilter(
+  'unstable',
+  'unstableOwnership',
+)

--- a/src/query/src/types.ts
+++ b/src/query/src/types.ts
@@ -1,6 +1,7 @@
 import { error } from '@vltpkg/error-cause'
 import type { EdgeLike, NodeLike } from '@vltpkg/graph'
 import type { SpecOptions } from '@vltpkg/spec/browser'
+import type { SecurityArchiveLike } from '@vltpkg/security-archive'
 import type {
   Tag,
   String,
@@ -49,6 +50,7 @@ export type ParserState = {
   signal?: AbortSignal
   walk: ParserFn
   partial: GraphSelectionState
+  securityArchive: SecurityArchiveLike | undefined
   specOptions: SpecOptions
 }
 

--- a/src/query/tap-snapshots/test/pseudo/abandoned.ts.test.cjs
+++ b/src/query/tap-snapshots/test/pseudo/abandoned.ts.test.cjs
@@ -1,0 +1,18 @@
+/* IMPORTANT
+ * This snapshot file is auto-generated, but designed for humans.
+ * It should be checked into source control and tracked carefully.
+ * Re-generate by setting TAP_SNAPSHOT=1 and running tests.
+ * Make sure to inspect the output below.  Do not ignore changes!
+ */
+'use strict'
+exports[`test/pseudo/abandoned.ts > TAP > selects packages with an abandoned alert > filter out any node that does not have the alert > must match snapshot 1`] = `
+Object {
+  "edges": Array [
+    "e",
+    "e",
+  ],
+  "nodes": Array [
+    "e",
+  ],
+}
+`

--- a/src/query/tap-snapshots/test/pseudo/confused.ts.test.cjs
+++ b/src/query/tap-snapshots/test/pseudo/confused.ts.test.cjs
@@ -1,0 +1,18 @@
+/* IMPORTANT
+ * This snapshot file is auto-generated, but designed for humans.
+ * It should be checked into source control and tracked carefully.
+ * Re-generate by setting TAP_SNAPSHOT=1 and running tests.
+ * Make sure to inspect the output below.  Do not ignore changes!
+ */
+'use strict'
+exports[`test/pseudo/confused.ts > TAP > selects packages with a manifestConfusion alert > filter out any node that does not have the alert > must match snapshot 1`] = `
+Object {
+  "edges": Array [
+    "e",
+    "e",
+  ],
+  "nodes": Array [
+    "e",
+  ],
+}
+`

--- a/src/query/tap-snapshots/test/pseudo/debug.ts.test.cjs
+++ b/src/query/tap-snapshots/test/pseudo/debug.ts.test.cjs
@@ -1,0 +1,18 @@
+/* IMPORTANT
+ * This snapshot file is auto-generated, but designed for humans.
+ * It should be checked into source control and tracked carefully.
+ * Re-generate by setting TAP_SNAPSHOT=1 and running tests.
+ * Make sure to inspect the output below.  Do not ignore changes!
+ */
+'use strict'
+exports[`test/pseudo/debug.ts > TAP > selects packages with a debugAccess alert > filter out any node that does not have the alert > must match snapshot 1`] = `
+Object {
+  "edges": Array [
+    "e",
+    "e",
+  ],
+  "nodes": Array [
+    "e",
+  ],
+}
+`

--- a/src/query/tap-snapshots/test/pseudo/deprecated.ts.test.cjs
+++ b/src/query/tap-snapshots/test/pseudo/deprecated.ts.test.cjs
@@ -1,0 +1,18 @@
+/* IMPORTANT
+ * This snapshot file is auto-generated, but designed for humans.
+ * It should be checked into source control and tracked carefully.
+ * Re-generate by setting TAP_SNAPSHOT=1 and running tests.
+ * Make sure to inspect the output below.  Do not ignore changes!
+ */
+'use strict'
+exports[`test/pseudo/deprecated.ts > TAP > selects packages with a deprecated alert > filter out any node that does not have the alert > must match snapshot 1`] = `
+Object {
+  "edges": Array [
+    "e",
+    "e",
+  ],
+  "nodes": Array [
+    "e",
+  ],
+}
+`

--- a/src/query/tap-snapshots/test/pseudo/dynamic.ts.test.cjs
+++ b/src/query/tap-snapshots/test/pseudo/dynamic.ts.test.cjs
@@ -1,0 +1,18 @@
+/* IMPORTANT
+ * This snapshot file is auto-generated, but designed for humans.
+ * It should be checked into source control and tracked carefully.
+ * Re-generate by setting TAP_SNAPSHOT=1 and running tests.
+ * Make sure to inspect the output below.  Do not ignore changes!
+ */
+'use strict'
+exports[`test/pseudo/dynamic.ts > TAP > selects packages with a dynamicRequire alert > filter out any node that does not have the alert > must match snapshot 1`] = `
+Object {
+  "edges": Array [
+    "e",
+    "e",
+  ],
+  "nodes": Array [
+    "e",
+  ],
+}
+`

--- a/src/query/tap-snapshots/test/pseudo/entropic.ts.test.cjs
+++ b/src/query/tap-snapshots/test/pseudo/entropic.ts.test.cjs
@@ -1,0 +1,18 @@
+/* IMPORTANT
+ * This snapshot file is auto-generated, but designed for humans.
+ * It should be checked into source control and tracked carefully.
+ * Re-generate by setting TAP_SNAPSHOT=1 and running tests.
+ * Make sure to inspect the output below.  Do not ignore changes!
+ */
+'use strict'
+exports[`test/pseudo/entropic.ts > TAP > selects packages with a highEntropyStrings alert > filter out any node that does not have the alert > must match snapshot 1`] = `
+Object {
+  "edges": Array [
+    "e",
+    "e",
+  ],
+  "nodes": Array [
+    "e",
+  ],
+}
+`

--- a/src/query/tap-snapshots/test/pseudo/env.ts.test.cjs
+++ b/src/query/tap-snapshots/test/pseudo/env.ts.test.cjs
@@ -1,0 +1,18 @@
+/* IMPORTANT
+ * This snapshot file is auto-generated, but designed for humans.
+ * It should be checked into source control and tracked carefully.
+ * Re-generate by setting TAP_SNAPSHOT=1 and running tests.
+ * Make sure to inspect the output below.  Do not ignore changes!
+ */
+'use strict'
+exports[`test/pseudo/env.ts > TAP > selects packages with a envVars alert > filter out any node that does not have the alert > must match snapshot 1`] = `
+Object {
+  "edges": Array [
+    "e",
+    "e",
+  ],
+  "nodes": Array [
+    "e",
+  ],
+}
+`

--- a/src/query/tap-snapshots/test/pseudo/eval.ts.test.cjs
+++ b/src/query/tap-snapshots/test/pseudo/eval.ts.test.cjs
@@ -1,0 +1,18 @@
+/* IMPORTANT
+ * This snapshot file is auto-generated, but designed for humans.
+ * It should be checked into source control and tracked carefully.
+ * Re-generate by setting TAP_SNAPSHOT=1 and running tests.
+ * Make sure to inspect the output below.  Do not ignore changes!
+ */
+'use strict'
+exports[`test/pseudo/eval.ts > TAP > selects packages with an eval alert > filter out any node that does not have the alert > must match snapshot 1`] = `
+Object {
+  "edges": Array [
+    "e",
+    "e",
+  ],
+  "nodes": Array [
+    "e",
+  ],
+}
+`

--- a/src/query/tap-snapshots/test/pseudo/fs.ts.test.cjs
+++ b/src/query/tap-snapshots/test/pseudo/fs.ts.test.cjs
@@ -1,0 +1,18 @@
+/* IMPORTANT
+ * This snapshot file is auto-generated, but designed for humans.
+ * It should be checked into source control and tracked carefully.
+ * Re-generate by setting TAP_SNAPSHOT=1 and running tests.
+ * Make sure to inspect the output below.  Do not ignore changes!
+ */
+'use strict'
+exports[`test/pseudo/fs.ts > TAP > selects packages with a filesystemAccess alert > filter out any node that does not have the alert > must match snapshot 1`] = `
+Object {
+  "edges": Array [
+    "e",
+    "e",
+  ],
+  "nodes": Array [
+    "e",
+  ],
+}
+`

--- a/src/query/tap-snapshots/test/pseudo/helpers.ts.test.cjs
+++ b/src/query/tap-snapshots/test/pseudo/helpers.ts.test.cjs
@@ -1,0 +1,18 @@
+/* IMPORTANT
+ * This snapshot file is auto-generated, but designed for humans.
+ * It should be checked into source control and tracked carefully.
+ * Re-generate by setting TAP_SNAPSHOT=1 and running tests.
+ * Make sure to inspect the output below.  Do not ignore changes!
+ */
+'use strict'
+exports[`test/pseudo/helpers.ts > TAP > selects packages with an unmaintained alert > filter out any node that does not have the alert > must match snapshot 1`] = `
+Object {
+  "edges": Array [
+    "e",
+    "e",
+  ],
+  "nodes": Array [
+    "e",
+  ],
+}
+`

--- a/src/query/tap-snapshots/test/pseudo/minified.ts.test.cjs
+++ b/src/query/tap-snapshots/test/pseudo/minified.ts.test.cjs
@@ -1,0 +1,18 @@
+/* IMPORTANT
+ * This snapshot file is auto-generated, but designed for humans.
+ * It should be checked into source control and tracked carefully.
+ * Re-generate by setting TAP_SNAPSHOT=1 and running tests.
+ * Make sure to inspect the output below.  Do not ignore changes!
+ */
+'use strict'
+exports[`test/pseudo/minified.ts > TAP > selects packages with a minifiedFile alert > filter out any node that does not have the alert > must match snapshot 1`] = `
+Object {
+  "edges": Array [
+    "e",
+    "e",
+  ],
+  "nodes": Array [
+    "e",
+  ],
+}
+`

--- a/src/query/tap-snapshots/test/pseudo/native.ts.test.cjs
+++ b/src/query/tap-snapshots/test/pseudo/native.ts.test.cjs
@@ -1,0 +1,18 @@
+/* IMPORTANT
+ * This snapshot file is auto-generated, but designed for humans.
+ * It should be checked into source control and tracked carefully.
+ * Re-generate by setting TAP_SNAPSHOT=1 and running tests.
+ * Make sure to inspect the output below.  Do not ignore changes!
+ */
+'use strict'
+exports[`test/pseudo/native.ts > TAP > selects packages with a hasNativeCode alert > filter out any node that does not have the alert > must match snapshot 1`] = `
+Object {
+  "edges": Array [
+    "e",
+    "e",
+  ],
+  "nodes": Array [
+    "e",
+  ],
+}
+`

--- a/src/query/tap-snapshots/test/pseudo/network.ts.test.cjs
+++ b/src/query/tap-snapshots/test/pseudo/network.ts.test.cjs
@@ -1,0 +1,18 @@
+/* IMPORTANT
+ * This snapshot file is auto-generated, but designed for humans.
+ * It should be checked into source control and tracked carefully.
+ * Re-generate by setting TAP_SNAPSHOT=1 and running tests.
+ * Make sure to inspect the output below.  Do not ignore changes!
+ */
+'use strict'
+exports[`test/pseudo/network.ts > TAP > selects packages with a networkAccess alert > filter out any node that does not have the alert > must match snapshot 1`] = `
+Object {
+  "edges": Array [
+    "e",
+    "e",
+  ],
+  "nodes": Array [
+    "e",
+  ],
+}
+`

--- a/src/query/tap-snapshots/test/pseudo/obfuscated.ts.test.cjs
+++ b/src/query/tap-snapshots/test/pseudo/obfuscated.ts.test.cjs
@@ -1,0 +1,18 @@
+/* IMPORTANT
+ * This snapshot file is auto-generated, but designed for humans.
+ * It should be checked into source control and tracked carefully.
+ * Re-generate by setting TAP_SNAPSHOT=1 and running tests.
+ * Make sure to inspect the output below.  Do not ignore changes!
+ */
+'use strict'
+exports[`test/pseudo/obfuscated.ts > TAP > selects packages with an obfuscated alert > filter out any node that does not have the alert > must match snapshot 1`] = `
+Object {
+  "edges": Array [
+    "e",
+    "e",
+  ],
+  "nodes": Array [
+    "e",
+  ],
+}
+`

--- a/src/query/tap-snapshots/test/pseudo/scripts.ts.test.cjs
+++ b/src/query/tap-snapshots/test/pseudo/scripts.ts.test.cjs
@@ -1,0 +1,18 @@
+/* IMPORTANT
+ * This snapshot file is auto-generated, but designed for humans.
+ * It should be checked into source control and tracked carefully.
+ * Re-generate by setting TAP_SNAPSHOT=1 and running tests.
+ * Make sure to inspect the output below.  Do not ignore changes!
+ */
+'use strict'
+exports[`test/pseudo/scripts.ts > TAP > selects packages with an installScripts alert > filter out any node that does not have the alert > must match snapshot 1`] = `
+Object {
+  "edges": Array [
+    "e",
+    "e",
+  ],
+  "nodes": Array [
+    "e",
+  ],
+}
+`

--- a/src/query/tap-snapshots/test/pseudo/shell.ts.test.cjs
+++ b/src/query/tap-snapshots/test/pseudo/shell.ts.test.cjs
@@ -1,0 +1,18 @@
+/* IMPORTANT
+ * This snapshot file is auto-generated, but designed for humans.
+ * It should be checked into source control and tracked carefully.
+ * Re-generate by setting TAP_SNAPSHOT=1 and running tests.
+ * Make sure to inspect the output below.  Do not ignore changes!
+ */
+'use strict'
+exports[`test/pseudo/shell.ts > TAP > selects packages with a shellAccess alert > filter out any node that does not have the alert > must match snapshot 1`] = `
+Object {
+  "edges": Array [
+    "e",
+    "e",
+  ],
+  "nodes": Array [
+    "e",
+  ],
+}
+`

--- a/src/query/tap-snapshots/test/pseudo/shrinkwrap.ts.test.cjs
+++ b/src/query/tap-snapshots/test/pseudo/shrinkwrap.ts.test.cjs
@@ -1,0 +1,18 @@
+/* IMPORTANT
+ * This snapshot file is auto-generated, but designed for humans.
+ * It should be checked into source control and tracked carefully.
+ * Re-generate by setting TAP_SNAPSHOT=1 and running tests.
+ * Make sure to inspect the output below.  Do not ignore changes!
+ */
+'use strict'
+exports[`test/pseudo/shrinkwrap.ts > TAP > selects packages with a shrinkwrap alert > filter out any node that does not have the alert > must match snapshot 1`] = `
+Object {
+  "edges": Array [
+    "e",
+    "e",
+  ],
+  "nodes": Array [
+    "e",
+  ],
+}
+`

--- a/src/query/tap-snapshots/test/pseudo/suspicious.ts.test.cjs
+++ b/src/query/tap-snapshots/test/pseudo/suspicious.ts.test.cjs
@@ -1,0 +1,18 @@
+/* IMPORTANT
+ * This snapshot file is auto-generated, but designed for humans.
+ * It should be checked into source control and tracked carefully.
+ * Re-generate by setting TAP_SNAPSHOT=1 and running tests.
+ * Make sure to inspect the output below.  Do not ignore changes!
+ */
+'use strict'
+exports[`test/pseudo/suspicious.ts > TAP > selects packages with a suspicious alert > filter out any node that does not have the alert > must match snapshot 1`] = `
+Object {
+  "edges": Array [
+    "e",
+    "e",
+  ],
+  "nodes": Array [
+    "e",
+  ],
+}
+`

--- a/src/query/tap-snapshots/test/pseudo/tracker.ts.test.cjs
+++ b/src/query/tap-snapshots/test/pseudo/tracker.ts.test.cjs
@@ -1,0 +1,18 @@
+/* IMPORTANT
+ * This snapshot file is auto-generated, but designed for humans.
+ * It should be checked into source control and tracked carefully.
+ * Re-generate by setting TAP_SNAPSHOT=1 and running tests.
+ * Make sure to inspect the output below.  Do not ignore changes!
+ */
+'use strict'
+exports[`test/pseudo/tracker.ts > TAP > selects packages with a tracker alert > filter out any node that does not have the alert > must match snapshot 1`] = `
+Object {
+  "edges": Array [
+    "e",
+    "e",
+  ],
+  "nodes": Array [
+    "e",
+  ],
+}
+`

--- a/src/query/tap-snapshots/test/pseudo/trivial.ts.test.cjs
+++ b/src/query/tap-snapshots/test/pseudo/trivial.ts.test.cjs
@@ -1,0 +1,18 @@
+/* IMPORTANT
+ * This snapshot file is auto-generated, but designed for humans.
+ * It should be checked into source control and tracked carefully.
+ * Re-generate by setting TAP_SNAPSHOT=1 and running tests.
+ * Make sure to inspect the output below.  Do not ignore changes!
+ */
+'use strict'
+exports[`test/pseudo/trivial.ts > TAP > selects packages with a trivial alert > filter out any node that does not have the alert > must match snapshot 1`] = `
+Object {
+  "edges": Array [
+    "e",
+    "e",
+  ],
+  "nodes": Array [
+    "e",
+  ],
+}
+`

--- a/src/query/tap-snapshots/test/pseudo/undesirable.ts.test.cjs
+++ b/src/query/tap-snapshots/test/pseudo/undesirable.ts.test.cjs
@@ -1,0 +1,18 @@
+/* IMPORTANT
+ * This snapshot file is auto-generated, but designed for humans.
+ * It should be checked into source control and tracked carefully.
+ * Re-generate by setting TAP_SNAPSHOT=1 and running tests.
+ * Make sure to inspect the output below.  Do not ignore changes!
+ */
+'use strict'
+exports[`test/pseudo/undesirable.ts > TAP > selects packages with an undesirable alert > filter out any node that does not have the alert > must match snapshot 1`] = `
+Object {
+  "edges": Array [
+    "e",
+    "e",
+  ],
+  "nodes": Array [
+    "e",
+  ],
+}
+`

--- a/src/query/tap-snapshots/test/pseudo/unknown.ts.test.cjs
+++ b/src/query/tap-snapshots/test/pseudo/unknown.ts.test.cjs
@@ -1,0 +1,18 @@
+/* IMPORTANT
+ * This snapshot file is auto-generated, but designed for humans.
+ * It should be checked into source control and tracked carefully.
+ * Re-generate by setting TAP_SNAPSHOT=1 and running tests.
+ * Make sure to inspect the output below.  Do not ignore changes!
+ */
+'use strict'
+exports[`test/pseudo/unknown.ts > TAP > selects packages with an unknown alert > filter out any node that does not have the alert > must match snapshot 1`] = `
+Object {
+  "edges": Array [
+    "e",
+    "e",
+  ],
+  "nodes": Array [
+    "e",
+  ],
+}
+`

--- a/src/query/tap-snapshots/test/pseudo/unmaintained.ts.test.cjs
+++ b/src/query/tap-snapshots/test/pseudo/unmaintained.ts.test.cjs
@@ -1,0 +1,18 @@
+/* IMPORTANT
+ * This snapshot file is auto-generated, but designed for humans.
+ * It should be checked into source control and tracked carefully.
+ * Re-generate by setting TAP_SNAPSHOT=1 and running tests.
+ * Make sure to inspect the output below.  Do not ignore changes!
+ */
+'use strict'
+exports[`test/pseudo/unmaintained.ts > TAP > selects packages with an unmaintained alert > filter out any node that does not have the alert > must match snapshot 1`] = `
+Object {
+  "edges": Array [
+    "e",
+    "e",
+  ],
+  "nodes": Array [
+    "e",
+  ],
+}
+`

--- a/src/query/tap-snapshots/test/pseudo/unpopular.ts.test.cjs
+++ b/src/query/tap-snapshots/test/pseudo/unpopular.ts.test.cjs
@@ -1,0 +1,18 @@
+/* IMPORTANT
+ * This snapshot file is auto-generated, but designed for humans.
+ * It should be checked into source control and tracked carefully.
+ * Re-generate by setting TAP_SNAPSHOT=1 and running tests.
+ * Make sure to inspect the output below.  Do not ignore changes!
+ */
+'use strict'
+exports[`test/pseudo/unpopular.ts > TAP > selects packages with an unpopular alert > filter out any node that does not have the alert > must match snapshot 1`] = `
+Object {
+  "edges": Array [
+    "e",
+    "e",
+  ],
+  "nodes": Array [
+    "e",
+  ],
+}
+`

--- a/src/query/tap-snapshots/test/pseudo/unstable.ts.test.cjs
+++ b/src/query/tap-snapshots/test/pseudo/unstable.ts.test.cjs
@@ -1,0 +1,18 @@
+/* IMPORTANT
+ * This snapshot file is auto-generated, but designed for humans.
+ * It should be checked into source control and tracked carefully.
+ * Re-generate by setting TAP_SNAPSHOT=1 and running tests.
+ * Make sure to inspect the output below.  Do not ignore changes!
+ */
+'use strict'
+exports[`test/pseudo/unstable.ts > TAP > selects packages with an unstable alert > filter out any node that does not have the alert > must match snapshot 1`] = `
+Object {
+  "edges": Array [
+    "e",
+    "e",
+  ],
+  "nodes": Array [
+    "e",
+  ],
+}
+`

--- a/src/query/test/attribute.ts
+++ b/src/query/test/attribute.ts
@@ -239,6 +239,7 @@ t.test('filterAttributes', async t => {
     partial: all,
     loose: false,
     walk: async (state: ParserState) => state,
+    securityArchive: undefined,
     specOptions: {},
   }
   filterAttributes(

--- a/src/query/test/fixtures/selector.ts
+++ b/src/query/test/fixtures/selector.ts
@@ -87,6 +87,7 @@ export const selectorFixture =
       initial,
       partial,
       walk,
+      securityArchive: undefined,
       specOptions: {},
     }
     const res = await testFn(state)

--- a/src/query/test/index.ts
+++ b/src/query/test/index.ts
@@ -147,7 +147,7 @@ t.test('bad search argument', async t => {
   const query = new Query({
     graph,
     securityArchive: undefined,
-    specOptions
+    specOptions,
   })
   await t.rejects(
     query.search(null as unknown as string),
@@ -188,10 +188,8 @@ t.test('trying to use string selectors', async t => {
     new Query({
       graph: getSimpleGraph(),
       securityArchive: undefined,
-      specOptions
-    }).search(
-      '"foo"',
-    ),
+      specOptions,
+    }).search('"foo"'),
     /Unsupported selector/,
     'should throw an unsupported selector error',
   )
@@ -221,4 +219,21 @@ t.test('cancellable search', async t => {
     /query aborted/,
     'should reject with abort error',
   )
+})
+
+t.test('Query.hasSecuritySelectors', async t => {
+  t.ok(
+    Query.hasSecuritySelectors(':root > *:unmaintained'),
+    'should return true',
+  )
+  t.ok(
+    Query.hasSecuritySelectors(':root > *:has(:unmaintained)'),
+    'should return true',
+  )
+  t.ok(
+    Query.hasSecuritySelectors(':unmaintained'),
+    'should return true',
+  )
+  t.notOk(Query.hasSecuritySelectors(':foo'), 'should return false')
+  t.notOk(Query.hasSecuritySelectors(':has'), 'should return false')
 })

--- a/src/query/test/index.ts
+++ b/src/query/test/index.ts
@@ -34,6 +34,7 @@ const testBrokenState = (): ParserState => {
     initial: copyGraphSelectionState(initial),
     partial: copyGraphSelectionState(initial),
     walk,
+    securityArchive: undefined,
     specOptions,
   }
   return state
@@ -78,7 +79,11 @@ t.test('simple graph', async t => {
     ['#a', ['a']], // identifier
   ])
 
-  const query = new Query({ graph, specOptions })
+  const query = new Query({
+    graph,
+    securityArchive: undefined,
+    specOptions,
+  })
   for (const [q, expected] of queryToExpected) {
     t.strictSame(
       (await query.search(q)).nodes.map(i => i.name),
@@ -98,7 +103,11 @@ t.test('workspace', async t => {
     [':root > :root', ['ws']], // :root always places a ref to root
     ['/* do something */ [name^=w]', ['ws', 'w']], // support comments
   ])
-  const query = new Query({ graph, specOptions })
+  const query = new Query({
+    graph,
+    securityArchive: undefined,
+    specOptions,
+  })
   for (const [q, expected] of queryToExpected) {
     t.strictSame(
       (await query.search(q)).nodes.map(i => i.name),
@@ -119,7 +128,11 @@ t.test('cycle', async t => {
     ['/* do something */ [name^=a]', ['a']], // support comments
     [':root > :root > .prod > *', ['b']], // mixed selectors
   ])
-  const query = new Query({ graph, specOptions })
+  const query = new Query({
+    graph,
+    securityArchive: undefined,
+    specOptions,
+  })
   for (const [q, expected] of queryToExpected) {
     t.strictSame(
       (await query.search(q)).nodes.map(i => i.name),
@@ -131,7 +144,11 @@ t.test('cycle', async t => {
 
 t.test('bad search argument', async t => {
   const graph = getSimpleGraph()
-  const query = new Query({ graph, specOptions })
+  const query = new Query({
+    graph,
+    securityArchive: undefined,
+    specOptions
+  })
   await t.rejects(
     query.search(null as unknown as string),
     /Query search argument needs to be a string/,
@@ -156,7 +173,11 @@ t.test('bad selector type [loose mode]', async t => {
 
 t.test('trying to use tag selectors', async t => {
   await t.rejects(
-    new Query({ graph: getSimpleGraph(), specOptions }).search('foo'),
+    new Query({
+      graph: getSimpleGraph(),
+      securityArchive: undefined,
+      specOptions,
+    }).search('foo'),
     /Unsupported selector/,
     'should throw an unsupported selector error',
   )
@@ -164,7 +185,11 @@ t.test('trying to use tag selectors', async t => {
 
 t.test('trying to use string selectors', async t => {
   await t.rejects(
-    new Query({ graph: getSimpleGraph(), specOptions }).search(
+    new Query({
+      graph: getSimpleGraph(),
+      securityArchive: undefined,
+      specOptions
+    }).search(
       '"foo"',
     ),
     /Unsupported selector/,
@@ -174,7 +199,11 @@ t.test('trying to use string selectors', async t => {
 
 t.test('cancellable search', async t => {
   const graph = getSingleWorkspaceGraph()
-  const query = new Query({ graph, specOptions })
+  const query = new Query({
+    graph,
+    securityArchive: undefined,
+    specOptions,
+  })
   const ac = new AbortController()
   const q = ':root > * > *'
   await t.rejects(

--- a/src/query/test/pseudo/abandoned.ts
+++ b/src/query/test/pseudo/abandoned.ts
@@ -1,0 +1,88 @@
+import t from 'tap'
+import postcssSelectorParser from 'postcss-selector-parser'
+import { joinDepIDTuple } from '@vltpkg/dep-id'
+import type { SecurityArchiveLike } from '@vltpkg/security-archive'
+import { getSimpleGraph } from '../fixtures/graph.ts'
+import type { ParserState } from '../../src/types.ts'
+import { abandoned } from '../../src/pseudo/abandoned.ts'
+
+t.test('selects packages with an abandoned alert', async t => {
+  const getState = (query: string, graph = getSimpleGraph()) => {
+    const ast = postcssSelectorParser().astSync(query)
+    const current = ast.first.first
+    const state: ParserState = {
+      current,
+      initial: {
+        edges: new Set(graph.edges.values()),
+        nodes: new Set(graph.nodes.values()),
+      },
+      partial: {
+        edges: new Set(graph.edges.values()),
+        nodes: new Set(graph.nodes.values()),
+      },
+      collect: {
+        edges: new Set(),
+        nodes: new Set(),
+      },
+      cancellable: async () => {},
+      walk: async i => i,
+      securityArchive: new Map([
+        [
+          joinDepIDTuple(['registry', '', 'e@1.0.0']),
+          { alerts: [{ type: 'missingAuthor' }] },
+        ],
+      ]) as SecurityArchiveLike,
+      specOptions: {},
+    }
+    return state
+  }
+
+  await t.test(
+    'filter out any node that does not have the alert',
+    async t => {
+      const res = await abandoned(getState(':abandoned'))
+      t.strictSame(
+        [...res.partial.nodes].map(n => n.name),
+        ['e'],
+        'should select only abandoned packages',
+      )
+      t.matchSnapshot({
+        nodes: [...res.partial.nodes].map(n => n.name),
+        edges: [...res.partial.edges].map(e => e.name),
+      })
+    },
+  )
+})
+
+t.test('missing security archive', async t => {
+  const getState = (query: string) => {
+    const ast = postcssSelectorParser().astSync(query)
+    const current = ast.first.first
+    const state: ParserState = {
+      current,
+      initial: {
+        edges: new Set(),
+        nodes: new Set(),
+      },
+      partial: {
+        edges: new Set(),
+        nodes: new Set(),
+      },
+      collect: {
+        edges: new Set(),
+        nodes: new Set(),
+      },
+      cancellable: async () => {},
+      walk: async i => i,
+      securityArchive: undefined,
+      specOptions: {},
+    }
+    return state
+  }
+
+  await t.rejects(
+    abandoned(getState(':abandoned')),
+    { message: /Missing security archive/ },
+    'should throw an error',
+  )
+})

--- a/src/query/test/pseudo/confused.ts
+++ b/src/query/test/pseudo/confused.ts
@@ -1,0 +1,88 @@
+import t from 'tap'
+import postcssSelectorParser from 'postcss-selector-parser'
+import { joinDepIDTuple } from '@vltpkg/dep-id'
+import type { SecurityArchiveLike } from '@vltpkg/security-archive'
+import { getSimpleGraph } from '../fixtures/graph.ts'
+import type { ParserState } from '../../src/types.ts'
+import { confused } from '../../src/pseudo/confused.ts'
+
+t.test('selects packages with a manifestConfusion alert', async t => {
+  const getState = (query: string, graph = getSimpleGraph()) => {
+    const ast = postcssSelectorParser().astSync(query)
+    const current = ast.first.first
+    const state: ParserState = {
+      current,
+      initial: {
+        edges: new Set(graph.edges.values()),
+        nodes: new Set(graph.nodes.values()),
+      },
+      partial: {
+        edges: new Set(graph.edges.values()),
+        nodes: new Set(graph.nodes.values()),
+      },
+      collect: {
+        edges: new Set(),
+        nodes: new Set(),
+      },
+      cancellable: async () => {},
+      walk: async i => i,
+      securityArchive: new Map([
+        [
+          joinDepIDTuple(['registry', '', 'e@1.0.0']),
+          { alerts: [{ type: 'manifestConfusion' }] },
+        ],
+      ]) as SecurityArchiveLike,
+      specOptions: {},
+    }
+    return state
+  }
+
+  await t.test(
+    'filter out any node that does not have the alert',
+    async t => {
+      const res = await confused(getState(':confused'))
+      t.strictSame(
+        [...res.partial.nodes].map(n => n.name),
+        ['e'],
+        'should select only confused packages',
+      )
+      t.matchSnapshot({
+        nodes: [...res.partial.nodes].map(n => n.name),
+        edges: [...res.partial.edges].map(e => e.name),
+      })
+    },
+  )
+})
+
+t.test('missing security archive', async t => {
+  const getState = (query: string) => {
+    const ast = postcssSelectorParser().astSync(query)
+    const current = ast.first.first
+    const state: ParserState = {
+      current,
+      initial: {
+        edges: new Set(),
+        nodes: new Set(),
+      },
+      partial: {
+        edges: new Set(),
+        nodes: new Set(),
+      },
+      collect: {
+        edges: new Set(),
+        nodes: new Set(),
+      },
+      cancellable: async () => {},
+      walk: async i => i,
+      securityArchive: undefined,
+      specOptions: {},
+    }
+    return state
+  }
+
+  await t.rejects(
+    confused(getState(':confused')),
+    { message: /Missing security archive/ },
+    'should throw an error',
+  )
+})

--- a/src/query/test/pseudo/debug.ts
+++ b/src/query/test/pseudo/debug.ts
@@ -1,0 +1,88 @@
+import t from 'tap'
+import postcssSelectorParser from 'postcss-selector-parser'
+import { joinDepIDTuple } from '@vltpkg/dep-id'
+import type { SecurityArchiveLike } from '@vltpkg/security-archive'
+import { getSimpleGraph } from '../fixtures/graph.ts'
+import type { ParserState } from '../../src/types.ts'
+import { debug } from '../../src/pseudo/debug.ts'
+
+t.test('selects packages with a debugAccess alert', async t => {
+  const getState = (query: string, graph = getSimpleGraph()) => {
+    const ast = postcssSelectorParser().astSync(query)
+    const current = ast.first.first
+    const state: ParserState = {
+      current,
+      initial: {
+        edges: new Set(graph.edges.values()),
+        nodes: new Set(graph.nodes.values()),
+      },
+      partial: {
+        edges: new Set(graph.edges.values()),
+        nodes: new Set(graph.nodes.values()),
+      },
+      collect: {
+        edges: new Set(),
+        nodes: new Set(),
+      },
+      cancellable: async () => {},
+      walk: async i => i,
+      securityArchive: new Map([
+        [
+          joinDepIDTuple(['registry', '', 'e@1.0.0']),
+          { alerts: [{ type: 'debugAccess' }] },
+        ],
+      ]) as SecurityArchiveLike,
+      specOptions: {},
+    }
+    return state
+  }
+
+  await t.test(
+    'filter out any node that does not have the alert',
+    async t => {
+      const res = await debug(getState(':debug'))
+      t.strictSame(
+        [...res.partial.nodes].map(n => n.name),
+        ['e'],
+        'should select only debug packages',
+      )
+      t.matchSnapshot({
+        nodes: [...res.partial.nodes].map(n => n.name),
+        edges: [...res.partial.edges].map(e => e.name),
+      })
+    },
+  )
+})
+
+t.test('missing security archive', async t => {
+  const getState = (query: string) => {
+    const ast = postcssSelectorParser().astSync(query)
+    const current = ast.first.first
+    const state: ParserState = {
+      current,
+      initial: {
+        edges: new Set(),
+        nodes: new Set(),
+      },
+      partial: {
+        edges: new Set(),
+        nodes: new Set(),
+      },
+      collect: {
+        edges: new Set(),
+        nodes: new Set(),
+      },
+      cancellable: async () => {},
+      walk: async i => i,
+      securityArchive: undefined,
+      specOptions: {},
+    }
+    return state
+  }
+
+  await t.rejects(
+    debug(getState(':debug')),
+    { message: /Missing security archive/ },
+    'should throw an error',
+  )
+})

--- a/src/query/test/pseudo/deprecated.ts
+++ b/src/query/test/pseudo/deprecated.ts
@@ -1,0 +1,88 @@
+import t from 'tap'
+import postcssSelectorParser from 'postcss-selector-parser'
+import { joinDepIDTuple } from '@vltpkg/dep-id'
+import type { SecurityArchiveLike } from '@vltpkg/security-archive'
+import { getSimpleGraph } from '../fixtures/graph.ts'
+import type { ParserState } from '../../src/types.ts'
+import { deprecated } from '../../src/pseudo/deprecated.ts'
+
+t.test('selects packages with a deprecated alert', async t => {
+  const getState = (query: string, graph = getSimpleGraph()) => {
+    const ast = postcssSelectorParser().astSync(query)
+    const current = ast.first.first
+    const state: ParserState = {
+      current,
+      initial: {
+        edges: new Set(graph.edges.values()),
+        nodes: new Set(graph.nodes.values()),
+      },
+      partial: {
+        edges: new Set(graph.edges.values()),
+        nodes: new Set(graph.nodes.values()),
+      },
+      collect: {
+        edges: new Set(),
+        nodes: new Set(),
+      },
+      cancellable: async () => {},
+      walk: async i => i,
+      securityArchive: new Map([
+        [
+          joinDepIDTuple(['registry', '', 'e@1.0.0']),
+          { alerts: [{ type: 'deprecated' }] },
+        ],
+      ]) as SecurityArchiveLike,
+      specOptions: {},
+    }
+    return state
+  }
+
+  await t.test(
+    'filter out any node that does not have the alert',
+    async t => {
+      const res = await deprecated(getState(':deprecated'))
+      t.strictSame(
+        [...res.partial.nodes].map(n => n.name),
+        ['e'],
+        'should select only deprecated packages',
+      )
+      t.matchSnapshot({
+        nodes: [...res.partial.nodes].map(n => n.name),
+        edges: [...res.partial.edges].map(e => e.name),
+      })
+    },
+  )
+})
+
+t.test('missing security archive', async t => {
+  const getState = (query: string) => {
+    const ast = postcssSelectorParser().astSync(query)
+    const current = ast.first.first
+    const state: ParserState = {
+      current,
+      initial: {
+        edges: new Set(),
+        nodes: new Set(),
+      },
+      partial: {
+        edges: new Set(),
+        nodes: new Set(),
+      },
+      collect: {
+        edges: new Set(),
+        nodes: new Set(),
+      },
+      cancellable: async () => {},
+      walk: async i => i,
+      securityArchive: undefined,
+      specOptions: {},
+    }
+    return state
+  }
+
+  await t.rejects(
+    deprecated(getState(':deprecated')),
+    { message: /Missing security archive/ },
+    'should throw an error',
+  )
+})

--- a/src/query/test/pseudo/dynamic.ts
+++ b/src/query/test/pseudo/dynamic.ts
@@ -1,0 +1,88 @@
+import t from 'tap'
+import postcssSelectorParser from 'postcss-selector-parser'
+import { joinDepIDTuple } from '@vltpkg/dep-id'
+import type { SecurityArchiveLike } from '@vltpkg/security-archive'
+import { getSimpleGraph } from '../fixtures/graph.ts'
+import type { ParserState } from '../../src/types.ts'
+import { dynamic } from '../../src/pseudo/dynamic.ts'
+
+t.test('selects packages with a dynamicRequire alert', async t => {
+  const getState = (query: string, graph = getSimpleGraph()) => {
+    const ast = postcssSelectorParser().astSync(query)
+    const current = ast.first.first
+    const state: ParserState = {
+      current,
+      initial: {
+        edges: new Set(graph.edges.values()),
+        nodes: new Set(graph.nodes.values()),
+      },
+      partial: {
+        edges: new Set(graph.edges.values()),
+        nodes: new Set(graph.nodes.values()),
+      },
+      collect: {
+        edges: new Set(),
+        nodes: new Set(),
+      },
+      cancellable: async () => {},
+      walk: async i => i,
+      securityArchive: new Map([
+        [
+          joinDepIDTuple(['registry', '', 'e@1.0.0']),
+          { alerts: [{ type: 'dynamicRequire' }] },
+        ],
+      ]) as SecurityArchiveLike,
+      specOptions: {},
+    }
+    return state
+  }
+
+  await t.test(
+    'filter out any node that does not have the alert',
+    async t => {
+      const res = await dynamic(getState(':dynamic'))
+      t.strictSame(
+        [...res.partial.nodes].map(n => n.name),
+        ['e'],
+        'should select only dynamic packages',
+      )
+      t.matchSnapshot({
+        nodes: [...res.partial.nodes].map(n => n.name),
+        edges: [...res.partial.edges].map(e => e.name),
+      })
+    },
+  )
+})
+
+t.test('missing security archive', async t => {
+  const getState = (query: string) => {
+    const ast = postcssSelectorParser().astSync(query)
+    const current = ast.first.first
+    const state: ParserState = {
+      current,
+      initial: {
+        edges: new Set(),
+        nodes: new Set(),
+      },
+      partial: {
+        edges: new Set(),
+        nodes: new Set(),
+      },
+      collect: {
+        edges: new Set(),
+        nodes: new Set(),
+      },
+      cancellable: async () => {},
+      walk: async i => i,
+      securityArchive: undefined,
+      specOptions: {},
+    }
+    return state
+  }
+
+  await t.rejects(
+    dynamic(getState(':dynamic')),
+    { message: /Missing security archive/ },
+    'should throw an error',
+  )
+})

--- a/src/query/test/pseudo/entropic.ts
+++ b/src/query/test/pseudo/entropic.ts
@@ -1,0 +1,91 @@
+import t from 'tap'
+import postcssSelectorParser from 'postcss-selector-parser'
+import { joinDepIDTuple } from '@vltpkg/dep-id'
+import type { SecurityArchiveLike } from '@vltpkg/security-archive'
+import { getSimpleGraph } from '../fixtures/graph.ts'
+import type { ParserState } from '../../src/types.ts'
+import { entropic } from '../../src/pseudo/entropic.ts'
+
+t.test(
+  'selects packages with a highEntropyStrings alert',
+  async t => {
+    const getState = (query: string, graph = getSimpleGraph()) => {
+      const ast = postcssSelectorParser().astSync(query)
+      const current = ast.first.first
+      const state: ParserState = {
+        current,
+        initial: {
+          edges: new Set(graph.edges.values()),
+          nodes: new Set(graph.nodes.values()),
+        },
+        partial: {
+          edges: new Set(graph.edges.values()),
+          nodes: new Set(graph.nodes.values()),
+        },
+        collect: {
+          edges: new Set(),
+          nodes: new Set(),
+        },
+        cancellable: async () => {},
+        walk: async i => i,
+        securityArchive: new Map([
+          [
+            joinDepIDTuple(['registry', '', 'e@1.0.0']),
+            { alerts: [{ type: 'highEntropyStrings' }] },
+          ],
+        ]) as SecurityArchiveLike,
+        specOptions: {},
+      }
+      return state
+    }
+
+    await t.test(
+      'filter out any node that does not have the alert',
+      async t => {
+        const res = await entropic(getState(':entropic'))
+        t.strictSame(
+          [...res.partial.nodes].map(n => n.name),
+          ['e'],
+          'should select only entropic packages',
+        )
+        t.matchSnapshot({
+          nodes: [...res.partial.nodes].map(n => n.name),
+          edges: [...res.partial.edges].map(e => e.name),
+        })
+      },
+    )
+  },
+)
+
+t.test('missing security archive', async t => {
+  const getState = (query: string) => {
+    const ast = postcssSelectorParser().astSync(query)
+    const current = ast.first.first
+    const state: ParserState = {
+      current,
+      initial: {
+        edges: new Set(),
+        nodes: new Set(),
+      },
+      partial: {
+        edges: new Set(),
+        nodes: new Set(),
+      },
+      collect: {
+        edges: new Set(),
+        nodes: new Set(),
+      },
+      cancellable: async () => {},
+      walk: async i => i,
+      securityArchive: undefined,
+      specOptions: {},
+    }
+    return state
+  }
+
+  await t.rejects(
+    entropic(getState(':entropic')),
+    { message: /Missing security archive/ },
+    'should throw an error',
+  )
+})

--- a/src/query/test/pseudo/env.ts
+++ b/src/query/test/pseudo/env.ts
@@ -1,0 +1,88 @@
+import t from 'tap'
+import postcssSelectorParser from 'postcss-selector-parser'
+import { joinDepIDTuple } from '@vltpkg/dep-id'
+import type { SecurityArchiveLike } from '@vltpkg/security-archive'
+import { getSimpleGraph } from '../fixtures/graph.ts'
+import type { ParserState } from '../../src/types.ts'
+import { env } from '../../src/pseudo/env.ts'
+
+t.test('selects packages with a envVars alert', async t => {
+  const getState = (query: string, graph = getSimpleGraph()) => {
+    const ast = postcssSelectorParser().astSync(query)
+    const current = ast.first.first
+    const state: ParserState = {
+      current,
+      initial: {
+        edges: new Set(graph.edges.values()),
+        nodes: new Set(graph.nodes.values()),
+      },
+      partial: {
+        edges: new Set(graph.edges.values()),
+        nodes: new Set(graph.nodes.values()),
+      },
+      collect: {
+        edges: new Set(),
+        nodes: new Set(),
+      },
+      cancellable: async () => {},
+      walk: async i => i,
+      securityArchive: new Map([
+        [
+          joinDepIDTuple(['registry', '', 'e@1.0.0']),
+          { alerts: [{ type: 'envVars' }] },
+        ],
+      ]) as SecurityArchiveLike,
+      specOptions: {},
+    }
+    return state
+  }
+
+  await t.test(
+    'filter out any node that does not have the alert',
+    async t => {
+      const res = await env(getState(':env'))
+      t.strictSame(
+        [...res.partial.nodes].map(n => n.name),
+        ['e'],
+        'should select only env packages',
+      )
+      t.matchSnapshot({
+        nodes: [...res.partial.nodes].map(n => n.name),
+        edges: [...res.partial.edges].map(e => e.name),
+      })
+    },
+  )
+})
+
+t.test('missing security archive', async t => {
+  const getState = (query: string) => {
+    const ast = postcssSelectorParser().astSync(query)
+    const current = ast.first.first
+    const state: ParserState = {
+      current,
+      initial: {
+        edges: new Set(),
+        nodes: new Set(),
+      },
+      partial: {
+        edges: new Set(),
+        nodes: new Set(),
+      },
+      collect: {
+        edges: new Set(),
+        nodes: new Set(),
+      },
+      cancellable: async () => {},
+      walk: async i => i,
+      securityArchive: undefined,
+      specOptions: {},
+    }
+    return state
+  }
+
+  await t.rejects(
+    env(getState(':env')),
+    { message: /Missing security archive/ },
+    'should throw an error',
+  )
+})

--- a/src/query/test/pseudo/eval.ts
+++ b/src/query/test/pseudo/eval.ts
@@ -1,0 +1,88 @@
+import t from 'tap'
+import postcssSelectorParser from 'postcss-selector-parser'
+import { joinDepIDTuple } from '@vltpkg/dep-id'
+import type { SecurityArchiveLike } from '@vltpkg/security-archive'
+import { getSimpleGraph } from '../fixtures/graph.ts'
+import type { ParserState } from '../../src/types.ts'
+import { evalParser } from '../../src/pseudo/eval.ts'
+
+t.test('selects packages with an eval alert', async t => {
+  const getState = (query: string, graph = getSimpleGraph()) => {
+    const ast = postcssSelectorParser().astSync(query)
+    const current = ast.first.first
+    const state: ParserState = {
+      current,
+      initial: {
+        edges: new Set(graph.edges.values()),
+        nodes: new Set(graph.nodes.values()),
+      },
+      partial: {
+        edges: new Set(graph.edges.values()),
+        nodes: new Set(graph.nodes.values()),
+      },
+      collect: {
+        edges: new Set(),
+        nodes: new Set(),
+      },
+      cancellable: async () => {},
+      walk: async i => i,
+      securityArchive: new Map([
+        [
+          joinDepIDTuple(['registry', '', 'e@1.0.0']),
+          { alerts: [{ type: 'usesEval' }] },
+        ],
+      ]) as SecurityArchiveLike,
+      specOptions: {},
+    }
+    return state
+  }
+
+  await t.test(
+    'filter out any node that does not have the alert',
+    async t => {
+      const res = await evalParser(getState(':eval'))
+      t.strictSame(
+        [...res.partial.nodes].map(n => n.name),
+        ['e'],
+        'should select only eval packages',
+      )
+      t.matchSnapshot({
+        nodes: [...res.partial.nodes].map(n => n.name),
+        edges: [...res.partial.edges].map(e => e.name),
+      })
+    },
+  )
+})
+
+t.test('missing security archive', async t => {
+  const getState = (query: string) => {
+    const ast = postcssSelectorParser().astSync(query)
+    const current = ast.first.first
+    const state: ParserState = {
+      current,
+      initial: {
+        edges: new Set(),
+        nodes: new Set(),
+      },
+      partial: {
+        edges: new Set(),
+        nodes: new Set(),
+      },
+      collect: {
+        edges: new Set(),
+        nodes: new Set(),
+      },
+      cancellable: async () => {},
+      walk: async i => i,
+      securityArchive: undefined,
+      specOptions: {},
+    }
+    return state
+  }
+
+  await t.rejects(
+    evalParser(getState(':eval')),
+    { message: /Missing security archive/ },
+    'should throw an error',
+  )
+})

--- a/src/query/test/pseudo/fs.ts
+++ b/src/query/test/pseudo/fs.ts
@@ -1,0 +1,88 @@
+import t from 'tap'
+import postcssSelectorParser from 'postcss-selector-parser'
+import { joinDepIDTuple } from '@vltpkg/dep-id'
+import type { SecurityArchiveLike } from '@vltpkg/security-archive'
+import { getSimpleGraph } from '../fixtures/graph.ts'
+import type { ParserState } from '../../src/types.ts'
+import { fs } from '../../src/pseudo/fs.ts'
+
+t.test('selects packages with a filesystemAccess alert', async t => {
+  const getState = (query: string, graph = getSimpleGraph()) => {
+    const ast = postcssSelectorParser().astSync(query)
+    const current = ast.first.first
+    const state: ParserState = {
+      current,
+      initial: {
+        edges: new Set(graph.edges.values()),
+        nodes: new Set(graph.nodes.values()),
+      },
+      partial: {
+        edges: new Set(graph.edges.values()),
+        nodes: new Set(graph.nodes.values()),
+      },
+      collect: {
+        edges: new Set(),
+        nodes: new Set(),
+      },
+      cancellable: async () => {},
+      walk: async i => i,
+      securityArchive: new Map([
+        [
+          joinDepIDTuple(['registry', '', 'e@1.0.0']),
+          { alerts: [{ type: 'filesystemAccess' }] },
+        ],
+      ]) as SecurityArchiveLike,
+      specOptions: {},
+    }
+    return state
+  }
+
+  await t.test(
+    'filter out any node that does not have the alert',
+    async t => {
+      const res = await fs(getState(':fs'))
+      t.strictSame(
+        [...res.partial.nodes].map(n => n.name),
+        ['e'],
+        'should select only fs packages',
+      )
+      t.matchSnapshot({
+        nodes: [...res.partial.nodes].map(n => n.name),
+        edges: [...res.partial.edges].map(e => e.name),
+      })
+    },
+  )
+})
+
+t.test('missing security archive', async t => {
+  const getState = (query: string) => {
+    const ast = postcssSelectorParser().astSync(query)
+    const current = ast.first.first
+    const state: ParserState = {
+      current,
+      initial: {
+        edges: new Set(),
+        nodes: new Set(),
+      },
+      partial: {
+        edges: new Set(),
+        nodes: new Set(),
+      },
+      collect: {
+        edges: new Set(),
+        nodes: new Set(),
+      },
+      cancellable: async () => {},
+      walk: async i => i,
+      securityArchive: undefined,
+      specOptions: {},
+    }
+    return state
+  }
+
+  await t.rejects(
+    fs(getState(':fs')),
+    { message: /Missing security archive/ },
+    'should throw an error',
+  )
+})

--- a/src/query/test/pseudo/helpers.ts
+++ b/src/query/test/pseudo/helpers.ts
@@ -1,5 +1,8 @@
 import t from 'tap'
+import postcssSelectorParser from 'postcss-selector-parser'
+import type { SecurityArchiveLike } from '@vltpkg/security-archive'
 import {
+  createSecuritySelectorFilter,
   removeDanglingEdges,
   removeNode,
   removeQuotes,
@@ -109,4 +112,93 @@ t.test('removeQuotes', async t => {
   t.equal(removeQuotes('"a"'), 'a', 'should remove quotes')
   t.equal(removeQuotes('a'), 'a', 'should not remove quotes')
   t.equal(removeQuotes('1234'), '1234', 'should not remove quotes')
+})
+
+t.test('selects packages with an unmaintained alert', async t => {
+  const getState = (query: string, graph = getSimpleGraph()) => {
+    const ast = postcssSelectorParser().astSync(query)
+    const current = ast.first.first
+    const state: ParserState = {
+      current,
+      initial: {
+        edges: new Set(graph.edges.values()),
+        nodes: new Set(graph.nodes.values()),
+      },
+      partial: {
+        edges: new Set(graph.edges.values()),
+        nodes: new Set(graph.nodes.values()),
+      },
+      collect: {
+        edges: new Set(),
+        nodes: new Set(),
+      },
+      cancellable: async () => {},
+      walk: async i => i,
+      securityArchive: new Map([
+        [
+          joinDepIDTuple(['registry', '', 'e@1.0.0']),
+          { alerts: [{ type: 'unmaintained' }] },
+        ],
+      ]) as SecurityArchiveLike,
+      specOptions: {},
+    }
+    return state
+  }
+
+  const unmaintained = createSecuritySelectorFilter(
+    'unmaintained',
+    'unmaintained',
+  )
+  await t.test(
+    'filter out any node that does not have the alert',
+    async t => {
+      const res = await unmaintained(getState(':unmaintained'))
+      t.strictSame(
+        [...res.partial.nodes].map(n => n.name),
+        ['e'],
+        'should select only unmaintained packages',
+      )
+      t.matchSnapshot({
+        nodes: [...res.partial.nodes].map(n => n.name),
+        edges: [...res.partial.edges].map(e => e.name),
+      })
+    },
+  )
+})
+
+t.test('missing security archive', async t => {
+  const getState = (query: string) => {
+    const ast = postcssSelectorParser().astSync(query)
+    const current = ast.first.first
+    const state: ParserState = {
+      current,
+      initial: {
+        edges: new Set(),
+        nodes: new Set(),
+      },
+      partial: {
+        edges: new Set(),
+        nodes: new Set(),
+      },
+      collect: {
+        edges: new Set(),
+        nodes: new Set(),
+      },
+      cancellable: async () => {},
+      walk: async i => i,
+      securityArchive: undefined,
+      specOptions: {},
+    }
+    return state
+  }
+
+  const unmaintained = createSecuritySelectorFilter(
+    'unmaintained',
+    'unmaintained',
+  )
+  await t.rejects(
+    unmaintained(getState(':unmaintained')),
+    { message: /Missing security archive/ },
+    'should throw an error',
+  )
 })

--- a/src/query/test/pseudo/minified.ts
+++ b/src/query/test/pseudo/minified.ts
@@ -1,0 +1,88 @@
+import t from 'tap'
+import postcssSelectorParser from 'postcss-selector-parser'
+import { joinDepIDTuple } from '@vltpkg/dep-id'
+import type { SecurityArchiveLike } from '@vltpkg/security-archive'
+import { getSimpleGraph } from '../fixtures/graph.ts'
+import type { ParserState } from '../../src/types.ts'
+import { minified } from '../../src/pseudo/minified.ts'
+
+t.test('selects packages with a minifiedFile alert', async t => {
+  const getState = (query: string, graph = getSimpleGraph()) => {
+    const ast = postcssSelectorParser().astSync(query)
+    const current = ast.first.first
+    const state: ParserState = {
+      current,
+      initial: {
+        edges: new Set(graph.edges.values()),
+        nodes: new Set(graph.nodes.values()),
+      },
+      partial: {
+        edges: new Set(graph.edges.values()),
+        nodes: new Set(graph.nodes.values()),
+      },
+      collect: {
+        edges: new Set(),
+        nodes: new Set(),
+      },
+      cancellable: async () => {},
+      walk: async i => i,
+      securityArchive: new Map([
+        [
+          joinDepIDTuple(['registry', '', 'e@1.0.0']),
+          { alerts: [{ type: 'minifiedFile' }] },
+        ],
+      ]) as SecurityArchiveLike,
+      specOptions: {},
+    }
+    return state
+  }
+
+  await t.test(
+    'filter out any node that does not have the alert',
+    async t => {
+      const res = await minified(getState(':minified'))
+      t.strictSame(
+        [...res.partial.nodes].map(n => n.name),
+        ['e'],
+        'should select only minified packages',
+      )
+      t.matchSnapshot({
+        nodes: [...res.partial.nodes].map(n => n.name),
+        edges: [...res.partial.edges].map(e => e.name),
+      })
+    },
+  )
+})
+
+t.test('missing security archive', async t => {
+  const getState = (query: string) => {
+    const ast = postcssSelectorParser().astSync(query)
+    const current = ast.first.first
+    const state: ParserState = {
+      current,
+      initial: {
+        edges: new Set(),
+        nodes: new Set(),
+      },
+      partial: {
+        edges: new Set(),
+        nodes: new Set(),
+      },
+      collect: {
+        edges: new Set(),
+        nodes: new Set(),
+      },
+      cancellable: async () => {},
+      walk: async i => i,
+      securityArchive: undefined,
+      specOptions: {},
+    }
+    return state
+  }
+
+  await t.rejects(
+    minified(getState(':minified')),
+    { message: /Missing security archive/ },
+    'should throw an error',
+  )
+})

--- a/src/query/test/pseudo/native.ts
+++ b/src/query/test/pseudo/native.ts
@@ -1,0 +1,88 @@
+import t from 'tap'
+import postcssSelectorParser from 'postcss-selector-parser'
+import { joinDepIDTuple } from '@vltpkg/dep-id'
+import type { SecurityArchiveLike } from '@vltpkg/security-archive'
+import { getSimpleGraph } from '../fixtures/graph.ts'
+import type { ParserState } from '../../src/types.ts'
+import { nativeParser } from '../../src/pseudo/native.ts'
+
+t.test('selects packages with a hasNativeCode alert', async t => {
+  const getState = (query: string, graph = getSimpleGraph()) => {
+    const ast = postcssSelectorParser().astSync(query)
+    const current = ast.first.first
+    const state: ParserState = {
+      current,
+      initial: {
+        edges: new Set(graph.edges.values()),
+        nodes: new Set(graph.nodes.values()),
+      },
+      partial: {
+        edges: new Set(graph.edges.values()),
+        nodes: new Set(graph.nodes.values()),
+      },
+      collect: {
+        edges: new Set(),
+        nodes: new Set(),
+      },
+      cancellable: async () => {},
+      walk: async i => i,
+      securityArchive: new Map([
+        [
+          joinDepIDTuple(['registry', '', 'e@1.0.0']),
+          { alerts: [{ type: 'hasNativeCode' }] },
+        ],
+      ]) as SecurityArchiveLike,
+      specOptions: {},
+    }
+    return state
+  }
+
+  await t.test(
+    'filter out any node that does not have the alert',
+    async t => {
+      const res = await nativeParser(getState(':native'))
+      t.strictSame(
+        [...res.partial.nodes].map(n => n.name),
+        ['e'],
+        'should select only native packages',
+      )
+      t.matchSnapshot({
+        nodes: [...res.partial.nodes].map(n => n.name),
+        edges: [...res.partial.edges].map(e => e.name),
+      })
+    },
+  )
+})
+
+t.test('missing security archive', async t => {
+  const getState = (query: string) => {
+    const ast = postcssSelectorParser().astSync(query)
+    const current = ast.first.first
+    const state: ParserState = {
+      current,
+      initial: {
+        edges: new Set(),
+        nodes: new Set(),
+      },
+      partial: {
+        edges: new Set(),
+        nodes: new Set(),
+      },
+      collect: {
+        edges: new Set(),
+        nodes: new Set(),
+      },
+      cancellable: async () => {},
+      walk: async i => i,
+      securityArchive: undefined,
+      specOptions: {},
+    }
+    return state
+  }
+
+  await t.rejects(
+    nativeParser(getState(':native')),
+    { message: /Missing security archive/ },
+    'should throw an error',
+  )
+})

--- a/src/query/test/pseudo/network.ts
+++ b/src/query/test/pseudo/network.ts
@@ -1,0 +1,88 @@
+import t from 'tap'
+import postcssSelectorParser from 'postcss-selector-parser'
+import { joinDepIDTuple } from '@vltpkg/dep-id'
+import type { SecurityArchiveLike } from '@vltpkg/security-archive'
+import { getSimpleGraph } from '../fixtures/graph.ts'
+import type { ParserState } from '../../src/types.ts'
+import { network } from '../../src/pseudo/network.ts'
+
+t.test('selects packages with a networkAccess alert', async t => {
+  const getState = (query: string, graph = getSimpleGraph()) => {
+    const ast = postcssSelectorParser().astSync(query)
+    const current = ast.first.first
+    const state: ParserState = {
+      current,
+      initial: {
+        edges: new Set(graph.edges.values()),
+        nodes: new Set(graph.nodes.values()),
+      },
+      partial: {
+        edges: new Set(graph.edges.values()),
+        nodes: new Set(graph.nodes.values()),
+      },
+      collect: {
+        edges: new Set(),
+        nodes: new Set(),
+      },
+      cancellable: async () => {},
+      walk: async i => i,
+      securityArchive: new Map([
+        [
+          joinDepIDTuple(['registry', '', 'e@1.0.0']),
+          { alerts: [{ type: 'networkAccess' }] },
+        ],
+      ]) as SecurityArchiveLike,
+      specOptions: {},
+    }
+    return state
+  }
+
+  await t.test(
+    'filter out any node that does not have the alert',
+    async t => {
+      const res = await network(getState(':network'))
+      t.strictSame(
+        [...res.partial.nodes].map(n => n.name),
+        ['e'],
+        'should select only network packages',
+      )
+      t.matchSnapshot({
+        nodes: [...res.partial.nodes].map(n => n.name),
+        edges: [...res.partial.edges].map(e => e.name),
+      })
+    },
+  )
+})
+
+t.test('missing security archive', async t => {
+  const getState = (query: string) => {
+    const ast = postcssSelectorParser().astSync(query)
+    const current = ast.first.first
+    const state: ParserState = {
+      current,
+      initial: {
+        edges: new Set(),
+        nodes: new Set(),
+      },
+      partial: {
+        edges: new Set(),
+        nodes: new Set(),
+      },
+      collect: {
+        edges: new Set(),
+        nodes: new Set(),
+      },
+      cancellable: async () => {},
+      walk: async i => i,
+      securityArchive: undefined,
+      specOptions: {},
+    }
+    return state
+  }
+
+  await t.rejects(
+    network(getState(':network')),
+    { message: /Missing security archive/ },
+    'should throw an error',
+  )
+})

--- a/src/query/test/pseudo/obfuscated.ts
+++ b/src/query/test/pseudo/obfuscated.ts
@@ -1,0 +1,88 @@
+import t from 'tap'
+import postcssSelectorParser from 'postcss-selector-parser'
+import { joinDepIDTuple } from '@vltpkg/dep-id'
+import type { SecurityArchiveLike } from '@vltpkg/security-archive'
+import { getSimpleGraph } from '../fixtures/graph.ts'
+import type { ParserState } from '../../src/types.ts'
+import { obfuscated } from '../../src/pseudo/obfuscated.ts'
+
+t.test('selects packages with an obfuscated alert', async t => {
+  const getState = (query: string, graph = getSimpleGraph()) => {
+    const ast = postcssSelectorParser().astSync(query)
+    const current = ast.first.first
+    const state: ParserState = {
+      current,
+      initial: {
+        edges: new Set(graph.edges.values()),
+        nodes: new Set(graph.nodes.values()),
+      },
+      partial: {
+        edges: new Set(graph.edges.values()),
+        nodes: new Set(graph.nodes.values()),
+      },
+      collect: {
+        edges: new Set(),
+        nodes: new Set(),
+      },
+      cancellable: async () => {},
+      walk: async i => i,
+      securityArchive: new Map([
+        [
+          joinDepIDTuple(['registry', '', 'e@1.0.0']),
+          { alerts: [{ type: 'obfuscatedFile' }] },
+        ],
+      ]) as SecurityArchiveLike,
+      specOptions: {},
+    }
+    return state
+  }
+
+  await t.test(
+    'filter out any node that does not have the alert',
+    async t => {
+      const res = await obfuscated(getState(':obfuscated'))
+      t.strictSame(
+        [...res.partial.nodes].map(n => n.name),
+        ['e'],
+        'should select only obfuscated packages',
+      )
+      t.matchSnapshot({
+        nodes: [...res.partial.nodes].map(n => n.name),
+        edges: [...res.partial.edges].map(e => e.name),
+      })
+    },
+  )
+})
+
+t.test('missing security archive', async t => {
+  const getState = (query: string) => {
+    const ast = postcssSelectorParser().astSync(query)
+    const current = ast.first.first
+    const state: ParserState = {
+      current,
+      initial: {
+        edges: new Set(),
+        nodes: new Set(),
+      },
+      partial: {
+        edges: new Set(),
+        nodes: new Set(),
+      },
+      collect: {
+        edges: new Set(),
+        nodes: new Set(),
+      },
+      cancellable: async () => {},
+      walk: async i => i,
+      securityArchive: undefined,
+      specOptions: {},
+    }
+    return state
+  }
+
+  await t.rejects(
+    obfuscated(getState(':obfuscated')),
+    { message: /Missing security archive/ },
+    'should throw an error',
+  )
+})

--- a/src/query/test/pseudo/outdated.ts
+++ b/src/query/test/pseudo/outdated.ts
@@ -123,6 +123,7 @@ const getState = (query: string, graph = getSemverRichGraph()) => {
     },
     cancellable: async () => {},
     walk: async i => i,
+    securityArchive: undefined,
     specOptions,
   }
   return state

--- a/src/query/test/pseudo/scripts.ts
+++ b/src/query/test/pseudo/scripts.ts
@@ -1,0 +1,88 @@
+import t from 'tap'
+import postcssSelectorParser from 'postcss-selector-parser'
+import { joinDepIDTuple } from '@vltpkg/dep-id'
+import type { SecurityArchiveLike } from '@vltpkg/security-archive'
+import { getSimpleGraph } from '../fixtures/graph.ts'
+import type { ParserState } from '../../src/types.ts'
+import { scripts } from '../../src/pseudo/scripts.ts'
+
+t.test('selects packages with an installScripts alert', async t => {
+  const getState = (query: string, graph = getSimpleGraph()) => {
+    const ast = postcssSelectorParser().astSync(query)
+    const current = ast.first.first
+    const state: ParserState = {
+      current,
+      initial: {
+        edges: new Set(graph.edges.values()),
+        nodes: new Set(graph.nodes.values()),
+      },
+      partial: {
+        edges: new Set(graph.edges.values()),
+        nodes: new Set(graph.nodes.values()),
+      },
+      collect: {
+        edges: new Set(),
+        nodes: new Set(),
+      },
+      cancellable: async () => {},
+      walk: async i => i,
+      securityArchive: new Map([
+        [
+          joinDepIDTuple(['registry', '', 'e@1.0.0']),
+          { alerts: [{ type: 'installScripts' }] },
+        ],
+      ]) as SecurityArchiveLike,
+      specOptions: {},
+    }
+    return state
+  }
+
+  await t.test(
+    'filter out any node that does not have the alert',
+    async t => {
+      const res = await scripts(getState(':scripts'))
+      t.strictSame(
+        [...res.partial.nodes].map(n => n.name),
+        ['e'],
+        'should select only scripts packages',
+      )
+      t.matchSnapshot({
+        nodes: [...res.partial.nodes].map(n => n.name),
+        edges: [...res.partial.edges].map(e => e.name),
+      })
+    },
+  )
+})
+
+t.test('missing security archive', async t => {
+  const getState = (query: string) => {
+    const ast = postcssSelectorParser().astSync(query)
+    const current = ast.first.first
+    const state: ParserState = {
+      current,
+      initial: {
+        edges: new Set(),
+        nodes: new Set(),
+      },
+      partial: {
+        edges: new Set(),
+        nodes: new Set(),
+      },
+      collect: {
+        edges: new Set(),
+        nodes: new Set(),
+      },
+      cancellable: async () => {},
+      walk: async i => i,
+      securityArchive: undefined,
+      specOptions: {},
+    }
+    return state
+  }
+
+  await t.rejects(
+    scripts(getState(':scripts')),
+    { message: /Missing security archive/ },
+    'should throw an error',
+  )
+})

--- a/src/query/test/pseudo/semver.ts
+++ b/src/query/test/pseudo/semver.ts
@@ -33,6 +33,7 @@ t.test('select from semver definition', async t => {
       },
       cancellable: async () => {},
       walk: async i => i,
+      securityArchive: undefined,
       specOptions: {},
     }
     return state

--- a/src/query/test/pseudo/shell.ts
+++ b/src/query/test/pseudo/shell.ts
@@ -1,0 +1,88 @@
+import t from 'tap'
+import postcssSelectorParser from 'postcss-selector-parser'
+import { joinDepIDTuple } from '@vltpkg/dep-id'
+import type { SecurityArchiveLike } from '@vltpkg/security-archive'
+import { getSimpleGraph } from '../fixtures/graph.ts'
+import type { ParserState } from '../../src/types.ts'
+import { shell } from '../../src/pseudo/shell.ts'
+
+t.test('selects packages with a shellAccess alert', async t => {
+  const getState = (query: string, graph = getSimpleGraph()) => {
+    const ast = postcssSelectorParser().astSync(query)
+    const current = ast.first.first
+    const state: ParserState = {
+      current,
+      initial: {
+        edges: new Set(graph.edges.values()),
+        nodes: new Set(graph.nodes.values()),
+      },
+      partial: {
+        edges: new Set(graph.edges.values()),
+        nodes: new Set(graph.nodes.values()),
+      },
+      collect: {
+        edges: new Set(),
+        nodes: new Set(),
+      },
+      cancellable: async () => {},
+      walk: async i => i,
+      securityArchive: new Map([
+        [
+          joinDepIDTuple(['registry', '', 'e@1.0.0']),
+          { alerts: [{ type: 'shellAccess' }] },
+        ],
+      ]) as SecurityArchiveLike,
+      specOptions: {},
+    }
+    return state
+  }
+
+  await t.test(
+    'filter out any node that does not have the alert',
+    async t => {
+      const res = await shell(getState(':shell'))
+      t.strictSame(
+        [...res.partial.nodes].map(n => n.name),
+        ['e'],
+        'should select only shell packages',
+      )
+      t.matchSnapshot({
+        nodes: [...res.partial.nodes].map(n => n.name),
+        edges: [...res.partial.edges].map(e => e.name),
+      })
+    },
+  )
+})
+
+t.test('missing security archive', async t => {
+  const getState = (query: string) => {
+    const ast = postcssSelectorParser().astSync(query)
+    const current = ast.first.first
+    const state: ParserState = {
+      current,
+      initial: {
+        edges: new Set(),
+        nodes: new Set(),
+      },
+      partial: {
+        edges: new Set(),
+        nodes: new Set(),
+      },
+      collect: {
+        edges: new Set(),
+        nodes: new Set(),
+      },
+      cancellable: async () => {},
+      walk: async i => i,
+      securityArchive: undefined,
+      specOptions: {},
+    }
+    return state
+  }
+
+  await t.rejects(
+    shell(getState(':shell')),
+    { message: /Missing security archive/ },
+    'should throw an error',
+  )
+})

--- a/src/query/test/pseudo/shrinkwrap.ts
+++ b/src/query/test/pseudo/shrinkwrap.ts
@@ -1,0 +1,88 @@
+import t from 'tap'
+import postcssSelectorParser from 'postcss-selector-parser'
+import { joinDepIDTuple } from '@vltpkg/dep-id'
+import type { SecurityArchiveLike } from '@vltpkg/security-archive'
+import { getSimpleGraph } from '../fixtures/graph.ts'
+import type { ParserState } from '../../src/types.ts'
+import { shrinkwrap } from '../../src/pseudo/shrinkwrap.ts'
+
+t.test('selects packages with a shrinkwrap alert', async t => {
+  const getState = (query: string, graph = getSimpleGraph()) => {
+    const ast = postcssSelectorParser().astSync(query)
+    const current = ast.first.first
+    const state: ParserState = {
+      current,
+      initial: {
+        edges: new Set(graph.edges.values()),
+        nodes: new Set(graph.nodes.values()),
+      },
+      partial: {
+        edges: new Set(graph.edges.values()),
+        nodes: new Set(graph.nodes.values()),
+      },
+      collect: {
+        edges: new Set(),
+        nodes: new Set(),
+      },
+      cancellable: async () => {},
+      walk: async i => i,
+      securityArchive: new Map([
+        [
+          joinDepIDTuple(['registry', '', 'e@1.0.0']),
+          { alerts: [{ type: 'shrinkwrap' }] },
+        ],
+      ]) as SecurityArchiveLike,
+      specOptions: {},
+    }
+    return state
+  }
+
+  await t.test(
+    'filter out any node that does not have the alert',
+    async t => {
+      const res = await shrinkwrap(getState(':shrinkwrap'))
+      t.strictSame(
+        [...res.partial.nodes].map(n => n.name),
+        ['e'],
+        'should select only shrinkwrap packages',
+      )
+      t.matchSnapshot({
+        nodes: [...res.partial.nodes].map(n => n.name),
+        edges: [...res.partial.edges].map(e => e.name),
+      })
+    },
+  )
+})
+
+t.test('missing security archive', async t => {
+  const getState = (query: string) => {
+    const ast = postcssSelectorParser().astSync(query)
+    const current = ast.first.first
+    const state: ParserState = {
+      current,
+      initial: {
+        edges: new Set(),
+        nodes: new Set(),
+      },
+      partial: {
+        edges: new Set(),
+        nodes: new Set(),
+      },
+      collect: {
+        edges: new Set(),
+        nodes: new Set(),
+      },
+      cancellable: async () => {},
+      walk: async i => i,
+      securityArchive: undefined,
+      specOptions: {},
+    }
+    return state
+  }
+
+  await t.rejects(
+    shrinkwrap(getState(':shrinkwrap')),
+    { message: /Missing security archive/ },
+    'should throw an error',
+  )
+})

--- a/src/query/test/pseudo/suspicious.ts
+++ b/src/query/test/pseudo/suspicious.ts
@@ -1,0 +1,88 @@
+import t from 'tap'
+import postcssSelectorParser from 'postcss-selector-parser'
+import { joinDepIDTuple } from '@vltpkg/dep-id'
+import type { SecurityArchiveLike } from '@vltpkg/security-archive'
+import { getSimpleGraph } from '../fixtures/graph.ts'
+import type { ParserState } from '../../src/types.ts'
+import { suspicious } from '../../src/pseudo/suspicious.ts'
+
+t.test('selects packages with a suspicious alert', async t => {
+  const getState = (query: string, graph = getSimpleGraph()) => {
+    const ast = postcssSelectorParser().astSync(query)
+    const current = ast.first.first
+    const state: ParserState = {
+      current,
+      initial: {
+        edges: new Set(graph.edges.values()),
+        nodes: new Set(graph.nodes.values()),
+      },
+      partial: {
+        edges: new Set(graph.edges.values()),
+        nodes: new Set(graph.nodes.values()),
+      },
+      collect: {
+        edges: new Set(),
+        nodes: new Set(),
+      },
+      cancellable: async () => {},
+      walk: async i => i,
+      securityArchive: new Map([
+        [
+          joinDepIDTuple(['registry', '', 'e@1.0.0']),
+          { alerts: [{ type: 'suspiciousStarActivity' }] },
+        ],
+      ]) as SecurityArchiveLike,
+      specOptions: {},
+    }
+    return state
+  }
+
+  await t.test(
+    'filter out any node that does not have the alert',
+    async t => {
+      const res = await suspicious(getState(':suspicious'))
+      t.strictSame(
+        [...res.partial.nodes].map(n => n.name),
+        ['e'],
+        'should select only suspicious packages',
+      )
+      t.matchSnapshot({
+        nodes: [...res.partial.nodes].map(n => n.name),
+        edges: [...res.partial.edges].map(e => e.name),
+      })
+    },
+  )
+})
+
+t.test('missing security archive', async t => {
+  const getState = (query: string) => {
+    const ast = postcssSelectorParser().astSync(query)
+    const current = ast.first.first
+    const state: ParserState = {
+      current,
+      initial: {
+        edges: new Set(),
+        nodes: new Set(),
+      },
+      partial: {
+        edges: new Set(),
+        nodes: new Set(),
+      },
+      collect: {
+        edges: new Set(),
+        nodes: new Set(),
+      },
+      cancellable: async () => {},
+      walk: async i => i,
+      securityArchive: undefined,
+      specOptions: {},
+    }
+    return state
+  }
+
+  await t.rejects(
+    suspicious(getState(':suspicious')),
+    { message: /Missing security archive/ },
+    'should throw an error',
+  )
+})

--- a/src/query/test/pseudo/tracker.ts
+++ b/src/query/test/pseudo/tracker.ts
@@ -1,0 +1,88 @@
+import t from 'tap'
+import postcssSelectorParser from 'postcss-selector-parser'
+import { joinDepIDTuple } from '@vltpkg/dep-id'
+import type { SecurityArchiveLike } from '@vltpkg/security-archive'
+import { getSimpleGraph } from '../fixtures/graph.ts'
+import type { ParserState } from '../../src/types.ts'
+import { tracker } from '../../src/pseudo/tracker.ts'
+
+t.test('selects packages with a tracker alert', async t => {
+  const getState = (query: string, graph = getSimpleGraph()) => {
+    const ast = postcssSelectorParser().astSync(query)
+    const current = ast.first.first
+    const state: ParserState = {
+      current,
+      initial: {
+        edges: new Set(graph.edges.values()),
+        nodes: new Set(graph.nodes.values()),
+      },
+      partial: {
+        edges: new Set(graph.edges.values()),
+        nodes: new Set(graph.nodes.values()),
+      },
+      collect: {
+        edges: new Set(),
+        nodes: new Set(),
+      },
+      cancellable: async () => {},
+      walk: async i => i,
+      securityArchive: new Map([
+        [
+          joinDepIDTuple(['registry', '', 'e@1.0.0']),
+          { alerts: [{ type: 'telemetry' }] },
+        ],
+      ]) as SecurityArchiveLike,
+      specOptions: {},
+    }
+    return state
+  }
+
+  await t.test(
+    'filter out any node that does not have the alert',
+    async t => {
+      const res = await tracker(getState(':tracker'))
+      t.strictSame(
+        [...res.partial.nodes].map(n => n.name),
+        ['e'],
+        'should select only tracker packages',
+      )
+      t.matchSnapshot({
+        nodes: [...res.partial.nodes].map(n => n.name),
+        edges: [...res.partial.edges].map(e => e.name),
+      })
+    },
+  )
+})
+
+t.test('missing security archive', async t => {
+  const getState = (query: string) => {
+    const ast = postcssSelectorParser().astSync(query)
+    const current = ast.first.first
+    const state: ParserState = {
+      current,
+      initial: {
+        edges: new Set(),
+        nodes: new Set(),
+      },
+      partial: {
+        edges: new Set(),
+        nodes: new Set(),
+      },
+      collect: {
+        edges: new Set(),
+        nodes: new Set(),
+      },
+      cancellable: async () => {},
+      walk: async i => i,
+      securityArchive: undefined,
+      specOptions: {},
+    }
+    return state
+  }
+
+  await t.rejects(
+    tracker(getState(':tracker')),
+    { message: /Missing security archive/ },
+    'should throw an error',
+  )
+})

--- a/src/query/test/pseudo/trivial.ts
+++ b/src/query/test/pseudo/trivial.ts
@@ -1,0 +1,88 @@
+import t from 'tap'
+import postcssSelectorParser from 'postcss-selector-parser'
+import { joinDepIDTuple } from '@vltpkg/dep-id'
+import type { SecurityArchiveLike } from '@vltpkg/security-archive'
+import { getSimpleGraph } from '../fixtures/graph.ts'
+import type { ParserState } from '../../src/types.ts'
+import { trivial } from '../../src/pseudo/trivial.ts'
+
+t.test('selects packages with a trivial alert', async t => {
+  const getState = (query: string, graph = getSimpleGraph()) => {
+    const ast = postcssSelectorParser().astSync(query)
+    const current = ast.first.first
+    const state: ParserState = {
+      current,
+      initial: {
+        edges: new Set(graph.edges.values()),
+        nodes: new Set(graph.nodes.values()),
+      },
+      partial: {
+        edges: new Set(graph.edges.values()),
+        nodes: new Set(graph.nodes.values()),
+      },
+      collect: {
+        edges: new Set(),
+        nodes: new Set(),
+      },
+      cancellable: async () => {},
+      walk: async i => i,
+      securityArchive: new Map([
+        [
+          joinDepIDTuple(['registry', '', 'e@1.0.0']),
+          { alerts: [{ type: 'trivialPackage' }] },
+        ],
+      ]) as SecurityArchiveLike,
+      specOptions: {},
+    }
+    return state
+  }
+
+  await t.test(
+    'filter out any node that does not have the alert',
+    async t => {
+      const res = await trivial(getState(':trivial'))
+      t.strictSame(
+        [...res.partial.nodes].map(n => n.name),
+        ['e'],
+        'should select only trivial packages',
+      )
+      t.matchSnapshot({
+        nodes: [...res.partial.nodes].map(n => n.name),
+        edges: [...res.partial.edges].map(e => e.name),
+      })
+    },
+  )
+})
+
+t.test('missing security archive', async t => {
+  const getState = (query: string) => {
+    const ast = postcssSelectorParser().astSync(query)
+    const current = ast.first.first
+    const state: ParserState = {
+      current,
+      initial: {
+        edges: new Set(),
+        nodes: new Set(),
+      },
+      partial: {
+        edges: new Set(),
+        nodes: new Set(),
+      },
+      collect: {
+        edges: new Set(),
+        nodes: new Set(),
+      },
+      cancellable: async () => {},
+      walk: async i => i,
+      securityArchive: undefined,
+      specOptions: {},
+    }
+    return state
+  }
+
+  await t.rejects(
+    trivial(getState(':trivial')),
+    { message: /Missing security archive/ },
+    'should throw an error',
+  )
+})

--- a/src/query/test/pseudo/undesirable.ts
+++ b/src/query/test/pseudo/undesirable.ts
@@ -1,0 +1,88 @@
+import t from 'tap'
+import postcssSelectorParser from 'postcss-selector-parser'
+import { joinDepIDTuple } from '@vltpkg/dep-id'
+import type { SecurityArchiveLike } from '@vltpkg/security-archive'
+import { getSimpleGraph } from '../fixtures/graph.ts'
+import type { ParserState } from '../../src/types.ts'
+import { undesirable } from '../../src/pseudo/undesirable.ts'
+
+t.test('selects packages with an undesirable alert', async t => {
+  const getState = (query: string, graph = getSimpleGraph()) => {
+    const ast = postcssSelectorParser().astSync(query)
+    const current = ast.first.first
+    const state: ParserState = {
+      current,
+      initial: {
+        edges: new Set(graph.edges.values()),
+        nodes: new Set(graph.nodes.values()),
+      },
+      partial: {
+        edges: new Set(graph.edges.values()),
+        nodes: new Set(graph.nodes.values()),
+      },
+      collect: {
+        edges: new Set(),
+        nodes: new Set(),
+      },
+      cancellable: async () => {},
+      walk: async i => i,
+      securityArchive: new Map([
+        [
+          joinDepIDTuple(['registry', '', 'e@1.0.0']),
+          { alerts: [{ type: 'troll' }] },
+        ],
+      ]) as SecurityArchiveLike,
+      specOptions: {},
+    }
+    return state
+  }
+
+  await t.test(
+    'filter out any node that does not have the alert',
+    async t => {
+      const res = await undesirable(getState(':undesirable'))
+      t.strictSame(
+        [...res.partial.nodes].map(n => n.name),
+        ['e'],
+        'should select only undesirable packages',
+      )
+      t.matchSnapshot({
+        nodes: [...res.partial.nodes].map(n => n.name),
+        edges: [...res.partial.edges].map(e => e.name),
+      })
+    },
+  )
+})
+
+t.test('missing security archive', async t => {
+  const getState = (query: string) => {
+    const ast = postcssSelectorParser().astSync(query)
+    const current = ast.first.first
+    const state: ParserState = {
+      current,
+      initial: {
+        edges: new Set(),
+        nodes: new Set(),
+      },
+      partial: {
+        edges: new Set(),
+        nodes: new Set(),
+      },
+      collect: {
+        edges: new Set(),
+        nodes: new Set(),
+      },
+      cancellable: async () => {},
+      walk: async i => i,
+      securityArchive: undefined,
+      specOptions: {},
+    }
+    return state
+  }
+
+  await t.rejects(
+    undesirable(getState(':undesirable')),
+    { message: /Missing security archive/ },
+    'should throw an error',
+  )
+})

--- a/src/query/test/pseudo/unknown.ts
+++ b/src/query/test/pseudo/unknown.ts
@@ -1,0 +1,88 @@
+import t from 'tap'
+import postcssSelectorParser from 'postcss-selector-parser'
+import { joinDepIDTuple } from '@vltpkg/dep-id'
+import type { SecurityArchiveLike } from '@vltpkg/security-archive'
+import { getSimpleGraph } from '../fixtures/graph.ts'
+import type { ParserState } from '../../src/types.ts'
+import { unknown } from '../../src/pseudo/unknown.ts'
+
+t.test('selects packages with an unknown alert', async t => {
+  const getState = (query: string, graph = getSimpleGraph()) => {
+    const ast = postcssSelectorParser().astSync(query)
+    const current = ast.first.first
+    const state: ParserState = {
+      current,
+      initial: {
+        edges: new Set(graph.edges.values()),
+        nodes: new Set(graph.nodes.values()),
+      },
+      partial: {
+        edges: new Set(graph.edges.values()),
+        nodes: new Set(graph.nodes.values()),
+      },
+      collect: {
+        edges: new Set(),
+        nodes: new Set(),
+      },
+      cancellable: async () => {},
+      walk: async i => i,
+      securityArchive: new Map([
+        [
+          joinDepIDTuple(['registry', '', 'e@1.0.0']),
+          { alerts: [{ type: 'newAuthor' }] },
+        ],
+      ]) as SecurityArchiveLike,
+      specOptions: {},
+    }
+    return state
+  }
+
+  await t.test(
+    'filter out any node that does not have the alert',
+    async t => {
+      const res = await unknown(getState(':unknown'))
+      t.strictSame(
+        [...res.partial.nodes].map(n => n.name),
+        ['e'],
+        'should select only unknown packages',
+      )
+      t.matchSnapshot({
+        nodes: [...res.partial.nodes].map(n => n.name),
+        edges: [...res.partial.edges].map(e => e.name),
+      })
+    },
+  )
+})
+
+t.test('missing security archive', async t => {
+  const getState = (query: string) => {
+    const ast = postcssSelectorParser().astSync(query)
+    const current = ast.first.first
+    const state: ParserState = {
+      current,
+      initial: {
+        edges: new Set(),
+        nodes: new Set(),
+      },
+      partial: {
+        edges: new Set(),
+        nodes: new Set(),
+      },
+      collect: {
+        edges: new Set(),
+        nodes: new Set(),
+      },
+      cancellable: async () => {},
+      walk: async i => i,
+      securityArchive: undefined,
+      specOptions: {},
+    }
+    return state
+  }
+
+  await t.rejects(
+    unknown(getState(':unknown')),
+    { message: /Missing security archive/ },
+    'should throw an error',
+  )
+})

--- a/src/query/test/pseudo/unmaintained.ts
+++ b/src/query/test/pseudo/unmaintained.ts
@@ -1,0 +1,88 @@
+import t from 'tap'
+import postcssSelectorParser from 'postcss-selector-parser'
+import { joinDepIDTuple } from '@vltpkg/dep-id'
+import type { SecurityArchiveLike } from '@vltpkg/security-archive'
+import { getSimpleGraph } from '../fixtures/graph.ts'
+import type { ParserState } from '../../src/types.ts'
+import { unmaintained } from '../../src/pseudo/unmaintained.ts'
+
+t.test('selects packages with an unmaintained alert', async t => {
+  const getState = (query: string, graph = getSimpleGraph()) => {
+    const ast = postcssSelectorParser().astSync(query)
+    const current = ast.first.first
+    const state: ParserState = {
+      current,
+      initial: {
+        edges: new Set(graph.edges.values()),
+        nodes: new Set(graph.nodes.values()),
+      },
+      partial: {
+        edges: new Set(graph.edges.values()),
+        nodes: new Set(graph.nodes.values()),
+      },
+      collect: {
+        edges: new Set(),
+        nodes: new Set(),
+      },
+      cancellable: async () => {},
+      walk: async i => i,
+      securityArchive: new Map([
+        [
+          joinDepIDTuple(['registry', '', 'e@1.0.0']),
+          { alerts: [{ type: 'unmaintained' }] },
+        ],
+      ]) as SecurityArchiveLike,
+      specOptions: {},
+    }
+    return state
+  }
+
+  await t.test(
+    'filter out any node that does not have the alert',
+    async t => {
+      const res = await unmaintained(getState(':unmaintained'))
+      t.strictSame(
+        [...res.partial.nodes].map(n => n.name),
+        ['e'],
+        'should select only unmaintained packages',
+      )
+      t.matchSnapshot({
+        nodes: [...res.partial.nodes].map(n => n.name),
+        edges: [...res.partial.edges].map(e => e.name),
+      })
+    },
+  )
+})
+
+t.test('missing security archive', async t => {
+  const getState = (query: string) => {
+    const ast = postcssSelectorParser().astSync(query)
+    const current = ast.first.first
+    const state: ParserState = {
+      current,
+      initial: {
+        edges: new Set(),
+        nodes: new Set(),
+      },
+      partial: {
+        edges: new Set(),
+        nodes: new Set(),
+      },
+      collect: {
+        edges: new Set(),
+        nodes: new Set(),
+      },
+      cancellable: async () => {},
+      walk: async i => i,
+      securityArchive: undefined,
+      specOptions: {},
+    }
+    return state
+  }
+
+  await t.rejects(
+    unmaintained(getState(':unmaintained')),
+    { message: /Missing security archive/ },
+    'should throw an error',
+  )
+})

--- a/src/query/test/pseudo/unpopular.ts
+++ b/src/query/test/pseudo/unpopular.ts
@@ -1,0 +1,88 @@
+import t from 'tap'
+import postcssSelectorParser from 'postcss-selector-parser'
+import { joinDepIDTuple } from '@vltpkg/dep-id'
+import type { SecurityArchiveLike } from '@vltpkg/security-archive'
+import { getSimpleGraph } from '../fixtures/graph.ts'
+import type { ParserState } from '../../src/types.ts'
+import { unpopular } from '../../src/pseudo/unpopular.ts'
+
+t.test('selects packages with an unpopular alert', async t => {
+  const getState = (query: string, graph = getSimpleGraph()) => {
+    const ast = postcssSelectorParser().astSync(query)
+    const current = ast.first.first
+    const state: ParserState = {
+      current,
+      initial: {
+        edges: new Set(graph.edges.values()),
+        nodes: new Set(graph.nodes.values()),
+      },
+      partial: {
+        edges: new Set(graph.edges.values()),
+        nodes: new Set(graph.nodes.values()),
+      },
+      collect: {
+        edges: new Set(),
+        nodes: new Set(),
+      },
+      cancellable: async () => {},
+      walk: async i => i,
+      securityArchive: new Map([
+        [
+          joinDepIDTuple(['registry', '', 'e@1.0.0']),
+          { alerts: [{ type: 'unpopularPackage' }] },
+        ],
+      ]) as SecurityArchiveLike,
+      specOptions: {},
+    }
+    return state
+  }
+
+  await t.test(
+    'filter out any node that does not have the alert',
+    async t => {
+      const res = await unpopular(getState(':unpopular'))
+      t.strictSame(
+        [...res.partial.nodes].map(n => n.name),
+        ['e'],
+        'should select only unpopular packages',
+      )
+      t.matchSnapshot({
+        nodes: [...res.partial.nodes].map(n => n.name),
+        edges: [...res.partial.edges].map(e => e.name),
+      })
+    },
+  )
+})
+
+t.test('missing security archive', async t => {
+  const getState = (query: string) => {
+    const ast = postcssSelectorParser().astSync(query)
+    const current = ast.first.first
+    const state: ParserState = {
+      current,
+      initial: {
+        edges: new Set(),
+        nodes: new Set(),
+      },
+      partial: {
+        edges: new Set(),
+        nodes: new Set(),
+      },
+      collect: {
+        edges: new Set(),
+        nodes: new Set(),
+      },
+      cancellable: async () => {},
+      walk: async i => i,
+      securityArchive: undefined,
+      specOptions: {},
+    }
+    return state
+  }
+
+  await t.rejects(
+    unpopular(getState(':unpopular')),
+    { message: /Missing security archive/ },
+    'should throw an error',
+  )
+})

--- a/src/query/test/pseudo/unstable.ts
+++ b/src/query/test/pseudo/unstable.ts
@@ -1,0 +1,88 @@
+import t from 'tap'
+import postcssSelectorParser from 'postcss-selector-parser'
+import { joinDepIDTuple } from '@vltpkg/dep-id'
+import type { SecurityArchiveLike } from '@vltpkg/security-archive'
+import { getSimpleGraph } from '../fixtures/graph.ts'
+import type { ParserState } from '../../src/types.ts'
+import { unstable } from '../../src/pseudo/unstable.ts'
+
+t.test('selects packages with an unstable alert', async t => {
+  const getState = (query: string, graph = getSimpleGraph()) => {
+    const ast = postcssSelectorParser().astSync(query)
+    const current = ast.first.first
+    const state: ParserState = {
+      current,
+      initial: {
+        edges: new Set(graph.edges.values()),
+        nodes: new Set(graph.nodes.values()),
+      },
+      partial: {
+        edges: new Set(graph.edges.values()),
+        nodes: new Set(graph.nodes.values()),
+      },
+      collect: {
+        edges: new Set(),
+        nodes: new Set(),
+      },
+      cancellable: async () => {},
+      walk: async i => i,
+      securityArchive: new Map([
+        [
+          joinDepIDTuple(['registry', '', 'e@1.0.0']),
+          { alerts: [{ type: 'unstableOwnership' }] },
+        ],
+      ]) as SecurityArchiveLike,
+      specOptions: {},
+    }
+    return state
+  }
+
+  await t.test(
+    'filter out any node that does not have the alert',
+    async t => {
+      const res = await unstable(getState(':unstable'))
+      t.strictSame(
+        [...res.partial.nodes].map(n => n.name),
+        ['e'],
+        'should select only unstable packages',
+      )
+      t.matchSnapshot({
+        nodes: [...res.partial.nodes].map(n => n.name),
+        edges: [...res.partial.edges].map(e => e.name),
+      })
+    },
+  )
+})
+
+t.test('missing security archive', async t => {
+  const getState = (query: string) => {
+    const ast = postcssSelectorParser().astSync(query)
+    const current = ast.first.first
+    const state: ParserState = {
+      current,
+      initial: {
+        edges: new Set(),
+        nodes: new Set(),
+      },
+      partial: {
+        edges: new Set(),
+        nodes: new Set(),
+      },
+      collect: {
+        edges: new Set(),
+        nodes: new Set(),
+      },
+      cancellable: async () => {},
+      walk: async i => i,
+      securityArchive: undefined,
+      specOptions: {},
+    }
+    return state
+  }
+
+  await t.rejects(
+    unstable(getState(':unstable')),
+    { message: /Missing security archive/ },
+    'should throw an error',
+  )
+})

--- a/src/security-archive/package.json
+++ b/src/security-archive/package.json
@@ -15,7 +15,8 @@
     ],
     "exports": {
       "./package.json": "./package.json",
-      ".": "./src/index.ts"
+      ".": "./src/index.ts",
+      "./browser": "./src/browser.ts"
     }
   },
   "dependencies": {
@@ -67,6 +68,11 @@
     ".": {
       "import": {
         "default": "./src/index.ts"
+      }
+    },
+    "./browser": {
+      "import": {
+        "default": "./src/browser.ts"
       }
     }
   },

--- a/src/security-archive/src/browser.ts
+++ b/src/security-archive/src/browser.ts
@@ -41,6 +41,8 @@ export class SecurityArchive
    * Loads a security archive from a valid JSON dump.
    */
   static load(dump: unknown) {
+    if (dump === undefined) return undefined
+
     const archive = new SecurityArchive()
     const json = asSecurityArchiveJSON(dump)
     for (const [key, value] of Object.entries(json)) {

--- a/src/security-archive/test/browser.ts
+++ b/src/security-archive/test/browser.ts
@@ -73,6 +73,9 @@ const json = {
 
 t.test('SecurityArchive.load', async t => {
   const archive = SecurityArchive.load(json)
+  if (!archive) {
+    throw new Error('expected archive to be loaded')
+  }
   t.strictSame(
     archive.get(
       joinDepIDTuple(['registry', '', 'english-days@1.0.0']),
@@ -83,8 +86,16 @@ t.test('SecurityArchive.load', async t => {
 
   await t.test('empty archive', async t => {
     const archive = SecurityArchive.load({})
+    if (!archive) {
+      throw new Error('expected archive to be loaded')
+    }
     t.strictSame(archive.size, 0, 'should have an empty archive')
   })
+})
+
+t.test('no archive', async t => {
+  const archive = SecurityArchive.load(undefined)
+  t.strictSame(archive, undefined, 'should return undefined')
 })
 
 t.test('load bad data', async t => {

--- a/src/server/package.json
+++ b/src/server/package.json
@@ -27,6 +27,7 @@
     "@vltpkg/init": "workspace:*",
     "@vltpkg/package-info": "workspace:*",
     "@vltpkg/package-json": "workspace:*",
+    "@vltpkg/security-archive": "workspace:*",
     "@vltpkg/spec": "workspace:*",
     "@vltpkg/types": "workspace:*",
     "@vltpkg/xdg": "workspace:*",

--- a/src/server/src/handle-request.ts
+++ b/src/server/src/handle-request.ts
@@ -123,7 +123,7 @@ export const handleRequest = async (
       try {
         await install(...parseInstallOptions(server.options, add))
         server.emit('needConfigUpdate', server.options.projectRoot)
-        server.updateGraph()
+        await server.updateGraph()
         return json.ok(res, 'ok')
       } catch (err) {
         return json.error(res, 'Install failed', err, 500)
@@ -147,7 +147,7 @@ export const handleRequest = async (
           ...parseUninstallOptions(server.options, remove),
         )
         server.emit('needConfigUpdate', server.options.projectRoot)
-        server.updateGraph()
+        await server.updateGraph()
         return json.ok(res, 'ok')
       } catch (err) {
         return json.error(res, 'Uninstall failed', err, 500)

--- a/src/server/src/index.ts
+++ b/src/server/src/index.ts
@@ -1,4 +1,5 @@
 import { error } from '@vltpkg/error-cause'
+import type { SecurityArchive } from '@vltpkg/security-archive'
 import type {
   ActualLoadOptions,
   InstallOptions,
@@ -72,6 +73,7 @@ export class VltServer extends EventEmitter<{
   publicDir?: string
   dashboardRoot: string[]
   assetsDir?: string
+  securityArchive: SecurityArchive | undefined
 
   constructor(options: VltServerOptions) {
     super()
@@ -137,8 +139,12 @@ export class VltServer extends EventEmitter<{
     await this.update()
   }
 
-  updateGraph(this: VltServerListening) {
-    updateGraphData(this.options, this.publicDir, this.hasDashboard)
+  async updateGraph(this: VltServerListening) {
+    await updateGraphData(
+      this.options,
+      this.publicDir,
+      this.hasDashboard,
+    )
   }
 
   updateOptions(options: VltServerOptions) {
@@ -154,7 +160,7 @@ export class VltServer extends EventEmitter<{
       publicDir: this.publicDir,
     })
     this.hasDashboard = await this.dashboard.update()
-    this.updateGraph()
+    await this.updateGraph()
   }
 
   async close() {

--- a/src/vlt/package.json
+++ b/src/vlt/package.json
@@ -33,6 +33,7 @@
     "@vltpkg/query": "workspace:*",
     "@vltpkg/registry-client": "workspace:*",
     "@vltpkg/run": "workspace:*",
+    "@vltpkg/security-archive": "workspace:*",
     "@vltpkg/server": "workspace:*",
     "@vltpkg/spec": "workspace:*",
     "@vltpkg/types": "workspace:*",

--- a/src/vlt/src/commands/list.ts
+++ b/src/vlt/src/commands/list.ts
@@ -11,6 +11,7 @@ import {
   mermaidOutput,
 } from '@vltpkg/graph'
 import { Query } from '@vltpkg/query'
+import { SecurityArchive } from '@vltpkg/security-archive'
 import { commandUsage } from '../config/usage.ts'
 import type { CommandFn, CommandUsage } from '../index.ts'
 import { startGUI } from '../start-gui.ts'
@@ -83,7 +84,17 @@ export const command: CommandFn<ListResult> = async conf => {
   const queryString = conf.positionals
     .map(k => (/^[@\w-]/.test(k) ? `#${k.replace(/\//, '\\/')}` : k))
     .join(', ')
-  const query = new Query({ graph, specOptions: conf.options })
+  const archive = await SecurityArchive.start({
+    graph,
+    specOptions: conf.options,
+  })
+  /* c8 ignore next */
+  const securityArchive = archive.ok ? archive : undefined
+  const query = new Query({
+    graph,
+    specOptions: conf.options,
+    securityArchive,
+  })
   const projectQueryString = ':project, :project > *'
   const selectImporters: string[] = []
 

--- a/src/vlt/src/commands/query.ts
+++ b/src/vlt/src/commands/query.ts
@@ -11,6 +11,7 @@ import {
   mermaidOutput,
 } from '@vltpkg/graph'
 import { Query } from '@vltpkg/query'
+import { SecurityArchive } from '@vltpkg/security-archive'
 import { commandUsage } from '../config/usage.ts'
 import type { CommandFn, CommandUsage } from '../index.ts'
 import { startGUI } from '../start-gui.ts'
@@ -77,7 +78,18 @@ export const command: CommandFn<QueryResult> = async conf => {
 
   const defaultQueryString = '*'
   const queryString = conf.positionals[0]
-  const query = new Query({ graph, specOptions: conf.options })
+  const archive = await SecurityArchive.start({
+    graph,
+    specOptions: conf.options,
+  })
+  /* c8 ignore next */
+  const securityArchive = archive.ok ? archive : undefined
+  const query = new Query({
+    graph,
+    specOptions: conf.options,
+    securityArchive,
+  })
+
   const { edges, nodes } = await query.search(
     queryString || defaultQueryString,
   )

--- a/src/vlt/test/commands/list.ts
+++ b/src/vlt/test/commands/list.ts
@@ -115,6 +115,15 @@ const mockList = async (
         ideal: {},
         asDependency: () => {},
       },
+      '@vltpkg/security-archive': {
+        SecurityArchive: {
+          async start() {
+            return {
+              ok: false,
+            }
+          },
+        },
+      },
       ...mocks,
     },
   )

--- a/src/vlt/test/commands/query.ts
+++ b/src/vlt/test/commands/query.ts
@@ -115,6 +115,15 @@ const mockQuery = async (
         ideal: {},
         asDependency: () => {},
       },
+      '@vltpkg/security-archive': {
+        SecurityArchive: {
+          async start() {
+            return {
+              ok: false,
+            }
+          },
+        },
+      },
       ...mocks,
     },
   )


### PR DESCRIPTION
Integrates usage of the new `@vltpkg/security-archive` module to the queries provided by `@vltpkg/query` in both the CLI and GUI interfaces.

Implementation details to keep in mind:
- Loading security data will be skipped in the CLI if the end-user provided query does not make usage of any of the security selectors.
- The security archive info is loaded upfront, so it renders the initial loading of large projects considerably slower when first hydrating the archive.

### Description

The following pseudo-selectors rely on security data provided by
[Socket](https://socket.dev/), the usage of any of these selectors is
going to require a network call to hydrate package report data. Keep
in mind that this is going to slow down end-user query usage since the
security data needs to be fetched prior to a `Query` instantiation.

- `:abandoned` Matches packages that were published by an npm account
  that no longer exists.
- `:confused` Matches packages affected by manifest confusion. This
  could be malicious or caused by an error when publishing the
  package.
- `:debug` Matches packages that use debug, reflection and dynamic
  code execution features.
- `:deprecated` Matches packages marked as deprecated. This could
  indicate that a single version should not be used, or that the
  package is no longer maintained and any new vulnerabilities will not
  be fixed.
- `:dynamic` Matches packages that uses dynamic imports.
- `:entropic` Matches packages that contains high entropic strings.
  This could be a sign of encrypted data, leaked secrets or obfuscated
  code.
- `:env` Matches packages that accesses environment variables, which
  may be a sign of credential stuffing or data theft.
- `:eval` Matches packages that use dynamic code execution (e.g.,
  eval()), which is a dangerous practice. This can prevent the code
  from running in certain environments and increases the risk that the
  code may contain exploits or malicious behavior.
- `:fs` Matches packages that accesses the file system, and could
  potentially read sensitive data.
- `:obfuscated` Matches packages that use obfuscated files,
  intentionally packed to hide their behavior. This could be a sign of
  malware.
- `:minified` Matches packages that contain minified code. This may be
  harmless in some cases where minified code is included in packaged
  libraries.
- `:native` Matches packages that contain native code (e.g., compiled
  binaries or shared libraries). Including native code can obscure
  malicious behavior.
- `:network` Matches packages that access the network.
- `:scripts` Matches packages that have scripts that are run when the
  package is installed. The majority of malware in npm is hidden in
  install scripts.
- `:shell` Matches packages that accesses the system shell. Accessing
  the system shell increases the risk of executing arbitrary code.
- `:shrinkwrap` Matches packages that contains a shrinkwrap file. This
  may allow the package to bypass normal install procedures.
- `:suspicious` Matches packages that may have its GitHub repository
  artificially inflated with stars (from bots, crowdsourcing, etc.).
- `:tracker` Matches packages that contains telemetry which tracks how
  it is used.
- `:trivial` Matches packages that have less than 10 lines of code.
  These packages are easily copied into your own project and may not
  warrant the additional supply chain risk of an external dependency.
- `:undesirable` Matches packages that are a joke, parody, or includes
  undocumented or hidden behavior unrelated to its primary function.
- `:unknown` Matches packages that have a new npm collaborator
  publishing a version of the package for the first time. New
  collaborators are usually benign additions to a project, but do
  indicate a change to the security surface area of a package.
- `:unmaintained` Matches packages that have not been updated in more
  than 5 years and may be unmaintained.
- `:unpopular` Matches packages that are not very popular.
- `:unstable` Matches packages with unstable ownership. This indicates
  a new collaborator has begun publishing package versions. Package
  stability and security risk may be elevated.
