### PR TITLE
fix `rollback-remove` when compiled

### DIFF
--- a/infra/smoke-test/test/rollback-remove.ts
+++ b/infra/smoke-test/test/rollback-remove.ts
@@ -1,0 +1,36 @@
+import t from 'tap'
+import { runMultiple } from './fixtures/run.ts'
+import { defaultVariants } from './fixtures/variants.ts'
+import { setTimeout } from 'node:timers/promises'
+import { readdirSync } from 'node:fs'
+import { join } from 'node:path'
+
+const findRollbacks = (dir: string) =>
+  readdirSync(dir, {
+    withFileTypes: true,
+  }).filter(f => f.name.startsWith('.VLT.DELETE.'))
+
+t.test('removes rollbacks after a successful install', async t => {
+  const { status } = await runMultiple(
+    t,
+    ['install', 'abbrev@2.0.0'],
+    {
+      packageJson: true,
+      variants: [...defaultVariants, 'denoBundle', 'denoSource'],
+      test: async (t, { dirs, run }) => {
+        await setTimeout(1000)
+        await run(['install', 'abbrev@3.0.0'])
+        await setTimeout(1000)
+        t.strictSame(
+          [
+            ...findRollbacks(join(dirs.project, 'node_modules')),
+            ...findRollbacks(join(dirs.project, 'node_modules/.vlt')),
+          ],
+          [],
+          'rollbacks have been cleaned up',
+        )
+      },
+    },
+  )
+  t.equal(status, 0)
+})

--- a/src/cache-unzip/src/index.ts
+++ b/src/cache-unzip/src/index.ts
@@ -24,7 +24,10 @@ const handleBeforeExit = () => {
     if (!r.size) return
     const env = { ...process.env }
     const args = []
-    /* c8 ignore start */
+    // Deno on Windows does not support detached processes
+    // https://github.com/denoland/deno/issues/25867
+    // TODO: figure out something better to do here?
+    const detached = !(isDeno && process.platform === 'win32')
     // When compiled the script to be run is passed as an
     // environment variable and then routed by the main entry point
     if (process.env.__VLT_INTERNAL_COMPILED) {
@@ -42,15 +45,9 @@ const handleBeforeExit = () => {
           '--unstable-bare-node-builtins',
         )
       }
-      /* c8 ignore stop */
       args.push(__CODE_SPLIT_SCRIPT_NAME, path)
     }
     registered.delete(path)
