### PR TITLE
smoke-test: dont match tty output across variants

### DIFF
--- a/infra/smoke-test/test/install.ts
+++ b/infra/smoke-test/test/install.ts
@@ -28,6 +28,7 @@ t.test('install a package', async t => {
 t.test('tty', { skip: process.platform === 'win32' }, async t => {
   const { status, output } = await runMultiple(t, ['i', 'abbrev'], {
     tty: true,
+    match: ['status'],
     cleanOutput: v =>
       stripVTControlCharacters(ansiToAnsi(v))
         .replace(/\d+(ms)/, '{{TIME}}$1')


### PR DESCRIPTION
This is non-deterministic due to how TTYs output. We are already testing
that the output matches what we expect, but we dont need to check that
each variant has the exact same output.

Should fix this flaky smoke-test run: https://github.com/vltpkg/vltpkg/actions/runs/14143455312/job/39627874959#step:9:713
