### PR TITLE
query: add scanned selector

### DIFF
--- a/src/cli-sdk/src/commands/list.ts
+++ b/src/cli-sdk/src/commands/list.ts
@@ -84,15 +84,13 @@ export const command: CommandFn<ListResult> = async conf => {
   const queryString = conf.positionals
     .map(k => (/^[@\w-]/.test(k) ? `#${k.replace(/\//, '\\/')}` : k))
     .join(', ')
-  const archive =
+  const securityArchive =
     Query.hasSecuritySelectors(queryString) ?
       await SecurityArchive.start({
         graph,
         specOptions: conf.options,
       })
     : undefined
-  /* c8 ignore next */
-  const securityArchive = archive?.ok ? archive : undefined
   const query = new Query({
     graph,
     specOptions: conf.options,

--- a/src/cli-sdk/src/commands/query.ts
+++ b/src/cli-sdk/src/commands/query.ts
@@ -78,15 +78,13 @@ export const command: CommandFn<QueryResult> = async conf => {
 
   const defaultQueryString = '*'
   const queryString = conf.positionals[0]
-  const archive =
+  const securityArchive =
     queryString && Query.hasSecuritySelectors(queryString) ?
       await SecurityArchive.start({
         graph,
         specOptions: conf.options,
       })
     : undefined
-  /* c8 ignore next */
-  const securityArchive = archive?.ok ? archive : undefined
   const query = new Query({
     graph,
     specOptions: conf.options,

--- a/src/cli-sdk/test/commands/list.ts
+++ b/src/cli-sdk/test/commands/list.ts
@@ -202,7 +202,7 @@ t.test('list', async t => {
       values: { view: 'human' },
       options,
     } as LoadedConfig),
-    /Missing security archive/,
+    /Failed to parse :malware selector/,
     'should fail to run with no security archive',
   )
 

--- a/src/cli-sdk/test/commands/query.ts
+++ b/src/cli-sdk/test/commands/query.ts
@@ -184,7 +184,7 @@ t.test('query', async t => {
       values: { view: 'human' },
       options,
     } as LoadedConfig),
-    /Missing security archive/,
+    /Failed to parse :malware selector/,
     'should fail to run with no security archive',
   )
 

--- a/src/gui/src/state/load-graph.ts
+++ b/src/gui/src/state/load-graph.ts
@@ -154,6 +154,17 @@ export const load = (transfered: TransferData): LoadResponse => {
     transfered.securityArchive,
   )
 
+  // validates that all nodes have a security archive entry
+  if (securityArchive) {
+    securityArchive.ok = true
+    for (const node of graph.nodes.values()) {
+      if (!securityArchive.has(node.id)) {
+        securityArchive.ok = false
+        break
+      }
+    }
+  }
+
   return {
     graph,
     specOptions,

--- a/src/query/README.md
+++ b/src/query/README.md
@@ -228,6 +228,12 @@ security data needs to be fetched prior to a `Query` instantiation.
 - `:obfuscated` Matches packages that use obfuscated files,
   intentionally packed to hide their behavior. This could be a sign of
   malware.
+- `:scanned` Ensures that security report data is available for all
+  packages in the current graph. This selector is useful for
+  validating that security data has been properly loaded before
+  running other security-related selectors. Make sure to prefix your
+  queries with `:scanned` to make sure all currently known package
+  alerts were checked.
 - `:scripts` Matches packages that have scripts that are run when the
   package is installed. The majority of malware in npm is hidden in
   install scripts.

--- a/src/query/src/attribute.ts
+++ b/src/query/src/attribute.ts
@@ -174,9 +174,9 @@ export const attribute = async (
       return state
     }
 
-    throw new Error(
-      `Unsupported attribute operator: ${curr.operator}`,
-    )
+    throw error(`Unsupported attribute operator: ${curr.operator}`, {
+      found: state.current,
+    })
   }
 
   const value = curr.value || ''

--- a/src/query/src/class.ts
+++ b/src/query/src/class.ts
@@ -1,3 +1,4 @@
+import { error } from '@vltpkg/error-cause'
 import { asClassNode } from './types.ts'
 import type { ParserFn, ParserState } from './types.ts'
 
@@ -128,7 +129,9 @@ export const classFn = async (state: ParserState) => {
       return state
     }
 
-    throw new Error(`Unsupported class: ${state.current.value}`)
+    throw error(`Unsupported class: ${state.current.value}`, {
+      found: state.current,
+    })
   }
   return comparatorFn(state)
 }

--- a/src/query/src/combinator.ts
+++ b/src/query/src/combinator.ts
@@ -1,6 +1,7 @@
 import type { EdgeLike, NodeLike } from '@vltpkg/graph'
 import { asCombinatorNode } from './types.ts'
 import type { ParserState, ParserFn } from './types.ts'
+import { error } from '@vltpkg/error-cause'
 
 /**
  * Returns a new set of nodes, containing all direct dependencies
@@ -123,7 +124,9 @@ export const combinator = async (state: ParserState) => {
       return state
     }
 
-    throw new Error(`Unsupported combinator: ${state.current.value}`)
+    throw error(`Unsupported combinator: ${state.current.value}`, {
+      found: state.current,
+    })
   }
   return parserFn(state)
 }

--- a/src/query/src/index.ts
+++ b/src/query/src/index.ts
@@ -65,8 +65,11 @@ export const walk = async (
       return state
     }
 
-    throw new Error(
+    throw error(
       `Missing parser for query node: ${state.current.type}`,
+      {
+        found: state.current,
+      },
     )
   }
   state = await parserFn(state)

--- a/src/query/src/index.ts
+++ b/src/query/src/index.ts
@@ -184,12 +184,6 @@ export class Query {
     query: string,
     signal?: AbortSignal,
   ): Promise<QueryResponse> {
-    if (typeof query !== 'string') {
-      throw new TypeError(
-        'Query search argument needs to be a string',
-      )
-    }
-
     if (!query) return { edges: [], nodes: [] }
 
     const cachedResult = this.#cache.get(query)

--- a/src/query/src/index.ts
+++ b/src/query/src/index.ts
@@ -133,6 +133,7 @@ const securitySelectors = new Set([
   ':native',
   ':network',
   ':obfuscated',
+  ':scanned',
   ':scripts',
   ':sev',
   ':severity',

--- a/src/query/src/pseudo.ts
+++ b/src/query/src/pseudo.ts
@@ -32,6 +32,7 @@ import { nativeParser } from './pseudo/native.ts'
 import { network } from './pseudo/network.ts'
 import { obfuscated } from './pseudo/obfuscated.ts'
 import { outdated } from './pseudo/outdated.ts'
+import { scanned } from './pseudo/scanned.ts'
 import { scripts } from './pseudo/scripts.ts'
 import { shell } from './pseudo/shell.ts'
 import { semverParser as semver } from './pseudo/semver.ts'
@@ -376,6 +377,7 @@ const pseudoSelectors = new Map<string, ParserFn>(
     private: privateFn,
     project,
     root,
+    scanned,
     scope,
     scripts,
     semver,

--- a/src/query/src/pseudo.ts
+++ b/src/query/src/pseudo.ts
@@ -413,9 +413,9 @@ export const pseudo = async (state: ParserState) => {
       return state
     }
 
-    throw new Error(
-      `Unsupported pseudo-class: ${state.current.value}`,
-    )
+    throw error(`Unsupported pseudo-class: ${state.current.value}`, {
+      found: state.current,
+    })
   }
   return parserFn(state)
 }

--- a/src/query/src/pseudo/cve.ts
+++ b/src/query/src/pseudo/cve.ts
@@ -8,6 +8,7 @@ import {
 } from '../types.ts'
 import type { ParserState, PostcssNode } from '../types.ts'
 import {
+  assertSecurityArchive,
   removeDanglingEdges,
   removeNode,
   removeQuotes,
@@ -48,12 +49,7 @@ export const parseInternals = (
  * Filters out any node that does not have a CVE alert with the specified CVE ID.
  */
 export const cve = async (state: ParserState) => {
-  if (!state.securityArchive) {
-    throw new Error(
-      'Missing security archive while trying to parse ' +
-        'the :cve security selector',
-    )
-  }
+  assertSecurityArchive(state.securityArchive, 'cve')
 
   let internals
   try {

--- a/src/query/src/pseudo/cve.ts
+++ b/src/query/src/pseudo/cve.ts
@@ -49,7 +49,7 @@ export const parseInternals = (
  * Filters out any node that does not have a CVE alert with the specified CVE ID.
  */
 export const cve = async (state: ParserState) => {
-  assertSecurityArchive(state.securityArchive, 'cve')
+  assertSecurityArchive(state, 'cve')
 
   let internals
   try {

--- a/src/query/src/pseudo/cwe.ts
+++ b/src/query/src/pseudo/cwe.ts
@@ -8,6 +8,7 @@ import {
 } from '../types.ts'
 import type { ParserState, PostcssNode } from '../types.ts'
 import {
+  assertSecurityArchive,
   removeDanglingEdges,
   removeNode,
   removeQuotes,
@@ -48,12 +49,7 @@ export const parseInternals = (
  * Filters out any node that does not have a CWE alert with the specified CWE ID.
  */
 export const cwe = async (state: ParserState) => {
-  if (!state.securityArchive) {
-    throw new Error(
-      'Missing security archive while trying to parse ' +
-        'the :cwe security selector',
-    )
-  }
+  assertSecurityArchive(state.securityArchive, 'cwe')
 
   let internals
   try {

--- a/src/query/src/pseudo/cwe.ts
+++ b/src/query/src/pseudo/cwe.ts
@@ -49,7 +49,7 @@ export const parseInternals = (
  * Filters out any node that does not have a CWE alert with the specified CWE ID.
  */
 export const cwe = async (state: ParserState) => {
-  assertSecurityArchive(state.securityArchive, 'cwe')
+  assertSecurityArchive(state, 'cwe')
 
   let internals
   try {

--- a/src/query/src/pseudo/helpers.ts
+++ b/src/query/src/pseudo/helpers.ts
@@ -29,6 +29,20 @@ export const removeQuotes = (value: string) =>
   value.replace(/^"(.*?)"$/, '$1')
 
 /**
+ * Asserts that the security archive is present.
+ */
+export const assertSecurityArchive: (
+  securityArchive: ParserState['securityArchive'],
+  name: string,
+) => asserts securityArchive = (securityArchive, name) => {
+  if (!securityArchive) {
+    throw new Error(
+      `Missing security archive while trying to parse the :${name} selector`,
+    )
+  }
+}
+
+/**
  * Reusable security selector alert filter.
  */
 export const createSecuritySelectorFilter = (
@@ -36,11 +50,7 @@ export const createSecuritySelectorFilter = (
   type: string,
 ) => {
   return async (state: ParserState) => {
-    if (!state.securityArchive) {
-      throw new Error(
-        `Missing security archive while trying to parse the :${name} security selector`,
-      )
-    }
+    assertSecurityArchive(state.securityArchive, name)
 
     for (const node of state.partial.nodes) {
       const report = state.securityArchive.get(node.id)

--- a/src/query/src/pseudo/helpers.ts
+++ b/src/query/src/pseudo/helpers.ts
@@ -1,5 +1,6 @@
 import type { NodeLike } from '@vltpkg/graph'
 import type { ParserState } from '../types.js'
+import { error } from '@vltpkg/error-cause'
 
 /**
  * Removes a node and its incoming edges from the results.
@@ -32,12 +33,15 @@ export const removeQuotes = (value: string) =>
  * Asserts that the security archive is present.
  */
 export const assertSecurityArchive: (
-  securityArchive: ParserState['securityArchive'],
+  state: ParserState,
   name: string,
-) => asserts securityArchive = (securityArchive, name) => {
-  if (!securityArchive) {
-    throw new Error(
+) => asserts state is ParserState & {
+  securityArchive: NonNullable<ParserState['securityArchive']>
+} = (state, name) => {
+  if (!state.securityArchive) {
+    throw error(
       `Missing security archive while trying to parse the :${name} selector`,
+      { found: state },
     )
   }
 }
@@ -50,7 +54,7 @@ export const createSecuritySelectorFilter = (
   type: string,
 ) => {
   return async (state: ParserState) => {
-    assertSecurityArchive(state.securityArchive, name)
+    assertSecurityArchive(state, name)
 
     for (const node of state.partial.nodes) {
       const report = state.securityArchive.get(node.id)

--- a/src/query/src/pseudo/license.ts
+++ b/src/query/src/pseudo/license.ts
@@ -8,6 +8,7 @@ import {
 } from '../types.ts'
 import type { ParserState, PostcssNode } from '../types.ts'
 import {
+  assertSecurityArchive,
   removeDanglingEdges,
   removeNode,
   removeQuotes,
@@ -86,12 +87,7 @@ export const parseInternals = (
 }
 
 export const license = async (state: ParserState) => {
-  if (!state.securityArchive) {
-    throw new Error(
-      'Missing security archive while trying to parse ' +
-        'the :license security selector',
-    )
-  }
+  assertSecurityArchive(state.securityArchive, 'license')
 
   let internals
   try {

--- a/src/query/src/pseudo/license.ts
+++ b/src/query/src/pseudo/license.ts
@@ -87,7 +87,7 @@ export const parseInternals = (
 }
 
 export const license = async (state: ParserState) => {
-  assertSecurityArchive(state.securityArchive, 'license')
+  assertSecurityArchive(state, 'license')
 
   let internals
   try {

--- a/src/query/src/pseudo/malware.ts
+++ b/src/query/src/pseudo/malware.ts
@@ -8,6 +8,7 @@ import {
 } from '../types.ts'
 import type { ParserState, PostcssNode } from '../types.ts'
 import {
+  assertSecurityArchive,
   removeDanglingEdges,
   removeNode,
   removeQuotes,
@@ -81,12 +82,7 @@ export const parseInternals = (
 }
 
 export const malware = async (state: ParserState) => {
-  if (!state.securityArchive) {
-    throw new Error(
-      'Missing security archive while trying to parse ' +
-        'the :malware security selector',
-    )
-  }
+  assertSecurityArchive(state.securityArchive, 'malware')
 
   let internals
   try {

--- a/src/query/src/pseudo/malware.ts
+++ b/src/query/src/pseudo/malware.ts
@@ -82,7 +82,7 @@ export const parseInternals = (
 }
 
 export const malware = async (state: ParserState) => {
-  assertSecurityArchive(state.securityArchive, 'malware')
+  assertSecurityArchive(state, 'malware')
 
   let internals
   try {

--- a/src/query/src/pseudo/scanned.ts
+++ b/src/query/src/pseudo/scanned.ts
@@ -1,0 +1,13 @@
+import { error } from '@vltpkg/error-cause'
+import type { ParserState } from '../types.ts'
+
+/**
+ * Ensures that security report data is available for all packages in the current graph.
+ * Throws an error if security data is not available.
+ */
+export const scanned = async (state: ParserState) => {
+  if (!state.securityArchive?.ok) {
+    throw error('Security report data missing')
+  }
+  return state
+}

--- a/src/query/src/pseudo/severity.ts
+++ b/src/query/src/pseudo/severity.ts
@@ -82,7 +82,7 @@ export const parseInternals = (
 }
 
 export const severity = async (state: ParserState) => {
-  assertSecurityArchive(state.securityArchive, 'severity')
+  assertSecurityArchive(state, 'severity')
 
   let internals
   try {

--- a/src/query/src/pseudo/severity.ts
+++ b/src/query/src/pseudo/severity.ts
@@ -8,6 +8,7 @@ import {
 } from '../types.ts'
 import type { ParserState, PostcssNode } from '../types.ts'
 import {
+  assertSecurityArchive,
   removeDanglingEdges,
   removeNode,
   removeQuotes,
@@ -81,12 +82,7 @@ export const parseInternals = (
 }
 
 export const severity = async (state: ParserState) => {
-  if (!state.securityArchive) {
-    throw new Error(
-      'Missing security archive while trying to parse ' +
-        'the :severity security selector',
-    )
-  }
+  assertSecurityArchive(state.securityArchive, 'severity')
 
   let internals
   try {

--- a/src/query/src/pseudo/squat.ts
+++ b/src/query/src/pseudo/squat.ts
@@ -67,7 +67,7 @@ export const parseInternals = (
 }
 
 export const squat = async (state: ParserState) => {
-  assertSecurityArchive(state.securityArchive, 'squat')
+  assertSecurityArchive(state, 'squat')
 
   let internals
   try {

--- a/src/query/src/pseudo/squat.ts
+++ b/src/query/src/pseudo/squat.ts
@@ -8,6 +8,7 @@ import {
 } from '../types.ts'
 import type { ParserState, PostcssNode } from '../types.ts'
 import {
+  assertSecurityArchive,
   removeDanglingEdges,
   removeNode,
   removeQuotes,
@@ -66,12 +67,7 @@ export const parseInternals = (
 }
 
 export const squat = async (state: ParserState) => {
-  if (!state.securityArchive) {
-    throw new Error(
-      'Missing security archive while trying to parse ' +
-        'the :squat security selector',
-    )
-  }
+  assertSecurityArchive(state.securityArchive, 'squat')
 
   let internals
   try {

--- a/src/query/test/index.ts
+++ b/src/query/test/index.ts
@@ -23,14 +23,13 @@ const testBrokenState = (): ParserState => {
     nodes: new Set(graph.nodes.values()),
     edges: new Set(graph.edges.values()),
   }
-  const current = { type: 'bork' } as unknown as PostcssNode
   const state: ParserState = {
     cancellable: async () => {},
     collect: {
       nodes: new Set(),
       edges: new Set(),
     },
-    current,
+    current: { type: 'bork' } as unknown as PostcssNode,
     initial: copyGraphSelectionState(initial),
     partial: copyGraphSelectionState(initial),
     walk,
@@ -140,20 +139,6 @@ t.test('cycle', async t => {
       `query > "${q}"`,
     )
   }
-})
-
-t.test('bad search argument', async t => {
-  const graph = getSimpleGraph()
-  const query = new Query({
-    graph,
-    securityArchive: undefined,
-    specOptions,
-  })
-  await t.rejects(
-    query.search(null as unknown as string),
-    /Query search argument needs to be a string/,
-    'should throw a type error',
-  )
 })
 
 t.test('bad selector type', async t => {

--- a/src/query/test/pseudo/abandoned.ts
+++ b/src/query/test/pseudo/abandoned.ts
@@ -1,7 +1,7 @@
 import t from 'tap'
 import postcssSelectorParser from 'postcss-selector-parser'
 import { joinDepIDTuple } from '@vltpkg/dep-id'
-import type { SecurityArchiveLike } from '@vltpkg/security-archive'
+import { asSecurityArchiveLike } from '@vltpkg/security-archive'
 import { getSimpleGraph } from '../fixtures/graph.ts'
 import type { ParserState } from '../../src/types.ts'
 import { abandoned } from '../../src/pseudo/abandoned.ts'
@@ -26,12 +26,14 @@ t.test('selects packages with an abandoned alert', async t => {
       },
       cancellable: async () => {},
       walk: async i => i,
-      securityArchive: new Map([
-        [
-          joinDepIDTuple(['registry', '', 'e@1.0.0']),
-          { alerts: [{ type: 'missingAuthor' }] },
-        ],
-      ]) as unknown as SecurityArchiveLike,
+      securityArchive: asSecurityArchiveLike(
+        new Map([
+          [
+            joinDepIDTuple(['registry', '', 'e@1.0.0']),
+            { alerts: [{ type: 'missingAuthor' }] },
+          ],
+        ]),
+      ),
       specOptions: {},
     }
     return state

--- a/src/query/test/pseudo/abandoned.ts
+++ b/src/query/test/pseudo/abandoned.ts
@@ -31,7 +31,7 @@ t.test('selects packages with an abandoned alert', async t => {
           joinDepIDTuple(['registry', '', 'e@1.0.0']),
           { alerts: [{ type: 'missingAuthor' }] },
         ],
-      ]) as SecurityArchiveLike,
+      ]) as unknown as SecurityArchiveLike,
       specOptions: {},
     }
     return state

--- a/src/query/test/pseudo/confused.ts
+++ b/src/query/test/pseudo/confused.ts
@@ -31,7 +31,7 @@ t.test('selects packages with a manifestConfusion alert', async t => {
           joinDepIDTuple(['registry', '', 'e@1.0.0']),
           { alerts: [{ type: 'manifestConfusion' }] },
         ],
-      ]) as SecurityArchiveLike,
+      ]) as unknown as SecurityArchiveLike,
       specOptions: {},
     }
     return state

--- a/src/query/test/pseudo/confused.ts
+++ b/src/query/test/pseudo/confused.ts
@@ -1,7 +1,7 @@
 import t from 'tap'
 import postcssSelectorParser from 'postcss-selector-parser'
 import { joinDepIDTuple } from '@vltpkg/dep-id'
-import type { SecurityArchiveLike } from '@vltpkg/security-archive'
+import { asSecurityArchiveLike } from '@vltpkg/security-archive'
 import { getSimpleGraph } from '../fixtures/graph.ts'
 import type { ParserState } from '../../src/types.ts'
 import { confused } from '../../src/pseudo/confused.ts'
@@ -26,12 +26,14 @@ t.test('selects packages with a manifestConfusion alert', async t => {
       },
       cancellable: async () => {},
       walk: async i => i,
-      securityArchive: new Map([
-        [
-          joinDepIDTuple(['registry', '', 'e@1.0.0']),
-          { alerts: [{ type: 'manifestConfusion' }] },
-        ],
-      ]) as unknown as SecurityArchiveLike,
+      securityArchive: asSecurityArchiveLike(
+        new Map([
+          [
+            joinDepIDTuple(['registry', '', 'e@1.0.0']),
+            { alerts: [{ type: 'manifestConfusion' }] },
+          ],
+        ]),
+      ),
       specOptions: {},
     }
     return state

--- a/src/query/test/pseudo/cve.ts
+++ b/src/query/test/pseudo/cve.ts
@@ -54,7 +54,7 @@ t.test('selects packages with a CVE alert', async t => {
             ],
           } as unknown as PackageReportData,
         ],
-      ]) as SecurityArchiveLike,
+      ]) as unknown as SecurityArchiveLike,
       specOptions: {},
     }
     return state
@@ -159,7 +159,7 @@ t.test('missing CVE ID', async t => {
       },
       cancellable: async () => {},
       walk: async i => i,
-      securityArchive: new Map(),
+      securityArchive: new Map() as unknown as SecurityArchiveLike,
       specOptions: {},
     }
     return state

--- a/src/query/test/pseudo/cve.ts
+++ b/src/query/test/pseudo/cve.ts
@@ -1,9 +1,9 @@
 import t from 'tap'
 import postcssSelectorParser from 'postcss-selector-parser'
 import { joinDepIDTuple } from '@vltpkg/dep-id'
-import type {
-  SecurityArchiveLike,
-  PackageReportData,
+import {
+  asPackageReportData,
+  asSecurityArchiveLike,
 } from '@vltpkg/security-archive'
 import { getSimpleGraph } from '../fixtures/graph.ts'
 import type { ParserState } from '../../src/types.ts'
@@ -29,32 +29,34 @@ t.test('selects packages with a CVE alert', async t => {
       },
       cancellable: async () => {},
       walk: async i => i,
-      securityArchive: new Map([
-        [
-          joinDepIDTuple(['registry', '', 'e@1.0.0']),
-          {
-            id: 'e@1.0.0',
-            author: [],
-            size: 0,
-            type: 'npm',
-            name: 'e',
-            version: '1.0.0',
-            license: 'MIT',
-            alerts: [
-              {
-                key: '12314320948130',
-                type: 'npm',
-                severity: 'high',
-                category: 'security',
-                props: {
-                  cveId: 'CVE-2023-1234',
-                  lastPublish: '2023-01-01',
+      securityArchive: asSecurityArchiveLike(
+        new Map([
+          [
+            joinDepIDTuple(['registry', '', 'e@1.0.0']),
+            asPackageReportData({
+              id: 'e@1.0.0',
+              author: [],
+              size: 0,
+              type: 'npm',
+              name: 'e',
+              version: '1.0.0',
+              license: 'MIT',
+              alerts: [
+                {
+                  key: '12314320948130',
+                  type: 'npm',
+                  severity: 'high',
+                  category: 'security',
+                  props: {
+                    cveId: 'CVE-2023-1234',
+                    lastPublish: '2023-01-01',
+                  },
                 },
-              },
-            ],
-          } as unknown as PackageReportData,
-        ],
-      ]) as unknown as SecurityArchiveLike,
+              ],
+            }),
+          ],
+        ]),
+      ),
       specOptions: {},
     }
     return state
@@ -159,7 +161,7 @@ t.test('missing CVE ID', async t => {
       },
       cancellable: async () => {},
       walk: async i => i,
-      securityArchive: new Map() as unknown as SecurityArchiveLike,
+      securityArchive: asSecurityArchiveLike(new Map()),
       specOptions: {},
     }
     return state

--- a/src/query/test/pseudo/cwe.ts
+++ b/src/query/test/pseudo/cwe.ts
@@ -58,7 +58,7 @@ t.test('selects packages with a CWE alert', async t => {
             ],
           } as PackageReportData,
         ],
-      ]) as SecurityArchiveLike,
+      ]) as unknown as SecurityArchiveLike,
       specOptions: {},
     }
     return state
@@ -163,7 +163,7 @@ t.test('missing CWE ID', async t => {
       },
       cancellable: async () => {},
       walk: async i => i,
-      securityArchive: new Map(),
+      securityArchive: new Map() as unknown as SecurityArchiveLike,
       specOptions: {},
     }
     return state

--- a/src/query/test/pseudo/cwe.ts
+++ b/src/query/test/pseudo/cwe.ts
@@ -1,10 +1,8 @@
 import t from 'tap'
 import postcssSelectorParser from 'postcss-selector-parser'
 import { joinDepIDTuple } from '@vltpkg/dep-id'
-import type {
-  SecurityArchiveLike,
-  PackageReportData,
-} from '@vltpkg/security-archive'
+import { asSecurityArchiveLike } from '@vltpkg/security-archive'
+import type { PackageReportData } from '@vltpkg/security-archive'
 import { getSimpleGraph } from '../fixtures/graph.ts'
 import type { ParserState } from '../../src/types.ts'
 import { cwe } from '../../src/pseudo/cwe.ts'
@@ -29,36 +27,38 @@ t.test('selects packages with a CWE alert', async t => {
       },
       cancellable: async () => {},
       walk: async i => i,
-      securityArchive: new Map([
-        [
-          joinDepIDTuple(['registry', '', 'e@1.0.0']),
-          {
-            id: 'e@1.0.0',
-            author: [],
-            size: 0,
-            type: 'npm',
-            name: 'e',
-            version: '1.0.0',
-            license: 'MIT',
-            alerts: [
-              {
-                key: '12314320948130',
-                type: 'cve',
-                severity: 'high',
-                category: 'security',
-                props: {
-                  lastPublish: '2023-01-01',
-                  cveId: 'CVE-2023-1234' as const,
-                  cwes: [
-                    { id: 'CWE-79' as const },
-                    { id: 'CWE-89' as const },
-                  ],
+      securityArchive: asSecurityArchiveLike(
+        new Map([
+          [
+            joinDepIDTuple(['registry', '', 'e@1.0.0']),
+            {
+              id: 'e@1.0.0',
+              author: [],
+              size: 0,
+              type: 'npm',
+              name: 'e',
+              version: '1.0.0',
+              license: 'MIT',
+              alerts: [
+                {
+                  key: '12314320948130',
+                  type: 'cve',
+                  severity: 'high',
+                  category: 'security',
+                  props: {
+                    lastPublish: '2023-01-01',
+                    cveId: 'CVE-2023-1234' as const,
+                    cwes: [
+                      { id: 'CWE-79' as const },
+                      { id: 'CWE-89' as const },
+                    ],
+                  },
                 },
-              },
-            ],
-          } as PackageReportData,
-        ],
-      ]) as unknown as SecurityArchiveLike,
+              ],
+            } as PackageReportData,
+          ],
+        ]),
+      ),
       specOptions: {},
     }
     return state
@@ -163,7 +163,7 @@ t.test('missing CWE ID', async t => {
       },
       cancellable: async () => {},
       walk: async i => i,
-      securityArchive: new Map() as unknown as SecurityArchiveLike,
+      securityArchive: asSecurityArchiveLike(new Map()),
       specOptions: {},
     }
     return state

--- a/src/query/test/pseudo/debug.ts
+++ b/src/query/test/pseudo/debug.ts
@@ -1,7 +1,7 @@
 import t from 'tap'
 import postcssSelectorParser from 'postcss-selector-parser'
 import { joinDepIDTuple } from '@vltpkg/dep-id'
-import type { SecurityArchiveLike } from '@vltpkg/security-archive'
+import { asSecurityArchiveLike } from '@vltpkg/security-archive'
 import { getSimpleGraph } from '../fixtures/graph.ts'
 import type { ParserState } from '../../src/types.ts'
 import { debug } from '../../src/pseudo/debug.ts'
@@ -26,12 +26,14 @@ t.test('selects packages with a debugAccess alert', async t => {
       },
       cancellable: async () => {},
       walk: async i => i,
-      securityArchive: new Map([
-        [
-          joinDepIDTuple(['registry', '', 'e@1.0.0']),
-          { alerts: [{ type: 'debugAccess' }] },
-        ],
-      ]) as unknown as SecurityArchiveLike,
+      securityArchive: asSecurityArchiveLike(
+        new Map([
+          [
+            joinDepIDTuple(['registry', '', 'e@1.0.0']),
+            { alerts: [{ type: 'debugAccess' }] },
+          ],
+        ]),
+      ),
       specOptions: {},
     }
     return state

--- a/src/query/test/pseudo/debug.ts
+++ b/src/query/test/pseudo/debug.ts
@@ -31,7 +31,7 @@ t.test('selects packages with a debugAccess alert', async t => {
           joinDepIDTuple(['registry', '', 'e@1.0.0']),
           { alerts: [{ type: 'debugAccess' }] },
         ],
-      ]) as SecurityArchiveLike,
+      ]) as unknown as SecurityArchiveLike,
       specOptions: {},
     }
     return state

--- a/src/query/test/pseudo/deprecated.ts
+++ b/src/query/test/pseudo/deprecated.ts
@@ -31,7 +31,7 @@ t.test('selects packages with a deprecated alert', async t => {
           joinDepIDTuple(['registry', '', 'e@1.0.0']),
           { alerts: [{ type: 'deprecated' }] },
         ],
-      ]) as SecurityArchiveLike,
+      ]) as unknown as SecurityArchiveLike,
       specOptions: {},
     }
     return state

--- a/src/query/test/pseudo/deprecated.ts
+++ b/src/query/test/pseudo/deprecated.ts
@@ -1,7 +1,7 @@
 import t from 'tap'
 import postcssSelectorParser from 'postcss-selector-parser'
 import { joinDepIDTuple } from '@vltpkg/dep-id'
-import type { SecurityArchiveLike } from '@vltpkg/security-archive'
+import { asSecurityArchiveLike } from '@vltpkg/security-archive'
 import { getSimpleGraph } from '../fixtures/graph.ts'
 import type { ParserState } from '../../src/types.ts'
 import { deprecated } from '../../src/pseudo/deprecated.ts'
@@ -26,12 +26,14 @@ t.test('selects packages with a deprecated alert', async t => {
       },
       cancellable: async () => {},
       walk: async i => i,
-      securityArchive: new Map([
-        [
-          joinDepIDTuple(['registry', '', 'e@1.0.0']),
-          { alerts: [{ type: 'deprecated' }] },
-        ],
-      ]) as unknown as SecurityArchiveLike,
+      securityArchive: asSecurityArchiveLike(
+        new Map([
+          [
+            joinDepIDTuple(['registry', '', 'e@1.0.0']),
+            { alerts: [{ type: 'deprecated' }] },
+          ],
+        ]),
+      ),
       specOptions: {},
     }
     return state

--- a/src/query/test/pseudo/dynamic.ts
+++ b/src/query/test/pseudo/dynamic.ts
@@ -31,7 +31,7 @@ t.test('selects packages with a dynamicRequire alert', async t => {
           joinDepIDTuple(['registry', '', 'e@1.0.0']),
           { alerts: [{ type: 'dynamicRequire' }] },
         ],
-      ]) as SecurityArchiveLike,
+      ]) as unknown as SecurityArchiveLike,
       specOptions: {},
     }
     return state

--- a/src/query/test/pseudo/dynamic.ts
+++ b/src/query/test/pseudo/dynamic.ts
@@ -1,7 +1,7 @@
 import t from 'tap'
 import postcssSelectorParser from 'postcss-selector-parser'
 import { joinDepIDTuple } from '@vltpkg/dep-id'
-import type { SecurityArchiveLike } from '@vltpkg/security-archive'
+import { asSecurityArchiveLike } from '@vltpkg/security-archive'
 import { getSimpleGraph } from '../fixtures/graph.ts'
 import type { ParserState } from '../../src/types.ts'
 import { dynamic } from '../../src/pseudo/dynamic.ts'
@@ -26,12 +26,14 @@ t.test('selects packages with a dynamicRequire alert', async t => {
       },
       cancellable: async () => {},
       walk: async i => i,
-      securityArchive: new Map([
-        [
-          joinDepIDTuple(['registry', '', 'e@1.0.0']),
-          { alerts: [{ type: 'dynamicRequire' }] },
-        ],
-      ]) as unknown as SecurityArchiveLike,
+      securityArchive: asSecurityArchiveLike(
+        new Map([
+          [
+            joinDepIDTuple(['registry', '', 'e@1.0.0']),
+            { alerts: [{ type: 'dynamicRequire' }] },
+          ],
+        ]),
+      ),
       specOptions: {},
     }
     return state

--- a/src/query/test/pseudo/entropic.ts
+++ b/src/query/test/pseudo/entropic.ts
@@ -33,7 +33,7 @@ t.test(
             joinDepIDTuple(['registry', '', 'e@1.0.0']),
             { alerts: [{ type: 'highEntropyStrings' }] },
           ],
-        ]) as SecurityArchiveLike,
+        ]) as unknown as SecurityArchiveLike,
         specOptions: {},
       }
       return state

--- a/src/query/test/pseudo/entropic.ts
+++ b/src/query/test/pseudo/entropic.ts
@@ -1,7 +1,7 @@
 import t from 'tap'
 import postcssSelectorParser from 'postcss-selector-parser'
 import { joinDepIDTuple } from '@vltpkg/dep-id'
-import type { SecurityArchiveLike } from '@vltpkg/security-archive'
+import { asSecurityArchiveLike } from '@vltpkg/security-archive'
 import { getSimpleGraph } from '../fixtures/graph.ts'
 import type { ParserState } from '../../src/types.ts'
 import { entropic } from '../../src/pseudo/entropic.ts'
@@ -28,12 +28,14 @@ t.test(
         },
         cancellable: async () => {},
         walk: async i => i,
-        securityArchive: new Map([
-          [
-            joinDepIDTuple(['registry', '', 'e@1.0.0']),
-            { alerts: [{ type: 'highEntropyStrings' }] },
-          ],
-        ]) as unknown as SecurityArchiveLike,
+        securityArchive: asSecurityArchiveLike(
+          new Map([
+            [
+              joinDepIDTuple(['registry', '', 'e@1.0.0']),
+              { alerts: [{ type: 'highEntropyStrings' }] },
+            ],
+          ]),
+        ),
         specOptions: {},
       }
       return state

--- a/src/query/test/pseudo/env.ts
+++ b/src/query/test/pseudo/env.ts
@@ -31,7 +31,7 @@ t.test('selects packages with a envVars alert', async t => {
           joinDepIDTuple(['registry', '', 'e@1.0.0']),
           { alerts: [{ type: 'envVars' }] },
         ],
-      ]) as SecurityArchiveLike,
+      ]) as unknown as SecurityArchiveLike,
       specOptions: {},
     }
     return state

--- a/src/query/test/pseudo/env.ts
+++ b/src/query/test/pseudo/env.ts
@@ -1,7 +1,7 @@
 import t from 'tap'
 import postcssSelectorParser from 'postcss-selector-parser'
 import { joinDepIDTuple } from '@vltpkg/dep-id'
-import type { SecurityArchiveLike } from '@vltpkg/security-archive'
+import { asSecurityArchiveLike } from '@vltpkg/security-archive'
 import { getSimpleGraph } from '../fixtures/graph.ts'
 import type { ParserState } from '../../src/types.ts'
 import { env } from '../../src/pseudo/env.ts'
@@ -26,12 +26,14 @@ t.test('selects packages with a envVars alert', async t => {
       },
       cancellable: async () => {},
       walk: async i => i,
-      securityArchive: new Map([
-        [
-          joinDepIDTuple(['registry', '', 'e@1.0.0']),
-          { alerts: [{ type: 'envVars' }] },
-        ],
-      ]) as unknown as SecurityArchiveLike,
+      securityArchive: asSecurityArchiveLike(
+        new Map([
+          [
+            joinDepIDTuple(['registry', '', 'e@1.0.0']),
+            { alerts: [{ type: 'envVars' }] },
+          ],
+        ]),
+      ),
       specOptions: {},
     }
     return state

--- a/src/query/test/pseudo/eval.ts
+++ b/src/query/test/pseudo/eval.ts
@@ -31,7 +31,7 @@ t.test('selects packages with an eval alert', async t => {
           joinDepIDTuple(['registry', '', 'e@1.0.0']),
           { alerts: [{ type: 'usesEval' }] },
         ],
-      ]) as SecurityArchiveLike,
+      ]) as unknown as SecurityArchiveLike,
       specOptions: {},
     }
     return state

--- a/src/query/test/pseudo/eval.ts
+++ b/src/query/test/pseudo/eval.ts
@@ -1,7 +1,7 @@
 import t from 'tap'
 import postcssSelectorParser from 'postcss-selector-parser'
 import { joinDepIDTuple } from '@vltpkg/dep-id'
-import type { SecurityArchiveLike } from '@vltpkg/security-archive'
+import { asSecurityArchiveLike } from '@vltpkg/security-archive'
 import { getSimpleGraph } from '../fixtures/graph.ts'
 import type { ParserState } from '../../src/types.ts'
 import { evalParser } from '../../src/pseudo/eval.ts'
@@ -26,12 +26,14 @@ t.test('selects packages with an eval alert', async t => {
       },
       cancellable: async () => {},
       walk: async i => i,
-      securityArchive: new Map([
-        [
-          joinDepIDTuple(['registry', '', 'e@1.0.0']),
-          { alerts: [{ type: 'usesEval' }] },
-        ],
-      ]) as unknown as SecurityArchiveLike,
+      securityArchive: asSecurityArchiveLike(
+        new Map([
+          [
+            joinDepIDTuple(['registry', '', 'e@1.0.0']),
+            { alerts: [{ type: 'usesEval' }] },
+          ],
+        ]),
+      ),
       specOptions: {},
     }
     return state

--- a/src/query/test/pseudo/fs.ts
+++ b/src/query/test/pseudo/fs.ts
@@ -31,7 +31,7 @@ t.test('selects packages with a filesystemAccess alert', async t => {
           joinDepIDTuple(['registry', '', 'e@1.0.0']),
           { alerts: [{ type: 'filesystemAccess' }] },
         ],
-      ]) as SecurityArchiveLike,
+      ]) as unknown as SecurityArchiveLike,
       specOptions: {},
     }
     return state

