### PR TITLE
add 'vlt cache' command

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -436,6 +436,9 @@ importers:
 
   src/cli-sdk:
     dependencies:
+      '@vltpkg/cache':
+        specifier: workspace:*
+        version: link:../cache
       '@vltpkg/dep-id':
         specifier: workspace:*
         version: link:../dep-id
@@ -517,6 +520,9 @@ importers:
       polite-json:
         specifier: 'catalog:'
         version: 5.0.0
+      pretty-bytes:
+        specifier: ^6.1.1
+        version: 6.1.1
       react:
         specifier: ^18.3.1
         version: 18.3.1
@@ -7189,6 +7195,10 @@ packages:
     resolution: {integrity: sha512-e9MewbtFo+Fevyuxn/4rrcDAaq0IYxPGLvObpQjiZBMAzB9IGmzlnG9RZy3FFas+eBMu2vA0CszMeduow5dIuQ==}
     engines: {node: '>=14'}
     hasBin: true
+
+  pretty-bytes@6.1.1:
+    resolution: {integrity: sha512-mQUvGU6aUFQ+rNvTIAcZuWGRT9a6f6Yrg9bHs4ImKF+HZCEK+plBvnAZYSIQztknZF2qnzNtr6F8s0+IuptdlQ==}
+    engines: {node: ^14.13.1 || >=16.0.0}
 
   pretty-format@27.5.1:
     resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
@@ -14702,6 +14712,8 @@ snapshots:
     optional: true
 
   prettier@3.4.2: {}
+
+  pretty-bytes@6.1.1: {}
 
   pretty-format@27.5.1:
     dependencies:

--- a/src/cache/test/index.ts
+++ b/src/cache/test/index.ts
@@ -108,7 +108,11 @@ t.test('delete from disk', async t => {
     '4a3ed8147e37876adc8f76328e5abcc1b470e6acfc18efea0135f983604953a5' +
       '8e183c1a6086e91ba3e821d926f5fdeb37761c7ca0328a963f5e92870675b728.key',
   ])
-  c.delete('xyz', true)
+  c.delete(
+    'xyz',
+    true,
+    `sha512-${createHash('sha512').update('hello, world').digest('base64')}`,
+  )
   await c.promise()
   t.equal(oddCalled, true, 'diskDelete has now been called')
   t.strictSame(readdirSync(t.testdirName), [])

