### PR TITLE
install: update ink

### DIFF
--- a/infra/build/src/bundle.ts
+++ b/infra/build/src/bundle.ts
@@ -293,14 +293,5 @@ export const bundle = async ({
     { recursive: true },
   )
 
-  // yoga.wasm is loaded at runtime by `ink` so we need to copy
-  // that file to the build directory
-  cpSync(
-    createRequire(
-      createRequire(join(CLI, 'node_modules')).resolve('ink'),
-    ).resolve('yoga-wasm-web/dist/yoga.wasm'),
-    join(outdir, 'yoga.wasm'),
-  )
-
   return { outdir }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -491,11 +491,11 @@ importers:
         specifier: 'catalog:'
         version: 5.3.0
       ink:
-        specifier: ^5.1.0
-        version: 5.1.0(@types/react@18.3.18)(react-devtools-core@4.28.5)(react@18.3.1)
+        specifier: ^5.2.0
+        version: 5.2.0(@types/react@18.3.18)(react-devtools-core@4.28.5)(react@18.3.1)
       ink-spinner:
         specifier: ^5.0.0
-        version: 5.0.0(ink@5.1.0(@types/react@18.3.18)(react-devtools-core@4.28.5)(react@18.3.1))(react@18.3.1)
+        version: 5.0.0(ink@5.2.0(@types/react@18.3.18)(react-devtools-core@4.28.5)(react@18.3.1))(react@18.3.1)
       jackspeak:
         specifier: ^4.0.3
         version: 4.0.3
@@ -6031,8 +6031,8 @@ packages:
       ink: '>=4.0.0'
       react: '>=18.0.0'
 
-  ink@5.1.0:
-    resolution: {integrity: sha512-3vIO+CU4uSg167/dZrg4wHy75llUINYXxN4OsdaCkE40q4zyOTPwNc2VEpLnnWsIvIQeo6x6lilAhuaSt+rIsA==}
+  ink@5.2.0:
+    resolution: {integrity: sha512-gHzSBBvsh/1ZYuGi+aKzU7RwnYIr6PSz56or9T90i4DDS99euhN7nYKOMR3OTev0dKIB6Zod3vSapYzqoilQcg==}
     engines: {node: '>=18'}
     peerDependencies:
       '@types/react': '>=18.0.0'
@@ -8630,8 +8630,8 @@ packages:
     resolution: {integrity: sha512-GQHQqAopRhwU8Kt1DDM8NjibDXHC8eoh1erhGAJPEyveY9qqVeXvVikNKrDz69sHowPMorbPUrH/mx8c50eiBQ==}
     engines: {node: '>=18'}
 
-  yoga-wasm-web@0.3.3:
-    resolution: {integrity: sha512-N+d4UJSJbt/R3wqY7Coqs5pcV0aUj2j9IaQ3rNj9bVCLld8tTGKRa2USARjnvZJWVx1NDmQev8EknoczaOQDOA==}
+  yoga-layout@3.2.1:
+    resolution: {integrity: sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ==}
 
   zod-to-json-schema@3.23.5:
     resolution: {integrity: sha512-5wlSS0bXfF/BrL4jPAbz9da5hDlDptdEppYfe+x4eIJ7jioqKG9uUxOwPzqof09u/XeVdrgFu29lZi+8XNDJtA==}
@@ -10919,7 +10919,7 @@ snapshots:
       '@tapjs/core': 4.0.1(@types/node@22.13.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@tapjs/stack': 4.0.0
       chalk: 5.3.0
-      ink: 5.1.0(@types/react@18.3.18)(react-devtools-core@4.28.5)(react@18.3.1)
+      ink: 5.2.0(@types/react@18.3.18)(react-devtools-core@4.28.5)(react@18.3.1)
       minipass: 7.1.2
       ms: 2.1.3
       patch-console: 2.0.0
@@ -13237,13 +13237,13 @@ snapshots:
 
   ini@4.1.3: {}
 
-  ink-spinner@5.0.0(ink@5.1.0(@types/react@18.3.18)(react-devtools-core@4.28.5)(react@18.3.1))(react@18.3.1):
+  ink-spinner@5.0.0(ink@5.2.0(@types/react@18.3.18)(react-devtools-core@4.28.5)(react@18.3.1))(react@18.3.1):
     dependencies:
       cli-spinners: 2.9.2
-      ink: 5.1.0(@types/react@18.3.18)(react-devtools-core@4.28.5)(react@18.3.1)
+      ink: 5.2.0(@types/react@18.3.18)(react-devtools-core@4.28.5)(react@18.3.1)
       react: 18.3.1
 
-  ink@5.1.0(@types/react@18.3.18)(react-devtools-core@4.28.5)(react@18.3.1):
+  ink@5.2.0(@types/react@18.3.18)(react-devtools-core@4.28.5)(react@18.3.1):
     dependencies:
       '@alcalzone/ansi-tokenize': 0.1.3
       ansi-escapes: 7.0.0
@@ -13269,7 +13269,7 @@ snapshots:
       widest-line: 5.0.0
       wrap-ansi: 9.0.0
       ws: 8.18.0
-      yoga-wasm-web: 0.3.3
+      yoga-layout: 3.2.1
     optionalDependencies:
       '@types/react': 18.3.18
       react-devtools-core: 4.28.5
@@ -16456,7 +16456,7 @@ snapshots:
 
   yoctocolors@2.1.1: {}
 
-  yoga-wasm-web@0.3.3: {}
+  yoga-layout@3.2.1: {}
 
   zod-to-json-schema@3.23.5(zod@3.23.8):
     dependencies:

--- a/src/cli-sdk/package.json
+++ b/src/cli-sdk/package.json
@@ -43,7 +43,7 @@
     "@vltpkg/xdg": "workspace:*",
     "ansi-to-pre": "^1.0.5",
     "chalk": "catalog:",
-    "ink": "^5.1.0",
+    "ink": "^5.2.0",
     "ink-spinner": "^5.0.0",
     "jackspeak": "^4.0.3",
     "package-json-from-dist": "catalog:",


### PR DESCRIPTION
With the latest version of ink we no longer need to manually
copy the yoga.wasm file to our bundled directory
