### PR TITLE
query: add cwe selector

### DIFF
--- a/src/query/README.md
+++ b/src/query/README.md
@@ -178,6 +178,9 @@ security data needs to be fetched prior to a `Query` instantiation.
   specified CVE ID. The ID parameter is required and should be a valid
   CVE identifier (e.g., `CVE-2023-1234`). This selector can be used to
   find packages affected by specific known vulnerabilities.
+- `:cwe(<id>)` Matches packages that have a CWE alert with the
+  specified CWE ID. The ID parameter is required and should be a valid
+  CWE identifier (e.g., `CWE-79`).
 - `:debug` Matches packages that use debug, reflection and dynamic
   code execution features.
 - `:deprecated` Matches packages marked as deprecated. This could

--- a/src/query/src/pseudo.ts
+++ b/src/query/src/pseudo.ts
@@ -17,6 +17,7 @@ import { abandoned } from './pseudo/abandoned.ts'
 import { attr } from './pseudo/attr.ts'
 import { confused } from './pseudo/confused.ts'
 import { cve } from './pseudo/cve.ts'
+import { cwe } from './pseudo/cwe.ts'
 import { debug } from './pseudo/debug.ts'
 import { deprecated } from './pseudo/deprecated.ts'
 import { dynamic } from './pseudo/dynamic.ts'
