### PR TITLE
query: add malware selector

### DIFF
--- a/src/query/README.md
+++ b/src/query/README.md
@@ -192,9 +192,25 @@ security data needs to be fetched prior to a `Query` instantiation.
   code may contain exploits or malicious behavior.
 - `:fs` Matches packages that accesses the file system, and could
   potentially read sensitive data.
-- `:obfuscated` Matches packages that use obfuscated files,
-  intentionally packed to hide their behavior. This could be a sign of
-  malware.
+- `:license(<type>)` Matches packages based on different potential
+  license issues:
+  - `:license(unlicensed)` Matches packages with no license.
+  - `:license(misc)` Matches packages with fine-grained problems.
+  - `:license(restricted)` Matches packages with a license that is not
+    permissive.
+  - `:license(ambiguous)` Matches packages with ambiguous licensing.
+  - `:license(copyleft)` Matches packages with a copyleft license.
+  - `:license(unknown)` Matches packages that have potential license
+    data but its type could not be determined.
+  - `:license(none)` Matches packages that have no license data.
+  - `:license(exception)` Matches packages that have SPDX license
+    exception.
+- `:malware(<type>)` Matches packages that may contain malware. The
+  type parameter is required and can be one of the following:
+  - `critical` or `0`
+  - `high` or `1`
+  - `medium` or `2`
+  - `low` or `3`
 - `:minified` Matches packages that contain minified code. This may be
   harmless in some cases where minified code is included in packaged
   libraries.
@@ -202,6 +218,9 @@ security data needs to be fetched prior to a `Query` instantiation.
   binaries or shared libraries). Including native code can obscure
   malicious behavior.
 - `:network` Matches packages that access the network.
+- `:obfuscated` Matches packages that use obfuscated files,
+  intentionally packed to hide their behavior. This could be a sign of
+  malware.
 - `:scripts` Matches packages that have scripts that are run when the
   package is installed. The majority of malware in npm is hidden in
   install scripts.

