### PR TITLE
cache-unzip: pass internal main path as file url

### DIFF
--- a/infra/smoke-test/test/cache-unzip.ts
+++ b/infra/smoke-test/test/cache-unzip.ts
@@ -1,20 +1,10 @@
 import t from 'tap'
 import { runMatch } from './fixtures/run.ts'
 import { defaultVariants } from './fixtures/variants.ts'
-import type { VariantType } from './fixtures/variants.ts'
 import { setTimeout } from 'node:timers/promises'
 import { readdirSync, readFileSync } from 'node:fs'
 import { join } from 'node:path'
 import { CacheEntry } from '@vltpkg/registry-client/cache-entry'
-
-const variants = [
-  // TODO: figure out why compiled deno is failing only on windows
-  ...defaultVariants.filter(v =>
-    process.platform === 'win32' && v === 'compile' ? false : true,
-  ),
-  'denoBundle',
-  'denoSource',
-] as VariantType[]
 
 t.test(
   'unzips all cache entries after a successful install',
@@ -29,11 +19,10 @@ t.test(
           name: 'hi',
           version: '1.0.0',
         },
-        variants,
+        variants: [...defaultVariants, 'denoBundle', 'denoSource'],
         test: async (t, { dir }) => {
-          // wait for unref'd process to finish
-          // this is an arbitrary amount of time but should be enough for
-          // a small install
+          // wait for unref'd process to finish. this is an arbitrary amount of
+          // time but should be enough for a small install.
           await setTimeout(1000)
 
           const cacheEntries = readdirSync(join(dir, 'cache/vlt'), {

--- a/src/cache-unzip/src/index.ts
+++ b/src/cache-unzip/src/index.ts
@@ -1,5 +1,6 @@
 import { spawn } from 'node:child_process'
 import { __CODE_SPLIT_SCRIPT_NAME } from './unzip.ts'
+import { pathToFileURL } from 'node:url'
 
 const isDeno =
   (globalThis as typeof globalThis & { Deno?: any }).Deno != undefined
@@ -27,7 +28,9 @@ const handleBeforeExit = () => {
     // When compiled the script to be run is passed as an
     // environment variable and then routed by the main entry point
     if (process.env.__VLT_INTERNAL_COMPILED) {
-      env.__VLT_INTERNAL_MAIN = __CODE_SPLIT_SCRIPT_NAME
+      env.__VLT_INTERNAL_MAIN = pathToFileURL(
+        __CODE_SPLIT_SCRIPT_NAME,
+      ).toString()
       args.push(path)
     } else {
       // If we are running deno from source we need to add the

--- a/src/cache-unzip/src/unzip.ts
+++ b/src/cache-unzip/src/unzip.ts
@@ -1,8 +1,13 @@
 import { Cache } from '@vltpkg/cache'
 import { error } from '@vltpkg/error-cause'
+import { pathToFileURL } from 'node:url'
 import { gunzipSync } from 'node:zlib'
 
 export const __CODE_SPLIT_SCRIPT_NAME = import.meta.filename
+
+const isMain = (path?: string) =>
+  path === __CODE_SPLIT_SCRIPT_NAME ||
+  path === pathToFileURL(__CODE_SPLIT_SCRIPT_NAME).toString()
 
 const main = async (
   path: undefined | string,
@@ -152,8 +157,7 @@ const g = globalThis as typeof globalThis & {
   __VLT_INTERNAL_MAIN?: string
 }
 
-const file = g.__VLT_INTERNAL_MAIN ?? process.argv[1]
-if (file === __CODE_SPLIT_SCRIPT_NAME) {
+if (isMain(g.__VLT_INTERNAL_MAIN ?? process.argv[1])) {
   process.title = 'vlt-cache-unzip'
   // When compiled there can be other leading args supplied by Deno
   // so always use the last arg unless there are only two which means


### PR DESCRIPTION
This change ensures that cache unzipping works on Windows when compiled.