--- a/src/query/test/pseudo/fs.ts
+++ b/src/query/test/pseudo/fs.ts
@@ -1,7 +1,7 @@
 import t from 'tap'
 import postcssSelectorParser from 'postcss-selector-parser'
 import { joinDepIDTuple } from '@vltpkg/dep-id'
-import type { SecurityArchiveLike } from '@vltpkg/security-archive'
+import { asSecurityArchiveLike } from '@vltpkg/security-archive'
 import { getSimpleGraph } from '../fixtures/graph.ts'
 import type { ParserState } from '../../src/types.ts'
 import { fs } from '../../src/pseudo/fs.ts'
@@ -26,12 +26,14 @@ t.test('selects packages with a filesystemAccess alert', async t => {
       },
       cancellable: async () => {},
       walk: async i => i,
-      securityArchive: new Map([
-        [
-          joinDepIDTuple(['registry', '', 'e@1.0.0']),
-          { alerts: [{ type: 'filesystemAccess' }] },
-        ],
-      ]) as unknown as SecurityArchiveLike,
+      securityArchive: asSecurityArchiveLike(
+        new Map([
+          [
+            joinDepIDTuple(['registry', '', 'e@1.0.0']),
+            { alerts: [{ type: 'filesystemAccess' }] },
+          ],
+        ]),
+      ),
       specOptions: {},
     }
     return state

