### PR TITLE
build: read gui assets dir from env in builds

### DIFF
--- a/src/vlt/package.json
+++ b/src/vlt/package.json
@@ -84,10 +84,7 @@
     "typecheck": "tsc --noEmit"
   },
   "tap": {
-    "extends": "../../tap-config.yaml",
-    "test-env": [
-      "__VLT_INTERNAL_GUI_ASSETS_DIR=/mock-path/to/gui/assets"
-    ]
+    "extends": "../../tap-config.yaml"
   },
   "prettier": "../../.prettierrc.js",
   "module": "./src/index.ts",

--- a/src/vlt/src/start-gui.ts
+++ b/src/vlt/src/start-gui.ts
@@ -4,6 +4,7 @@ import { urlOpen } from '@vltpkg/url-open'
 import type { PathScurry } from 'path-scurry'
 import type { LoadedConfig } from './config/index.ts'
 import { stdout } from './output.ts'
+import { resolve } from 'node:path'
 
 export const getDefaultStartingRoute = async (options: {
   startingRoute?: string
@@ -18,11 +19,25 @@ export const getDefaultStartingRoute = async (options: {
     : '/'
 }
 
+const getAssetsDir = () => {
+  /* c8 ignore start */
+  if (process.env.__VLT_INTERNAL_GUI_ASSETS_DIR) {
+    return resolve(
+      import.meta.dirname,
+      process.env.__VLT_INTERNAL_GUI_ASSETS_DIR,
+    )
+  }
+  /* c8 ignore stop */
+}
+
 export const startGUI = async (
   conf: LoadedConfig,
   startingRoute?: string,
 ) => {
-  const server = createServer(conf.options)
+  const server = createServer({
+    ...conf.options,
+    assetsDir: getAssetsDir(),
+  })
   server.on('needConfigUpdate', dir => {
     conf.resetOptions(dir)
     ;(server as VltServerListening).updateOptions(conf.options)

--- a/src/vlt/test/start-gui.ts
+++ b/src/vlt/test/start-gui.ts
@@ -88,7 +88,10 @@ t.test('startGUI()', async t => {
     },
     '@vltpkg/server': {
       createServer: (options: unknown) => {
-        t.equal(options, conf.options)
+        t.strictSame(options, {
+          ...conf.options,
+          assetsDir: undefined,
+        })
         serverCreated = true
         return mockServer
       },


### PR DESCRIPTION
This is not the first time this has broken which means it definitely needs a test but that is blocked by #456. I've confirmed this fix works for me locally and will test that the GUI works when bundled/compiled as part of fixing #456.