### PR TITLE
cli-sdk: add generic error stderr print

### DIFF
--- a/src/cli-sdk/src/print-err.ts
+++ b/src/cli-sdk/src/print-err.ts
@@ -10,9 +10,11 @@ export const printErr = (
   stderr: (...a: unknown[]) => void,
 ) => {
   if (!isErrorRoot(err)) {
-    // TODO: print _something_ here, but we're in weird broken territory
-    // don't just dump it and flood the terminal, though, maybe sniff for code
-    // message, stack, etc?
+    // generic error handling, any errors without a cause will stop here
+    const msg = (err as { message: string }).message
+    if (msg) {
+      stderr(`Error: ${msg}`)
+    }
     return
   }
   if (isErrorRoot(err) && print(err, usage, stderr)) return

--- a/src/cli-sdk/test/print-err.ts
+++ b/src/cli-sdk/test/print-err.ts
@@ -15,9 +15,15 @@ const usage = (() => ({
   usage: () => 'usage',
 })) as unknown as CommandUsage
 
-t.test('if not root error, print nothing', t => {
+t.test('if not an error, print nothing', t => {
   printErr(false, usage, stderr)
   t.strictSame(printed, [])
+  t.end()
+})
+
+t.test('print message for errors with no cause', t => {
+  printErr(new Error('foo bar'), usage, stderr)
+  t.strictSame(printed, [['Error: foo bar']])
   t.end()
 })
 


### PR DESCRIPTION
Error objects that have no `cause` property should still print something to `stderr` to acknowledge the error to the end user.

More specifically this fixes problems with validation code in the `@vltpkg/query` module that will throw errors that don't necessarily have an underlying `Error` cause but rather intentional validation performed by our implementation.

A simple example of usage with this PR is:

```
vlt query ':bork'
Error: Unsupported pseudo-class: :bork
```