### PR TITLE
query: add cve selector

### DIFF
--- a/src/query/README.md
+++ b/src/query/README.md
@@ -174,6 +174,10 @@ security data needs to be fetched prior to a `Query` instantiation.
 - `:confused` Matches packages affected by manifest confusion. This
   could be malicious or caused by an error when publishing the
   package.
+- `:cve(<id>)` Matches packages that have a CVE alert with the
+  specified CVE ID. The ID parameter is required and should be a valid
+  CVE identifier (e.g., `CVE-2023-1234`). This selector can be used to
+  find packages affected by specific known vulnerabilities.
 - `:debug` Matches packages that use debug, reflection and dynamic
   code execution features.
 - `:deprecated` Matches packages marked as deprecated. This could

--- a/src/query/src/index.ts
+++ b/src/query/src/index.ts
@@ -119,6 +119,7 @@ export type QueryOptions = {
 const securitySelectors = new Set([
   ':abandoned',
   ':confused',
+  ':cve',
   ':debug',
   ':deprecated',
   ':dynamic',

--- a/src/query/src/pseudo.ts
+++ b/src/query/src/pseudo.ts
@@ -16,6 +16,7 @@ import type { ParserFn, ParserState } from './types.ts'
 import { abandoned } from './pseudo/abandoned.ts'
 import { attr } from './pseudo/attr.ts'
 import { confused } from './pseudo/confused.ts'
+import { cve } from './pseudo/cve.ts'
 import { debug } from './pseudo/debug.ts'
 import { deprecated } from './pseudo/deprecated.ts'
 import { dynamic } from './pseudo/dynamic.ts'
@@ -348,6 +349,7 @@ const pseudoSelectors = new Map<string, ParserFn>(
     abandoned,
     attr,
     confused,
+    cve,
     debug,
     deprecated,
     dynamic,

--- a/src/query/src/pseudo/cve.ts
+++ b/src/query/src/pseudo/cve.ts
@@ -1,0 +1,83 @@
+import { error } from '@vltpkg/error-cause'
+import {
+  asPostcssNodeWithChildren,
+  asStringNode,
+  asTagNode,
+  isStringNode,
+  isTagNode,
+} from '../types.ts'
+import type { ParserState, PostcssNode } from '../types.ts'
+import {
+  removeDanglingEdges,
+  removeNode,
+  removeQuotes,
+} from './helpers.ts'
+
+export type CveInternals = {
+  cveId: string
+}
+
+export const parseInternals = (
+  nodes: PostcssNode[],
+): CveInternals => {
+  let cveId = ''
+
+  if (isStringNode(asPostcssNodeWithChildren(nodes[0]).nodes[0])) {
+    cveId = removeQuotes(
+      asStringNode(asPostcssNodeWithChildren(nodes[0]).nodes[0])
+        .value,
+    )
+  } else if (
+    isTagNode(asPostcssNodeWithChildren(nodes[0]).nodes[0])
+  ) {
+    cveId = asTagNode(
+      asPostcssNodeWithChildren(nodes[0]).nodes[0],
+    ).value
+  }
+
+  if (!cveId) {
+    throw error('Expected a CVE ID', {
+      found: asPostcssNodeWithChildren(nodes[0]).nodes[0],
+    })
+  }
+
+  return { cveId }
+}
+
+/**
+ * Filters out any node that does not have a CVE alert with the specified CVE ID.
+ */
+export const cve = async (state: ParserState) => {
+  if (!state.securityArchive) {
+    throw new Error(
+      'Missing security archive while trying to parse ' +
+        'the :cve security selector',
+    )
+  }
+
+  let internals
+  try {
+    internals = parseInternals(
+      asPostcssNodeWithChildren(state.current).nodes,
+    )
+  } catch (err) {
+    throw error('Failed to parse :cve selector', { cause: err })
+  }
+
+  const { cveId } = internals
+  for (const node of state.partial.nodes) {
+    const report = state.securityArchive.get(node.id)
+    const exclude = !report?.alerts.some(
+      alert =>
+        alert.props.cveId.trim().toLowerCase() ===
+        cveId.trim().toLowerCase(),
+    )
+    if (exclude) {
+      removeNode(state, node)
+    }
+  }
+
+  removeDanglingEdges(state)
+
+  return state
+}

--- a/src/query/tap-snapshots/test/pseudo/cve.ts.test.cjs
+++ b/src/query/tap-snapshots/test/pseudo/cve.ts.test.cjs
@@ -1,0 +1,37 @@
+/* IMPORTANT
+ * This snapshot file is auto-generated, but designed for humans.
+ * It should be checked into source control and tracked carefully.
+ * Re-generate by setting TAP_SNAPSHOT=1 and running tests.
+ * Make sure to inspect the output below.  Do not ignore changes!
+ */
+'use strict'
+exports[`test/pseudo/cve.ts > TAP > selects packages with a CVE alert > filter out any node that does not have the alert > must match snapshot 1`] = `
+Object {
+  "edges": Array [
+    "e",
+    "e",
+  ],
+  "nodes": Array [
+    "e",
+  ],
+}
+`
+
+exports[`test/pseudo/cve.ts > TAP > selects packages with a CVE alert > filter out any node that does not match the quoted CVE ID > must match snapshot 1`] = `
+Object {
+  "edges": Array [
+    "e",
+    "e",
+  ],
+  "nodes": Array [
+    "e",
+  ],
+}
+`
+
+exports[`test/pseudo/cve.ts > TAP > selects packages with a CVE alert > should not match an unseen CVE ID > must match snapshot 1`] = `
+Object {
+  "edges": Array [],
+  "nodes": Array [],
+}
+`

--- a/src/query/test/pseudo/cve.ts
+++ b/src/query/test/pseudo/cve.ts
@@ -1,0 +1,173 @@
+import t from 'tap'
+import postcssSelectorParser from 'postcss-selector-parser'
+import { joinDepIDTuple } from '@vltpkg/dep-id'
+import type {
+  SecurityArchiveLike,
+  PackageReportData,
+} from '@vltpkg/security-archive'
+import { getSimpleGraph } from '../fixtures/graph.ts'
+import type { ParserState } from '../../src/types.ts'
+import { cve } from '../../src/pseudo/cve.ts'
+
+t.test('selects packages with a CVE alert', async t => {
+  const getState = (query: string, graph = getSimpleGraph()) => {
+    const ast = postcssSelectorParser().astSync(query)
+    const current = ast.first.first
+    const state: ParserState = {
+      current,
+      initial: {
+        edges: new Set(graph.edges.values()),
+        nodes: new Set(graph.nodes.values()),
+      },
+      partial: {
+        edges: new Set(graph.edges.values()),
+        nodes: new Set(graph.nodes.values()),
+      },
+      collect: {
+        edges: new Set(),
+        nodes: new Set(),
+      },
+      cancellable: async () => {},
+      walk: async i => i,
+      securityArchive: new Map([
+        [
+          joinDepIDTuple(['registry', '', 'e@1.0.0']),
+          {
+            id: 'e@1.0.0',
+            author: [],
+            size: 0,
+            type: 'npm',
+            name: 'e',
+            version: '1.0.0',
+            license: 'MIT',
+            alerts: [
+              {
+                key: '12314320948130',
+                type: 'npm',
+                severity: 'high',
+                category: 'security',
+                props: {
+                  cveId: 'CVE-2023-1234',
+                  lastPublish: '2023-01-01',
+                },
+              },
+            ],
+          } as PackageReportData,
+        ],
+      ]) as SecurityArchiveLike,
+      specOptions: {},
+    }
+    return state
+  }
+
+  await t.test(
+    'filter out any node that does not have the alert',
+    async t => {
+      const res = await cve(getState(':cve(CVE-2023-1234)'))
+      t.strictSame(
+        [...res.partial.nodes].map(n => n.name),
+        ['e'],
+        'should select only packages with matching CVE ID',
+      )
+      t.matchSnapshot({
+        nodes: [...res.partial.nodes].map(n => n.name),
+        edges: [...res.partial.edges].map(e => e.name),
+      })
+    },
+  )
+
+  await t.test('should not match an unseen CVE ID', async t => {
+    const res = await cve(getState(':cve(CVE-2023-5678)'))
+    t.strictSame(
+      [...res.partial.nodes].map(n => n.name),
+      [],
+      'should not select any packages when CVE ID does not match',
+    )
+    t.matchSnapshot({
+      nodes: [...res.partial.nodes].map(n => n.name),
+      edges: [...res.partial.edges].map(e => e.name),
+    })
+  })
+
+  await t.test(
+    'filter out any node that does not match the quoted CVE ID',
+    async t => {
+      const res = await cve(getState(':cve("CVE-2023-1234")'))
+      t.strictSame(
+        [...res.partial.nodes].map(n => n.name),
+        ['e'],
+        'should select only packages with matching CVE ID',
+      )
+      t.matchSnapshot({
+        nodes: [...res.partial.nodes].map(n => n.name),
+        edges: [...res.partial.edges].map(e => e.name),
+      })
+    },
+  )
+})
+
+t.test('missing security archive', async t => {
+  const getState = (query: string) => {
+    const ast = postcssSelectorParser().astSync(query)
+    const current = ast.first.first
+    const state: ParserState = {
+      current,
+      initial: {
+        edges: new Set(),
+        nodes: new Set(),
+      },
+      partial: {
+        edges: new Set(),
+        nodes: new Set(),
+      },
+      collect: {
+        edges: new Set(),
+        nodes: new Set(),
+      },
+      cancellable: async () => {},
+      walk: async i => i,
+      securityArchive: undefined,
+      specOptions: {},
+    }
+    return state
+  }
+
+  await t.rejects(
+    cve(getState(':cve(CVE-2023-1234)')),
+    /Missing security archive/,
+    'should throw an error',
+  )
+})
+
+t.test('missing CVE ID', async t => {
+  const getState = (query: string) => {
+    const ast = postcssSelectorParser().astSync(query)
+    const current = ast.first.first
+    const state: ParserState = {
+      current,
+      initial: {
+        edges: new Set(),
+        nodes: new Set(),
+      },
+      partial: {
+        edges: new Set(),
+        nodes: new Set(),
+      },
+      collect: {
+        edges: new Set(),
+        nodes: new Set(),
+      },
+      cancellable: async () => {},
+      walk: async i => i,
+      securityArchive: new Map(),
+      specOptions: {},
+    }
+    return state
+  }
+
+  await t.rejects(
+    cve(getState(':cve()')),
+    /Failed to parse :cve selector/,
+    'should throw an error',
+  )
+})

--- a/src/security-archive/src/types.ts
+++ b/src/security-archive/src/types.ts
@@ -34,6 +34,7 @@ export interface SecurityArchiveLike {
  */
 export type PackageAlertProps = {
   lastPublish: string
+  cveId: `CVE-${string}`
 }
 
 /**


### PR DESCRIPTION
Adds a new `:cve(<id>)` selector that filters packages based on a given cve id.