### PR TITLE
query: fix removing dangling edges

### DIFF
--- a/src/query/src/pseudo/malware.ts
+++ b/src/query/src/pseudo/malware.ts
@@ -7,7 +7,11 @@ import {
   isTagNode,
 } from '../types.ts'
 import type { ParserState, PostcssNode } from '../types.ts'
-import { removeNode, removeQuotes } from './helpers.ts'
+import {
+  removeDanglingEdges,
+  removeNode,
+  removeQuotes,
+} from './helpers.ts'
 
 export type MalwareKinds =
   | '0'
@@ -104,6 +108,8 @@ export const malware = async (state: ParserState) => {
       removeNode(state, node)
     }
   }
+
+  removeDanglingEdges(state)
 
   return state
 }

--- a/src/query/src/pseudo/severity.ts
+++ b/src/query/src/pseudo/severity.ts
@@ -7,7 +7,11 @@ import {
   isTagNode,
 } from '../types.ts'
 import type { ParserState, PostcssNode } from '../types.ts'
-import { removeNode, removeQuotes } from './helpers.ts'
+import {
+  removeDanglingEdges,
+  removeNode,
+  removeQuotes,
+} from './helpers.ts'
 
 export type SeverityKinds =
   | '0'
@@ -104,6 +108,8 @@ export const severity = async (state: ParserState) => {
       removeNode(state, node)
     }
   }
+
+  removeDanglingEdges(state)
 
   return state
 }

--- a/src/query/src/pseudo/squat.ts
+++ b/src/query/src/pseudo/squat.ts
@@ -7,7 +7,11 @@ import {
   isTagNode,
 } from '../types.ts'
 import type { ParserState, PostcssNode } from '../types.ts'
-import { removeNode, removeQuotes } from './helpers.ts'
+import {
+  removeDanglingEdges,
+  removeNode,
+  removeQuotes,
+} from './helpers.ts'
 
 export type SquatKinds = '0' | '2' | 'critical' | 'medium' | undefined
 
@@ -89,6 +93,8 @@ export const squat = async (state: ParserState) => {
       removeNode(state, node)
     }
   }
+
+  removeDanglingEdges(state)
 
   return state
 }


### PR DESCRIPTION
The `:malware()`, `:severity()` and `:squat()` selectors need to remove from the partially selected results any edges that are pointing to missing packages, similar to the other security selectors.