--- a/src/query/test/pseudo/helpers.ts
+++ b/src/query/test/pseudo/helpers.ts
@@ -1,6 +1,6 @@
 import t from 'tap'
 import postcssSelectorParser from 'postcss-selector-parser'
-import type { SecurityArchiveLike } from '@vltpkg/security-archive'
+import { asSecurityArchiveLike } from '@vltpkg/security-archive'
 import {
   createSecuritySelectorFilter,
   removeDanglingEdges,
@@ -134,12 +134,14 @@ t.test('selects packages with an unmaintained alert', async t => {
       },
       cancellable: async () => {},
       walk: async i => i,
-      securityArchive: new Map([
-        [
-          joinDepIDTuple(['registry', '', 'e@1.0.0']),
-          { alerts: [{ type: 'unmaintained' }] },
-        ],
-      ]) as unknown as SecurityArchiveLike,
+      securityArchive: asSecurityArchiveLike(
+        new Map([
+          [
+            joinDepIDTuple(['registry', '', 'e@1.0.0']),
+            { alerts: [{ type: 'unmaintained' }] },
+          ],
+        ]),
+      ),
       specOptions: {},
     }
     return state

--- a/src/query/test/pseudo/helpers.ts
+++ b/src/query/test/pseudo/helpers.ts
@@ -139,7 +139,7 @@ t.test('selects packages with an unmaintained alert', async t => {
           joinDepIDTuple(['registry', '', 'e@1.0.0']),
           { alerts: [{ type: 'unmaintained' }] },
         ],
-      ]) as SecurityArchiveLike,
+      ]) as unknown as SecurityArchiveLike,
       specOptions: {},
     }
     return state