--- a/src/query/src/index.ts
+++ b/src/query/src/index.ts
@@ -127,6 +127,7 @@ const securitySelectors = new Set([
   ':eval',
   ':fs',
   ':license',
+  ':malware',
   ':minified',
   ':native',
   ':network',

--- a/src/query/src/pseudo.ts
+++ b/src/query/src/pseudo.ts
@@ -24,6 +24,7 @@ import { env } from './pseudo/env.ts'
 import { evalParser } from './pseudo/eval.ts'
 import { fs } from './pseudo/fs.ts'
 import { license } from './pseudo/license.ts'
+import { malware } from './pseudo/malware.ts'
 import { minified } from './pseudo/minified.ts'
 import { nativeParser } from './pseudo/native.ts'
 import { network } from './pseudo/network.ts'
@@ -357,6 +358,7 @@ const pseudoSelectors = new Map<string, ParserFn>(
     is,
     // TODO: link
     license,
+    malware,
     minified,
     missing,
     native: nativeParser,

--- a/src/query/src/pseudo/malware.ts
+++ b/src/query/src/pseudo/malware.ts
@@ -1,0 +1,109 @@
+import { error } from '@vltpkg/error-cause'
+import {
+  asPostcssNodeWithChildren,
+  asStringNode,
+  asTagNode,
+  isStringNode,
+  isTagNode,
+} from '../types.ts'
+import type { ParserState, PostcssNode } from '../types.ts'
+import { removeNode, removeQuotes } from './helpers.ts'
+
+export type MalwareKinds =
+  | '0'
+  | '1'
+  | '2'
+  | '3'
+  | 'critical'
+  | 'high'
+  | 'medium'
+  | 'low'
+  | undefined
+
+export type MalwareAlertTypes =
+  | 'malware'
+  | 'gptMalware'
+  | 'gptSecurity'
+  | 'gptAnomaly'
+  | undefined
+
+const kindsMap = new Map<MalwareKinds, MalwareAlertTypes>([
+  ['critical', 'malware'],
+  ['high', 'gptMalware'],
+  ['medium', 'gptSecurity'],
+  ['low', 'gptAnomaly'],
+  ['0', 'malware'],
+  ['1', 'gptMalware'],
+  ['2', 'gptSecurity'],
+  ['3', 'gptAnomaly'],
+])
+const kinds = new Set(kindsMap.keys())
+
+export const isMalwareKind = (
+  value?: string,
+): value is MalwareKinds => kinds.has(value as MalwareKinds)
+
+export const asMalwareKind = (value?: string): MalwareKinds => {
+  if (!isMalwareKind(value)) {
+    throw error('Expected a valid malware kind', {
+      found: value,
+      validOptions: Array.from(kinds),
+    })
+  }
+  return value
+}
+
+export const parseInternals = (
+  nodes: PostcssNode[],
+): { kind: MalwareKinds } => {
+  let kind: MalwareKinds
+
+  if (isStringNode(asPostcssNodeWithChildren(nodes[0]).nodes[0])) {
+    kind = asMalwareKind(
+      removeQuotes(
+        asStringNode(asPostcssNodeWithChildren(nodes[0]).nodes[0])
+          .value,
+      ),
+    )
+  } else if (
+    isTagNode(asPostcssNodeWithChildren(nodes[0]).nodes[0])
+  ) {
+    kind = asMalwareKind(
+      asTagNode(asPostcssNodeWithChildren(nodes[0]).nodes[0]).value,
+    )
+  }
+
+  return { kind }
+}
+
+export const malware = async (state: ParserState) => {
+  if (!state.securityArchive) {
+    throw new Error(
+      'Missing security archive while trying to parse ' +
+        'the :malware security selector',
+    )
+  }
+
+  let internals
+  try {
+    internals = parseInternals(
+      asPostcssNodeWithChildren(state.current).nodes,
+    )
+  } catch (err) {
+    throw error('Failed to parse :malware selector', { cause: err })
+  }
+
+  const { kind } = internals
+  const alertName = kindsMap.get(kind)
+  for (const node of state.partial.nodes) {
+    const report = state.securityArchive.get(node.id)
+    const exclude = !report?.alerts.some(
+      alert => alert.type === alertName,
+    )
+    if (exclude) {
+      removeNode(state, node)
+    }
+  }
+
+  return state
+}

--- a/src/query/tap-snapshots/test/pseudo/malware.ts.test.cjs
+++ b/src/query/tap-snapshots/test/pseudo/malware.ts.test.cjs
@@ -1,0 +1,41 @@
+/* IMPORTANT
+ * This snapshot file is auto-generated, but designed for humans.
+ * It should be checked into source control and tracked carefully.
+ * Re-generate by setting TAP_SNAPSHOT=1 and running tests.
+ * Make sure to inspect the output below.  Do not ignore changes!
+ */
+'use strict'
+exports[`test/pseudo/malware.ts > TAP > selects packages with a specific malware kind > filter out any node that does not have the malware alert > must match snapshot 1`] = `
+Object {
+  "edges": Array [
+    "e",
+    "e",
+  ],
+  "nodes": Array [
+    "e",
+  ],
+}
+`
+
+exports[`test/pseudo/malware.ts > TAP > selects packages with a specific malware kind > filter out using unquoted param > must match snapshot 1`] = `
+Object {
+  "edges": Array [
+    "f",
+  ],
+  "nodes": Array [
+    "f",
+  ],
+}
+`
+
+exports[`test/pseudo/malware.ts > TAP > selects packages with a specific malware kind > filter using numbered param > must match snapshot 1`] = `
+Object {
+  "edges": Array [
+    "e",
+    "e",
+  ],
+  "nodes": Array [
+    "e",
+  ],
+}
+`

--- a/src/query/test/pseudo/malware.ts
+++ b/src/query/test/pseudo/malware.ts
@@ -1,0 +1,160 @@
+import t from 'tap'
+import postcssSelectorParser from 'postcss-selector-parser'
+import { joinDepIDTuple } from '@vltpkg/dep-id'
+import type { SecurityArchiveLike } from '@vltpkg/security-archive'
+import { getSimpleGraph } from '../fixtures/graph.ts'
+import type { ParserState } from '../../src/types.ts'
+import {
+  malware,
+  isMalwareKind,
+  asMalwareKind,
+} from '../../src/pseudo/malware.ts'
+
+t.test('selects packages with a specific malware kind', async t => {
+  const getState = (query: string, graph = getSimpleGraph()) => {
+    const ast = postcssSelectorParser().astSync(query)
+    const current = ast.first.first
+    const state: ParserState = {
+      current,
+      initial: {
+        edges: new Set(graph.edges.values()),
+        nodes: new Set(graph.nodes.values()),
+      },
+      partial: {
+        edges: new Set(graph.edges.values()),
+        nodes: new Set(graph.nodes.values()),
+      },
+      collect: {
+        edges: new Set(),
+        nodes: new Set(),
+      },
+      cancellable: async () => {},
+      walk: async i => i,
+      securityArchive: new Map([
+        [
+          joinDepIDTuple(['registry', '', 'e@1.0.0']),
+          {
+            id: joinDepIDTuple(['registry', '', 'e@1.0.0']),
+            alerts: [{ type: 'malware' }],
+          },
+        ],
+        [
+          joinDepIDTuple(['registry', '', 'f@1.0.0']),
+          {
+            id: joinDepIDTuple(['registry', '', 'f@1.0.0']),
+            alerts: [{ type: 'gptMalware' }],
+          },
+        ],
+      ]) as SecurityArchiveLike,
+      specOptions: {},
+    }
+    return state
+  }
+
+  await t.test(
+    'filter out any node that does not have the malware alert',
+    async t => {
+      const res = await malware(getState(':malware("critical")'))
+      t.strictSame(
+        [...res.partial.nodes].map(n => n.name),
+        ['e'],
+        'should select only packages with the specified malware alert',
+      )
+      t.matchSnapshot({
+        nodes: [...res.partial.nodes].map(n => n.name),
+        edges: [...res.partial.edges].map(e => e.name),
+      })
+    },
+  )
+
+  await t.test('filter using numbered param', async t => {
+    const res = await malware(getState(':malware(0)'))
+    t.strictSame(
+      [...res.partial.nodes].map(n => n.name),
+      ['e'],
+      'should select only packages with the specified malware alert',
+    )
+    t.matchSnapshot({
+      nodes: [...res.partial.nodes].map(n => n.name),
+      edges: [...res.partial.edges].map(e => e.name),
+    })
+  })
+
+  await t.test('filter out using unquoted param', async t => {
+    const res = await malware(getState(':malware(high)'))
+    t.strictSame(
+      [...res.partial.nodes].map(n => n.name),
+      ['f'],
+      'should select only packages with the specified malware alert',
+    )
+    t.matchSnapshot({
+      nodes: [...res.partial.nodes].map(n => n.name),
+      edges: [...res.partial.edges].map(e => e.name),
+    })
+  })
+
+  await t.test('wrong parameter', async t => {
+    await t.rejects(
+      malware(getState(':malware')),
+      { message: /Failed to parse :malware selector/ },
+      'should throw an error',
+    )
+  })
+})
+
+t.test('missing security archive', async t => {
+  const getState = (query: string) => {
+    const ast = postcssSelectorParser().astSync(query)
+    const current = ast.first.first
+    const state: ParserState = {
+      current,
+      initial: {
+        edges: new Set(),
+        nodes: new Set(),
+      },
+      partial: {
+        edges: new Set(),
+        nodes: new Set(),
+      },
+      collect: {
+        edges: new Set(),
+        nodes: new Set(),
+      },
+      cancellable: async () => {},
+      walk: async i => i,
+      securityArchive: undefined,
+      specOptions: {},
+    }
+    return state
+  }
+
+  await t.rejects(
+    malware(getState(':malware(critical)')),
+    { message: /Missing security archive/ },
+    'should throw an error',
+  )
+})
+
+t.test('isMalwareKind', async t => {
+  t.ok(
+    isMalwareKind('critical'),
+    'should return true for valid malware kinds',
+  )
+  t.notOk(
+    isMalwareKind('invalid'),
+    'should return false for invalid malware kinds',
+  )
+})
+
+t.test('asMalwareKind', async t => {
+  t.equal(
+    asMalwareKind('critical'),
+    'critical',
+    'should return the malware kind',
+  )
+  t.throws(
+    () => asMalwareKind('invalid'),
+    { message: /Expected a valid malware kind/ },
+    'should throw an error for invalid malware kinds',
+  )
+})


### PR DESCRIPTION
Add a `:malware(<kind>)` selector that filters nodes based on malware-related alert types from the security-archive.