### PR TITLE
registry-client: update to undici@7

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1369,8 +1369,8 @@ importers:
         specifier: 'catalog:'
         version: 1.0.1
       undici:
-        specifier: ^6.20.0
-        version: 6.20.0
+        specifier: ^7.5.0
+        version: 7.5.0
     devDependencies:
       '@eslint/js':
         specifier: 'catalog:'
@@ -8158,9 +8158,9 @@ packages:
   undici-types@6.20.0:
     resolution: {integrity: sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==}
 
-  undici@6.20.0:
-    resolution: {integrity: sha512-AITZfPuxubm31Sx0vr8bteSalEbs9wQb/BOBi9FPlD9Qpd6HxZ4Q0+hI742jBhkPb4RT2v5MQzaW5VhRVyj+9A==}
-    engines: {node: '>=18.17'}
+  undici@7.5.0:
+    resolution: {integrity: sha512-NFQG741e8mJ0fLQk90xKxFdaSM7z4+IQpAgsFI36bCDY9Z2+aXXZjVy2uUksMouWfMI9+w5ejOq5zYYTBCQJDQ==}
+    engines: {node: '>=20.18.1'}
 
   unified-prettier@2.0.1:
     resolution: {integrity: sha512-6KKgdlY8wLsUMdGOFx61RVfCggKF47iE1cFvUcrs5jjH9xbkVMaQ48Qy8MXNjhexzKwxsoBYB/Qc7ZtPw7/Oyg==}
@@ -15989,7 +15989,7 @@ snapshots:
 
   undici-types@6.20.0: {}
 
-  undici@6.20.0: {}
+  undici@7.5.0: {}
 
   unified-prettier@2.0.1(prettier@3.4.2):
     dependencies:

--- a/src/registry-client/package.json
+++ b/src/registry-client/package.json
@@ -31,7 +31,7 @@
     "@vltpkg/xdg": "workspace:*",
     "cache-control-parser": "^2.0.5",
     "package-json-from-dist": "catalog:",
-    "undici": "^6.20.0"
+    "undici": "^7.5.0"
   },
   "devDependencies": {
     "@eslint/js": "catalog:",


### PR DESCRIPTION
@darcyclarke reported a deno crash with the following stack:

```
error: Uncaught TypeError: fastNowTimeout.refresh is not a function
       fastNowTimeout.refresh();
                     ^
at refreshTimeout (file:///var/folders/gd/1pffxr4d603251w7w1q_cb_40000gn/T/deno-compile-vlt/chunk-06ZDSGAE.js:1863:24)
at onTick (file:///var/folders/gd/1pffxr4d603251w7w1q_cb_40000gn/T/deno-compile-vlt/chunk-06ZDSGAE.js: 1858:9)
at callback (ext: deno_web/02_timers. js:58:7)
at eventLoopTick (ext:core/01_core.js:212:13)
```

This code lives in undici, so I think updating undici to the latest version will make it easier to triage future bugs/crashes like this.