-    // Deno on Windows does not support detached processes
-    // https://github.com/denoland/deno/issues/25867
-    // TODO: figure out something better to do here?
-    /* c8 ignore next */
-    const detached = !(isDeno && process.platform === 'win32')
     const proc = spawn(process.execPath, args, {
       detached,
       stdio: ['pipe', 'ignore', 'ignore'],

--- a/src/rollback-remove/src/index.ts
+++ b/src/rollback-remove/src/index.ts
@@ -3,6 +3,10 @@ import { rename } from 'node:fs/promises'
 import { basename, dirname } from 'node:path'
 import { rimraf } from 'rimraf'
 import { __CODE_SPLIT_SCRIPT_NAME } from './remove.ts'
+import { pathToFileURL } from 'node:url'
+
+const isDeno =
+  (globalThis as typeof globalThis & { Deno?: any }).Deno != undefined
 
 export class RollbackRemove {
   #key = String(Math.random()).substring(2)
@@ -25,19 +29,42 @@ export class RollbackRemove {
     // nothing to confirm!
     if (!this.#paths.size) return
 
-    const child = spawn(
-      process.execPath,
-      [__CODE_SPLIT_SCRIPT_NAME],
-      {
-        stdio: ['pipe', 'ignore', 'ignore'],
-        detached: true,
-      },
-    )
-    child.unref()
+    const env = { ...process.env }
+    const args = []
+    // Deno on Windows does not support detached processes
+    // https://github.com/denoland/deno/issues/25867
+    // TODO: figure out something better to do here?
+    const detached = !(isDeno && process.platform === 'win32')
+    // When compiled the script to be run is passed as an
+    // environment variable and then routed by the main entry point
+    if (process.env.__VLT_INTERNAL_COMPILED) {
+      env.__VLT_INTERNAL_MAIN = pathToFileURL(
+        __CODE_SPLIT_SCRIPT_NAME,
+      ).toString()
+    } else {
+      // If we are running deno from source we need to add the
+      // unstable flags we need. The '-A' flag does not need
+      // to be passed in as Deno supplies that automatically.
+      if (isDeno) {
+        args.push(
+          '--unstable-node-globals',
+          '--unstable-bare-node-builtins',
+        )
+      }
+      args.push(__CODE_SPLIT_SCRIPT_NAME)
+    }
+    const child = spawn(process.execPath, args, {
+      stdio: ['pipe', 'ignore', 'ignore'],
+      detached,
+      env,
+    })
     for (const path of this.#paths.values()) {
       child.stdin.write(path + '\u0000')
     }
     child.stdin.end()
+    if (detached) {
+      child.unref()
+    }
     this.#paths.clear()
   }
 

--- a/src/rollback-remove/src/remove.ts
+++ b/src/rollback-remove/src/remove.ts
@@ -1,6 +1,11 @@
+import { pathToFileURL } from 'node:url'
 import { rimraf } from 'rimraf'
 
 export const __CODE_SPLIT_SCRIPT_NAME = import.meta.filename
+
+const isMain = (path?: string) =>
+  path === __CODE_SPLIT_SCRIPT_NAME ||
+  path === pathToFileURL(__CODE_SPLIT_SCRIPT_NAME).toString()
 
 // This is run as a background process, and all the paths to
 // be removed written into stdin. We can't pass on argv, because
@@ -17,6 +22,10 @@ const main = () => {
   })
 }
 
-if (process.argv[1] === import.meta.filename) {
+const g = globalThis as typeof globalThis & {
+  __VLT_INTERNAL_MAIN?: string
+}
+
+if (isMain(g.__VLT_INTERNAL_MAIN ?? process.argv[1])) {
   main()
 }

--- a/src/rollback-remove/test/index.ts
+++ b/src/rollback-remove/test/index.ts
@@ -1,70 +1,92 @@
+import assert from 'node:assert'
 import type { SpawnOptions } from 'node:child_process'
 import { readdirSync } from 'node:fs'
 import t from 'tap'
+import type { Test } from 'tap'
 
-const spawns: MockSpawn[] = []
-t.beforeEach(() => (spawns.length = 0))
-
-type MockSpawn = {
-  cmd: string
-  args: string[]
-  options: SpawnOptions
-  written: Buffer[]
-  stdinEnded: boolean
-  stdin: {
-    write: (chunk: Buffer) => any
-    end: () => any
-  }
-  reffed: boolean
-  unref: () => any
-}
-
-const mockSpawn = (
-  cmd: string,
-  args: string[],
-  options: SpawnOptions,
-): MockSpawn => {
-  const cp = {
-    cmd,
-    args,
-    options,
-    written: [] as Buffer[],
-    stdinEnded: false,
+const mockRollbackRemove = async (
+  t: Test,
+  { testdir }: { testdir: Parameters<Test['testdir']>[0] },
+) => {
+  type MockSpawn = {
+    cmd: string
+    args: string[]
+    options: SpawnOptions
+    written: Buffer[]
+    stdinEnded: boolean
     stdin: {
-      write: (chunk: Buffer) => cp.written.push(chunk),
-      end: () => (cp.stdinEnded = true),
-    },
-    reffed: true,
-    unref: () => (cp.reffed = false),
+      write: (chunk: Buffer) => any
+      end: () => any
+    }
+    reffed: boolean
+    unref: () => any
   }
-  spawns.push(cp)
-  return cp
+
+  let mockedSpawn: MockSpawn | null = null
+
+  const mockSpawn = (
+    cmd: string,
+    args: string[],
+    options: SpawnOptions,
+  ): MockSpawn => {
+    const cp = {
+      cmd,
+      args,
+      options,
+      written: [] as Buffer[],
+      stdinEnded: false,
+      stdin: {
+        write: (chunk: Buffer) => cp.written.push(chunk),
+        end: () => (cp.stdinEnded = true),
+      },
+      reffed: true,
+      unref: () => (cp.reffed = false),
+    }
+    mockedSpawn = cp
+    return cp
+  }
+
+  const { RollbackRemove } = await t.mockImport<
+    typeof import('../src/index.ts')
+  >('../src/index.ts', {
+    child_process: {
+      spawn: mockSpawn,
+    },
+  })
+
+  t.chdir(t.testdir(testdir))
+
+  return {
+    remover: new RollbackRemove(),
+    hasSpawned: () => mockedSpawn !== null,
+    getSpawn: () => {
+      assert(mockedSpawn)
+      return mockedSpawn
+    },
+  }
 }
 
 t.test('delete some stuff', async t => {
-  const { RollbackRemove } = await t.mockImport<
-    typeof import('../src/index.ts')
-  >('../src/index.ts', {
-    child_process: {
-      spawn: mockSpawn,
+  const { remover, getSpawn, hasSpawned } = await mockRollbackRemove(
+    t,
+    {
+      testdir: {
+        a: {
+          b: '',
+          c: '',
+        },
+        d: {
+          e: '',
+          f: '',
+        },
+      },
     },
-  })
-  t.chdir(
-    t.testdir({
-      a: {
-        b: '',
-        c: '',
-      },
-      d: {
-        e: '',
-        f: '',
-      },
-    }),
   )
-  const remover = new RollbackRemove()
+
   // no-op if nothing has been removed
   remover.confirm()
-  t.strictSame(spawns, [])
+  t.strictSame(hasSpawned(), false)
+
   await remover.rm('a/b')
   await remover.rm('d')
   await remover.rm('noent')
@@ -76,32 +98,24 @@ t.test('delete some stuff', async t => {
     new Set(readdirSync(t.testdirName)),
     new Set([/^\.VLT\.DELETE\.[0-9]+\.d$/, 'a']),
   )
+
   remover.confirm()
-  t.matchStrict(spawns, [
-    {
-      cmd: process.execPath,
-      args: [/[\\/]remove\.ts$/],
-      options: { detached: true },
-      written: [
-        /^a[\\/]\.VLT\.DELETE\.[0-9]+\.b\x00$/,
-        /^.[\\/]\.VLT\.DELETE\.[0-9]+\.d\x00$/,
-      ],
-      stdinEnded: true,
-      reffed: false,
-    },
-  ])
+  t.matchStrict(getSpawn(), {
+    cmd: process.execPath,
+    args: [/[\\/]remove\.ts$/],
+    options: { detached: true },
+    written: [
+      /^a[\\/]\.VLT\.DELETE\.[0-9]+\.b\x00$/,
+      /^.[\\/]\.VLT\.DELETE\.[0-9]+\.d\x00$/,
+    ],
+    stdinEnded: true,
+    reffed: false,
+  })
 })
 
 t.test('do not delete some stuff', async t => {
-  const { RollbackRemove } = await t.mockImport<
-    typeof import('../src/index.ts')
-  >('../src/index.ts', {
-    child_process: {
-      spawn: mockSpawn,
-    },
-  })
-  t.chdir(
-    t.testdir({
+  const { remover, hasSpawned } = await mockRollbackRemove(t, {
+    testdir: {
       a: {
         b: '',
         c: '',
@@ -110,12 +124,13 @@ t.test('do not delete some stuff', async t => {
         e: '',
         f: '',
       },
-    }),
-  )
-  const remover = new RollbackRemove()
+    },
+  })
+
   // no-op if nothing has been removed
   remover.confirm()
-  t.strictSame(spawns, [])
+  t.strictSame(hasSpawned(), false)
+
   await remover.rm('a/b')
   await remover.rm('d')
   await remover.rm('noent')
@@ -127,11 +142,113 @@ t.test('do not delete some stuff', async t => {
     new Set(readdirSync(t.testdirName)),
     new Set([/^\.VLT\.DELETE\.[0-9]+\.d$/, 'a']),
   )
+
   await remover.rollback()
-  t.strictSame(spawns, [])
+  t.strictSame(hasSpawned(), false)
   t.strictSame(new Set(readdirSync('a')), new Set(['b', 'c']))
   t.strictSame(
     new Set(readdirSync(t.testdirName)),
     new Set(['d', 'a']),
   )
+})
+
+t.test('compiled', async t => {
+  t.intercept(process, 'env', {
+    value: { __VLT_INTERNAL_COMPILED: 'true' },
+  })
+
+  const { remover, getSpawn } = await mockRollbackRemove(t, {
+    testdir: {
+      a: {
+        b: '',
+      },
+    },
+  })
+
+  await remover.rm('a/b')
+
+  remover.confirm()
+
+  t.matchStrict(getSpawn(), {
+    args: [],
+    options: {
+      detached: true,
+      env: {
+        __VLT_INTERNAL_MAIN: /^file:.*[\\/]remove\.ts$/,
+      },
+    },
+    reffed: false,
+  })
+})
+
+t.test('deno', async t => {
+  t.intercept(
+    globalThis as typeof globalThis & { Deno?: any },
+    'Deno',
+    {
+      value: {},
+    },
+  )
+
+  t.intercept(process, 'platform', { value: 'linux' })
+
+  const { remover, getSpawn } = await mockRollbackRemove(t, {
+    testdir: {
+      a: {
+        b: '',
+      },
+    },
+  })
+
+  await remover.rm('a/b')
+
+  remover.confirm()
+
+  t.matchStrict(getSpawn(), {
+    args: [
+      '--unstable-node-globals',
+      '--unstable-bare-node-builtins',
+      /[\\/]remove\.ts$/,
+    ],
+    options: {
+      detached: true,
+    },
+    reffed: false,
+  })
+})
+
+t.test('deno + windows', async t => {
+  t.intercept(
+    globalThis as typeof globalThis & { Deno?: any },
+    'Deno',
+    {
+      value: {},
+    },
+  )
+
+  t.intercept(process, 'platform', { value: 'win32' })
+
+  const { remover, getSpawn } = await mockRollbackRemove(t, {
+    testdir: {
+      a: {
+        b: '',
+      },
+    },
+  })
+
+  await remover.rm('a/b')
+
+  remover.confirm()
+
+  t.matchStrict(getSpawn(), {
+    args: [
+      '--unstable-node-globals',
+      '--unstable-bare-node-builtins',
+      /[\\/]remove\.ts$/,
+    ],
+    options: {
+      detached: false,
+    },
+    reffed: true,
+  })
 })


### PR DESCRIPTION
This does for `rollback-remove` what #553 and #564 and did for `cache-unzip`.

Now that this pattern is better established it also adds some tests for it in both `cache-unzip` and `rollback-remove`.

It also adds a smoke test to assert that `rollback-remove` runs successfully when compiled by installing two different versions of the same package by-to-back and testing that the old version has no `.VLT.DELETE.` files left behind.