--- a/src/query/test/pseudo/license.ts
+++ b/src/query/test/pseudo/license.ts
@@ -45,7 +45,7 @@ t.test('selects packages with a specific license kind', async t => {
             alerts: [{ type: 'miscLicenseIssues' }],
           },
         ],
-      ]) as SecurityArchiveLike,
+      ]) as unknown as SecurityArchiveLike,
       specOptions: {},
     }
     return state

--- a/src/query/test/pseudo/license.ts
+++ b/src/query/test/pseudo/license.ts
@@ -1,7 +1,7 @@
 import t from 'tap'
 import postcssSelectorParser from 'postcss-selector-parser'
 import { joinDepIDTuple } from '@vltpkg/dep-id'
-import type { SecurityArchiveLike } from '@vltpkg/security-archive'
+import { asSecurityArchiveLike } from '@vltpkg/security-archive'
 import { getSimpleGraph } from '../fixtures/graph.ts'
 import type { ParserState } from '../../src/types.ts'
 import {
@@ -30,22 +30,24 @@ t.test('selects packages with a specific license kind', async t => {
       },
       cancellable: async () => {},
       walk: async i => i,
-      securityArchive: new Map([
-        [
-          joinDepIDTuple(['registry', '', 'e@1.0.0']),
-          {
-            id: joinDepIDTuple(['registry', '', 'e@1.0.0']),
-            alerts: [{ type: 'explicitlyUnlicensedItem' }],
-          },
-        ],
-        [
-          joinDepIDTuple(['registry', '', 'f@1.0.0']),
-          {
-            id: joinDepIDTuple(['registry', '', 'f@1.0.0']),
-            alerts: [{ type: 'miscLicenseIssues' }],
-          },
-        ],
-      ]) as unknown as SecurityArchiveLike,
+      securityArchive: asSecurityArchiveLike(
+        new Map([
+          [
+            joinDepIDTuple(['registry', '', 'e@1.0.0']),
+            {
+              id: joinDepIDTuple(['registry', '', 'e@1.0.0']),
+              alerts: [{ type: 'explicitlyUnlicensedItem' }],
+            },
+          ],
+          [
+            joinDepIDTuple(['registry', '', 'f@1.0.0']),
+            {
+              id: joinDepIDTuple(['registry', '', 'f@1.0.0']),
+              alerts: [{ type: 'miscLicenseIssues' }],
+            },
+          ],
+        ]),
+      ),
       specOptions: {},
     }
     return state

--- a/src/query/test/pseudo/malware.ts
+++ b/src/query/test/pseudo/malware.ts
@@ -1,7 +1,7 @@
 import t from 'tap'
 import postcssSelectorParser from 'postcss-selector-parser'
 import { joinDepIDTuple } from '@vltpkg/dep-id'
-import type { SecurityArchiveLike } from '@vltpkg/security-archive'
+import { asSecurityArchiveLike } from '@vltpkg/security-archive'
 import { getSimpleGraph } from '../fixtures/graph.ts'
 import type { ParserState } from '../../src/types.ts'
 import {
@@ -30,22 +30,24 @@ t.test('selects packages with a specific malware kind', async t => {
       },
       cancellable: async () => {},
       walk: async i => i,
-      securityArchive: new Map([
-        [
-          joinDepIDTuple(['registry', '', 'e@1.0.0']),
-          {
-            id: joinDepIDTuple(['registry', '', 'e@1.0.0']),
-            alerts: [{ type: 'malware' }],
-          },
-        ],
-        [
-          joinDepIDTuple(['registry', '', 'f@1.0.0']),
-          {
-            id: joinDepIDTuple(['registry', '', 'f@1.0.0']),
-            alerts: [{ type: 'gptMalware' }],
-          },
-        ],
-      ]) as unknown as SecurityArchiveLike,
+      securityArchive: asSecurityArchiveLike(
+        new Map([
+          [
+            joinDepIDTuple(['registry', '', 'e@1.0.0']),
+            {
+              id: joinDepIDTuple(['registry', '', 'e@1.0.0']),
+              alerts: [{ type: 'malware' }],
+            },
+          ],
+          [
+            joinDepIDTuple(['registry', '', 'f@1.0.0']),
+            {
+              id: joinDepIDTuple(['registry', '', 'f@1.0.0']),
+              alerts: [{ type: 'gptMalware' }],
+            },
+          ],
+        ]),
+      ),
       specOptions: {},
     }
     return state

--- a/src/query/test/pseudo/malware.ts
+++ b/src/query/test/pseudo/malware.ts
@@ -45,7 +45,7 @@ t.test('selects packages with a specific malware kind', async t => {
             alerts: [{ type: 'gptMalware' }],
           },
         ],
-      ]) as SecurityArchiveLike,
+      ]) as unknown as SecurityArchiveLike,
       specOptions: {},
     }
     return state