@@ -350,6 +351,7 @@ const pseudoSelectors = new Map<string, ParserFn>(
     attr,
     confused,
     cve,
+    cwe,
     debug,
     deprecated,
     dynamic,

--- a/src/query/src/pseudo/cwe.ts
+++ b/src/query/src/pseudo/cwe.ts
@@ -1,0 +1,84 @@
+import { error } from '@vltpkg/error-cause'
+import {
+  asPostcssNodeWithChildren,
+  asStringNode,
+  asTagNode,
+  isStringNode,
+  isTagNode,
+} from '../types.ts'
+import type { ParserState, PostcssNode } from '../types.ts'
+import {
+  removeDanglingEdges,
+  removeNode,
+  removeQuotes,
+} from './helpers.ts'
+
+export type CweInternals = {
+  cweId: string
+}
+
+export const parseInternals = (
+  nodes: PostcssNode[],
+): CweInternals => {
+  let cweId = ''
+
+  if (isStringNode(asPostcssNodeWithChildren(nodes[0]).nodes[0])) {
+    cweId = removeQuotes(
+      asStringNode(asPostcssNodeWithChildren(nodes[0]).nodes[0])
+        .value,
+    )
+  } else if (
+    isTagNode(asPostcssNodeWithChildren(nodes[0]).nodes[0])
+  ) {
+    cweId = asTagNode(
+      asPostcssNodeWithChildren(nodes[0]).nodes[0],
+    ).value
+  }
+
+  if (!cweId) {
+    throw error('Expected a CWE ID', {
+      found: asPostcssNodeWithChildren(nodes[0]).nodes[0],
+    })
+  }
+
+  return { cweId }
+}
+
+/**
+ * Filters out any node that does not have a CWE alert with the specified CWE ID.
+ */
+export const cwe = async (state: ParserState) => {
+  if (!state.securityArchive) {
+    throw new Error(
+      'Missing security archive while trying to parse ' +
+        'the :cwe security selector',
+    )
+  }
+
+  let internals
+  try {
+    internals = parseInternals(
+      asPostcssNodeWithChildren(state.current).nodes,
+    )
+  } catch (err) {
+    throw error('Failed to parse :cwe selector', { cause: err })
+  }
+
+  const { cweId } = internals
+  for (const node of state.partial.nodes) {
+    const report = state.securityArchive.get(node.id)
+    const exclude = !report?.alerts.some(alert =>
+      alert.props.cwes.some(
+        cwe =>
+          cwe.id.trim().toLowerCase() === cweId.trim().toLowerCase(),
+      ),
+    )
+    if (exclude) {
+      removeNode(state, node)
+    }
+  }
+
+  removeDanglingEdges(state)
+
+  return state
+}

--- a/src/query/tap-snapshots/test/pseudo/cwe.ts.test.cjs
+++ b/src/query/tap-snapshots/test/pseudo/cwe.ts.test.cjs
@@ -1,0 +1,37 @@
+/* IMPORTANT
+ * This snapshot file is auto-generated, but designed for humans.
+ * It should be checked into source control and tracked carefully.
+ * Re-generate by setting TAP_SNAPSHOT=1 and running tests.
+ * Make sure to inspect the output below.  Do not ignore changes!
+ */
+'use strict'
+exports[`test/pseudo/cwe.ts > TAP > selects packages with a CWE alert > filter out any node that does not have the alert > must match snapshot 1`] = `
+Object {
+  "edges": Array [
+    "e",
+    "e",
+  ],
+  "nodes": Array [
+    "e",
+  ],
+}
+`
+
+exports[`test/pseudo/cwe.ts > TAP > selects packages with a CWE alert > filter out any node that does not match the quoted CWE ID > must match snapshot 1`] = `
+Object {
+  "edges": Array [
+    "e",
+    "e",
+  ],
+  "nodes": Array [
+    "e",
+  ],
+}
+`
+
+exports[`test/pseudo/cwe.ts > TAP > selects packages with a CWE alert > should not match an unseen CWE ID > must match snapshot 1`] = `
+Object {
+  "edges": Array [],
+  "nodes": Array [],
+}
+`

--- a/src/query/test/pseudo/cwe.ts
+++ b/src/query/test/pseudo/cwe.ts
@@ -7,9 +7,9 @@ import type {
 } from '@vltpkg/security-archive'
 import { getSimpleGraph } from '../fixtures/graph.ts'
 import type { ParserState } from '../../src/types.ts'
-import { cve } from '../../src/pseudo/cve.ts'
+import { cwe } from '../../src/pseudo/cwe.ts'
 
-t.test('selects packages with a CVE alert', async t => {
+t.test('selects packages with a CWE alert', async t => {
   const getState = (query: string, graph = getSimpleGraph()) => {
     const ast = postcssSelectorParser().astSync(query)
     const current = ast.first.first
@@ -43,16 +43,20 @@ t.test('selects packages with a CVE alert', async t => {
             alerts: [
               {
                 key: '12314320948130',
-                type: 'npm',
+                type: 'cve',
                 severity: 'high',
                 category: 'security',
                 props: {
-                  cveId: 'CVE-2023-1234',
                   lastPublish: '2023-01-01',
+                  cveId: 'CVE-2023-1234' as const,
+                  cwes: [
+                    { id: 'CWE-79' as const },
+                    { id: 'CWE-89' as const },
+                  ],
                 },
               },
             ],
-          } as unknown as PackageReportData,
+          } as PackageReportData,
         ],
       ]) as SecurityArchiveLike,
       specOptions: {},
@@ -63,11 +67,11 @@ t.test('selects packages with a CVE alert', async t => {
   await t.test(
     'filter out any node that does not have the alert',
     async t => {
-      const res = await cve(getState(':cve(CVE-2023-1234)'))
+      const res = await cwe(getState(':cwe(CWE-79)'))
       t.strictSame(
         [...res.partial.nodes].map(n => n.name),
         ['e'],
-        'should select only packages with matching CVE ID',
+        'should select only packages with matching CWE ID',
       )
       t.matchSnapshot({
         nodes: [...res.partial.nodes].map(n => n.name),
@@ -76,12 +80,12 @@ t.test('selects packages with a CVE alert', async t => {
     },
   )
 
-  await t.test('should not match an unseen CVE ID', async t => {
-    const res = await cve(getState(':cve(CVE-2023-5678)'))
+  await t.test('should not match an unseen CWE ID', async t => {
+    const res = await cwe(getState(':cwe(CWE-123)'))
     t.strictSame(
       [...res.partial.nodes].map(n => n.name),
       [],
-      'should not select any packages when CVE ID does not match',
+      'should not select any packages when CWE ID does not match',
     )
     t.matchSnapshot({
       nodes: [...res.partial.nodes].map(n => n.name),
@@ -90,13 +94,13 @@ t.test('selects packages with a CVE alert', async t => {
   })
 
   await t.test(
-    'filter out any node that does not match the quoted CVE ID',
+    'filter out any node that does not match the quoted CWE ID',
     async t => {
-      const res = await cve(getState(':cve("CVE-2023-1234")'))
+      const res = await cwe(getState(':cwe("CWE-89")'))
       t.strictSame(
         [...res.partial.nodes].map(n => n.name),
         ['e'],
-        'should select only packages with matching CVE ID',
+        'should select only packages with matching CWE ID',
       )
       t.matchSnapshot({
         nodes: [...res.partial.nodes].map(n => n.name),
@@ -133,13 +137,13 @@ t.test('missing security archive', async t => {
   }
 
   await t.rejects(
-    cve(getState(':cve(CVE-2023-1234)')),
+    cwe(getState(':cwe(CWE-79)')),
     /Missing security archive/,
     'should throw an error',
   )
 })
 
-t.test('missing CVE ID', async t => {
+t.test('missing CWE ID', async t => {
   const getState = (query: string) => {
     const ast = postcssSelectorParser().astSync(query)
     const current = ast.first.first
@@ -166,8 +170,8 @@ t.test('missing CVE ID', async t => {
   }
 
   await t.rejects(
-    cve(getState(':cve()')),
-    /Failed to parse :cve selector/,
+    cwe(getState(':cwe()')),
+    /Failed to parse :cwe selector/,
     'should throw an error',
   )
 })

--- a/src/security-archive/src/types.ts
+++ b/src/security-archive/src/types.ts
@@ -35,6 +35,7 @@ export interface SecurityArchiveLike {
 export type PackageAlertProps = {
   lastPublish: string
   cveId: `CVE-${string}`
+  cwes: { id: `CWE-${string}` }[]
 }
 
 /**


### PR DESCRIPTION
Add a `:cwe(<id>)` selector that filters packages by a given cwe id.