### PR TITLE
cli-sdk: fix skipping security data

### DIFF
--- a/src/cli-sdk/src/commands/list.ts
+++ b/src/cli-sdk/src/commands/list.ts
@@ -84,12 +84,15 @@ export const command: CommandFn<ListResult> = async conf => {
   const queryString = conf.positionals
     .map(k => (/^[@\w-]/.test(k) ? `#${k.replace(/\//, '\\/')}` : k))
     .join(', ')
-  const archive = await SecurityArchive.start({
-    graph,
-    specOptions: conf.options,
-  })
+  const archive =
+    Query.hasSecuritySelectors(queryString) ?
+      await SecurityArchive.start({
+        graph,
+        specOptions: conf.options,
+      })
+    : undefined
   /* c8 ignore next */
-  const securityArchive = archive.ok ? archive : undefined
+  const securityArchive = archive?.ok ? archive : undefined
   const query = new Query({
     graph,
     specOptions: conf.options,

--- a/src/cli-sdk/src/commands/query.ts
+++ b/src/cli-sdk/src/commands/query.ts
@@ -78,12 +78,15 @@ export const command: CommandFn<QueryResult> = async conf => {
 
   const defaultQueryString = '*'
   const queryString = conf.positionals[0]
-  const archive = await SecurityArchive.start({
-    graph,
-    specOptions: conf.options,
-  })
+  const archive =
+    queryString && Query.hasSecuritySelectors(queryString) ?
+      await SecurityArchive.start({
+        graph,
+        specOptions: conf.options,
+      })
+    : undefined
   /* c8 ignore next */
-  const securityArchive = archive.ok ? archive : undefined
+  const securityArchive = archive?.ok ? archive : undefined
   const query = new Query({
     graph,
     specOptions: conf.options,

--- a/src/cli-sdk/test/commands/list.ts
+++ b/src/cli-sdk/test/commands/list.ts
@@ -196,6 +196,16 @@ t.test('list', async t => {
     'should list all pkgs in mermaid format',
   )
 
+  await t.rejects(
+    Command.command({
+      positionals: ['*:malware'],
+      values: { view: 'human' },
+      options,
+    } as LoadedConfig),
+    /Missing security archive/,
+    'should fail to run with no security archive',
+  )
+
   t.matchSnapshot(
     await runCommand(t, {
       positionals: ['@foo/bazz', 'bar'],

--- a/src/cli-sdk/test/commands/query.ts
+++ b/src/cli-sdk/test/commands/query.ts
@@ -178,6 +178,16 @@ t.test('query', async t => {
     'should list mermaid in json format',
   )
 
+  await t.rejects(
+    Command.command({
+      positionals: ['*:malware'],
+      values: { view: 'human' },
+      options,
+    } as LoadedConfig),
+    /Missing security archive/,
+    'should fail to run with no security archive',
+  )
+
   await t.test('workspaces', async t => {
     const mainManifest = {
       name: 'my-project',


### PR DESCRIPTION
We can avoid loading security data in case no security selector was used in one of the cli commands. e.g: `vlt ls`, `vlt query`