### PR TITLE
error-cause: more generic type checks

### DIFF
--- a/src/cli-sdk/src/exec-command.ts
+++ b/src/cli-sdk/src/exec-command.ts
@@ -2,7 +2,7 @@
  * Implementation shared between `vlt run`, `vlt run-exec`, and `vlt exec`
  */
 
-import { error, isErrorRoot } from '@vltpkg/error-cause'
+import { error, isErrorWithCause } from '@vltpkg/error-cause'
 import { isRunResult } from '@vltpkg/run'
 import type {
   exec,
@@ -94,7 +94,7 @@ export class ExecCommand<B extends RunnerBG, F extends RunnerFG> {
       if (!failed) stderr(`${ws.path} ${arg0}`)
       const result = await this.bg(this.bgArg(ws)).catch(
         (er: unknown) => {
-          if (isErrorRoot(er) && isRunResult(er.cause)) {
+          if (isErrorWithCause(er) && isRunResult(er.cause)) {
             this.printResult(ws, er.cause)
           }
           failed = true

--- a/src/cli-sdk/src/print-err.ts
+++ b/src/cli-sdk/src/print-err.ts
@@ -1,5 +1,5 @@
-import { isErrorRoot } from '@vltpkg/error-cause'
-import type { ErrorWithCauseObject } from '@vltpkg/error-cause'
+import { isErrorWithCode } from '@vltpkg/error-cause'
+import type { ErrorWithCode } from '@vltpkg/error-cause'
 import type { CommandUsage } from './index.ts'
 import type { InspectOptions } from 'node:util'
 import { formatWithOptions } from 'node:util'
@@ -49,7 +49,7 @@ export const printErr = (
   // This is an error with a cause, check if it we know about its
   // code and try to print it. If it did not print then fallback
   // to the next option.
-  if (isErrorRoot(err) && print(err, usage, stderr, format)) {
+  if (isErrorWithCode(err) && print(err, usage, stderr, format)) {
     return
   }
 
@@ -86,7 +86,7 @@ export const printErr = (
 }
 
 const print = (
-  err: ErrorWithCauseObject,
+  err: ErrorWithCode,
   usage: CommandUsage,
   stderr: (...a: string[]) => void,
   format: Formatter,
@@ -125,6 +125,4 @@ const print = (
       return true
     }
   }
-
-  return false
 }

--- a/src/error-cause/test/index.ts
+++ b/src/error-cause/test/index.ts
@@ -2,24 +2,42 @@ import {
   error,
   syntaxError,
   typeError,
-  asErrorCause,
-  isErrorRoot,
   asError,
+  isErrorWithCause,
+  isErrorWithCode,
 } from '../src/index.ts'
+import type { Codes } from '../src/index.ts'
 import t from 'tap'
 
-t.test('setting cause', t => {
-  const cause = { status: 1 }
-  const te = typeError('status is one', cause)
-  t.equal(te.cause, cause)
-  t.end()
+t.test('error types', async t => {
+  t.equal(error('x').name, 'Error')
+  t.equal(typeError('x').name, 'TypeError')
+  t.equal(syntaxError('x').name, 'SyntaxError')
 })
 
-t.test('setting cause about syntax', t => {
-  const cause = { found: 'x', wanted: /[a-b]/ }
-  const te = syntaxError('x is not a or b', cause)
-  t.equal(te.cause, cause)
-  t.end()
+t.test('setting causes', async t => {
+  t.test('object', async t => {
+    const cause = { status: 1 }
+    const er = error('status is one', cause)
+    t.strictSame(er.cause, cause)
+  })
+
+  t.test('error', async t => {
+    const cause = new Error('foo')
+    const er = error('msg', cause)
+    t.strictSame(er.cause, cause)
+  })
+
+  t.test('error try/catch', async t => {
+    let cause: unknown = null
+    try {
+      throw new Error('foo')
+    } catch (er) {
+      cause = er
+    }
+    const er = error('msg', { cause })
+    t.strictSame(er.cause, { cause })
+  })
 })
 
 t.test('invalid causes cause TS errors', t => {
@@ -28,11 +46,11 @@ t.test('invalid causes cause TS errors', t => {
   //@ts-expect-error
   error('x', { code: 1 })
   //@ts-expect-error
-  typeError('x', { code: 123 })
+  error('x', { code: 123 })
   //@ts-expect-error
-  typeError('x', { code: 'E_I_AM_SO_CREATIVE' })
+  error('x', { code: 'E_I_AM_SO_CREATIVE' })
   //@ts-expect-error
-  syntaxError('x', { status: true })
+  error('x', { status: true })
   //@ts-expect-error
   error('x', { version: true })
   //@ts-expect-error
@@ -52,32 +70,66 @@ t.test('stack pruning', t => {
   t.end()
 })
 
-t.test('asErrorCause', t => {
-  const err = new Error('an error')
-  t.strictSame(asErrorCause(err), err)
-  const errCause = { code: 'ok' }
-  t.strictSame(asErrorCause(errCause), errCause)
-  t.match(asErrorCause(0), new Error('0'))
-  t.match(asErrorCause(false), new Error('false'))
-  t.match(asErrorCause(true), new Error('true'))
-  const unknownErr = new Error('Unknown error')
-  t.match(asErrorCause(''), unknownErr)
-  t.match(asErrorCause(null), unknownErr)
-  t.match(asErrorCause(undefined), unknownErr)
-  t.match(asErrorCause([]), unknownErr)
-  t.end()
-})
-
-t.test('isErrorRoot', t => {
-  t.equal(isErrorRoot(new Error('', { cause: {} })), true)
-  t.equal(isErrorRoot(new Error('')), false)
-  t.equal(isErrorRoot(new Error('', { cause: null })), false)
-  t.end()
-})
-
 t.test('asError', t => {
   t.ok(asError(new Error('')) instanceof Error)
   t.ok(asError(null) instanceof Error)
   t.ok(asError('').message === 'Unknown error')
   t.end()
+})
+
+t.test('isErrorWithCause type guard', async t => {
+  t.equal(isErrorWithCause(new Error('plain')), false)
+  t.equal(
+    isErrorWithCause(error('with cause', new Error('inner cause'))),
+    true,
+  )
+  t.equal(
+    isErrorWithCause(error('with cause obj', { code: 'ENOENT' })),
+    true,
+  )
+  t.equal(isErrorWithCause({ cause: 'something' }), false) // Not an Error instance
+  t.equal(isErrorWithCause({ message: 'no cause' }), false)
+  t.equal(isErrorWithCause(null), false)
+  t.equal(isErrorWithCause(undefined), false)
+  t.equal(isErrorWithCause('a string'), false)
+  t.equal(isErrorWithCause(123), false)
+})
+
+t.test('isErrorWithCode type guard', async t => {
+  t.equal(
+    isErrorWithCode(error('with code', { code: 'EINTEGRITY' })),
+    true,
+  )
+  t.equal(isErrorWithCode(new Error('plain')), false)
+  t.equal(
+    isErrorWithCode(error('with cause', new Error('inner cause'))),
+    false,
+  )
+  t.equal(
+    isErrorWithCode(error('with cause obj', { path: '/tmp' })),
+    false,
+  )
+  t.equal(
+    isErrorWithCode(
+      error('with invalid code', {
+        code: 'THIS_IS_NOT_A_VALID_CODE' as Codes,
+      }),
+    ),
+    false,
+  )
+  t.equal(
+    isErrorWithCode(
+      error('with non-string code', { code: 123 as any }),
+    ),
+    false,
+  )
+  t.equal(
+    isErrorWithCode(error('with null code', { code: null as any })),
+    false,
+  )
+  t.equal(isErrorWithCode({ cause: { code: 'ENOENT' } }), false)
+  t.equal(isErrorWithCode(null), false)
+  t.equal(isErrorWithCode(undefined), false)
+  t.equal(isErrorWithCode('a string'), false)
+  t.equal(isErrorWithCode(123), false)
 })

--- a/src/package-info/src/index.ts
+++ b/src/package-info/src/index.ts
@@ -1,4 +1,4 @@
-import type { ErrorCauseObject } from '@vltpkg/error-cause'
+import type { ErrorCauseOptions } from '@vltpkg/error-cause'
 import { error } from '@vltpkg/error-cause'
 import { clone, resolve as gitResolve, revs } from '@vltpkg/git'
 import { PackageJson } from '@vltpkg/package-json'
@@ -728,7 +728,7 @@ export class PackageInfoClient {
     spec?: Spec,
     options: PackageInfoClientRequestOptions = {},
     message = 'Could not resolve',
-    extra: ErrorCauseObject = {},
+    extra: ErrorCauseOptions = {},
   ) {
     const { from = this.#projectRoot } = options
     const er = error(

--- a/src/package-json/src/index.ts
+++ b/src/package-json/src/index.ts
@@ -1,5 +1,5 @@
 import { error } from '@vltpkg/error-cause'
-import type { ErrorCauseObject } from '@vltpkg/error-cause'
+import type { ErrorCauseOptions } from '@vltpkg/error-cause'
 import { asManifest, longDependencyTypes } from '@vltpkg/types'
 import type { Manifest } from '@vltpkg/types'
 import { readFileSync, writeFileSync } from 'node:fs'
@@ -20,7 +20,7 @@ export class PackageJson {
   /**
    * cache of load errors
    */
-  #errCache = new Map<string, ErrorCauseObject>()
+  #errCache = new Map<string, ErrorCauseOptions>()
 
   /**
    * Reads and parses contents of a `package.json` file at a directory `dir`.
@@ -34,7 +34,7 @@ export class PackageJson {
 
     const filename = resolve(dir, 'package.json')
 
-    const fail = (err: ErrorCauseObject) =>
+    const fail = (err: ErrorCauseOptions) =>
       error('Could not read package.json file', err, this.read)
 
     const cachedError = !reload && this.#errCache.get(dir)
@@ -50,7 +50,7 @@ export class PackageJson {
       this.#pathCache.set(res, dir)
       return res
     } catch (err) {
-      const ec: ErrorCauseObject = {
+      const ec: ErrorCauseOptions = {
         path: filename,
         cause: err,
       }

--- a/src/promise-spawn/src/index.ts
+++ b/src/promise-spawn/src/index.ts
@@ -1,5 +1,5 @@
 import { error } from '@vltpkg/error-cause'
-import type { ErrorCause } from '@vltpkg/error-cause'
+import type { ErrorCauseOptions } from '@vltpkg/error-cause'
 import { spawn } from 'node:child_process'
 import type {
   ChildProcess,
@@ -265,7 +265,7 @@ export class SpawnPromise<
         signal?: NodeJS.Signals | null,
       ) => {
         const stdio = stdioResult(stdout, stderr, opts)
-        const errorResult: ErrorCause = {
+        const errorResult: ErrorCauseOptions = {
           command,
           args,
           stdout: stdio.stdout,

--- a/src/registry-client/src/cache-entry.ts
+++ b/src/registry-client/src/cache-entry.ts
@@ -19,7 +19,7 @@
 // From there, the body can be of any indeterminate length, and is the rest
 // of the file.
 
-import type { ErrorCauseObject } from '@vltpkg/error-cause'
+import type { ErrorCauseOptions } from '@vltpkg/error-cause'
 import { error } from '@vltpkg/error-cause'
 import type { Integrity, JSONField } from '@vltpkg/types'
 import ccp from 'cache-control-parser'
@@ -276,7 +276,7 @@ export class CacheEntry {
    * Returns true if anything was actually verified.
    */
   checkIntegrity(
-    context: ErrorCauseObject = {},
+    context: ErrorCauseOptions = {},
   ): this is CacheEntry & { integrity: Integrity } {
     if (!this.#integrity) return false
     if (this.integrityActual !== this.#integrity) {

--- a/src/spec/src/browser.ts
+++ b/src/spec/src/browser.ts
@@ -1,4 +1,4 @@
-import type { ErrorCauseObject } from '@vltpkg/error-cause'
+import type { ErrorCauseOptions } from '@vltpkg/error-cause'
 import { error, typeError } from '@vltpkg/error-cause'
 import type { Range } from '@vltpkg/semver'
 import { parseRange } from '@vltpkg/semver'
@@ -600,7 +600,7 @@ export class Spec implements SpecLike<Spec> {
     return this.subspec
   }
 
-  #error(message: string, extra: ErrorCauseObject = {}) {
+  #error(message: string, extra: ErrorCauseOptions = {}) {
     return error(message, { spec: this.spec, ...extra }, this.#error)
   }
 


### PR DESCRIPTION
This removes the `isErrorRoot` type guard in favor of a new one `isErrorWithCode`. This better matches what is actually being done with the type guard in `print-err`.

Previously it was only checking if the error had a cause that was an object, but asserting that the cause was one thrown by `@vltpkg/error-cause`. Now it is checking if the code is one of our known codes.

This also takes any `cause.cause` (which has to be `unknown` for compatability with TS) and converts it to an `Error` and updates the resulting types appropriately.