--- a/src/query/test/pseudo/minified.ts
+++ b/src/query/test/pseudo/minified.ts
@@ -31,7 +31,7 @@ t.test('selects packages with a minifiedFile alert', async t => {
           joinDepIDTuple(['registry', '', 'e@1.0.0']),
           { alerts: [{ type: 'minifiedFile' }] },
         ],
-      ]) as SecurityArchiveLike,
+      ]) as unknown as SecurityArchiveLike,
       specOptions: {},
     }
     return state

--- a/src/query/test/pseudo/minified.ts
+++ b/src/query/test/pseudo/minified.ts
@@ -1,7 +1,7 @@
 import t from 'tap'
 import postcssSelectorParser from 'postcss-selector-parser'
 import { joinDepIDTuple } from '@vltpkg/dep-id'
-import type { SecurityArchiveLike } from '@vltpkg/security-archive'
+import { asSecurityArchiveLike } from '@vltpkg/security-archive'
 import { getSimpleGraph } from '../fixtures/graph.ts'
 import type { ParserState } from '../../src/types.ts'
 import { minified } from '../../src/pseudo/minified.ts'
@@ -26,12 +26,14 @@ t.test('selects packages with a minifiedFile alert', async t => {
       },
       cancellable: async () => {},
       walk: async i => i,
-      securityArchive: new Map([
-        [
-          joinDepIDTuple(['registry', '', 'e@1.0.0']),
-          { alerts: [{ type: 'minifiedFile' }] },
-        ],
-      ]) as unknown as SecurityArchiveLike,
+      securityArchive: asSecurityArchiveLike(
+        new Map([
+          [
+            joinDepIDTuple(['registry', '', 'e@1.0.0']),
+            { alerts: [{ type: 'minifiedFile' }] },
+          ],
+        ]),
+      ),
       specOptions: {},
     }
     return state

--- a/src/query/test/pseudo/native.ts
+++ b/src/query/test/pseudo/native.ts
@@ -31,7 +31,7 @@ t.test('selects packages with a hasNativeCode alert', async t => {
           joinDepIDTuple(['registry', '', 'e@1.0.0']),
           { alerts: [{ type: 'hasNativeCode' }] },
         ],
-      ]) as SecurityArchiveLike,
+      ]) as unknown as SecurityArchiveLike,
       specOptions: {},
     }
     return state

--- a/src/query/test/pseudo/native.ts
+++ b/src/query/test/pseudo/native.ts
@@ -1,7 +1,7 @@
 import t from 'tap'
 import postcssSelectorParser from 'postcss-selector-parser'
 import { joinDepIDTuple } from '@vltpkg/dep-id'
-import type { SecurityArchiveLike } from '@vltpkg/security-archive'
+import { asSecurityArchiveLike } from '@vltpkg/security-archive'
 import { getSimpleGraph } from '../fixtures/graph.ts'
 import type { ParserState } from '../../src/types.ts'
 import { nativeParser } from '../../src/pseudo/native.ts'
@@ -26,12 +26,14 @@ t.test('selects packages with a hasNativeCode alert', async t => {
       },
       cancellable: async () => {},
       walk: async i => i,
-      securityArchive: new Map([
-        [
-          joinDepIDTuple(['registry', '', 'e@1.0.0']),
-          { alerts: [{ type: 'hasNativeCode' }] },
-        ],
-      ]) as unknown as SecurityArchiveLike,
+      securityArchive: asSecurityArchiveLike(
+        new Map([
+          [
+            joinDepIDTuple(['registry', '', 'e@1.0.0']),
+            { alerts: [{ type: 'hasNativeCode' }] },
+          ],
+        ]),
+      ),
       specOptions: {},
     }
     return state

--- a/src/query/test/pseudo/network.ts
+++ b/src/query/test/pseudo/network.ts
@@ -1,7 +1,7 @@
 import t from 'tap'
 import postcssSelectorParser from 'postcss-selector-parser'
 import { joinDepIDTuple } from '@vltpkg/dep-id'
-import type { SecurityArchiveLike } from '@vltpkg/security-archive'
+import { asSecurityArchiveLike } from '@vltpkg/security-archive'
 import { getSimpleGraph } from '../fixtures/graph.ts'
 import type { ParserState } from '../../src/types.ts'
 import { network } from '../../src/pseudo/network.ts'
@@ -26,12 +26,14 @@ t.test('selects packages with a networkAccess alert', async t => {
       },
       cancellable: async () => {},
       walk: async i => i,
-      securityArchive: new Map([
-        [
-          joinDepIDTuple(['registry', '', 'e@1.0.0']),
-          { alerts: [{ type: 'networkAccess' }] },
-        ],
-      ]) as unknown as SecurityArchiveLike,
+      securityArchive: asSecurityArchiveLike(
+        new Map([
+          [
+            joinDepIDTuple(['registry', '', 'e@1.0.0']),
+            { alerts: [{ type: 'networkAccess' }] },
+          ],
+        ]),
+      ),
       specOptions: {},
     }
     return state

--- a/src/query/test/pseudo/network.ts
+++ b/src/query/test/pseudo/network.ts
@@ -31,7 +31,7 @@ t.test('selects packages with a networkAccess alert', async t => {
           joinDepIDTuple(['registry', '', 'e@1.0.0']),
           { alerts: [{ type: 'networkAccess' }] },
         ],
-      ]) as SecurityArchiveLike,
+      ]) as unknown as SecurityArchiveLike,
       specOptions: {},
     }
     return state

--- a/src/query/test/pseudo/obfuscated.ts
+++ b/src/query/test/pseudo/obfuscated.ts
@@ -1,7 +1,7 @@
 import t from 'tap'
 import postcssSelectorParser from 'postcss-selector-parser'
 import { joinDepIDTuple } from '@vltpkg/dep-id'
-import type { SecurityArchiveLike } from '@vltpkg/security-archive'
+import { asSecurityArchiveLike } from '@vltpkg/security-archive'
 import { getSimpleGraph } from '../fixtures/graph.ts'
 import type { ParserState } from '../../src/types.ts'
 import { obfuscated } from '../../src/pseudo/obfuscated.ts'
@@ -26,12 +26,14 @@ t.test('selects packages with an obfuscated alert', async t => {
       },
       cancellable: async () => {},
       walk: async i => i,
-      securityArchive: new Map([
-        [
-          joinDepIDTuple(['registry', '', 'e@1.0.0']),
-          { alerts: [{ type: 'obfuscatedFile' }] },
-        ],
-      ]) as unknown as SecurityArchiveLike,
+      securityArchive: asSecurityArchiveLike(
+        new Map([
+          [
+            joinDepIDTuple(['registry', '', 'e@1.0.0']),
+            { alerts: [{ type: 'obfuscatedFile' }] },
+          ],
+        ]),
+      ),
       specOptions: {},
     }
     return state

--- a/src/query/test/pseudo/obfuscated.ts
+++ b/src/query/test/pseudo/obfuscated.ts
@@ -31,7 +31,7 @@ t.test('selects packages with an obfuscated alert', async t => {
           joinDepIDTuple(['registry', '', 'e@1.0.0']),
           { alerts: [{ type: 'obfuscatedFile' }] },
         ],
-      ]) as SecurityArchiveLike,
+      ]) as unknown as SecurityArchiveLike,
       specOptions: {},
     }
     return state

--- a/src/query/test/pseudo/scanned.ts
+++ b/src/query/test/pseudo/scanned.ts
@@ -1,10 +1,8 @@
 import t from 'tap'
 import postcssSelectorParser from 'postcss-selector-parser'
 import { joinDepIDTuple } from '@vltpkg/dep-id'
