### PR TITLE
query: add severity selector

### DIFF
--- a/src/query/README.md
+++ b/src/query/README.md
@@ -224,6 +224,13 @@ security data needs to be fetched prior to a `Query` instantiation.
 - `:scripts` Matches packages that have scripts that are run when the
   package is installed. The majority of malware in npm is hidden in
   install scripts.
+- `:severity` Matches packages based of the severity level of any
+  attached CVE. The type paremeter is required and can be one of the
+  following:
+  - `critical` or `0`
+  - `high` or `1`
+  - `medium` or `2`
+  - `low` or `3`
 - `:shell` Matches packages that accesses the system shell. Accessing
   the system shell increases the risk of executing arbitrary code.
 - `:shrinkwrap` Matches packages that contains a shrinkwrap file. This

--- a/src/query/src/index.ts
+++ b/src/query/src/index.ts
@@ -133,6 +133,8 @@ const securitySelectors = new Set([
   ':network',
   ':obfuscated',
   ':scripts',
+  ':sev',
+  ':severity',
   ':shell',
   ':shrinkwrap',
   ':suspicious',

--- a/src/query/src/pseudo.ts
+++ b/src/query/src/pseudo.ts
@@ -33,6 +33,7 @@ import { outdated } from './pseudo/outdated.ts'
 import { scripts } from './pseudo/scripts.ts'
 import { shell } from './pseudo/shell.ts'
 import { semverParser as semver } from './pseudo/semver.ts'
+import { severity } from './pseudo/severity.ts'
 import { shrinkwrap } from './pseudo/shrinkwrap.ts'
 import { suspicious } from './pseudo/suspicious.ts'
 import { tracker } from './pseudo/tracker.ts'
@@ -373,6 +374,8 @@ const pseudoSelectors = new Map<string, ParserFn>(
     scope,
     scripts,
     semver,
+    sev: severity,
+    severity,
     shell,
     shrinkwrap,
     suspicious,

--- a/src/query/src/pseudo/severity.ts
+++ b/src/query/src/pseudo/severity.ts
@@ -1,0 +1,109 @@
+import { error } from '@vltpkg/error-cause'
+import {
+  asPostcssNodeWithChildren,
+  asStringNode,
+  asTagNode,
+  isStringNode,
+  isTagNode,
+} from '../types.ts'
+import type { ParserState, PostcssNode } from '../types.ts'
+import { removeNode, removeQuotes } from './helpers.ts'
+
+export type SeverityKinds =
+  | '0'
+  | '1'
+  | '2'
+  | '3'
+  | 'critical'
+  | 'high'
+  | 'medium'
+  | 'low'
+  | undefined
+
+export type SeverityAlertTypes =
+  | 'criticalCVE'
+  | 'cve'
+  | 'potentialVulnerability'
+  | 'mildCVE'
+  | undefined
+
+const kindsMap = new Map<SeverityKinds, SeverityAlertTypes>([
+  ['critical', 'criticalCVE'],
+  ['high', 'cve'],
+  ['medium', 'potentialVulnerability'],
+  ['low', 'mildCVE'],
+  ['0', 'criticalCVE'],
+  ['1', 'cve'],
+  ['2', 'potentialVulnerability'],
+  ['3', 'mildCVE'],
+])
+const kinds = new Set(kindsMap.keys())
+
+export const isSeverityKind = (
+  value?: string,
+): value is SeverityKinds => kinds.has(value as SeverityKinds)
+
+export const asSeverityKind = (value?: string): SeverityKinds => {
+  if (!isSeverityKind(value)) {
+    throw error('Expected a valid severity kind', {
+      found: value,
+      validOptions: Array.from(kinds),
+    })
+  }
+  return value
+}
+
+export const parseInternals = (
+  nodes: PostcssNode[],
+): { kind: SeverityKinds } => {
+  let kind: SeverityKinds
+
+  if (isStringNode(asPostcssNodeWithChildren(nodes[0]).nodes[0])) {
+    kind = asSeverityKind(
+      removeQuotes(
+        asStringNode(asPostcssNodeWithChildren(nodes[0]).nodes[0])
+          .value,
+      ),
+    )
+  } else if (
+    isTagNode(asPostcssNodeWithChildren(nodes[0]).nodes[0])
+  ) {
+    kind = asSeverityKind(
+      asTagNode(asPostcssNodeWithChildren(nodes[0]).nodes[0]).value,
+    )
+  }
+
+  return { kind }
+}
+
+export const severity = async (state: ParserState) => {
+  if (!state.securityArchive) {
+    throw new Error(
+      'Missing security archive while trying to parse ' +
+        'the :severity security selector',
+    )
+  }
+
+  let internals
+  try {
+    internals = parseInternals(
+      asPostcssNodeWithChildren(state.current).nodes,
+    )
+  } catch (err) {
+    throw error('Failed to parse :severity selector', { cause: err })
+  }
+
+  const { kind } = internals
+  const alertName = kindsMap.get(kind)
+  for (const node of state.partial.nodes) {
+    const report = state.securityArchive.get(node.id)
+    const exclude = !report?.alerts.some(
+      alert => alert.type === alertName,
+    )
+    if (exclude) {
+      removeNode(state, node)
+    }
+  }
+
+  return state
+}

--- a/src/query/tap-snapshots/test/pseudo/severity.ts.test.cjs
+++ b/src/query/tap-snapshots/test/pseudo/severity.ts.test.cjs
@@ -1,0 +1,41 @@
+/* IMPORTANT
+ * This snapshot file is auto-generated, but designed for humans.
+ * It should be checked into source control and tracked carefully.
+ * Re-generate by setting TAP_SNAPSHOT=1 and running tests.
+ * Make sure to inspect the output below.  Do not ignore changes!
+ */
+'use strict'
+exports[`test/pseudo/severity.ts > TAP > selects packages with a specific severity kind > filter out any node that does not have the severity alert > must match snapshot 1`] = `
+Object {
+  "edges": Array [
+    "e",
+    "e",
+  ],
+  "nodes": Array [
+    "e",
+  ],
+}
+`
+
+exports[`test/pseudo/severity.ts > TAP > selects packages with a specific severity kind > filter out using unquoted param > must match snapshot 1`] = `
+Object {
+  "edges": Array [
+    "f",
+  ],
+  "nodes": Array [
+    "f",
+  ],
+}
+`
+
+exports[`test/pseudo/severity.ts > TAP > selects packages with a specific severity kind > filter using numbered param > must match snapshot 1`] = `
+Object {
+  "edges": Array [
+    "e",
+    "e",
+  ],
+  "nodes": Array [
+    "e",
+  ],
+}
+`

--- a/src/query/test/pseudo/severity.ts
+++ b/src/query/test/pseudo/severity.ts
@@ -1,0 +1,160 @@
+import t from 'tap'
+import postcssSelectorParser from 'postcss-selector-parser'
+import { joinDepIDTuple } from '@vltpkg/dep-id'
+import type { SecurityArchiveLike } from '@vltpkg/security-archive'
+import { getSimpleGraph } from '../fixtures/graph.ts'
+import type { ParserState } from '../../src/types.ts'
+import {
+  severity,
+  isSeverityKind,
+  asSeverityKind,
+} from '../../src/pseudo/severity.ts'
+
+t.test('selects packages with a specific severity kind', async t => {
+  const getState = (query: string, graph = getSimpleGraph()) => {
+    const ast = postcssSelectorParser().astSync(query)
+    const current = ast.first.first
+    const state: ParserState = {
+      current,
+      initial: {
+        edges: new Set(graph.edges.values()),
+        nodes: new Set(graph.nodes.values()),
+      },
+      partial: {
+        edges: new Set(graph.edges.values()),
+        nodes: new Set(graph.nodes.values()),
+      },
+      collect: {
+        edges: new Set(),
+        nodes: new Set(),
+      },
+      cancellable: async () => {},
+      walk: async i => i,
+      securityArchive: new Map([
+        [
+          joinDepIDTuple(['registry', '', 'e@1.0.0']),
+          {
+            id: joinDepIDTuple(['registry', '', 'e@1.0.0']),
+            alerts: [{ type: 'criticalCVE' }],
+          },
+        ],
+        [
+          joinDepIDTuple(['registry', '', 'f@1.0.0']),
+          {
+            id: joinDepIDTuple(['registry', '', 'f@1.0.0']),
+            alerts: [{ type: 'cve' }],
+          },
+        ],
+      ]) as SecurityArchiveLike,
+      specOptions: {},
+    }
+    return state
+  }
+
+  await t.test(
+    'filter out any node that does not have the severity alert',
+    async t => {
+      const res = await severity(getState(':severity("critical")'))
+      t.strictSame(
+        [...res.partial.nodes].map(n => n.name),
+        ['e'],
+        'should select only packages with the specified severity alert',
+      )
+      t.matchSnapshot({
+        nodes: [...res.partial.nodes].map(n => n.name),
+        edges: [...res.partial.edges].map(e => e.name),
+      })
+    },
+  )
+
+  await t.test('filter using numbered param', async t => {
+    const res = await severity(getState(':severity(0)'))
+    t.strictSame(
+      [...res.partial.nodes].map(n => n.name),
+      ['e'],
+      'should select only packages with the specified severity alert',
+    )
+    t.matchSnapshot({
+      nodes: [...res.partial.nodes].map(n => n.name),
+      edges: [...res.partial.edges].map(e => e.name),
+    })
+  })
+
+  await t.test('filter out using unquoted param', async t => {
+    const res = await severity(getState(':severity(high)'))
+    t.strictSame(
+      [...res.partial.nodes].map(n => n.name),
+      ['f'],
+      'should select only packages with the specified severity alert',
+    )
+    t.matchSnapshot({
+      nodes: [...res.partial.nodes].map(n => n.name),
+      edges: [...res.partial.edges].map(e => e.name),
+    })
+  })
+
+  await t.test('wrong parameter', async t => {
+    await t.rejects(
+      severity(getState(':severity')),
+      { message: /Failed to parse :severity selector/ },
+      'should throw an error',
+    )
+  })
+})
+
+t.test('missing security archive', async t => {
+  const getState = (query: string) => {
+    const ast = postcssSelectorParser().astSync(query)
+    const current = ast.first.first
+    const state: ParserState = {
+      current,
+      initial: {
+        edges: new Set(),
+        nodes: new Set(),
+      },
+      partial: {
+        edges: new Set(),
+        nodes: new Set(),
+      },
+      collect: {
+        edges: new Set(),
+        nodes: new Set(),
+      },
+      cancellable: async () => {},
+      walk: async i => i,
+      securityArchive: undefined,
+      specOptions: {},
+    }
+    return state
+  }
+
+  await t.rejects(
+    severity(getState(':severity(critical)')),
+    { message: /Missing security archive/ },
+    'should throw an error',
+  )
+})
+
+t.test('isSeverityKind', async t => {
+  t.ok(
+    isSeverityKind('critical'),
+    'should return true for valid severity kinds',
+  )
+  t.notOk(
+    isSeverityKind('invalid'),
+    'should return false for invalid severity kinds',
+  )
+})
+
+t.test('asSeverityKind', async t => {
+  t.equal(
+    asSeverityKind('critical'),
+    'critical',
+    'should return the severity kind',
+  )
+  t.throws(
+    () => asSeverityKind('invalid'),
+    { message: /Expected a valid severity kind/ },
+    'should throw an error for invalid severity kinds',
+  )
+})


### PR DESCRIPTION
Add a `:severity(<kind>)` / `:sev(<kind>)` selector that filters nodes based on license-related alert types from the security-archive.