### PR TITLE
smoke-test: reduce flakes

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -14,9 +14,7 @@ concurrency:
 jobs:
   lint:
     name: Benchmark
-
     runs-on: ubuntu-latest
-
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,10 @@
 name: CI
 
 on:
+  push:
+    branches:
+      - main
+  pull_request:
   workflow_dispatch:
     inputs:
       filter:
@@ -8,71 +12,82 @@ on:
       full-matrix:
         description: 'Whether to run the full matrix of environments for testing.'
         type: boolean
-  push:
-    branches:
-      - main
-  pull_request:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
-  detect-filter:
-    name: Detect Filter
+  pre-check:
+    name: Pre-Check
     runs-on: ubuntu-latest
     outputs:
       changed: ${{ steps.filters.outputs.changed }}
       dependent: ${{ steps.filters.outputs.dependent }}
       related: ${{ steps.filters.outputs.related }}
-      full-matrix: ${{ steps.filters.outputs.full-matrix }}
-      git-ref: ${{ steps.filters.outputs.git-ref }}
+      base-ref: ${{ steps.filters.outputs.base-ref }}
+      full-matrix: ${{ steps.full-matrix.outputs.value }}
     steps:
-      - name: Checkout Code
-        uses: actions/checkout@v4
-
-      - name: Set run-script filters
-        id: filters
+      - name: Release PR
+        id: release-pr
         run: |
-          BRANCH="${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}"
-
-          # Non release PRs run only changes from main and the smaller matrix
-          if [[ "${{ github.event_name }}" == "pull_request" ]] && [[ "$BRANCH" != "release" ]]; then
-            filter="[origin/${{ github.base_ref }}]"
-            echo "changed=--filter \"$filter\"" >> "$GITHUB_OUTPUT"
-            echo "dependent=--filter \"...$filter\"" >> "$GITHUB_OUTPUT"
-            echo "related=--filter \"...$filter...\"" >> "$GITHUB_OUTPUT"
-            echo "full-matrix=false" >> "$GITHUB_OUTPUT"
-            echo "git-ref=${{ github.base_ref }}" >> "$GITHUB_OUTPUT"
-            exit 0
+          if [[ "${{ github.event_name }}" == "pull_request" && "${{ github.head_ref }}" == "release" ]]; then
+            echo "value=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "value=false" >> "$GITHUB_OUTPUT"
           fi
 
-          # Use the passed in filter otherwise default to running everything
-          filter="${{ inputs.filter }}"
-          if [[ -n "$filter" ]]; then              
-            echo "changed=--filter \"$filter\"" >> "$GITHUB_OUTPUT"
-            echo "dependent=--filter \"...$filter\"" >> "$GITHUB_OUTPUT"
-            echo "related=--filter \"...$filter...\"" >> "$GITHUB_OUTPUT"
+      - name: Recursive
+        id: recursive
+        run: |
+          if [[
+            "${{ steps.release-pr.outputs.value }}" == "true" ||
+            "${{ github.event_name }}" == "push" ||
+            ("${{ github.event_name }}" == "workflow_dispatch" && -z "${{ inputs.filter }}")
+          ]]; then
+            echo "value=true" >> "$GITHUB_OUTPUT"
           else
+            echo "value=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Filters
+        id: filters
+        run: |
+          if [[ "${{ steps.recursive.outputs.value }}" == "true" ]]; then
             echo "changed=--recursive" >> "$GITHUB_OUTPUT"
             echo "dependent=--recursive" >> "$GITHUB_OUTPUT"
             echo "related=--recursive" >> "$GITHUB_OUTPUT"
+            exit 0
           fi
 