-import type {
-  SecurityArchiveLike,
-  PackageReportData,
-} from '@vltpkg/security-archive'
+import { asSecurityArchiveLike } from '@vltpkg/security-archive'
+import type { PackageReportData } from '@vltpkg/security-archive'
 import { scanned } from '../../src/pseudo/scanned.ts'
 import { getSimpleGraph } from '../fixtures/graph.ts'
 import type { ParserState } from '../../src/types.ts'
@@ -15,25 +13,27 @@ t.test('scanned selector', async t => {
     const ast = postcssSelectorParser().astSync(':scanned')
     const current = ast.first.first
     const testId = joinDepIDTuple(['registry', '', 'e@1.0.0'])
-    const securityArchive = new Map<string, PackageReportData>(
-      hasSecurityData ?
-        [
+    const securityArchive = asSecurityArchiveLike(
+      new Map<string, PackageReportData>(
+        hasSecurityData ?
           [
-            testId,
-            {
-              id: 'e@1.0.0',
-              author: [],
-              size: 0,
-              type: 'npm',
-              name: 'e',
-              version: '1.0.0',
-              license: 'MIT',
-              alerts: [],
-            },
-          ],
-        ]
-      : [],
-    ) as unknown as SecurityArchiveLike
+            [
+              testId,
+              {
+                id: 'e@1.0.0',
+                author: [],
+                size: 0,
+                type: 'npm',
+                name: 'e',
+                version: '1.0.0',
+                license: 'MIT',
+                alerts: [],
+              },
+            ],
+          ]
+        : [],
+      ),
+    )
     securityArchive.ok = hasSecurityData
     const state: ParserState = {
       current,

--- a/src/query/test/pseudo/scanned.ts
+++ b/src/query/test/pseudo/scanned.ts
@@ -1,0 +1,84 @@
+import t from 'tap'
+import postcssSelectorParser from 'postcss-selector-parser'
+import { joinDepIDTuple } from '@vltpkg/dep-id'
+import type {
+  SecurityArchiveLike,
+  PackageReportData,
+} from '@vltpkg/security-archive'
+import { scanned } from '../../src/pseudo/scanned.ts'
+import { getSimpleGraph } from '../fixtures/graph.ts'
+import type { ParserState } from '../../src/types.ts'
+
+t.test('scanned selector', async t => {
+  const getState = (hasSecurityData: boolean) => {
+    const graph = getSimpleGraph()
+    const ast = postcssSelectorParser().astSync(':scanned')
+    const current = ast.first.first
+    const testId = joinDepIDTuple(['registry', '', 'e@1.0.0'])
+    const securityArchive = new Map<string, PackageReportData>(
+      hasSecurityData ?
+        [
+          [
+            testId,
+            {
+              id: 'e@1.0.0',
+              author: [],
+              size: 0,
+              type: 'npm',
+              name: 'e',
+              version: '1.0.0',
+              license: 'MIT',
+              alerts: [],
+            },
+          ],
+        ]
+      : [],
+    ) as unknown as SecurityArchiveLike
+    securityArchive.ok = hasSecurityData
+    const state: ParserState = {
+      current,
+      initial: {
+        edges: new Set(graph.edges.values()),
+        nodes: new Set(graph.nodes.values()),
+      },
+      partial: {
+        edges: new Set(graph.edges.values()),
+        nodes: new Set(graph.nodes.values()),
+      },
+      collect: {
+        edges: new Set(),
+        nodes: new Set(),
+      },
+      cancellable: async () => {},
+      walk: async i => i,
+      securityArchive,
+      specOptions: {},
+    }
+    return state
+  }
+
+  await t.test(
+    'should throw when security archive is not available',
+    async t => {
+      const state = getState(false)
+      await t.rejects(
+        scanned(state),
+        /Security report data missing/,
+        'should throw when security archive is not available',
+      )
+    },
+  )
+
+  await t.test(
+    'should return state when security archive is available',
+    async t => {
+      const state = getState(true)
+      const result = await scanned(state)
+      t.strictSame(
+        result,
+        state,
+        'should passthrough if security archive data is available',
+      )
+    },
+  )
+})

--- a/src/query/test/pseudo/scripts.ts
+++ b/src/query/test/pseudo/scripts.ts
@@ -31,7 +31,7 @@ t.test('selects packages with an installScripts alert', async t => {
           joinDepIDTuple(['registry', '', 'e@1.0.0']),
           { alerts: [{ type: 'installScripts' }] },
         ],
-      ]) as SecurityArchiveLike,
+      ]) as unknown as SecurityArchiveLike,
       specOptions: {},
     }
     return state

--- a/src/query/test/pseudo/scripts.ts
+++ b/src/query/test/pseudo/scripts.ts
@@ -1,7 +1,7 @@
 import t from 'tap'
 import postcssSelectorParser from 'postcss-selector-parser'
 import { joinDepIDTuple } from '@vltpkg/dep-id'
-import type { SecurityArchiveLike } from '@vltpkg/security-archive'
+import { asSecurityArchiveLike } from '@vltpkg/security-archive'
 import { getSimpleGraph } from '../fixtures/graph.ts'
 import type { ParserState } from '../../src/types.ts'
 import { scripts } from '../../src/pseudo/scripts.ts'
@@ -26,12 +26,14 @@ t.test('selects packages with an installScripts alert', async t => {
       },
       cancellable: async () => {},
       walk: async i => i,
-      securityArchive: new Map([
-        [
-          joinDepIDTuple(['registry', '', 'e@1.0.0']),
-          { alerts: [{ type: 'installScripts' }] },
-        ],
-      ]) as unknown as SecurityArchiveLike,
+      securityArchive: asSecurityArchiveLike(
+        new Map([
+          [
+            joinDepIDTuple(['registry', '', 'e@1.0.0']),
+            { alerts: [{ type: 'installScripts' }] },
+          ],
+        ]),
+      ),
       specOptions: {},
     }
     return state

--- a/src/query/test/pseudo/semver.ts
+++ b/src/query/test/pseudo/semver.ts
@@ -492,10 +492,6 @@ t.test('isSemverFunctionName', async t => {
     isSemverFunctionName('unsupported'),
     'should return false for valid semver function name',
   )
-  t.notOk(
-    isSemverFunctionName(undefined as unknown as string),
-    'should return false for missing semver function name',
-  )
 })
 
 t.test('asSemverFunctionName', async t => {

--- a/src/query/test/pseudo/severity.ts
+++ b/src/query/test/pseudo/severity.ts
@@ -1,7 +1,7 @@
 import t from 'tap'
 import postcssSelectorParser from 'postcss-selector-parser'
 import { joinDepIDTuple } from '@vltpkg/dep-id'
-import type { SecurityArchiveLike } from '@vltpkg/security-archive'
+import { asSecurityArchiveLike } from '@vltpkg/security-archive'
 import { getSimpleGraph } from '../fixtures/graph.ts'
 import type { ParserState } from '../../src/types.ts'
 import {
@@ -30,22 +30,24 @@ t.test('selects packages with a specific severity kind', async t => {
       },
       cancellable: async () => {},
       walk: async i => i,
-      securityArchive: new Map([
-        [
-          joinDepIDTuple(['registry', '', 'e@1.0.0']),
-          {
-            id: joinDepIDTuple(['registry', '', 'e@1.0.0']),
-            alerts: [{ type: 'criticalCVE' }],
-          },
-        ],
-        [
-          joinDepIDTuple(['registry', '', 'f@1.0.0']),
-          {
-            id: joinDepIDTuple(['registry', '', 'f@1.0.0']),
-            alerts: [{ type: 'cve' }],
-          },
-        ],
-      ]) as unknown as SecurityArchiveLike,
+      securityArchive: asSecurityArchiveLike(
+        new Map([
+          [
+            joinDepIDTuple(['registry', '', 'e@1.0.0']),
+            {
+              id: joinDepIDTuple(['registry', '', 'e@1.0.0']),
+              alerts: [{ type: 'criticalCVE' }],
+            },
+          ],
+          [
+            joinDepIDTuple(['registry', '', 'f@1.0.0']),
+            {
+              id: joinDepIDTuple(['registry', '', 'f@1.0.0']),
+              alerts: [{ type: 'cve' }],
+            },
+          ],
+        ]),
+      ),
       specOptions: {},
     }
     return state

--- a/src/query/test/pseudo/severity.ts
+++ b/src/query/test/pseudo/severity.ts
@@ -45,7 +45,7 @@ t.test('selects packages with a specific severity kind', async t => {
             alerts: [{ type: 'cve' }],
           },
         ],
-      ]) as SecurityArchiveLike,
+      ]) as unknown as SecurityArchiveLike,
       specOptions: {},
     }
     return state

--- a/src/query/test/pseudo/shell.ts
+++ b/src/query/test/pseudo/shell.ts
@@ -1,7 +1,7 @@
 import t from 'tap'
 import postcssSelectorParser from 'postcss-selector-parser'
 import { joinDepIDTuple } from '@vltpkg/dep-id'
-import type { SecurityArchiveLike } from '@vltpkg/security-archive'
+import { asSecurityArchiveLike } from '@vltpkg/security-archive'
 import { getSimpleGraph } from '../fixtures/graph.ts'
 import type { ParserState } from '../../src/types.ts'
 import { shell } from '../../src/pseudo/shell.ts'
@@ -26,12 +26,14 @@ t.test('selects packages with a shellAccess alert', async t => {
       },
       cancellable: async () => {},
       walk: async i => i,
-      securityArchive: new Map([
-        [
-          joinDepIDTuple(['registry', '', 'e@1.0.0']),
-          { alerts: [{ type: 'shellAccess' }] },
-        ],
-      ]) as unknown as SecurityArchiveLike,
+      securityArchive: asSecurityArchiveLike(
+        new Map([
+          [
+            joinDepIDTuple(['registry', '', 'e@1.0.0']),
+            { alerts: [{ type: 'shellAccess' }] },
+          ],
+        ]),
+      ),
       specOptions: {},
     }
     return state

--- a/src/query/test/pseudo/shell.ts
+++ b/src/query/test/pseudo/shell.ts
@@ -31,7 +31,7 @@ t.test('selects packages with a shellAccess alert', async t => {
           joinDepIDTuple(['registry', '', 'e@1.0.0']),
           { alerts: [{ type: 'shellAccess' }] },
         ],
-      ]) as SecurityArchiveLike,
+      ]) as unknown as SecurityArchiveLike,
       specOptions: {},
     }
     return state

--- a/src/query/test/pseudo/shrinkwrap.ts
+++ b/src/query/test/pseudo/shrinkwrap.ts
@@ -31,7 +31,7 @@ t.test('selects packages with a shrinkwrap alert', async t => {
           joinDepIDTuple(['registry', '', 'e@1.0.0']),
           { alerts: [{ type: 'shrinkwrap' }] },
         ],
-      ]) as SecurityArchiveLike,
+      ]) as unknown as SecurityArchiveLike,
       specOptions: {},
     }
     return state

