### PR TITLE
security-archive: fix incorrect SQL

### DIFF
--- a/src/security-archive/src/index.ts
+++ b/src/security-archive/src/index.ts
@@ -180,7 +180,7 @@ export class SecurityArchive
         `(SELECT UNIXEPOCH('subsecond')) as now ` +
         'FROM cache ' +
         `WHERE depID IN (${depIDs.join(',')}) ` +
-        'GROUP BY depID HAVING SUM(start + ttl) > now',
+        '  AND (start + ttl) > now',
     )
     for (const entry of dbRead.all() as DBReadEntry[]) {
       const { depID, report, start, ttl } = entry


### PR DESCRIPTION
The `GROUP BY depID HAVING SUM(...)` phrase means:

- Get all the records for a given depID, and group them by depID
- For each depID, add up the sum all of the `start + ttl` values of the records in that group.
- If the sum of _all_ those values is greater than `now`, include the entire group.

As `depID` is a unique key on that table, grouping by it has no effect, because there can only ever be a single record for a given `depID`. But, if that is ever not the case (for example, if we start tracking reports from multiple sources separately, have records for each CVE, etc.), then this will result in never expiring any items that have more than one record!

For example, imagine that there are two records for a given depID, which are both fetched at `1743000000000`, each having a 24 hour TTL `86400000`. Each record would have a `start + ttl` value of `1743000000000 + 86400000 = 1743086400000`, or `2025-03-27T14:40:00.000Z`.

But! The `SUM(start + ttl)` of the _group_ would have a combined value of `1743086400000 + 1743086400000 = 3486172800000` and thus would not expire until `2080-06-21T05:20:00.000Z`, effectively extending the expiration of both by the length of time since the start of the Unix Epoch, for each record in the group beyond the first.

The way to do this is just to add a `AND` section to the `WHERE` clause, not a `GROUP BY` with a `HAVING SUM`.