### PR TITLE
gui: router history bugfix

### DIFF
--- a/src/gui/src/components/navigation/sidebar/nav-project-queries.tsx
+++ b/src/gui/src/components/navigation/sidebar/nav-project-queries.tsx
@@ -1,4 +1,4 @@
-import { useNavigate } from 'react-router'
+import { useLocation, useNavigate } from 'react-router'
 import { useEffect, useState } from 'react'
 import {
   SidebarMenuSub,
@@ -29,6 +29,7 @@ import { selectQuery } from '@/components/queries/saved-item.jsx'
 
 const SidebarQueryProjectNav = () => {
   const navigate = useNavigate()
+  const { pathname } = useLocation()
   const { open: sidebarOpen, setOpen: setSidebarOpen } = useSidebar()
   const savedQueries = useGraphStore(state => state.savedQueries)
   const [projectQueries, setProjectQueries] = useState<SavedQuery[]>(
@@ -92,6 +93,8 @@ const SidebarQueryProjectNav = () => {
       setGlobalQueriesOpen(false)
     }
   }, [sidebarOpen])
+
+  if (!pathname.includes('/explore')) return null
 
   if (globalQueries.length === 0 && projectQueries.length === 0)
     return null

--- a/src/gui/src/state/index.ts
+++ b/src/gui/src/state/index.ts
@@ -248,5 +248,16 @@ export const useGraphStore = create<Action & State>((set, get) => {
     },
   }
 
+  /** update the `query` state based on the state stored in the history entry */
+  window.addEventListener('popstate', (e: PopStateEvent): void => {
+    if (!e.state) return
+    const { query } = e.state as {
+      query?: string
+    }
+    if (query != null) {
+      store.updateQuery(query)
+    }
+  })
+
   return store
 })

--- a/src/gui/test/components/navigation/sidebar/nav-project-queries.tsx
+++ b/src/gui/test/components/navigation/sidebar/nav-project-queries.tsx
@@ -3,6 +3,11 @@ import { cleanup, render } from '@testing-library/react'
 import html from 'diffable-html'
 import { useGraphStore as useStore } from '@/state/index.js'
 
+vi.mock('react-router', () => ({
+  useLocation: vi.fn().mockReturnValue({ pathname: '/explore' }),
+  useNavigate: vi.fn(),
+}))
+
 vi.mock('@/components/ui/sidebar.jsx', () => ({
   SidebarMenuSub: 'gui-sidebar-menu-sub',
   SidebarMenu: 'gui-sidebar-menu',


### PR DESCRIPTION
- **bugfix**: listens to `popstate` event to track state `query`
- **bugfix**: hides ProjectQueries if the !`pathname` includes '/explore'
