### PR TITLE
query: add squat selector

### DIFF
--- a/src/query/README.md
+++ b/src/query/README.md
@@ -235,6 +235,11 @@ security data needs to be fetched prior to a `Query` instantiation.
   the system shell increases the risk of executing arbitrary code.
 - `:shrinkwrap` Matches packages that contains a shrinkwrap file. This
   may allow the package to bypass normal install procedures.
+- `:squat(<type>)` Matches packages with names similar to other
+  popular packages and may not be the package you want. The type
+  parameter is required and can be one of the following:
+  - `critical` or `0`
+  - `medium` or `2`
 - `:suspicious` Matches packages that may have its GitHub repository
   artificially inflated with stars (from bots, crowdsourcing, etc.).
 - `:tracker` Matches packages that contains telemetry which tracks how

--- a/src/query/src/index.ts
+++ b/src/query/src/index.ts
@@ -137,6 +137,7 @@ const securitySelectors = new Set([
   ':severity',
   ':shell',
   ':shrinkwrap',
+  ':squat',
   ':suspicious',
   ':tracker',
   ':trivial',

--- a/src/query/src/pseudo.ts
+++ b/src/query/src/pseudo.ts
@@ -35,6 +35,7 @@ import { shell } from './pseudo/shell.ts'
 import { semverParser as semver } from './pseudo/semver.ts'
 import { severity } from './pseudo/severity.ts'
 import { shrinkwrap } from './pseudo/shrinkwrap.ts'
+import { squat } from './pseudo/squat.ts'
 import { suspicious } from './pseudo/suspicious.ts'
 import { tracker } from './pseudo/tracker.ts'
 import { trivial } from './pseudo/trivial.ts'
@@ -378,6 +379,7 @@ const pseudoSelectors = new Map<string, ParserFn>(
     severity,
     shell,
     shrinkwrap,
+    squat,
     suspicious,
     tracker,
     trivial,

--- a/src/query/src/pseudo/squat.ts
+++ b/src/query/src/pseudo/squat.ts
@@ -1,0 +1,94 @@
+import { error } from '@vltpkg/error-cause'
+import {
+  asPostcssNodeWithChildren,
+  asStringNode,
+  asTagNode,
+  isStringNode,
+  isTagNode,
+} from '../types.ts'
+import type { ParserState, PostcssNode } from '../types.ts'
+import { removeNode, removeQuotes } from './helpers.ts'
+
+export type SquatKinds = '0' | '2' | 'critical' | 'medium' | undefined
+
+export type SquatAlertTypes =
+  | 'didYouMean'
+  | 'gptDidYouMean'
+  | undefined
+
+const kindsMap = new Map<SquatKinds, SquatAlertTypes>([
+  ['critical', 'didYouMean'],
+  ['medium', 'gptDidYouMean'],
+  ['0', 'didYouMean'],
+  ['2', 'gptDidYouMean'],
+  [undefined, undefined],
+])
+const kinds = new Set(kindsMap.keys())
+
+export const isSquatKind = (value?: string): value is SquatKinds =>
+  kinds.has(value as SquatKinds)
+
+export const asSquatKind = (value?: string): SquatKinds => {
+  if (!isSquatKind(value)) {
+    throw error('Expected a valid squat kind', {
+      found: value,
+      validOptions: Array.from(kinds),
+    })
+  }
+  return value
+}
+
+export const parseInternals = (
+  nodes: PostcssNode[],
+): { kind: SquatKinds } => {
+  let kind: SquatKinds
+
+  if (isStringNode(asPostcssNodeWithChildren(nodes[0]).nodes[0])) {
+    kind = asSquatKind(
+      removeQuotes(
+        asStringNode(asPostcssNodeWithChildren(nodes[0]).nodes[0])
+          .value,
+      ),
+    )
+  } else if (
+    isTagNode(asPostcssNodeWithChildren(nodes[0]).nodes[0])
+  ) {
+    kind = asSquatKind(
+      asTagNode(asPostcssNodeWithChildren(nodes[0]).nodes[0]).value,
+    )
+  }
+
+  return { kind }
+}
+
+export const squat = async (state: ParserState) => {
+  if (!state.securityArchive) {
+    throw new Error(
+      'Missing security archive while trying to parse ' +
+        'the :squat security selector',
+    )
+  }
+
+  let internals
+  try {
+    internals = parseInternals(
+      asPostcssNodeWithChildren(state.current).nodes,
+    )
+  } catch (err) {
+    throw error('Failed to parse :squat selector', { cause: err })
+  }
+
+  const { kind } = internals
+  const alertName = kindsMap.get(kind)
+  for (const node of state.partial.nodes) {
+    const report = state.securityArchive.get(node.id)
+    const exclude = !report?.alerts.some(
+      alert => alert.type === alertName,
+    )
+    if (exclude) {
+      removeNode(state, node)
+    }
+  }
+
+  return state
+}

--- a/src/query/tap-snapshots/test/pseudo/squat.ts.test.cjs
+++ b/src/query/tap-snapshots/test/pseudo/squat.ts.test.cjs
@@ -1,0 +1,41 @@
+/* IMPORTANT
+ * This snapshot file is auto-generated, but designed for humans.
+ * It should be checked into source control and tracked carefully.
+ * Re-generate by setting TAP_SNAPSHOT=1 and running tests.
+ * Make sure to inspect the output below.  Do not ignore changes!
+ */
+'use strict'
+exports[`test/pseudo/squat.ts > TAP > selects packages with a specific squat kind > filter out any node that does not have the squat alert > must match snapshot 1`] = `
+Object {
+  "edges": Array [
+    "e",
+    "e",
+  ],
+  "nodes": Array [
+    "e",
+  ],
+}
+`
+
+exports[`test/pseudo/squat.ts > TAP > selects packages with a specific squat kind > filter out using unquoted param > must match snapshot 1`] = `
+Object {
+  "edges": Array [
+    "f",
+  ],
+  "nodes": Array [
+    "f",
+  ],
+}
+`
+
+exports[`test/pseudo/squat.ts > TAP > selects packages with a specific squat kind > filter using numbered param > must match snapshot 1`] = `
+Object {
+  "edges": Array [
+    "e",
+    "e",
+  ],
+  "nodes": Array [
+    "e",
+  ],
+}
+`

--- a/src/query/test/pseudo/squat.ts
+++ b/src/query/test/pseudo/squat.ts
@@ -1,0 +1,160 @@
+import t from 'tap'
+import postcssSelectorParser from 'postcss-selector-parser'
+import { joinDepIDTuple } from '@vltpkg/dep-id'
+import type { SecurityArchiveLike } from '@vltpkg/security-archive'
+import { getSimpleGraph } from '../fixtures/graph.ts'
+import type { ParserState } from '../../src/types.ts'
+import {
+  squat,
+  isSquatKind,
+  asSquatKind,
+} from '../../src/pseudo/squat.ts'
+
+t.test('selects packages with a specific squat kind', async t => {
+  const getState = (query: string, graph = getSimpleGraph()) => {
+    const ast = postcssSelectorParser().astSync(query)
+    const current = ast.first.first
+    const state: ParserState = {
+      current,
+      initial: {
+        edges: new Set(graph.edges.values()),
+        nodes: new Set(graph.nodes.values()),
+      },
+      partial: {
+        edges: new Set(graph.edges.values()),
+        nodes: new Set(graph.nodes.values()),
+      },
+      collect: {
+        edges: new Set(),
+        nodes: new Set(),
+      },
+      cancellable: async () => {},
+      walk: async i => i,
+      securityArchive: new Map([
+        [
+          joinDepIDTuple(['registry', '', 'e@1.0.0']),
+          {
+            id: joinDepIDTuple(['registry', '', 'e@1.0.0']),
+            alerts: [{ type: 'didYouMean' }],
+          },
+        ],
+        [
+          joinDepIDTuple(['registry', '', 'f@1.0.0']),
+          {
+            id: joinDepIDTuple(['registry', '', 'f@1.0.0']),
+            alerts: [{ type: 'gptDidYouMean' }],
+          },
+        ],
+      ]) as SecurityArchiveLike,
+      specOptions: {},
+    }
+    return state
+  }
+
+  await t.test(
+    'filter out any node that does not have the squat alert',
+    async t => {
+      const res = await squat(getState(':squat("critical")'))
+      t.strictSame(
+        [...res.partial.nodes].map(n => n.name),
+        ['e'],
+        'should select only packages with the specified squat alert',
+      )
+      t.matchSnapshot({
+        nodes: [...res.partial.nodes].map(n => n.name),
+        edges: [...res.partial.edges].map(e => e.name),
+      })
+    },
+  )
+
+  await t.test('filter out using unquoted param', async t => {
+    const res = await squat(getState(':squat(medium)'))
+    t.strictSame(
+      [...res.partial.nodes].map(n => n.name),
+      ['f'],
+      'should select only packages with the specified squat alert',
+    )
+    t.matchSnapshot({
+      nodes: [...res.partial.nodes].map(n => n.name),
+      edges: [...res.partial.edges].map(e => e.name),
+    })
+  })
+
+  await t.test('filter using numbered param', async t => {
+    const res = await squat(getState(':squat(0)'))
+    t.strictSame(
+      [...res.partial.nodes].map(n => n.name),
+      ['e'],
+      'should select only packages with the specified squat alert',
+    )
+    t.matchSnapshot({
+      nodes: [...res.partial.nodes].map(n => n.name),
+      edges: [...res.partial.edges].map(e => e.name),
+    })
+  })
+
+  await t.test('wrong parameter', async t => {
+    await t.rejects(
+      squat(getState(':squat')),
+      { message: /Failed to parse :squat selector/ },
+      'should throw an error',
+    )
+  })
+})
+
+t.test('missing security archive', async t => {
+  const getState = (query: string) => {
+    const ast = postcssSelectorParser().astSync(query)
+    const current = ast.first.first
+    const state: ParserState = {
+      current,
+      initial: {
+        edges: new Set(),
+        nodes: new Set(),
+      },
+      partial: {
+        edges: new Set(),
+        nodes: new Set(),
+      },
+      collect: {
+        edges: new Set(),
+        nodes: new Set(),
+      },
+      cancellable: async () => {},
+      walk: async i => i,
+      securityArchive: undefined,
+      specOptions: {},
+    }
+    return state
+  }
+
+  await t.rejects(
+    squat(getState(':squat(critical)')),
+    { message: /Missing security archive/ },
+    'should throw an error',
+  )
+})
+
+t.test('isSquatKind', async t => {
+  t.ok(
+    isSquatKind('critical'),
+    'should return true for valid squat kinds',
+  )
+  t.notOk(
+    isSquatKind('invalid'),
+    'should return false for invalid squat kinds',
+  )
+})
+
+t.test('asSquatKind', async t => {
+  t.equal(
+    asSquatKind('critical'),
+    'critical',
+    'should return the squat kind',
+  )
+  t.throws(
+    () => asSquatKind('invalid'),
+    { message: /Expected a valid squat kind/ },
+    'should throw an error for invalid squat kinds',
+  )
+})


### PR DESCRIPTION
Add a `:squat(<kind>)` selector that filters nodes based on squat-related alert types from the security-archive.