-          # Run the full matrix is explicitly requested. Other workflow_dispatch events
-          # will not run the full matrix. Everything else will run the full matrix.
-          if [[ "${{ inputs.full-matrix }}" == "true" ]]; then
-            echo "full-matrix=true" >> "$GITHUB_OUTPUT"
-          elif [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
-            echo "full-matrix=false" >> "$GITHUB_OUTPUT"
+          if [[ -n "${{ inputs.filter}}" ]]; then
+            filter="${{ inputs.filter }}"
           else
-            echo "full-matrix=true" >> "$GITHUB_OUTPUT"
+            filter="[origin/${{ github.base_ref }}]"
+            echo "base-ref=${{ github.base_ref }}" >> "$GITHUB_OUTPUT"
+          fi
+
+          echo "changed=--filter \"$filter\"" >> "$GITHUB_OUTPUT"
+          echo "dependent=--filter \"...$filter\"" >> "$GITHUB_OUTPUT"
+          echo "related=--filter \"...$filter...\"" >> "$GITHUB_OUTPUT"
+
+      - name: Matrix
+        id: full-matrix
+        run: |
+          if [[
+            "${{ github.event_name }}" == "push" ||
+            "${{ steps.release-pr.outputs.value }}" == "true" ||
+            "${{ inputs.full-matrix }}" == "true"
+          ]]; then
+            echo "value=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "value=false" >> "$GITHUB_OUTPUT"
           fi
 
   lint:
     name: Lint
     # TODO: use filters to run a subset of lint/format
-    # needs: detect-filter
+    needs: pre-check
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
@@ -90,7 +105,7 @@ jobs:
           cache: pnpm
           check-latest: true
 
-      - name: Install dependencies
+      - name: Install Dependencies
         run: pnpm install
 
       - name: Formatting
@@ -144,7 +159,7 @@ jobs:
 
   test:
     name: Test - ${{ matrix.platform.name }} - ${{ matrix.node-version }}
-    needs: detect-filter
+    needs: pre-check
     runs-on: ${{ matrix.platform.os }}
     defaults:
       run:
@@ -169,18 +184,14 @@ jobs:
             os: windows-latest
             shell: powershell
         exclude:
-          - platform: ${{ fromJSON(needs.detect-filter.outputs.full-matrix == 'false' && '{"name":"macOS","os":"macos-latest","shell":"bash"}') }}
-          - platform: ${{ fromJSON(needs.detect-filter.outputs.full-matrix == 'false' && '{"name":"macOS Intel","os":"macos-13","shell":"bash"}') }}
-          - platform: ${{ fromJSON(needs.detect-filter.outputs.full-matrix == 'false' && '{"name":"Windows Powershell","os":"windows-latest","shell":"powershell"}') }}
+          - platform: ${{ fromJSON(needs.pre-check.outputs.full-matrix == 'false' && '{"name":"macOS","os":"macos-latest","shell":"bash"}') }}
+          - platform: ${{ fromJSON(needs.pre-check.outputs.full-matrix == 'false' && '{"name":"macOS Intel","os":"macos-13","shell":"bash"}') }}
+          - platform: ${{ fromJSON(needs.pre-check.outputs.full-matrix == 'false' && '{"name":"Windows Powershell","os":"windows-latest","shell":"powershell"}') }}
       fail-fast: false
 
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
-
-      - name: Fetch Git Ref to Compare
-        if: needs.detect-filter.outputs.git-ref
-        run: git fetch --no-tags --prune --depth=1 origin +refs/heads/${{ needs.detect-filter.outputs.git-ref }}:refs/remotes/origin/${{ needs.detect-filter.outputs.git-ref }}
 
       - uses: denoland/setup-deno@v2
         with:
@@ -198,29 +209,15 @@ jobs:
           cache: pnpm
           check-latest: true
 
-      - name: Install dependencies
-        run: pnpm ${{ needs.detect-filter.outputs.related }} install --ignore-scripts
+      - name: Fetch Git Ref to Compare
+        if: needs.pre-check.outputs.base-ref
+        run: git fetch --no-tags --prune --depth=1 origin +refs/heads/${{ needs.pre-check.outputs.base-ref }}:refs/remotes/origin/${{ needs.pre-check.outputs.base-ref }}
+
+      - name: Install Dependencies
+        run: pnpm ${{ needs.pre-check.outputs.related }} --filter="!smoke-test" install --ignore-scripts
 
       - name: Prepare
-        run: pnpm ${{ needs.detect-filter.outputs.related }} prepare
+        run: pnpm ${{ needs.pre-check.outputs.related }} --filter="!smoke-test" prepare
 
       - name: Run Tests
-        run: pnpm ${{ needs.detect-filter.outputs.dependent }} --filter="!smoke-test" --no-bail --aggregate-output test
-
-      - name: Needs Smoke Test
-        id: smoke-test
-        shell: bash
-        run: |
-          if [[ "${{ needs.detect-filter.outputs.full-matrix }}" == "true" ]]; then
-            echo "value=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          if pnpm ${{ needs.detect-filter.outputs.changed }} exec pwd | grep "smoke-test"; then
-            echo "value=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          echo "value=false" >> "$GITHUB_OUTPUT"
-
-      - name: Smoke Tests
-        if: steps.smoke-test.outputs.value == 'true'
-        run: pnpm --filter smoke-test test
+        run: pnpm ${{ needs.pre-check.outputs.dependent }} --filter="!smoke-test" --no-bail --aggregate-output test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ on:
         options:
           - pr
           - publish
-      dryRun:
+      dry-run:
         description: 'Dry run the PR creation or release'
         type: boolean
 
@@ -21,31 +21,25 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  detect-action:
-    name: Detect Release Action
+  pre-check:
+    name: Pre-Check
     runs-on: ubuntu-latest
     outputs:
-      action: ${{ steps.action.outputs.value }}
+      action: ${{ steps.action.outputs.value }}g
       dry-run: ${{ steps.dry-run.outputs.value }}
     steps:
-      - name: Checkout Code
-        uses: actions/checkout@v4
-
-      - name: Determine Dry run
+      - name: Dry Run
         id: dry-run
-        run: echo "value=${{ inputs.dryRun }}" >> $GITHUB_OUTPUT
+        run: echo "value=${{ inputs.dry-run }}" >> $GITHUB_OUTPUT
 
-      - name: Determine Action
+      - name: Action
         id: action
         run: |
-          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
-            if [[ -n "${{ inputs.action }}" ]]; then
-              echo "value=${{ inputs.action }}" >> $GITHUB_OUTPUT
-              exit 0
-            fi
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" && -n "${{ inputs.action }}" ]]; then
+            echo "value=${{ inputs.action }}" >> $GITHUB_OUTPUT
+            exit 0
           fi
-          MESSAGE=$(git log -1 --pretty=%B | head -n 1)
-          if [[ "$MESSAGE" =~ ^Release\ v ]]; then
+          if [[ "$(git log -1 --pretty=%B | head -n 1)" =~ ^Release\ v ]]; then
             echo "value=publish" >> $GITHUB_OUTPUT
           else
             echo "value=pr" >> $GITHUB_OUTPUT
@@ -54,8 +48,8 @@ jobs:
   pr:
     name: Release PR
     runs-on: ubuntu-latest
-    needs: detect-action
-    if: needs.detect-action.outputs.action == 'pr'
+    needs: pre-check
+    if: needs.pre-check.outputs.action == 'pr'
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
@@ -155,7 +149,7 @@ jobs:
 
       - name: Create or Update PR
         id: pr
-        if: needs.detect-action.outputs.dry-run != 'true'
+        if: needs.pre-check.outputs.dry-run != 'true'
         uses: peter-evans/create-pull-request@v7
         with:
           title: 'Release v${{ steps.version.outputs.value }}'
@@ -209,8 +203,8 @@ jobs:
   publish:
     name: Publish
     runs-on: ubuntu-latest
-    needs: detect-action
-    if: needs.detect-action.outputs.action == 'publish'
+    needs: pre-check
+    if: needs.pre-check.outputs.action == 'publish'
     permissions:
       contents: write
     steps:
@@ -249,12 +243,12 @@ jobs:
             --access=public \
             --no-git-checks \
             --publish-branch="${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}" \
-            ${{ needs.detect-action.outputs.dry-run == 'true' && '--dry-run' }}
+            ${{ needs.pre-check.outputs.dry-run == 'true' && '--dry-run' }}
         env:
           NPM_AUTH_TOKEN: ${{ secrets.VLT_CLI_PUBLISH_TOKEN }}
 
       - name: Create Git Tag
-        if: needs.detect-action.outputs.dry-run != 'true'
+        if: needs.pre-check.outputs.dry-run != 'true'
         run: |
           VERSION=$(jq -r .version ./infra/cli-compiled/package.json)
           git config --global user.email "vltops@users.noreply.github.com"

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -1,0 +1,88 @@
+name: Smoke Test
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  pre-check:
+    name: Pre-Check
+    runs-on: ubuntu-latest
+    outputs:
+      smoke-test: ${{ steps.smoke-test.outputs.value }}
+    steps:
+      - name: Smoke Test
+        id: smoke-test
+        run: |
+          if [[ "${{ github.event_name }}" == "pull_request" && "${{ github.head_ref }}" != "release" ]]; then
+            echo "value=false" >> $GITHUB_OUTPUT
+          else
+            echo "value=true" >> $GITHUB_OUTPUT
+          fi
+
+  test:
+    name: Test - ${{ matrix.platform.name }} - ${{ matrix.node-version }}
+    needs: pre-check
+    if: needs.pre-check.outputs.smoke-test == 'true'
+    runs-on: ${{ matrix.platform.os }}
+    defaults:
+      run:
+        shell: ${{ matrix.platform.shell }}
+    strategy:
+      matrix:
+        node-version: [22.x]
+        platform:
+          - name: Ubuntu
+            os: ubuntu-latest
+            shell: bash
+          - name: macOS
+            os: macos-latest
+            shell: bash
+          - name: macOS Intel
+            os: macos-13
+            shell: bash
+          - name: Windows
+            os: windows-latest
+            shell: bash
+          - name: Windows Powershell
+            os: windows-latest
+            shell: powershell
+      fail-fast: false
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - uses: denoland/setup-deno@v2
+        with:
+          deno-version: v2.x
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+          run_install: false
+
+      - name: Use Nodejs ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: pnpm
+          check-latest: true
+
+      - name: Install Dependencies
+        run: pnpm --filter="...smoke-test..." install --ignore-scripts
+
+      - name: Prepare
+        run: pnpm --filter="...smoke-test..." prepare
+
+      - name: Run Tests
+        run: pnpm --filter=smoke-test test
+        env:
+          TAP_JOBS: 1

--- a/infra/smoke-test/package.json
+++ b/infra/smoke-test/package.json
@@ -42,7 +42,8 @@
     "extends": "../../tap-config.yaml",
     "after": "./test/fixtures/after.ts",
     "before": "./test/fixtures/before.ts",
-    "disable-coverage": true
+    "disable-coverage": true,
+    "save-fixture": true
   },
   "prettier": "../../.prettierrc.js",
   "module": "./src/index.ts",

