### PR TITLE
gui: dont mark as private in package.json

### DIFF
--- a/src/cli-sdk/package.json
+++ b/src/cli-sdk/package.json
@@ -15,7 +15,10 @@
     ],
     "exports": {
       "./package.json": "./package.json",
-      ".": "./src/index.ts"
+      ".": "./src/index.ts",
+      "./config": "./src/config/index.ts",
+      "./definition": "./src/config/definition.ts",
+      "./view": "./src/view.ts"
     }
   },
   "dependencies": {

--- a/src/cli-sdk/src/index.ts
+++ b/src/cli-sdk/src/index.ts
@@ -6,8 +6,6 @@ import { Config } from './config/index.ts'
 import { outputCommand, stdout } from './output.ts'
 import type { Views } from './view.ts'
 
-export type { Views }
-
 export type CommandUsage = () => Jack
 
 /**

--- a/src/gui/package.json
+++ b/src/gui/package.json
@@ -2,7 +2,6 @@
   "name": "@vltpkg/gui",
   "description": "Look under the hood of a vlt install in HD",
   "version": "0.0.0-6",
-  "private": true,
   "repository": {
     "type": "git",
     "url": "git+https://github.com/vltpkg/vltpkg.git",
@@ -90,7 +89,9 @@
   "prettier": "../../.prettierrc.js",
   "type": "module",
   "exports": {
-    "./package.json": "./package.json",
-    ".": "./dist"
-  }
+    "./package.json": "./package.json"
+  },
+  "files": [
+    "dist"
+  ]
 }

--- a/src/server/package.json
+++ b/src/server/package.json
@@ -15,7 +15,9 @@
     ],
     "exports": {
       "./package.json": "./package.json",
-      ".": "./src/index.ts"
+      ".": "./src/index.ts",
+      "./dashboard": "./src/dashboard.ts",
+      "./project-tools": "./src/project-tools.ts"
     }
   },
   "dependencies": {

--- a/www/docs/typedoc.workspace.mjs
+++ b/www/docs/typedoc.workspace.mjs
@@ -29,11 +29,14 @@ export default cwd => {
     'exports' in tshy && typeof tshy.exports === 'object' ?
       tshy.exports
     : null
+  if (!exports) {
+    return
+  }
   return {
     // get readme local to workspace
     readme: join(cwd, './README.md'),
     // get entry points from package.json exports
-    entryPoints: Object.values(exports ?? {})
+    entryPoints: Object.values(exports)
       .filter(p => !p.endsWith('package.json'))
       .map(p => join(cwd, p)),
   }


### PR DESCRIPTION
Previously the GUI was marked as private so that it wouldn't appear in the
generated typedoc docs. But now that we are publishing workspaces, if the
GUI is private then anything that depends on it would need to be private
also. It's easier to make everything public and publishable and not worry
about it.

The GUI is now excluded from generated docs since it has no observable
exports.
