### PR TITLE
lk/add generic error message

### DIFF
--- a/src/cli-sdk/src/output.ts
+++ b/src/cli-sdk/src/output.ts
@@ -14,6 +14,7 @@ export const stdout = (...args: unknown[]) => console.log(...args)
 export const stderr = (...args: unknown[]) => console.error(...args)
 
 const identity = <T>(x: T): T => x
+
 export const getView = <T>(
   conf: LoadedConfig,
   views?: Views<T>,
@@ -55,7 +56,11 @@ export const startView = <T>(
   onError?: (err: unknown) => void
 } => {
   const View = getView<T>(conf, views)
-  const opts = { colors: conf.values.color ? chalk : undefined }
+
+  const opts = {
+    colors: conf.values.color ? chalk : undefined,
+  }
+
   if (isViewClass(View)) {
     const view = new View(opts, conf)
     view.start()
@@ -67,14 +72,13 @@ export const startView = <T>(
         view.error(err)
       },
     }
-  } else {
-    return {
-      async onDone(r) {
-        if (r === undefined) return
-        const res = await View(r, opts, conf)
-        return res
-      },
-    }
+  }
+
+  return {
+    async onDone(r) {
+      if (r === undefined) return
+      return View(r, opts, conf)
+    },
   }
 }
 