--- a/infra/smoke-test/test/cache-unzip.ts
+++ b/infra/smoke-test/test/cache-unzip.ts
@@ -4,13 +4,13 @@ import { join } from 'node:path'
 import { setTimeout } from 'node:timers/promises'
 import t from 'tap'
 import { runMultiple } from './fixtures/run.ts'
-import { defaultVariants } from './fixtures/variants.ts'
+import { allVariants } from './fixtures/variants.ts'
 
 t.test(
   'unzips all cache entries after a successful install',
   async t => {
-    const { status } = await runMultiple(t, ['install', 'abbrev'], {
-      variants: [...defaultVariants, 'denoBundle', 'denoSource'],
+    const { status } = await runMultiple(t, ['i', 'abbrev'], {
+      variants: allVariants,
       test: async (t, { dirs }) => {
         // wait for unref'd process to finish. this is an arbitrary amount of
         // time but should be enough for a small install.

--- a/infra/smoke-test/test/fixtures/after.ts
+++ b/infra/smoke-test/test/fixtures/after.ts
@@ -1,8 +1,5 @@
-import t from 'tap'
-import { Variants } from './variants.ts'
+import { Artifacts } from './variants.ts'
 
-if (!t.saveFixture) {
-  for (const variant of Object.values(Variants)) {
-    variant.cleanup?.()
-  }
+for (const artifact of Object.values(Artifacts)) {
+  artifact.cleanup()
 }

--- a/infra/smoke-test/test/fixtures/before.ts
+++ b/infra/smoke-test/test/fixtures/before.ts
@@ -1,6 +1,5 @@
-import { Variants } from './variants.ts'
+import { Artifacts } from './variants.ts'
 
-for (const variant of Object.values(Variants)) {
-  variant.cleanup?.()
-  await variant.setup?.()
+for (const artifact of Object.values(Artifacts)) {
+  await artifact.prepare()
 }

--- a/infra/smoke-test/test/install.ts
+++ b/infra/smoke-test/test/install.ts
@@ -9,7 +9,7 @@ t.test('help', async t => {
 })
 
 t.test('install a package', async t => {
-  const { status } = await runMultiple(t, ['install', 'eslint'], {
+  const { status } = await runMultiple(t, ['i', 'eslint'], {
     test: async (t, { dirs }) => {
       const lock = JSON.parse(
         readFileSync(join(dirs.project, 'vlt-lock.json'), 'utf-8'),

--- a/infra/smoke-test/test/postinstall.ts
+++ b/infra/smoke-test/test/postinstall.ts
@@ -4,88 +4,73 @@ import { Bins } from './fixtures/variants.ts'
 import type { Variant } from './fixtures/variants.ts'
 import { runVariant } from './fixtures/run.ts'
 import { join, resolve, basename, sep } from 'node:path'
-import { cpSync } from 'node:fs'
+import { cpSync, realpathSync } from 'node:fs'
 import { spawnSync } from 'node:child_process'
 import assert from 'node:assert'
 import Cli from '@vltpkg/cli-sdk/package.json' with { type: 'json' }
+import { whichSync } from '@vltpkg/which'
 
 type Tarball = { path: string; name: string }
-type Packed<T = Tarball> = { root: Tarball | T; tarballs: Tarball[] }
+type Packed = { root: Tarball; tarballs: Tarball[] }
 
-class PackTarballs {
-  #PACKED: Packed | null = null
+t.before(() => {
+  const pnpm = realpathSync(whichSync('pnpm'))
 
-  get packed() {
-    assert(
-      this.#PACKED,
-      'pack() must be called before accessing packed',
-    )
-    return this.#PACKED
-  }
-
-  constructor() {
-    this.#PACKED = this.pack()
-  }
-
-  pack() {
-    const packed = spawnSync(
-      'pnpm',
-      ['--filter', '"./infra/cli-*"', 'exec', 'pnpm', 'pack'],
-      {
-        cwd: resolve(import.meta.dirname, '../../..'),
-        stdio: 'pipe',
-        encoding: 'utf8',
-        shell: true,
-        windowsHide: true,
-        env: {
-          ...process.env,
-          __VLT_INTERNAL_LOCAL_OPTIONAL_DEPS: '1',
-          __VLT_INTERNAL_COMPILED_BINS: Bins.join(','),
-        },
+  const proc = spawnSync(
+    pnpm,
+    ['--filter', '"./infra/cli-*"', 'exec', pnpm, 'pack'],
+    {
+      cwd: resolve(import.meta.dirname, '../../..'),
+      stdio: 'pipe',
+      encoding: 'utf8',
+      shell: true,
+      windowsHide: true,
+      env: {
+        ...process.env,
+        __VLT_INTERNAL_LOCAL_OPTIONAL_DEPS: '1',
+        __VLT_INTERNAL_COMPILED_BINS: Bins.join(','),
       },
+    },
+  )
+
+  assert(
+    proc.status === 0,
+    new Error(`Failed to pack tarballs`, { cause: proc }),
+  )
+
+  const { root, tarballs } = proc.stdout
+    .split('\n')
+    .filter(l => l.includes('.tgz'))
+    .map(l => ({ path: l, name: basename(l) }))
+    .reduce<{ root: Tarball | null; tarballs: Tarball[] }>(
+      (acc, tarball) => {
+        if (tarball.path.includes(`${sep}cli-compiled${sep}`)) {
+          acc.root = tarball
+        } else {
+          acc.tarballs.push(tarball)
+        }
+        return acc
+      },
+      { root: null, tarballs: [] },
     )
 
-    assert(
-      packed.status === 0,
-      new Error(`Failed to pack tarballs`, { cause: packed }),
-    )
+  assert(root, new Error('root tarball not found', { cause: proc }))
+  assert(
+    tarballs.length,
+    new Error('platform tarballs not found', { cause: proc }),
+  )
 
-    const { root, tarballs } = packed.stdout
-      .split('\n')
-      .filter(l => l.includes('.tgz'))
-      .map(l => ({ path: l, name: basename(l) }))
-      .reduce<Packed<null>>(
-        (acc, tarball) => {
-          if (tarball.path.includes(`${sep}cli-compiled${sep}`)) {
-            acc.root = tarball
-          } else {
-            acc.tarballs.push(tarball)
-          }
-          return acc
-        },
-        { root: null, tarballs: [] },
-      )
-
-    assert(
-      root,
-      new Error('root tarball not found', { cause: packed }),
-    )
-    assert(
-      tarballs.length,
-      new Error('platform tarballs not found', { cause: packed }),
-    )
-
-    return { root, tarballs }
-  }
-}
-
-const packer = new PackTarballs()
+  t.context.packed = { root, tarballs }
+})
 
 const installPacked = (
   t: Test,
-  p: PackTarballs,
   npmInstallArgs: string[] = [],
 ): Variant => {
+  const npm = realpathSync(whichSync('npm'))
+
+  const { root, tarballs } = t.context.packed as Packed
+
   const testdir = t.testdir({
     'package.json': JSON.stringify({
       name: 'root-compile-dir-smoke-test',
@@ -94,15 +79,12 @@ const installPacked = (
     }),
   })
 
-  const { root, tarballs } = p.packed
-
-  cpSync(root.path, join(testdir, basename(root.name)))
-  for (const tarball of tarballs) {
+  for (const tarball of [root, ...tarballs]) {
     cpSync(tarball.path, join(testdir, basename(tarball.name)))
   }
 
   const install = spawnSync(
-    'npm',
+    npm,
     ['install', `".${sep}${root.name}"`, ...npmInstallArgs],
     {
       cwd: testdir,
@@ -121,33 +103,24 @@ const installPacked = (
   )
 
   return {
-    spawn: bin => [bin],
+    args: bin => [bin],
     PATH: join(testdir, 'node_modules', '.bin'),
   }
 }
 
-t.test(
-  'postinstall script works to place platform specific bins',
-  async t => {
-    const v = installPacked(t, packer)
-    t.test('vlt --version', async t => {
-      const res = await runVariant(v, t, ['--version'])
-      t.equal(res.status, 0)
-      t.equal(res.stdout, Cli.version)
-      t.equal(res.stderr, '')
-    })
-  },
-)
+t.test('works by default', async t => {
+  const v = installPacked(t)
+  t.test('node_modules/.bin', async t => {
+    const res = await runVariant(v, t, ['--version'])
+    t.equal(res.status, 0)
+    t.equal(res.stdout, Cli.version)
+  })
+})
 
-t.test(
-  'no bins exist if --ignore-scripts is passed to npm install',
-  async t => {
-    const v = installPacked(t, packer, ['--ignore-scripts'])
-    t.test('vlt --version', async t => {
-      const res = await runVariant(v, t, ['--version'])
-      t.ok(typeof res.status === 'number' && res.status > 0)
-      t.equal(res.stdout, '')
-      t.ok(res.stderr, 'wrote something to stderr')
-    })
-  },
-)
+t.test('fails with --ignore-scripts', async t => {
+  const v = installPacked(t, ['--ignore-scripts'])
+  t.test('node_modules/.bin', async t => {
+    const res = await runVariant(v, t, ['--version'])
+    t.ok(typeof res.status === 'number' && res.status > 0)
+  })
+})

--- a/infra/smoke-test/test/rollback-remove.ts
+++ b/infra/smoke-test/test/rollback-remove.ts
@@ -1,6 +1,6 @@
 import t from 'tap'
 import { runMultiple } from './fixtures/run.ts'
-import { defaultVariants } from './fixtures/variants.ts'
+import { allVariants } from './fixtures/variants.ts'
 import { setTimeout } from 'node:timers/promises'
 import { readdirSync } from 'node:fs'
 import { join } from 'node:path'
@@ -11,26 +11,22 @@ const findRollbacks = (dir: string) =>
   }).filter(f => f.name.startsWith('.VLT.DELETE.'))
 
 t.test('removes rollbacks after a successful install', async t => {
-  const { status } = await runMultiple(
-    t,
-    ['install', 'abbrev@2.0.0'],
-    {
-      packageJson: true,
-      variants: [...defaultVariants, 'denoBundle', 'denoSource'],
-      test: async (t, { dirs, run }) => {
-        await setTimeout(1000)
-        await run(['install', 'abbrev@3.0.0'])
-        await setTimeout(1000)
-        t.strictSame(
-          [
-            ...findRollbacks(join(dirs.project, 'node_modules')),
-            ...findRollbacks(join(dirs.project, 'node_modules/.vlt')),
-          ],
-          [],
-          'rollbacks have been cleaned up',
-        )
-      },
+  const { status } = await runMultiple(t, ['i', 'abbrev@2.0.0'], {
+    packageJson: true,
+    variants: allVariants,
+    test: async (t, { dirs, run }) => {
+      await setTimeout(1000)
+      await run(['install', 'abbrev@3.0.0'])
+      await setTimeout(1000)
+      t.strictSame(
+        [
+          ...findRollbacks(join(dirs.project, 'node_modules')),
+          ...findRollbacks(join(dirs.project, 'node_modules/.vlt')),
+        ],
+        [],
+        'rollbacks have been cleaned up',
+      )
     },
-  )
+  })
   t.equal(status, 0)
 })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12544,7 +12544,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.0(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.7.0(eslint-plugin-import@2.31.0)(eslint@9.20.0(jiti@2.4.2)))(eslint@9.20.0(jiti@2.4.2)):
+  eslint-module-utils@2.12.0(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.7.0)(eslint@9.20.0(jiti@2.4.2)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
@@ -12565,7 +12565,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.20.0(jiti@2.4.2)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.0(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.7.0(eslint-plugin-import@2.31.0)(eslint@9.20.0(jiti@2.4.2)))(eslint@9.20.0(jiti@2.4.2))
+      eslint-module-utils: 2.12.0(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.7.0)(eslint@9.20.0(jiti@2.4.2))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3


### PR DESCRIPTION
The smoke tests were previously flaky for two reasons:

- Errors when cleaning up all the generated fixtures
- Timeouts where a spawned `vlt` command would hang

This PR works around those two issues by setting `save-fixture: true` and `jobs: 1` in the tap config.

It's worth noting that the errors when cleaning up fixtures doesn't point to any real bugs in vlt, it's just hard for CI to reliably delete 1000s of files especially when we have detached processes that might be operating on those files.

But the spawned processes hanging *might* point to a real bug, but I was unable to pinpoint it. There's no reason the smoke tests shouldn't be able to run in parallel. Each spawned command is given it's own directory and isolated by setting `HOME` and `XDG_*` environment variables. I was also unable to reproduce the parallelism issue locally but in CI I attempted to run the smoke tests 10x and would reliably see timeouts.