### PR TITLE
normalize version values

### DIFF
--- a/src/dep-id/src/index.ts
+++ b/src/dep-id/src/index.ts
@@ -272,10 +272,16 @@ export const getTuple = (spec: Spec, mani: Manifest): DepIDTuple => {
           }
         }
       }
+      const version =
+        mani.version ?
+          mani.version.startsWith('v') ?
+            mani.version.slice(1)
+          : mani.version
+        : f.bareSpec
       return [
         f.type,
         f.namedRegistry ?? reg,
-        `${mani.name ?? spec.name}@${mani.version ?? spec.bareSpec}`,
+        `${mani.name ?? f.name}@${version}`,
       ]
     }
     case 'git': {

--- a/src/dep-id/tap-snapshots/test/index.ts.test.cjs
+++ b/src/dep-id/tap-snapshots/test/index.ts.test.cjs
@@ -209,6 +209,17 @@ Array [
 ]
 `
 
+exports[`test/index.ts > TAP > valid specs > must match snapshot 1`] = `
+Array [
+  "··manifest-name@1.2.3",
+  Array [
+    "registry",
+    "",
+    "manifest-name@1.2.3",
+  ],
+]
+`
+
 exports[`test/index.ts > TAP > valid specs > x@1 > hydrated 1`] = `
 x@npm:manifest-name@1.2.3
 `

--- a/src/dep-id/test/index.ts
+++ b/src/dep-id/test/index.ts
@@ -97,6 +97,15 @@ t.test('valid specs', t => {
     })
   }
 
+  const prefixedVersionManifest = {
+    name: 'manifest-name',
+    version: 'v1.2.3',
+  }
+  const pSpec = Spec.parse('manifest-name@^1.0.0')
+  const pTuple = getTuple(pSpec, prefixedVersionManifest)
+  const pId = getId(pSpec, prefixedVersionManifest)
+  t.matchSnapshot([pId, pTuple])
+
   t.end()
 })
 

--- a/src/graph/src/node.ts
+++ b/src/graph/src/node.ts
@@ -225,7 +225,11 @@ export class Node implements NodeLike {
     this.graph = options.graph
     this.manifest = manifest
     this.#name = name || this.manifest?.name
+
     this.version = version || this.manifest?.version
+    if (this.version?.startsWith('v')) {
+      this.version = this.version.slice(1)
+    }
   }
 
   /**

--- a/src/graph/test/node.ts
+++ b/src/graph/test/node.ts
@@ -284,6 +284,23 @@ t.test('Node', async t => {
     version: '1.0.0',
   })
   t.matchSnapshot(String(wsMani), 'should stringify workspace node')
+
+  const prefixedVersionMani = {
+    name: 'prefixed-version',
+    version: 'v1.0.0',
+  }
+  const prefixedVersionSpec = Spec.parse('foo@^1.0.0')
+  const prefixedVersionNode = new Node(
+    opts,
+    undefined,
+    prefixedVersionMani,
+    prefixedVersionSpec,
+  )
+  t.strictSame(
+    prefixedVersionNode.version,
+    '1.0.0',
+    'should return a normalized version value',
+  )
 })
 
 t.test('nodeModules path and inVltStore flag', t => {


### PR DESCRIPTION
I stumbled across a couple of edge case scenarios that were breaking query functionality that were caused by random packages in a large install having `manifest.version` values with a prefixed v, e.g: `"version": "v1.2.3"`

This PR:

- Removes any preppending `v` from a `node.version` value.
- The `getId` method now removes any preppending `v` value from the resulting `DepID` when reading from a manifest.