--- a/src/query/test/pseudo/shrinkwrap.ts
+++ b/src/query/test/pseudo/shrinkwrap.ts
@@ -1,7 +1,7 @@
 import t from 'tap'
 import postcssSelectorParser from 'postcss-selector-parser'
 import { joinDepIDTuple } from '@vltpkg/dep-id'
-import type { SecurityArchiveLike } from '@vltpkg/security-archive'
+import { asSecurityArchiveLike } from '@vltpkg/security-archive'
 import { getSimpleGraph } from '../fixtures/graph.ts'
 import type { ParserState } from '../../src/types.ts'
 import { shrinkwrap } from '../../src/pseudo/shrinkwrap.ts'
@@ -26,12 +26,14 @@ t.test('selects packages with a shrinkwrap alert', async t => {
       },
       cancellable: async () => {},
       walk: async i => i,
-      securityArchive: new Map([
-        [
-          joinDepIDTuple(['registry', '', 'e@1.0.0']),
-          { alerts: [{ type: 'shrinkwrap' }] },
-        ],
-      ]) as unknown as SecurityArchiveLike,
+      securityArchive: asSecurityArchiveLike(
+        new Map([
+          [
+            joinDepIDTuple(['registry', '', 'e@1.0.0']),
+            { alerts: [{ type: 'shrinkwrap' }] },
+          ],
+        ]),
+      ),
       specOptions: {},
     }
     return state

--- a/src/query/test/pseudo/squat.ts
+++ b/src/query/test/pseudo/squat.ts
@@ -45,7 +45,7 @@ t.test('selects packages with a specific squat kind', async t => {
             alerts: [{ type: 'gptDidYouMean' }],
           },
         ],
-      ]) as SecurityArchiveLike,
+      ]) as unknown as SecurityArchiveLike,
       specOptions: {},
     }
     return state

--- a/src/query/test/pseudo/squat.ts
+++ b/src/query/test/pseudo/squat.ts
@@ -1,7 +1,7 @@
 import t from 'tap'
 import postcssSelectorParser from 'postcss-selector-parser'
 import { joinDepIDTuple } from '@vltpkg/dep-id'
-import type { SecurityArchiveLike } from '@vltpkg/security-archive'
+import { asSecurityArchiveLike } from '@vltpkg/security-archive'
 import { getSimpleGraph } from '../fixtures/graph.ts'
 import type { ParserState } from '../../src/types.ts'
 import {
@@ -30,22 +30,24 @@ t.test('selects packages with a specific squat kind', async t => {
       },
       cancellable: async () => {},
       walk: async i => i,
-      securityArchive: new Map([
-        [
-          joinDepIDTuple(['registry', '', 'e@1.0.0']),
-          {
-            id: joinDepIDTuple(['registry', '', 'e@1.0.0']),
-            alerts: [{ type: 'didYouMean' }],
-          },
-        ],
-        [
-          joinDepIDTuple(['registry', '', 'f@1.0.0']),
-          {
-            id: joinDepIDTuple(['registry', '', 'f@1.0.0']),
-            alerts: [{ type: 'gptDidYouMean' }],
-          },
-        ],
-      ]) as unknown as SecurityArchiveLike,
+      securityArchive: asSecurityArchiveLike(
+        new Map([
+          [
+            joinDepIDTuple(['registry', '', 'e@1.0.0']),
+            {
+              id: joinDepIDTuple(['registry', '', 'e@1.0.0']),
+              alerts: [{ type: 'didYouMean' }],
+            },
+          ],
+          [
+            joinDepIDTuple(['registry', '', 'f@1.0.0']),
+            {
+              id: joinDepIDTuple(['registry', '', 'f@1.0.0']),
+              alerts: [{ type: 'gptDidYouMean' }],
+            },
+          ],
+        ]),
+      ),
       specOptions: {},
     }
     return state

--- a/src/query/test/pseudo/suspicious.ts
+++ b/src/query/test/pseudo/suspicious.ts
@@ -1,7 +1,7 @@
 import t from 'tap'
 import postcssSelectorParser from 'postcss-selector-parser'
 import { joinDepIDTuple } from '@vltpkg/dep-id'
-import type { SecurityArchiveLike } from '@vltpkg/security-archive'
+import { asSecurityArchiveLike } from '@vltpkg/security-archive'
 import { getSimpleGraph } from '../fixtures/graph.ts'
 import type { ParserState } from '../../src/types.ts'
 import { suspicious } from '../../src/pseudo/suspicious.ts'
@@ -26,12 +26,14 @@ t.test('selects packages with a suspicious alert', async t => {
       },
       cancellable: async () => {},
       walk: async i => i,
-      securityArchive: new Map([
-        [
-          joinDepIDTuple(['registry', '', 'e@1.0.0']),
-          { alerts: [{ type: 'suspiciousStarActivity' }] },
-        ],
-      ]) as unknown as SecurityArchiveLike,
+      securityArchive: asSecurityArchiveLike(
+        new Map([
+          [
+            joinDepIDTuple(['registry', '', 'e@1.0.0']),
+            { alerts: [{ type: 'suspiciousStarActivity' }] },
+          ],
+        ]),
+      ),
       specOptions: {},
     }
     return state

--- a/src/query/test/pseudo/suspicious.ts
+++ b/src/query/test/pseudo/suspicious.ts
@@ -31,7 +31,7 @@ t.test('selects packages with a suspicious alert', async t => {
           joinDepIDTuple(['registry', '', 'e@1.0.0']),
           { alerts: [{ type: 'suspiciousStarActivity' }] },
         ],
-      ]) as SecurityArchiveLike,
+      ]) as unknown as SecurityArchiveLike,
       specOptions: {},
     }
     return state

--- a/src/query/test/pseudo/tracker.ts
+++ b/src/query/test/pseudo/tracker.ts
@@ -31,7 +31,7 @@ t.test('selects packages with a tracker alert', async t => {
           joinDepIDTuple(['registry', '', 'e@1.0.0']),
           { alerts: [{ type: 'telemetry' }] },
         ],
-      ]) as SecurityArchiveLike,
+      ]) as unknown as SecurityArchiveLike,
       specOptions: {},
     }
     return state

--- a/src/query/test/pseudo/tracker.ts
+++ b/src/query/test/pseudo/tracker.ts
@@ -1,7 +1,7 @@
 import t from 'tap'
 import postcssSelectorParser from 'postcss-selector-parser'
 import { joinDepIDTuple } from '@vltpkg/dep-id'
-import type { SecurityArchiveLike } from '@vltpkg/security-archive'
+import { asSecurityArchiveLike } from '@vltpkg/security-archive'
 import { getSimpleGraph } from '../fixtures/graph.ts'
 import type { ParserState } from '../../src/types.ts'
 import { tracker } from '../../src/pseudo/tracker.ts'
@@ -26,12 +26,14 @@ t.test('selects packages with a tracker alert', async t => {
       },
       cancellable: async () => {},
       walk: async i => i,
-      securityArchive: new Map([
-        [
-          joinDepIDTuple(['registry', '', 'e@1.0.0']),
-          { alerts: [{ type: 'telemetry' }] },
-        ],
-      ]) as unknown as SecurityArchiveLike,
+      securityArchive: asSecurityArchiveLike(
+        new Map([
+          [
+            joinDepIDTuple(['registry', '', 'e@1.0.0']),
+            { alerts: [{ type: 'telemetry' }] },
+          ],
+        ]),
+      ),
       specOptions: {},
     }
     return state

--- a/src/query/test/pseudo/trivial.ts
+++ b/src/query/test/pseudo/trivial.ts
@@ -1,7 +1,7 @@
 import t from 'tap'
 import postcssSelectorParser from 'postcss-selector-parser'
 import { joinDepIDTuple } from '@vltpkg/dep-id'
-import type { SecurityArchiveLike } from '@vltpkg/security-archive'
+import { asSecurityArchiveLike } from '@vltpkg/security-archive'
 import { getSimpleGraph } from '../fixtures/graph.ts'
 import type { ParserState } from '../../src/types.ts'
 import { trivial } from '../../src/pseudo/trivial.ts'
@@ -26,12 +26,14 @@ t.test('selects packages with a trivial alert', async t => {
       },
       cancellable: async () => {},
       walk: async i => i,
-      securityArchive: new Map([
-        [
-          joinDepIDTuple(['registry', '', 'e@1.0.0']),
-          { alerts: [{ type: 'trivialPackage' }] },
-        ],
-      ]) as unknown as SecurityArchiveLike,
+      securityArchive: asSecurityArchiveLike(
+        new Map([
+          [
+            joinDepIDTuple(['registry', '', 'e@1.0.0']),
+            { alerts: [{ type: 'trivialPackage' }] },
+          ],
+        ]),
+      ),
       specOptions: {},
     }
     return state

--- a/src/query/test/pseudo/trivial.ts
+++ b/src/query/test/pseudo/trivial.ts
@@ -31,7 +31,7 @@ t.test('selects packages with a trivial alert', async t => {
           joinDepIDTuple(['registry', '', 'e@1.0.0']),
           { alerts: [{ type: 'trivialPackage' }] },
         ],
-      ]) as SecurityArchiveLike,
+      ]) as unknown as SecurityArchiveLike,
       specOptions: {},
     }
     return state

--- a/src/query/test/pseudo/undesirable.ts
+++ b/src/query/test/pseudo/undesirable.ts
@@ -1,7 +1,7 @@
 import t from 'tap'
 import postcssSelectorParser from 'postcss-selector-parser'
 import { joinDepIDTuple } from '@vltpkg/dep-id'
-import type { SecurityArchiveLike } from '@vltpkg/security-archive'
+import { asSecurityArchiveLike } from '@vltpkg/security-archive'
 import { getSimpleGraph } from '../fixtures/graph.ts'
 import type { ParserState } from '../../src/types.ts'
 import { undesirable } from '../../src/pseudo/undesirable.ts'
@@ -26,12 +26,14 @@ t.test('selects packages with an undesirable alert', async t => {
       },
       cancellable: async () => {},
       walk: async i => i,
-      securityArchive: new Map([
-        [
-          joinDepIDTuple(['registry', '', 'e@1.0.0']),
-          { alerts: [{ type: 'troll' }] },
-        ],
-      ]) as unknown as SecurityArchiveLike,
+      securityArchive: asSecurityArchiveLike(
+        new Map([
+          [
+            joinDepIDTuple(['registry', '', 'e@1.0.0']),
+            { alerts: [{ type: 'troll' }] },
+          ],
+        ]),
+      ),
       specOptions: {},
     }
     return state

--- a/src/query/test/pseudo/undesirable.ts
+++ b/src/query/test/pseudo/undesirable.ts
@@ -31,7 +31,7 @@ t.test('selects packages with an undesirable alert', async t => {
           joinDepIDTuple(['registry', '', 'e@1.0.0']),
           { alerts: [{ type: 'troll' }] },
         ],
-      ]) as SecurityArchiveLike,
+      ]) as unknown as SecurityArchiveLike,
       specOptions: {},
     }
     return state

--- a/src/query/test/pseudo/unknown.ts
+++ b/src/query/test/pseudo/unknown.ts
@@ -1,7 +1,7 @@
 import t from 'tap'
 import postcssSelectorParser from 'postcss-selector-parser'
 import { joinDepIDTuple } from '@vltpkg/dep-id'