--- a/src/cli-sdk/src/print-err.ts
+++ b/src/cli-sdk/src/print-err.ts
@@ -10,9 +10,11 @@ export const printErr = (
   stderr: (...a: unknown[]) => void,
 ) => {
   if (!isErrorRoot(err)) {
-    // TODO: print _something_ here, but we're in weird broken territory
-    // don't just dump it and flood the terminal, though, maybe sniff for code
-    // message, stack, etc?
+    // generic error handling, any errors without a cause will stop here
+    const msg = (err as { message: string }).message
+    if (msg) {
+      stderr(`Error: ${msg}`)
+    }
     return
   }
   if (isErrorRoot(err) && print(err, usage, stderr)) return

--- a/src/cli-sdk/src/print-err.ts
+++ b/src/cli-sdk/src/print-err.ts
@@ -1,68 +1,140 @@
 import { isErrorRoot } from '@vltpkg/error-cause'
 import type { ErrorWithCauseObject } from '@vltpkg/error-cause'
 import type { CommandUsage } from './index.ts'
-import type { Spec } from '@vltpkg/spec'
+import type { InspectOptions } from 'node:util'
+import { formatWithOptions } from 'node:util'
+
+export type ErrorFormatOptions = InspectOptions & {
+  maxLines?: number
+}
+
+type Formatter = (
+  arg: unknown,
+  options?: ErrorFormatOptions & { indent?: number },
+) => string
+
+const parseErrorStack = (err: Error) => {
+  if (err.stack) {
+    const lines = err.stack.trim().split('\n')
+    if (lines[0] === `${err.name}: ${err.message}`) {
+      lines.shift()
+    }
+    return lines.join('\n')
+  }
+}
+
+const omit = <T extends object>(obj: T, ...keys: string[]): T => {
+  const entries = Object.entries(obj).filter(
+    ([key]) => !keys.includes(key),
+  )
+  return Object.fromEntries(entries) as T
+}
 
 export const printErr = (
   err: unknown,
   usage: CommandUsage,
-  stderr: (...a: unknown[]) => void,
+  stderr: (...a: string[]) => void,
+  baseOpts?: ErrorFormatOptions,
 ) => {
-  if (isErrorRoot(err)) {
-    return print(err, usage, stderr)
+  const format: Formatter = (arg: unknown, options) => {
+    const {
+      maxLines = 200,
+      indent,
+      ...rest
+    } = {
+      ...baseOpts,
+      ...options,
+    }
+    const lines = formatWithOptions(rest, arg).split('\n')
+    const totalLines = lines.length
+    if (totalLines > maxLines) {
+      lines.length = maxLines
+      lines.push(`... ${totalLines - maxLines} lines hidden ...`)
+    }
+    return (
+      indent && lines.length > 1 ?
+        lines.map(l => ' '.repeat(indent) + l)
+      : lines).join('\n')
   }
-  // We don't know exactly what this is but we need to print something to help
-  // us debug unknown unknown errors especially in the compiled/bundled
-  // versions. The word "Unknown" is a signal that this is different than the
-  // generic handled errors that are printed.
-  const msg = err instanceof Error ? err.message : ''
-  stderr(`Unknown Error${msg ? `: ${msg}` : ''}`)
+
+  // This is an error thrown by us with an error cause object
+  // that we can use to print a more informative error message.
+  if (isErrorRoot(err)) {
+    return print(err, usage, stderr, format)
+  }
+
+  // We have an error but it's not one we know about.
+  // Just print it as best we can.
+  if (err instanceof Error) {
+    stderr(`Unknown ${err.name}: ${err.message}`)
+    const stack = parseErrorStack(err)
+    if (stack) {
+      stderr(`  Stack:`)
+      stderr(format(stack, { indent: 4 }))
+    }
+    return
+  }
+
+  // We don't know what this is, just print it.
+  stderr(`Unknown Error:`, format(err))
 }
 
 const print = (
   err: ErrorWithCauseObject,
   usage: CommandUsage,
-  stderr: (...a: unknown[]) => void,
+  stderr: (...a: string[]) => void,
+  format: Formatter,
 ) => {
-  switch (err.cause.code) {
+  const { cause, message, name } = err
+  const { code } = cause
+
+  switch (code) {
     case 'EUSAGE': {
+      const { found, validOptions } = cause
       stderr(usage().usage())
-      stderr(`Error: ${err.message}`)
-      if (err.cause.found) {
-        stderr(`  Found: ${err.cause.found}`)
+      stderr(`Usage Error: ${message}`)
+      if (found) {
+        stderr(`  Found:`, format(found, { indent: 2 }))
       }
-      if (err.cause.validOptions) {
-        stderr(
-          `  Valid options: ${err.cause.validOptions.join(', ')}`,
-        )
+      if (validOptions) {
+        stderr(`  Valid options: ${validOptions.join(', ')}`)
       }
       return
     }
 
     case 'ERESOLVE': {
-      stderr(`Resolve Error: ${err.message}`)
-      const { url, from, response, spec } = err.cause
+      const { url, from, response, spec } = cause
+      stderr(`Resolve Error: ${message}`)
       if (url) {
         stderr(`  While fetching: ${url}`)
       }
       if (spec) {
-        stderr(`  To satisfy: ${spec as string | Spec}`)
+        stderr(`  To satisfy:`, format(spec, { indent: 2 }))
       }
       if (from) {
         stderr(`  From: ${from}`)
       }
       if (response) {
-        stderr('Response:', response)
+        stderr('  Response:', format(response, { indent: 2 }))
       }
       return
     }
 
+    // If we have not written a formatter for this error code yet,
+    // do our best to print some relevant information from it for
+    // debugging without showing too much since the cause could
+    // be nested and large.
     default: {
-      // We know it is one of our errors but the cause could be large so we
-      // don't dump the whole thing to the terminal. Codes should be added as
-      // cases above to specifically handle causes that can be really long.
-      const code = err.cause.code ? `${err.cause.code} ` : ''
-      stderr(`${code}Error: ${err.message}`)
+      stderr(`${name}: ${message}`)
+      if (code) {
+        stderr(`  Code: ${code}`)
+      }
+      stderr(`  Cause:`, format(omit(cause, 'code'), { indent: 2 }))
+      const stack = parseErrorStack(err)
+      if (stack) {
+        stderr(`  Stack:`)
+        stderr(format(stack, { indent: 4 }))
+      }
       return
     }
   }

--- a/src/cli-sdk/src/view.ts
+++ b/src/cli-sdk/src/view.ts
@@ -27,7 +27,7 @@ export class ViewClass<T = unknown> {
   // run the command", for example to have the gui just open a web browser
   // to the page relevant to a given thing, rather than computing it twice
   start() {}
-  done(_result: T, _opts: { time: number }): undefined | string {
+  done(_result: T, _opts: { time: number }): unknown {
     return
   }
   error(_err: unknown) {}

--- a/src/cli-sdk/test/output.ts
+++ b/src/cli-sdk/test/output.ts
@@ -41,13 +41,13 @@ t.test('getView', async t => {
   const json = (x: unknown) => x
   const human = (x: unknown) => x
   const x = {}
-  const options = {} as unknown as ViewOptions
+  const options: ViewOptions = {}
   const confJson = {
     values: { view: 'json' },
-  } as unknown as LoadedConfig
+  } as LoadedConfig
   const confHuman = {
     values: { view: 'human' },
-  } as unknown as LoadedConfig
+  } as LoadedConfig
   t.equal(getView(confJson, { json, human }), json)
   const id = getView(confHuman) as ViewFn
   const xx = id(x, options, confHuman)
@@ -55,12 +55,12 @@ t.test('getView', async t => {
 
   const confGui = {
     values: { view: 'gui' },
-  } as unknown as LoadedConfig
+  } as LoadedConfig
   process.env.VLT_VIEW = 'gui'
   const gui = getView(confGui, { json, human })
   t.equal(gui, json, 'json view was returned for unknown view name')
   t.equal(process.env.VLT_VIEW, 'json', 'set view config to default')
-  const viewFn = (() => {}) as unknown as ViewFn<true>
+  const viewFn = (() => {}) as ViewFn<true>
   t.equal(getView(confHuman, viewFn), viewFn)
   t.end()
 })
@@ -68,16 +68,16 @@ t.test('getView', async t => {
 t.test('startView', async t => {
   const confJson = {
     values: { view: 'json', color: false },
-  } as unknown as LoadedConfig
+  } as LoadedConfig
   const confHuman = {
     values: { view: 'human', color: true },
-  } as unknown as LoadedConfig
+  } as LoadedConfig
   const confMermaid = {
     values: { view: 'mermaid' },
-  } as unknown as LoadedConfig
+  } as LoadedConfig
   const confGui = {
     values: { view: 'gui' },
-  } as unknown as LoadedConfig
+  } as LoadedConfig
 
   let startCalled = false
   let doneCalled = false
@@ -102,11 +102,9 @@ t.test('startView', async t => {
   }
 
   t.test('using view class', async t => {
-    const { onDone, onError } = startView(
-      confHuman as unknown as LoadedConfig,
-      views,
-      { start: 100 },
-    )
+    const { onDone, onError } = startView(confHuman, views, {
+      start: 100,
+    })
     t.equal(startCalled, true)
     t.equal(doneCalled, false)
     t.equal(errCalled, false)
@@ -120,32 +118,25 @@ t.test('startView', async t => {
   })
 
   t.test('using a view function for JSON', async t => {
-    const { onDone, onError } = startView(
-      confJson as unknown as LoadedConfig,
-      views,
-    )
+    const { onDone, onError } = startView(confJson, views)
     t.equal(onError, undefined)
-    t.equal(await onDone(true), 'true')
-    t.equal(await onDone(undefined as unknown as true), undefined)
+    t.equal(await onDone(true), true)
+    // @ts-expect-error - testing error case
+    t.equal(await onDone(undefined), undefined)
     t.end()
   })
 
   t.test('using a view function not json', async t => {
-    const { onDone, onError } = startView(
-      confMermaid as unknown as LoadedConfig,
-      views,
-    )
+    const { onDone, onError } = startView(confMermaid, views)
     t.equal(onError, undefined)
-    t.equal(await onDone(true), '{ underthesea: true }')
-    t.equal(await onDone(undefined as unknown as true), undefined)
+    t.strictSame(await onDone(true), { underthesea: true })
+    // @ts-expect-error - testing error case
+    t.equal(await onDone(undefined), undefined)
     t.end()
   })
 
   t.test('using a view that returns undefined', async t => {
-    const { onDone, onError } = startView(
-      confGui as unknown as LoadedConfig,
-      views,
-    )
+    const { onDone, onError } = startView(confGui, views)
     t.equal(onError, undefined)
     t.equal(typeof (await onDone(true)), 'undefined')
     t.end()
@@ -155,26 +146,26 @@ t.test('startView', async t => {
 t.test('outputCommand', async t => {
   const confJson = {
     values: { view: 'json' },
-    get: () => false,
-  } as unknown as LoadedConfig
+    get: (_k: 'color') => false,
+  } as LoadedConfig
   const confHuman = {
     values: { view: 'human' },
-    get: () => false,
-  } as unknown as LoadedConfig
+    get: (_k: 'color') => false,
+  } as LoadedConfig
   const confInspect = {
     values: { view: 'inspect' },
-    get: () => false,
-  } as unknown as LoadedConfig
+    get: (_k: 'color') => false,
+  } as LoadedConfig
   const confHelp = {
     values: { help: true },
-    get: () => true,
-  } as unknown as LoadedConfig
+    get: (_k: 'color') => true,
+  } as LoadedConfig
 
   const cliCommand: Command<true> = {
     async command() {
       return true
     },
-    usage: () => ({ usage: () => 'usage' }) as unknown as Jack,
+    usage: () => ({ usage: () => 'usage' }) as Jack,
     views: {
       json: x => x,
       human: x => ({ ohthehumanity: x }),

--- a/src/cli-sdk/test/print-err.ts
+++ b/src/cli-sdk/test/print-err.ts
@@ -15,9 +15,15 @@ const usage = (() => ({
   usage: () => 'usage',
 })) as unknown as CommandUsage
 
-t.test('if not root error, print nothing', t => {
+t.test('if not an error, print nothing', t => {
   printErr(false, usage, stderr)
   t.strictSame(printed, [])
+  t.end()
+})
+
+t.test('print message for errors with no cause', t => {
+  printErr(new Error('foo bar'), usage, stderr)
+  t.strictSame(printed, [['Error: foo bar']])
   t.end()
 })
 

--- a/src/error-cause/src/index.ts
+++ b/src/error-cause/src/index.ts
@@ -82,7 +82,7 @@ export type ErrorCauseObject = {
    * Array of valid options when something is not a valid option.
    * (For use in `did you mean X?` output.)
    */
-  validOptions?: any[]
+  validOptions?: unknown[]
 
   /**
    * message indicating what bit of work this might be a part of, what feature
@@ -94,10 +94,10 @@ export type ErrorCauseObject = {
    * A desired value that was not found, or a regular expression or other
    * pattern describing it.
    */
-  wanted?: any
+  wanted?: unknown
 
   /** actual value, which was not wanted */
-  found?: any
+  found?: unknown
 
   /** HTTP message, fetch.Response, or `@vltpkg/registry-client.CacheEntry` */
   response?:
@@ -152,10 +152,10 @@ export type ErrorCauseObject = {
   }
 
   /** maximum value, which was exceeded */
-  max?: any
+  max?: unknown
 
   /** minimum value, which was not met */
-  min?: any
+  min?: unknown
 }
 
 export type DuckTypeManifest = Record<string, any> & {
@@ -239,37 +239,39 @@ type ErrorCtor<T extends Error> = new (
   options?: { cause: ErrorCause },
 ) => T
 
+export type From = ((...a: any[]) => any) | (new (...a: any[]) => any)
+
 function create<T extends Error>(
   cls: ErrorCtor<T>,
-  defaultFrom: ((...a: any[]) => any) | (new (...a: any[]) => any),
+  defaultFrom: From,
   message: string,
   cause?: undefined,
   from?: From,
 ): T
 function create<T extends Error>(
   cls: ErrorCtor<T>,
-  defaultFrom: ((...a: any[]) => any) | (new (...a: any[]) => any),
+  defaultFrom: From,
   message: string,
   cause?: ErrorCauseObject,
   from?: From,
 ): T & { cause: ErrorCauseObject }
 function create<T extends Error>(
   cls: ErrorCtor<T>,
-  defaultFrom: ((...a: any[]) => any) | (new (...a: any[]) => any),
+  defaultFrom: From,
   message: string,
   cause?: Error,
   from?: From,
 ): T & { cause: Error }
 function create<T extends Error>(
   cls: ErrorCtor<T>,
-  defaultFrom: ((...a: any[]) => any) | (new (...a: any[]) => any),
+  defaultFrom: From,
   message: string,
   cause?: ErrorCause,
   from?: From,
 ): T & { cause: ErrorCause }
 function create<T extends Error>(
   cls: ErrorCtor<T>,
-  defaultFrom: ((...a: any[]) => any) | (new (...a: any[]) => any),
+  defaultFrom: From,
   message: string,
   cause?: ErrorCause,
   from: From = defaultFrom,
@@ -279,8 +281,6 @@ function create<T extends Error>(
   Error.captureStackTrace?.(er, from)
   return er
 }
-
-export type From = ((...a: any[]) => any) | (new (...a: any[]) => any)
 
 export function error(
   message: string,


### PR DESCRIPTION
Replaces #570. This is slightly different than #570 but I think accomplishes the same goal.

There are two scenarios this PR addresses:

**Known Errors with codes where we dont yet support detailed errors**

When we have known root error but haven't explicitly handled the code output a shorter message instead of the full error object. This prevents outputting pages of error messaging when there is a large error cause during commands like `install`. I've seen cases where the output exceeds the terminal buffer making debugging difficult.

```
ECODE Error: This is the error message
```

**Unknown Errors**

For unknown errors always print _something_. This wasn't as necessary originally but as we experiment with runtimes there are many errors we can't foresee and so always printing something at least gives us a place to start debugging.

```
Uknown Error: This is the error message
```