### PR TITLE
fix: `nvm` doesn't understand `"^"` `node-semver` range selectors

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Setup Nodejs
         uses: actions/setup-node@v4
         with:
-          node-version-file: '.nvmrc'
+          node-version: '^22.14.0'
           cache: pnpm
           check-latest: true
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,7 +79,7 @@ jobs:
       - name: Setup Nodejs
         uses: actions/setup-node@v4
         with:
-          node-version-file: '.nvmrc'
+          node-version: '^22.14.0'
           cache: pnpm
           check-latest: true
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,7 +72,7 @@ jobs:
       - name: Setup Nodejs
         uses: actions/setup-node@v4
         with:
-          node-version-file: '.nvmrc'
+          node-version: '^22.14.0'
           cache: pnpm
           check-latest: true
 

--- a/.nvmrc
+++ b/.nvmrc
@@ -1,1 +1,5 @@
-^22.14.0
+lts/jod 
+# "jod" is the 22.x node release line
+# there are known issues with <22.14 & unknown compat for >=23
+# configuration is intended explicitely for local environments
+# configuration for CI/`setup-node` can be found in .github/workflows/*.yml 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,7 +51,7 @@ process, run
 `export NODE_OPTIONS=--experimental-strip-types --no-warnings` to set
 this in the environment, rather than on each command.
 
-## `nave` Conveniences
+## Using `nave`
 
 If you use [nave](https://npm.im/nave) then you can enable `nave auto`
 behavior in your bash profile by adding something like this:
@@ -71,6 +71,22 @@ export PROMPT_COMMAND="__nave_prompt_command || true; ${PROMPT_COMMAND}"
 Then, the appropriate node version and `NODE_OPTIONS` flags will be
 set to be able to always run TypeScript files directly in the context
 of this project.
+
+## Using NVM
+
+If you use [`nvm`](https://github.com/nvm-sh/nvm), a compatible
+version of `node` should be automatically installed & used as defined
+in our project's root `.nvmrc` file. Notably, there are known issues
+in `node` versions `<22.14` and unknown compatibility for `>=23`. If
+you are using a version outside of the known-good range set you are
+likely to experience errors when developing and should install an
+in-range version.
+
+## Using `setup-node` in CI
+
+Our CI uses the `setup-node` action and is explictely configured to
+use the "latest", known-good version of `node` (`^22.14.0`) available.
+You can find this configuration in `.github/workflows/*.yml`.
 
 ## Root Level Scripts
 


### PR DESCRIPTION
`nvm` does not understand all of npm-style semver range selectors (specifically `"^"`). The current range `^22.14.0` fails to be parsed & errors accordingly (although this _does_ work in CI because `setup-node` manually reads from & then evaluates this value using `node-semver`). This PR switches the value back to something `nvm` understands while trying to stay as close to the intent of the original change.

- switch nvm to use `lts/jod` which is the "latest" `22` release line
- switch our workflows to use `node-version` config which _does_ support npm-style semver range selectors
- document these changes in `CONTRIBUTING.md`