-import type { SecurityArchiveLike } from '@vltpkg/security-archive'
+import { asSecurityArchiveLike } from '@vltpkg/security-archive'
 import { getSimpleGraph } from '../fixtures/graph.ts'
 import type { ParserState } from '../../src/types.ts'
 import { unknown } from '../../src/pseudo/unknown.ts'
@@ -26,12 +26,14 @@ t.test('selects packages with an unknown alert', async t => {
       },
       cancellable: async () => {},
       walk: async i => i,
-      securityArchive: new Map([
-        [
-          joinDepIDTuple(['registry', '', 'e@1.0.0']),
-          { alerts: [{ type: 'newAuthor' }] },
-        ],
-      ]) as unknown as SecurityArchiveLike,
+      securityArchive: asSecurityArchiveLike(
+        new Map([
+          [
+            joinDepIDTuple(['registry', '', 'e@1.0.0']),
+            { alerts: [{ type: 'newAuthor' }] },
+          ],
+        ]),
+      ),
       specOptions: {},
     }
     return state

--- a/src/query/test/pseudo/unknown.ts
+++ b/src/query/test/pseudo/unknown.ts
@@ -31,7 +31,7 @@ t.test('selects packages with an unknown alert', async t => {
           joinDepIDTuple(['registry', '', 'e@1.0.0']),
           { alerts: [{ type: 'newAuthor' }] },
         ],
-      ]) as SecurityArchiveLike,
+      ]) as unknown as SecurityArchiveLike,
       specOptions: {},
     }
     return state

--- a/src/query/test/pseudo/unmaintained.ts
+++ b/src/query/test/pseudo/unmaintained.ts
@@ -1,7 +1,7 @@
 import t from 'tap'
 import postcssSelectorParser from 'postcss-selector-parser'
 import { joinDepIDTuple } from '@vltpkg/dep-id'
-import type { SecurityArchiveLike } from '@vltpkg/security-archive'
+import { asSecurityArchiveLike } from '@vltpkg/security-archive'
 import { getSimpleGraph } from '../fixtures/graph.ts'
 import type { ParserState } from '../../src/types.ts'
 import { unmaintained } from '../../src/pseudo/unmaintained.ts'
@@ -26,12 +26,14 @@ t.test('selects packages with an unmaintained alert', async t => {
       },
       cancellable: async () => {},
       walk: async i => i,
-      securityArchive: new Map([
-        [
-          joinDepIDTuple(['registry', '', 'e@1.0.0']),
-          { alerts: [{ type: 'unmaintained' }] },
-        ],
-      ]) as unknown as SecurityArchiveLike,
+      securityArchive: asSecurityArchiveLike(
+        new Map([
+          [
+            joinDepIDTuple(['registry', '', 'e@1.0.0']),
+            { alerts: [{ type: 'unmaintained' }] },
+          ],
+        ]),
+      ),
       specOptions: {},
     }
     return state

--- a/src/query/test/pseudo/unmaintained.ts
+++ b/src/query/test/pseudo/unmaintained.ts
@@ -31,7 +31,7 @@ t.test('selects packages with an unmaintained alert', async t => {
           joinDepIDTuple(['registry', '', 'e@1.0.0']),
           { alerts: [{ type: 'unmaintained' }] },
         ],
-      ]) as SecurityArchiveLike,
+      ]) as unknown as SecurityArchiveLike,
       specOptions: {},
     }
     return state

--- a/src/query/test/pseudo/unpopular.ts
+++ b/src/query/test/pseudo/unpopular.ts
@@ -1,7 +1,7 @@
 import t from 'tap'
 import postcssSelectorParser from 'postcss-selector-parser'
 import { joinDepIDTuple } from '@vltpkg/dep-id'
-import type { SecurityArchiveLike } from '@vltpkg/security-archive'
+import { asSecurityArchiveLike } from '@vltpkg/security-archive'
 import { getSimpleGraph } from '../fixtures/graph.ts'
 import type { ParserState } from '../../src/types.ts'
 import { unpopular } from '../../src/pseudo/unpopular.ts'
@@ -26,12 +26,14 @@ t.test('selects packages with an unpopular alert', async t => {
       },
       cancellable: async () => {},
       walk: async i => i,
-      securityArchive: new Map([
-        [
-          joinDepIDTuple(['registry', '', 'e@1.0.0']),
-          { alerts: [{ type: 'unpopularPackage' }] },
-        ],
-      ]) as unknown as SecurityArchiveLike,
+      securityArchive: asSecurityArchiveLike(
+        new Map([
+          [
+            joinDepIDTuple(['registry', '', 'e@1.0.0']),
+            { alerts: [{ type: 'unpopularPackage' }] },
+          ],
+        ]),
+      ),
       specOptions: {},
     }
     return state

--- a/src/query/test/pseudo/unpopular.ts
+++ b/src/query/test/pseudo/unpopular.ts
@@ -31,7 +31,7 @@ t.test('selects packages with an unpopular alert', async t => {
           joinDepIDTuple(['registry', '', 'e@1.0.0']),
           { alerts: [{ type: 'unpopularPackage' }] },
         ],
-      ]) as SecurityArchiveLike,
+      ]) as unknown as SecurityArchiveLike,
       specOptions: {},
     }
     return state

--- a/src/query/test/pseudo/unstable.ts
+++ b/src/query/test/pseudo/unstable.ts
@@ -31,7 +31,7 @@ t.test('selects packages with an unstable alert', async t => {
           joinDepIDTuple(['registry', '', 'e@1.0.0']),
           { alerts: [{ type: 'unstableOwnership' }] },
         ],
-      ]) as SecurityArchiveLike,
+      ]) as unknown as SecurityArchiveLike,
       specOptions: {},
     }
     return state

--- a/src/query/test/pseudo/unstable.ts
+++ b/src/query/test/pseudo/unstable.ts
@@ -1,7 +1,7 @@
 import t from 'tap'
 import postcssSelectorParser from 'postcss-selector-parser'
 import { joinDepIDTuple } from '@vltpkg/dep-id'
-import type { SecurityArchiveLike } from '@vltpkg/security-archive'
+import { asSecurityArchiveLike } from '@vltpkg/security-archive'
 import { getSimpleGraph } from '../fixtures/graph.ts'
 import type { ParserState } from '../../src/types.ts'
 import { unstable } from '../../src/pseudo/unstable.ts'
@@ -26,12 +26,14 @@ t.test('selects packages with an unstable alert', async t => {
       },
       cancellable: async () => {},
       walk: async i => i,
-      securityArchive: new Map([
-        [
-          joinDepIDTuple(['registry', '', 'e@1.0.0']),
-          { alerts: [{ type: 'unstableOwnership' }] },
-        ],
-      ]) as unknown as SecurityArchiveLike,
+      securityArchive: asSecurityArchiveLike(
+        new Map([
+          [
+            joinDepIDTuple(['registry', '', 'e@1.0.0']),
+            { alerts: [{ type: 'unstableOwnership' }] },
+          ],
+        ]),
+      ),
       specOptions: {},
     }
     return state

--- a/src/security-archive/src/browser.ts
+++ b/src/security-archive/src/browser.ts
@@ -38,6 +38,11 @@ export class SecurityArchive
   implements SecurityArchiveLike
 {
   /**
+   * Whether the security archive is valid.
+   */
+  ok = false
+
+  /**
    * Loads a security archive from a valid JSON dump.
    */
   static load(dump: unknown) {

--- a/src/security-archive/src/index.ts
+++ b/src/security-archive/src/index.ts
@@ -373,8 +373,6 @@ export class SecurityArchive
    * Outputs the current in-memory cache as a JSON object.
    */
   toJSON() {
-    if (!this.ok) return undefined
-
     const obj: Record<DepID, PackageReportData> = {}
     for (const [key, value] of this.dump()) {
       obj[key] = value.value

--- a/src/security-archive/src/index.ts
+++ b/src/security-archive/src/index.ts
@@ -15,7 +15,7 @@ import type {
   SecurityArchiveRefreshOptions,
 } from './types.ts'
 
-export type * from './types.ts'
+export * from './types.ts'
 
 const SOCKET_API_V0_URL = 'https://api.socket.dev/v0/purl?alerts=true'
 const SOCKET_PUBLIC_API_TOKEN =

--- a/src/security-archive/src/types.ts
+++ b/src/security-archive/src/types.ts
@@ -27,6 +27,7 @@ export interface SecurityArchiveLike {
   delete: (depId: DepID) => void
   has: (depId: DepID) => boolean
   clear: () => void
+  ok: boolean
 }
 
 /**

--- a/src/security-archive/src/types.ts
+++ b/src/security-archive/src/types.ts
@@ -27,7 +27,27 @@ export interface SecurityArchiveLike {
   delete: (depId: DepID) => void
   has: (depId: DepID) => boolean
   clear: () => void
-  ok: boolean
+  ok?: boolean
+}
+
+export const isSecurityArchiveLike = (
+  o: unknown,
+): o is SecurityArchiveLike =>
+  typeof o === 'object' &&
+  o != null &&
+  'get' in o &&
+  'set' in o &&
+  'delete' in o &&
+  'has' in o &&
+  'clear' in o
+
+export const asSecurityArchiveLike = (
+  o: unknown,
+): SecurityArchiveLike => {
+  if (!isSecurityArchiveLike(o)) {
+    throw error('Invalid security archive like', { found: o })
+  }
+  return o
 }
 
 /**

--- a/src/security-archive/test/index.ts
+++ b/src/security-archive/test/index.ts
@@ -205,14 +205,6 @@ ${JSON.stringify(englishDaysReport)}
     'should have removed the borked entry from the database',
   )
 
-  // check that the toJSON method returns undefined
-  // when the archive is in an invalid state (archive.ok=false)
-  t.strictSame(
-    archive.toJSON(),
-    undefined,
-    'should output undefined when the archive is in an invalid state',
-  )
-
   db.close()
 
   await t.test('extraneous package in API response', async t => {

--- a/src/server/src/graph-data.ts
+++ b/src/server/src/graph-data.ts
@@ -64,7 +64,7 @@ const getGraphData = async (
     importers,
     lockfile: graph,
     projectInfo: getProjectData({ packageJson, scurry }, folder),
-    securityArchive: securityArchive.ok ? securityArchive : undefined,
+    securityArchive,
   }
 }
 

--- a/src/server/test/graph-data.ts
+++ b/src/server/test/graph-data.ts
@@ -183,6 +183,7 @@ t.test('graph data for depless vlt project', async t => {
       edges: {},
     },
     projectInfo: { tools: ['vlt'], vltInstalled: true },
+    securityArchive: { ok: false },
   })
 })
 


### PR DESCRIPTION
When present in a query, the `:scanned` selector will throw an error if the current security archive is missing data for any package of the graph being queried. It's a way to validate that a given query checked report data for all packages.

As part of this change, many of the preemptive checks for `securityArchive.ok` were removed and that check is now optionally run at query parsing time, only happening when using the new `:scanned` selector.