### PR TITLE
compile: use deno --unstable flags instead of rolling our own

### DIFF
--- a/infra/build/src/compile.ts
+++ b/infra/build/src/compile.ts
@@ -47,6 +47,8 @@ const spawnCompile = ({
       '--no-npm',
       '--no-check',
       '--no-lock',
+      '--unstable-node-globals',
+      '--unstable-bare-node-builtins',
       `--output=${outfile}`,
       `--target=${[
         {


### PR DESCRIPTION
Previously `esbuild` was used for setting globals and converting to `node:` prefixed imports so that `deno compile` would work. This PR opts in to using deno's `--unstable-node-globals` and `--unstable-bare-node-builtins` flags since they do the same thing.