### PR TITLE
security-archive: fix cache ttl check

### DIFF
--- a/src/security-archive/src/index.ts
+++ b/src/security-archive/src/index.ts
@@ -177,7 +177,7 @@ export class SecurityArchive
     // and only include entries that have a valid TTL value
     const dbRead = db.prepare(
       'SELECT depID, report, start, ttl, ' +
-        `(SELECT UNIXEPOCH('subsecond')) as now ` +
+        `(SELECT UNIXEPOCH('subsecond') * 1000) as now ` +
         'FROM cache ' +
         `WHERE depID IN (${depIDs.join(',')}) ` +
         '  AND (start + ttl) > now',


### PR DESCRIPTION
The value returned by the sqlite time method is still in seconds even when you add subsecond precision, this change will make sure it's normalized to ms so that the ttl check works as intended.