--- a/src/cli-sdk/package.json
+++ b/src/cli-sdk/package.json
@@ -22,6 +22,7 @@
     }
   },
   "dependencies": {
+    "@vltpkg/cache": "workspace:*",
     "@vltpkg/dep-id": "workspace:*",
     "@vltpkg/dot-prop": "workspace:*",
     "@vltpkg/error-cause": "workspace:*",
@@ -49,6 +50,7 @@
     "package-json-from-dist": "catalog:",
     "path-scurry": "catalog:",
     "polite-json": "catalog:",
+    "pretty-bytes": "^6.1.1",
     "react": "^18.3.1",
     "react-devtools-core": "^4.28.5",
     "walk-up-path": "catalog:"

--- a/src/cli-sdk/src/commands/cache.ts
+++ b/src/cli-sdk/src/commands/cache.ts
@@ -1,0 +1,312 @@
+import { error } from '@vltpkg/error-cause'
+import { CacheEntry } from '@vltpkg/registry-client'
+import { Spec } from '@vltpkg/spec'
+import { mkdir, rm } from 'node:fs/promises'
+import prettyBytes from 'pretty-bytes'
+import type { LoadedConfig } from '../config/index.ts'
+import type { CommandUsageDefinition } from '../config/usage.ts'
+import { commandUsage } from '../config/usage.ts'
+import type { CommandFn, CommandUsage } from '../index.ts'
+import { stdout } from '../output.ts'
+import type { ViewOptions, Views } from '../view.ts'
+import { ViewClass } from '../view.ts'
+
+export type CacheMap = Record<
+  string,
+  ReturnType<CacheEntry['toJSON']>
+>
+
+export type CacheSubcommands = keyof (typeof usageDef)['subcommands']
+
+let view: CacheView
+export class CacheView extends ViewClass {
+  constructor(options: ViewOptions, conf: LoadedConfig) {
+    super(options, conf)
+    view = this
+  }
+  stdout(...args: unknown[]) {
+    stdout(...args)
+  }
+  error(e: unknown) {
+    throw e
+  }
+}
+
+export const views: Views<void | CacheMap> = {
+  human: CacheView,
+}
+
+const usageDef = {
+  command: 'cache',
+  usage: '<command> [flags]',
+  description: 'Work with vlt cache folders',
+
+  subcommands: {
+    add: {
+      usage: '<package-spec> [<package-spec>...]',
+      description: `Resolve the referenced package identifiers and ensure they
+                    are cached.`,
+    },
+
+    ls: {
+      usage: '[<key>...]',
+      description: `Show cache entries. If no keys are provided, then a list of
+                    available keys will be printed. If one or more keys are
+                    provided, then details will be shown for the specified
+                    items.`,
+    },
+
+    clean: {
+      usage: '[<key>...]',
+      description: `Purge expired cache entries. If one or more keys are
+                    provided, then only those cache entries will be
+                    considered.`,
+    },
+
+    delete: {
+      usage: '<key> [<key>...]',
+      description: `Purge items explicitly, whether expired or not.  If one or
+                    more keys are provided, then only those cache entries will
+                    be considered.`,
+    },
+
+    'delete-before': {
+      usage: '<date>',
+      description: `Purge all cache items from before a given date. Date can be
+                    provided in any format that JavaScript can parse.`,
+    },
+
+    'delete-all': {
+      usage: '',
+      description: `Delete the entire cache folder to make vlt slower.`,
+    },
+  },
+} as const satisfies CommandUsageDefinition
+
+export const usage: CommandUsage = () => commandUsage(usageDef)
+
+export const command: CommandFn<void | CacheMap> = async conf => {
+  const [sub, ...args] = conf.positionals
+  switch (sub) {
+    case 'ls':
+      return ls(conf, args, view)
+
+    case 'add':
+      return add(conf, args, view)
+
+    case 'clean':
+      return clean(conf, args, view)
+
+    case 'delete':
+      return deleteKeys(conf, args, view)
+
+    case 'delete-before':
+      return deleteBefore(conf, args, view)
+
+    case 'delete-all':
+      return deleteAll(conf, args, view)
+
+    default: {
+      throw error('Unrecognized cache command', {
+        code: 'EUSAGE',
+        found: sub,
+        validOptions: ['ls', 'add', 'clean'],
+      })
+    }
+  }
+}
+
+const ls = async (
+  conf: LoadedConfig,
+  keys: string[],
+  view?: CacheView,
+): Promise<CacheMap> =>
+  keys.length ?
+    await fetchKeys(
+      conf,
+      keys,
+      (entry: CacheEntry, key: string) => {
+        view?.stdout(
+          key.includes(' ') ? JSON.stringify(key) : key,
+          entry,
+        )
+        return true
+      },
+      view,
+    )
+  : await fetchAll(conf, (_, key) => {
+      view?.stdout(key.includes(' ') ? JSON.stringify(key) : key)
+      return true
+    })
+
+const fetchAll = async (
+  conf: LoadedConfig,
+  test: (entry: CacheEntry, key: string, val: Buffer) => boolean,
+) => {
+  const rc = conf.options.packageInfo.registryClient
+  const { cache } = rc
+  const map: CacheMap = {}
+  for await (const [key, val] of cache) {
+    const entry = CacheEntry.decode(val)
+    if (!test(entry, key, val)) continue
+    map[key] = entry.toJSON()
+  }
+  return map
+}
+
+const fetchKeys = async (
+  conf: LoadedConfig,
+  keys: string[],
+  test: (entry: CacheEntry, key: string, buf: Buffer) => boolean,
+  view?: CacheView,
+) => {
+  const rc = conf.options.packageInfo.registryClient
+  const { cache } = rc
+  const map: CacheMap = {}
+  const results: [string, Buffer | undefined][] = await Promise.all(
+    keys.map(async key => {
+      return [key, await cache.fetch(key)]
+    }),
+  )
+  for (const [key, val] of results) {
+    if (!val) {
+      view?.stdout('Not found:', key)
+    } else {
+      const entry = CacheEntry.decode(val)
+      if (!test(entry, key, val)) continue
+      map[key] = entry.toJSON()
+    }
+  }
+
+  return map
+}
+
+const deleteEntries = async (
+  conf: LoadedConfig,
+  keys: string[],
+  test: (entry: CacheEntry) => boolean,
+  view?: CacheView,
+) => {
+  const rc = conf.options.packageInfo.registryClient
+  const { cache } = rc
+
+  let count = 0
+  let size = 0
+  const testAction = (
+    entry: CacheEntry,
+    key: string,
+    val: Buffer,
+  ) => {
+    if (!test(entry)) {
+      return false
+    }
+    count++
+    const s = val.byteLength + key.length
+    cache.delete(key, true, entry.integrity)
+    const k = key.includes(' ') ? JSON.stringify(key) : key
+    view?.stdout('-', k, s)
+    size += s
+    return true
+  }
+
+  const map = await (keys.length ?
+    fetchKeys(conf, keys, testAction, view)
+  : fetchAll(conf, testAction))
+
+  const pb = prettyBytes(size, { binary: true })
+
+  const s = count === 1 ? '' : 's'
+  await cache.promise()
+  view?.stdout(`Removed ${count} item${s} totalling ${pb}`)
+  return map
+}
+
+const clean = async (
+  conf: LoadedConfig,
+  keys: string[],
+  view?: CacheView,
+) => deleteEntries(conf, keys, entry => !entry.valid, view)
+
+const deleteBefore = async (
+  conf: LoadedConfig,
+  args: string[],
+  view?: CacheView,
+) => {
+  if (!args.length) {
+    throw error('Must provide a date to delete before', {
+      code: 'EUSAGE',
+    })
+  }
+  const now = new Date()
+  const before = new Date(args.join(' '))
+  if (before >= now) {
+    throw error('Cannot delete cache entries from the future', {
+      code: 'EUSAGE',
+      found: before,
+    })
+  }
+  return deleteEntries(
+    conf,
+    [],
+    entry => !!entry.date && entry.date < before,
+    view,
+  )
+}
+
+const deleteKeys = async (
+  conf: LoadedConfig,
+  keys: string[],
+  view?: CacheView,
+) => {
+  if (!keys.length) {
+    throw error('Must provide cache keys to delete', {
+      code: 'EUSAGE',
+    })
+  }
+  return deleteEntries(conf, keys, () => true, view)
+}
+
+const deleteAll = async (
+  conf: LoadedConfig,
+  _: string[],
+  view?: CacheView,
+) => {
+  const { cache } = conf.options.packageInfo.registryClient
+  await rm(cache.path(), { recursive: true, force: true })
+  await mkdir(cache.path(), { recursive: true })
+  view?.stdout('Deleted all cache entries.')
+}
+
+const add = async (
+  conf: LoadedConfig,
+  specs: string[],
+  view?: CacheView,
+) => {
+  if (!specs.length) {
+    throw error('Must provide specs to add to the cache', {
+      code: 'EUSAGE',
+    })
+  }
+  const { packageInfo } = conf.options
+  const promises: Promise<void>[] = []
+
+  for (const spec of specs) {
+    const p = packageInfo
+      .resolve(Spec.parseArgs(spec, conf.options), {
+        staleWhileRevalidate: false,
+      })
+      .then(async r => {
+        const { resolved, integrity } = r
+        await packageInfo.registryClient.request(resolved, {
+          ...conf.options,
+          integrity,
+          staleWhileRevalidate: false,
+        })
+        view?.stdout('+', spec, r.resolved)
+      })
+
+    promises.push(p)
+  }
+
+  await Promise.all(promises)
+}

--- a/src/cli-sdk/src/commands/whoami.ts
+++ b/src/cli-sdk/src/commands/whoami.ts
@@ -25,7 +25,7 @@ export const command: CommandFn<CommandResult> = async conf => {
   const rc = new RegistryClient(conf.options)
   const response = await rc.request(
     new URL('-/whoami', conf.options.registry),
-    { cache: false },
+    { useCache: false },
   )
   const { username } = response.json()
   return { username }

--- a/src/cli-sdk/src/config/definition.ts
+++ b/src/cli-sdk/src/config/definition.ts
@@ -4,6 +4,7 @@ import { jack } from 'jackspeak'
 export const defaultView = process.stdout.isTTY ? 'human' : 'json'
 
 const canonicalCommands = {
+  cache: 'cache',
   config: 'config',
   exec: 'exec',
   gui: 'gui',

--- a/src/cli-sdk/src/config/usage.ts
+++ b/src/cli-sdk/src/config/usage.ts
@@ -9,14 +9,7 @@ const code = (v: string) => [v, { pre: true }] as const
 const join = (args: (string | undefined)[], joiner = ' ') =>
   args.filter(Boolean).join(joiner)
 
-export const commandUsage = ({
-  command,
-  usage,
-  description,
-  subcommands,
-  examples,
-  options,
-}: {
+export type CommandUsageDefinition = {
   command: string
   usage: string | string[]
   description: string
@@ -26,7 +19,16 @@ export const commandUsage = ({
   >
   examples?: Record<string, { description: string }>
   options?: Record<string, { value?: string; description: string }>
-}): ReturnType<CommandUsage> => {
+}
+
+export const commandUsage = ({
+  command,
+  usage,
+  description,
+  subcommands,
+  examples,
+  options,
+}: CommandUsageDefinition): ReturnType<CommandUsage> => {
   const vlt = (s?: string) => join([`vlt`, command, s])
 
   const joinUsage = (usages?: string | string[]) =>

--- a/src/cli-sdk/tap-snapshots/test/commands/cache.ts.test.cjs
+++ b/src/cli-sdk/tap-snapshots/test/commands/cache.ts.test.cjs
@@ -1,0 +1,164 @@
+/* IMPORTANT
+ * This snapshot file is auto-generated, but designed for humans.
+ * It should be checked into source control and tracked carefully.
+ * Re-generate by setting TAP_SNAPSHOT=1 and running tests.
+ * Make sure to inspect the output below.  Do not ignore changes!
+ */
+'use strict'
+exports[`test/commands/cache.ts > TAP > cache basics > must match snapshot 1`] = `
+Usage:
+
+\`\`\`
+vlt cache <command> [flags]
+\`\`\`
+
+Work with vlt cache folders
+
+## Subcommands
+
+### add
+
+Resolve the referenced package identifiers and ensure they are cached.
+
+\`\`\`
+vlt cache add <package-spec> [<package-spec>...]
+\`\`\`
+
+### ls
+
+Show cache entries. If no keys are provided, then a list of available keys will be printed. If one or more keys are provided, then details will be shown for the specified items.
+
+\`\`\`
+vlt cache ls [<key>...]
+\`\`\`
+
+### clean
+
+Purge expired cache entries. If one or more keys are provided, then only those cache entries will be considered.
+
+\`\`\`
+vlt cache clean [<key>...]
+\`\`\`
+
+### delete
+
+Purge items explicitly, whether expired or not. If one or more keys are provided, then only those cache entries will be considered.
+
+\`\`\`
+vlt cache delete <key> [<key>...]
+\`\`\`
+
+### delete-before
+
+Purge all cache items from before a given date. Date can be provided in any format that JavaScript can parse.
+
+\`\`\`
+vlt cache delete-before <date>
+\`\`\`
+
+### delete-all
+
+Delete the entire cache folder to make vlt slower.
+
+\`\`\`
+vlt cache delete-all
+\`\`\`
+
+`
+
+exports[`test/commands/cache.ts > TAP > logged by add 1`] = `
+Array [
+  Array [
+    "+",
+    "pkg",
+    "https://registry.npmjs.org/pkg/-/pkg-1.2.3.tgz",
+  ],
+]
+`
+
+exports[`test/commands/cache.ts > TAP > logged by cache basics 1`] = `
+Array []
+`
+
+exports[`test/commands/cache.ts > TAP > logged by clean 1`] = `
+Array []
+`
+
+exports[`test/commands/cache.ts > TAP > logged by delete 1`] = `
+Array [
+  Array [
+    "-",
+    "https://registry.npmjs.org/xyz",
+    488,
+  ],
+  Array [
+    "Not found:",
+    "some-random-key-not-found",
+  ],
+  Array [
+    "Removed 1 item totalling 488 B",
+  ],
+]
+`
+
+exports[`test/commands/cache.ts > TAP > logged by delete-all 1`] = `
+Array [
+  Array [
+    "Deleted all cache entries.",
+  ],
+]
+`
+
+exports[`test/commands/cache.ts > TAP > logged by delete-before 1`] = `
+Array []
+`
+
+exports[`test/commands/cache.ts > TAP > logged by human view coverage bits 1`] = `
+Array [
+  Array [
+    "hello",
+    "world",
+  ],
+]
+`
+
+exports[`test/commands/cache.ts > TAP > logged by ls 1`] = `
+Array [
+  Array [
+    "\\"HEAD https://registry.npmjs.org/xyz\\"",
+  ],
+  Array [
+    "\\"HEAD https://registry.npmjs.org/xyz\\"",
+    CacheEntry {},
+  ],
+  Array [
+    "https://registry.npmjs.org/xyz",
+  ],
+  Array [
+    "https://registry.npmjs.org/xyz",
+    CacheEntry {},
+  ],
+  Array [
+    "https://registry.npmjs.org/xyz/-/xyz-1.2.3.tgz",
+  ],
+  Array [
+    "Not found:",
+    "asdfasdfasdf",
+  ],
+]
+`
+
+exports[`test/commands/cache.ts > TAP > ls > all results 1`] = `
+Array [
+  "HEAD https://registry.npmjs.org/xyz",
+  "https://registry.npmjs.org/xyz",
+  "https://registry.npmjs.org/xyz/-/xyz-1.2.3.tgz",
+]
+`
+
+exports[`test/commands/cache.ts > TAP > ls > one result 1`] = `
+Array [
+  "https://registry.npmjs.org/xyz",
+  "HEAD https://registry.npmjs.org/xyz",
+]
+`

--- a/src/cli-sdk/tap-snapshots/test/config/definition.ts.test.cjs
+++ b/src/cli-sdk/tap-snapshots/test/config/definition.ts.test.cjs
@@ -9,6 +9,7 @@ exports[`test/config/definition.ts > TAP > commands 1`] = `
 Object {
   "?": "help",
   "add": "install",
+  "cache": "cache",
   "conf": "config",
   "config": "config",
   "exec": "exec",
@@ -105,6 +106,7 @@ Object {
     "hint": "command",
     "type": "string",
     "validOptions": Array [
+      "cache",
       "config",
       "exec",
       "gui",

--- a/src/cli-sdk/test/commands/cache.ts
+++ b/src/cli-sdk/test/commands/cache.ts
@@ -1,0 +1,399 @@
+/* eslint-disable @typescript-eslint/no-extraneous-class */
+import { PackageInfoClient } from '@vltpkg/package-info'
+import type { RegistryClientRequestOptions } from '@vltpkg/registry-client'
+import { CacheEntry } from '@vltpkg/registry-client'
+import { Spec } from '@vltpkg/spec'
+import type { Integrity } from '@vltpkg/types'
+import { createHash } from 'crypto'
+import { statSync } from 'fs'
+import { resolve } from 'path'
+import type { Test } from 'tap'
+import t from 'tap'
+import type { LoadedConfig } from '../../src/config/index.ts'
+import type { ViewOptions } from '../../src/view.ts'
+
+const logged: unknown[][] = []
+const stdout = (...a: unknown[]) => logged.push(a)
+t.beforeEach(() => {
+  logged.length = 0
+})
+t.afterEach(test => {
+  t.matchSnapshot(
+    logged.sort((a, b) => String(a).localeCompare(String(b))),
+    `logged by ${test.name}`,
+  )
+})
+
+const mockCommand = (t: Test, mocks: Record<string, any> = {}) =>
+  t.mockImport<typeof import('../../src/commands/cache.ts')>(
+    '../../src/commands/cache.ts',
+    {
+      '../../src/output.ts': { stdout },
+      ...mocks,
+    },
+  )
+
+t.test('cache basics', async t => {
+  const { command, usage, views, CacheView } = await mockCommand(t)
+
+  t.strictSame(views, { human: CacheView })
+  t.matchSnapshot(usage().usageMarkdown())
+
+  await t.rejects(
+    command({
+      positionals: ['unknown'],
+    } as unknown as LoadedConfig),
+    { cause: { code: 'EUSAGE' } },
+  )
+})
+
+t.test('add', async t => {
+  let resolved = false
+  let requested = false
+
+  const conf = {
+    positionals: ['add', 'pkg'],
+    options: {
+      packageInfo: {
+        resolve: async (s: Spec) => {
+          resolved = true
+          t.match(s, Spec.parse('pkg@'))
+          return {
+            resolved:
+              'https://registry.npmjs.org/pkg/-/pkg-1.2.3.tgz',
+            integrity:
+              'sha512-00000000000000000000000000000000000000000000000000000000000000000000000000000000000000==',
+          }
+        },
+        registryClient: {
+          request: async (
+            url: string,
+            options: RegistryClientRequestOptions,
+          ) => {
+            requested = true
+            t.equal(
+              url,
+              'https://registry.npmjs.org/pkg/-/pkg-1.2.3.tgz',
+            )
+            t.matchStrict(options, {
+              integrity:
+                'sha512-00000000000000000000000000000000000000000000000000000000000000000000000000000000000000==',
+              staleWhileRevalidate: false,
+            })
+          },
+        },
+      },
+    },
+  } as unknown as LoadedConfig
+
+  const { command, CacheView } = await mockCommand(t)
+
+  new CacheView(
+    {} as unknown as ViewOptions,
+    {} as unknown as LoadedConfig,
+  )
+  const result = await command(conf)
+  t.equal(result, undefined)
+  t.equal(requested, true)
+  t.equal(resolved, true)
+  await t.rejects(
+    command({
+      positionals: ['add'],
+    } as unknown as LoadedConfig),
+    {
+      message: 'Must provide specs to add to the cache',
+      cause: { code: 'EUSAGE' },
+    },
+  )
+})
+
+t.test('delete-all', async t => {
+  const dir = t.testdir({
+    cache: {
+      some: 'stuff',
+      inhere: {
+        more: 'stuff',
+      },
+    },
+  })
+
+  class MockRegistryClient {
+    cache = {
+      path: () => resolve(dir, 'cache'),
+    }
+  }
+
+  const { command, CacheView } = await mockCommand(t)
+  new CacheView(
+    {} as unknown as ViewOptions,
+    {} as unknown as LoadedConfig,
+  )
+  await command({
+    positionals: ['delete-all'],
+    options: {
+      packageInfo: {
+        registryClient: new MockRegistryClient(),
+      },
+    },
+  } as unknown as LoadedConfig)
+  t.equal(statSync(resolve(dir, 'cache')).isDirectory(), true)
+  t.throws(() => statSync(resolve(dir, 'cache', 'some')))
+  t.throws(() => statSync(resolve(dir, 'cache', 'inhere')))
+})
+
+const hashBuf = createHash('sha512').update('xyz').digest()
+const hash64 = hashBuf.toString('base64')
+const hashHex = hashBuf.toString('hex')
+const integrity: Integrity = `sha512-${hash64}`
+
+const pakukey = 'https://registry.npmjs.org/xyz'
+const pakukeyHash = createHash('sha512').update(pakukey).digest('hex')
+const headPakukey = 'HEAD https://registry.npmjs.org/xyz'
+const headPakukeyHash = createHash('sha512')
+  .update(headPakukey)
+  .digest('hex')
+const tgzkey = 'https://registry.npmjs.org/xyz/-/xyz-1.2.3.tgz'
+const tgzkeyHash = createHash('sha512').update(tgzkey).digest('hex')
+const createCache = (t: Test) => {
+  const headPakuEntry = new CacheEntry(200, [
+    Buffer.from('content-type'),
+    Buffer.from('application/json'),
+    Buffer.from('cache-control'),
+    Buffer.from('public, max-age=300'),
+    Buffer.from('date'),
+    Buffer.from(new Date(Date.now() - 1000 * 1000).toUTCString()),
+  ])
+  const pakuEntry = new CacheEntry(200, [
+    Buffer.from('content-type'),
+    Buffer.from('application/json'),
+    Buffer.from('cache-control'),
+    Buffer.from('public, max-age=300'),
+    Buffer.from('date'),
+    Buffer.from(new Date(Date.now() - 1000 * 1000).toUTCString()),
+  ])
+  pakuEntry.addBody(
+    Buffer.from(
+      JSON.stringify({
+        name: 'xyz',
+        'dist-tags': {
+          latest: '1.2.3',
+        },
+        versions: {
+          '1.2.3': {
+            name: 'xyz',
+            version: '1.2.3',
+            dist: {
+              tarball:
+                'https://registry.npmjs.org/xyz/-/xyz-1.2.3.tgz',
+              integrity,
+            },
+          },
+        },
+      }),
+    ),
+  )
+
+  const tgzEntry = new CacheEntry(
+    200,
+    [
+      Buffer.from('content-type'),
+      Buffer.from('application/octet-stream'),
+      Buffer.from('cache-control'),
+      Buffer.from('public, immutable, max-age=315557600'),
+    ],
+    { integrity, trustIntegrity: true },
+  )
+
+  return t.testdir({
+    'registry-client': {
+      [headPakukeyHash]: headPakuEntry.encode(),
+      [`${headPakukeyHash}.key`]: headPakukey,
+      [pakukeyHash]: pakuEntry.encode(),
+      [`${pakukeyHash}.key`]: pakukey,
+      [tgzkeyHash]: tgzEntry.encode(),
+      [`${tgzkeyHash}.key`]: tgzkey,
+      [hashHex]: t.fixture('link', tgzkeyHash),
+    },
+  })
+}
+
+t.test('delete', async t => {
+  const dir = createCache(t)
+  const { command, CacheView } = await mockCommand(t)
+  new CacheView(
+    {} as unknown as ViewOptions,
+    {} as unknown as LoadedConfig,
+  )
+
+  const options = {
+    cache: dir,
+  }
+  Object.assign(options, {
+    packageInfo: new PackageInfoClient(options),
+  })
+
+  await t.rejects(
+    command({
+      positionals: ['delete'],
+      options,
+    } as unknown as LoadedConfig),
+    { cause: { code: 'EUSAGE' } },
+  )
+
+  await command({
+    positionals: ['delete', pakukey, 'some-random-key-not-found'],
+    options,
+  } as unknown as LoadedConfig)
+
+  t.equal(
+    statSync(resolve(dir, 'registry-client')).isDirectory(),
+    true,
+  )
+  t.throws(() =>
+    statSync(resolve(dir, 'registry-client', pakukeyHash)),
+  )
+  t.throws(() =>
+    statSync(resolve(dir, 'registry-client', pakukeyHash) + '.key'),
+  )
+})
+
+t.test('delete-before', async t => {
+  const dir = createCache(t)
+  const { command } = await mockCommand(t)
+
+  const options = { cache: dir }
+  Object.assign(options, {
+    packageInfo: new PackageInfoClient(options),
+  })
+
+  await t.rejects(
+    command({
+      positionals: ['delete-before'],
+      options,
+    } as unknown as LoadedConfig),
+    { cause: { code: 'EUSAGE' } },
+  )
+
+  await t.rejects(
+    command({
+      positionals: [
+        'delete-before',
+        new Date(Date.now() + 1000 * 60 * 60 * 24),
+      ],
+      options,
+    } as unknown as LoadedConfig),
+    { cause: { code: 'EUSAGE', found: Date } },
+  )
+
+  await command({
+    positionals: [
+      'delete-before',
+      new Date(Date.now() - 500 * 1000).toUTCString(),
+    ],
+    options,
+  } as unknown as LoadedConfig)
+
+  t.equal(
+    statSync(resolve(dir, 'registry-client')).isDirectory(),
+    true,
+  )
+  t.throws(() =>
+    statSync(resolve(dir, 'registry-client', pakukeyHash)),
+  )
+  t.throws(() =>
+    statSync(resolve(dir, 'registry-client', pakukeyHash) + '.key'),
+  )
+})
+
+t.test('clean', async t => {
+  const dir = createCache(t)
+  const { command } = await mockCommand(t)
+
+  const options = { cache: dir }
+  Object.assign(options, {
+    packageInfo: new PackageInfoClient(options),
+  })
+
+  await command({
+    positionals: ['clean'],
+    options,
+  } as unknown as LoadedConfig)
+
+  await command({
+    positionals: ['clean', tgzkey],
+    options,
+  } as unknown as LoadedConfig)
+
+  t.equal(
+    statSync(resolve(dir, 'registry-client')).isDirectory(),
+    true,
+  )
+  t.equal(
+    statSync(resolve(dir, 'registry-client', tgzkeyHash)).isFile(),
+    true,
+    'tgz not expired, so not deleted',
+  )
+  t.throws(() =>
+    statSync(resolve(dir, 'registry-client', pakukeyHash)),
+  )
+  t.throws(() =>
+    statSync(resolve(dir, 'registry-client', pakukeyHash) + '.key'),
+  )
+})
+
+t.test('ls', async t => {
+  const dir = createCache(t)
+  const { command, CacheView } = await mockCommand(t)
+  const options = { cache: dir }
+  Object.assign(options, {
+    packageInfo: new PackageInfoClient(options),
+  })
+
+  const conf = {
+    positionals: ['ls'],
+    options,
+  } as unknown as LoadedConfig
+
+  new CacheView({} as unknown as ViewOptions, conf)
+
+  const result = await command(conf)
+  if (!result) throw new Error('no result??')
+  t.matchSnapshot(
+    Object.keys(result).sort((a, b) => a.localeCompare(b, 'en')),
+    'all results',
+  )
+
+  const resultSingle = await command({
+    positionals: ['ls', pakukey, headPakukey, 'asdfasdfasdf'],
+    options,
+  } as unknown as LoadedConfig)
+  if (!resultSingle) throw new Error('no result??')
+  t.matchSnapshot(Object.keys(resultSingle), 'one result')
+
+  t.equal(
+    statSync(resolve(dir, 'registry-client')).isDirectory(),
+    true,
+  )
+  t.equal(
+    statSync(resolve(dir, 'registry-client', pakukeyHash)).isFile(),
+    true,
+  )
+  t.equal(
+    statSync(
+      resolve(dir, 'registry-client', pakukeyHash) + '.key',
+    ).isFile(),
+    true,
+  )
+})
+
+t.test('human view coverage bits', async t => {
+  const { CacheView } = await mockCommand(t)
+
+  const view = new CacheView(
+    {} as unknown as ViewOptions,
+    {} as unknown as LoadedConfig,
+  )
+
+  view.stdout('hello', 'world')
+  t.throws(() => view.error(new Error('hello')), new Error('hello'))
+})

--- a/src/cli-sdk/test/commands/whoami.ts
+++ b/src/cli-sdk/test/commands/whoami.ts
@@ -6,9 +6,9 @@ const Command = await t.mockImport<
 >('../../src/commands/whoami.ts', {
   '@vltpkg/registry-client': {
     RegistryClient: class {
-      async request(url: string | URL, config: { cache: false }) {
+      async request(url: string | URL, config: { useCache: false }) {
         t.equal(String(url), 'https://registry/-/whoami')
-        t.strictSame(config, { cache: false })
+        t.strictSame(config, { useCache: false })
         return {
           json: () => ({ username: 'username' }),
         }

--- a/src/cli-sdk/test/index.ts
+++ b/src/cli-sdk/test/index.ts
@@ -26,6 +26,7 @@ export const run = async (
     {
       '../src/output.ts': {
         stdout: (v: string) => state.logs.push(v),
+        stderr: (v: string) => state.logs.push(v),
         outputCommand: (_: unknown, conf: LoadedConfig) =>
           (state.config = conf),
       },

--- a/src/package-info/src/index.ts
+++ b/src/package-info/src/index.ts
@@ -4,7 +4,10 @@ import { clone, resolve as gitResolve, revs } from '@vltpkg/git'
 import { PackageJson } from '@vltpkg/package-json'
 import type { PickManifestOptions } from '@vltpkg/pick-manifest'
 import { pickManifest } from '@vltpkg/pick-manifest'
-import type { RegistryClientOptions } from '@vltpkg/registry-client'
+import type {
+  RegistryClientOptions,
+  RegistryClientRequestOptions,
+} from '@vltpkg/registry-client'
 import { RegistryClient } from '@vltpkg/registry-client'
 import type { SpecOptions } from '@vltpkg/spec'
 import { Spec } from '@vltpkg/spec'
@@ -49,10 +52,11 @@ export type PackageInfoClientOptions = RegistryClientOptions &
     workspace?: string[]
   }
 
-export type PackageInfoClientRequestOptions = PickManifestOptions & {
-  /** dir to resolve `file://` specifiers against. Defaults to projectRoot. */
-  from?: string
-}
+export type PackageInfoClientRequestOptions = PickManifestOptions &
+  RegistryClientRequestOptions & {
+    /** dir to resolve `file://` specifiers against. Defaults to projectRoot. */
+    from?: string
+  }
 
 export type PackageInfoClientExtractOptions =
   PackageInfoClientRequestOptions & {
@@ -297,6 +301,7 @@ export class PackageInfoClient {
           this.#trustedIntegrities.get(tarball) === integrity
 
         const response = await this.registryClient.request(tarball, {
+          ...options,
           integrity,
           trustIntegrity,
         })

--- a/src/registry-client/tap-snapshots/test/cache-entry.ts.test.cjs
+++ b/src/registry-client/tap-snapshots/test/cache-entry.ts.test.cjs
@@ -8,14 +8,22 @@
 exports[`test/cache-entry.ts > TAP > inspect value (should include color codes for displayed object) 1`] = `
 @vltpkg/registry-client.CacheEntry {
   statusCode: [33m200[39m,
-  headers: [ [ [32m'key'[39m, [32m'value'[39m ], [ [32m'x'[39m, [32m'y'[39m ] ],
-  text: [32m''[39m,
+  headers: [
+    [ [32m'key'[39m, [32m'value'[39m ],
+    [ [32m'x'[39m, [32m'y'[39m ],
+    [
+      [32m'integrity'[39m,
+      [32m'sha512-ySpg5uL81UchHRtZ6rp4W9o9t6N/Gk8IZmtNs29m67Dt/ZQjqNsm5HIPDcujWGvEHPsTtI5dCR7nLHRqanslfA=='[39m
+    ]
+  ],
   contentType: [32m''[39m,
-  date: [90mundefined[39m,
+  integrity: [32m'sha512-ySpg5uL81UchHRtZ6rp4W9o9t6N/Gk8IZmtNs29m67Dt/ZQjqNsm5HIPDcujWGvEHPsTtI5dCR7nLHRqanslfA=='[39m,
   cacheControl: {},
   valid: [33mfalse[39m,
   staleWhileRevalidate: [33mtrue[39m,
-  age: [90mundefined[39m
+  maxAge: [33m300[39m,
+  isGzip: [33mfalse[39m,
+  isJSON: [33mfalse[39m
 }
 `
 
@@ -23,13 +31,13 @@ exports[`test/cache-entry.ts > TAP > inspect value should not dump excessively l
 @vltpkg/registry-client.CacheEntry {
   statusCode: 200,
   headers: [ [ 'content-encoding', 'identity' ], [ 'content-length', '1024' ] ],
-  text: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa…',
   contentType: '',
-  date: undefined,
   cacheControl: {},
   valid: false,
   staleWhileRevalidate: true,
-  age: undefined
+  maxAge: 300,
+  isGzip: false,
+  isJSON: false
 }
 `
 
@@ -37,12 +45,12 @@ exports[`test/cache-entry.ts > TAP > inspect value should not dump noisy binary 
 @vltpkg/registry-client.CacheEntry {
   statusCode: 200,
   headers: [ [ 'content-encoding', 'identity' ], [ 'content-length', '6' ] ],
-  text: '[binary data]',
   contentType: '',
-  date: undefined,
   cacheControl: {},
   valid: false,
   staleWhileRevalidate: true,
-  age: undefined
+  maxAge: 300,
+  isGzip: false,
+  isJSON: false
 }
 `

--- a/src/registry-client/test/index.ts
+++ b/src/registry-client/test/index.ts
@@ -314,8 +314,7 @@ t.test('make a request', { saveFixture: true }, async t => {
 
   // make it look like an old cache entry that's an etag match
   res2.setHeader('date', new Date('2020-01-01').toISOString())
-  const { origin, pathname } = new URL(`${registryURL}/abbrev`)
-  const key = JSON.stringify([origin, 'GET', pathname])
+  const key = `${registryURL}/abbrev`
   rc.cache.set(key, res2.encode())
 
   // make a cache hit request
@@ -333,7 +332,7 @@ t.test('register unzipping for gzip responses', async t => {
   t.strictSame(unzipRegistered, [
     [
       resolve(t.testdirName, 'registry-client'),
-      JSON.stringify([registryURL, 'GET', '/some/tarball']),
+      String(new URL('/some/tarball', registryURL)),
     ],
   ])
 })
@@ -635,7 +634,7 @@ t.test('401 prompting otplease', async t => {
   const rc = t.context.rc as RegistryClient
   const result = await rc.request(
     new URL('/-/401/yolo', registryURL),
-    { cache: false },
+    { useCache: false },
   )
   t.match(result, { statusCode: 200 })
 })

--- a/src/spec/src/browser.ts
+++ b/src/spec/src/browser.ts
@@ -1,8 +1,7 @@
-import { error, typeError } from '@vltpkg/error-cause'
 import type { ErrorCauseObject } from '@vltpkg/error-cause'
-import { parseRange } from '@vltpkg/semver'
+import { error, typeError } from '@vltpkg/error-cause'
 import type { Range } from '@vltpkg/semver'
-export * from './types.ts'
+import { parseRange } from '@vltpkg/semver'
 import type {
   GitSelectorParsed,
   Scope,
@@ -10,6 +9,7 @@ import type {
   SpecOptions,
   SpecOptionsFilled,
 } from './types.ts'
+export * from './types.ts'
 
 export const kCustomInspect = Symbol.for('nodejs.util.inspect.custom')
 


### PR DESCRIPTION
```
Usage:
  vlt cache <command> [flags]

Work with vlt cache folders

  Subcommands

    add
      Resolve the referenced package identifiers and ensure they are cached

      ​vlt cache add <package-spec> [<package-spec>...]

    ls
      Show cache entries

      ​vlt cache ls [<key>...]

    clean
      Purge expired cache entries

      ​vlt cache clean [<key>...]

    delete
      Purge items explicitly, whether expired or not

      ​vlt cache delete <key> [<key>...]

    delete-before
      Purge all cache items from before a given date

      ​vlt cache delete-before <date>

    delete-all
      Delete the entire cache folder to make vlt slower

      ​vlt cache delete-all

```