### PR TITLE
query: add insights to query response node

### DIFF
--- a/src/query/src/index.ts
+++ b/src/query/src/index.ts
@@ -123,6 +123,7 @@ const securitySelectors = new Set([
   ':abandoned',
   ':confused',
   ':cve',
+  ':cwe',
   ':debug',
   ':deprecated',
   ':dynamic',

--- a/src/query/src/pseudo/cve.ts
+++ b/src/query/src/pseudo/cve.ts
@@ -65,7 +65,7 @@ export const cve = async (state: ParserState) => {
     const report = state.securityArchive.get(node.id)
     const exclude = !report?.alerts.some(
       alert =>
-        alert.props.cveId.trim().toLowerCase() ===
+        alert.props.cveId?.trim().toLowerCase() ===
         cveId.trim().toLowerCase(),
     )
     if (exclude) {

--- a/src/query/src/pseudo/cwe.ts
+++ b/src/query/src/pseudo/cwe.ts
@@ -64,7 +64,7 @@ export const cwe = async (state: ParserState) => {
   for (const node of state.partial.nodes) {
     const report = state.securityArchive.get(node.id)
     const exclude = !report?.alerts.some(alert =>
-      alert.props.cwes.some(
+      alert.props.cwes?.some(
         cwe =>
           cwe.id.trim().toLowerCase() === cweId.trim().toLowerCase(),
       ),

--- a/src/query/src/types.ts
+++ b/src/query/src/types.ts
@@ -56,7 +56,71 @@ export type ParserState = {
 
 export type QueryResponse = {
   edges: EdgeLike[]
-  nodes: NodeLike[]
+  nodes: QueryResponseNode[]
+}
+
+export type QueryResponseNode = {
+  insights: Insights
+} & NodeLike
+
+export type Insights = {
+  abandoned?: boolean
+  confused?: boolean
+  cve?: `CVE-${string}`[]
+  cwe?: `CWE-${string}`[]
+  debug?: boolean
+  deprecated?: boolean
+  dynamic?: boolean
+  entropic?: boolean
+  env?: boolean
+  eval?: boolean
+  fs?: boolean
+  license?: LicenseInsights
+  malware?: MalwareInsights
+  minified?: boolean
+  native?: boolean
+  network?: boolean
+  obfuscated?: boolean
+  scanned: boolean
+  scripts?: boolean
+  severity?: SeverityInsights
+  shell?: boolean
+  shrinkwrap?: boolean
+  squat?: SquatInsights
+  suspicious?: boolean
+  tracker?: boolean
+  trivial?: boolean
+  undesirable?: boolean
+  unknown?: boolean
+  unmaintained?: boolean
+  unpopular?: boolean
+  unstable?: boolean
+}
+
+export type LicenseInsights = {
+  unlicensed: boolean
+  misc: boolean
+  restricted: boolean
+  ambiguous: boolean
+  copyleft: boolean
+  unknown: boolean
+  none: boolean
+  exception: boolean
+}
+
+export type LeveledInsights = {
+  low: boolean
+  medium: boolean
+  high: boolean
+  critical: boolean
+}
+
+export type MalwareInsights = LeveledInsights
+export type SeverityInsights = LeveledInsights
+
+export type SquatInsights = {
+  medium: boolean
+  critical: boolean
 }
 
 export type ParserFn = (opt: ParserState) => Promise<ParserState>

--- a/src/query/test/pseudo/cve.ts
+++ b/src/query/test/pseudo/cve.ts
@@ -44,7 +44,7 @@ t.test('selects packages with a CVE alert', async t => {
               alerts: [
                 {
                   key: '12314320948130',
-                  type: 'npm',
+                  type: 'cve',
                   severity: 'high',
                   category: 'security',
                   props: {

--- a/src/security-archive/src/types.ts
+++ b/src/security-archive/src/types.ts
@@ -55,8 +55,8 @@ export const asSecurityArchiveLike = (
  */
 export type PackageAlertProps = {
   lastPublish: string
-  cveId: `CVE-${string}`
-  cwes: { id: `CWE-${string}` }[]
+  cveId?: `CVE-${string}`
+  cwes?: { id: `CWE-${string}` }[]
 }
 
 /**


### PR DESCRIPTION
Adds a new `insights` object to each node in the query search
response that contains metadata parsed from the security archive.

Fixes: https://github.com/vltpkg/vltpkg/issues/597