### PR TITLE
query: add retry logic to outdated selector

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1428,6 +1428,9 @@ importers:
       '@vltpkg/types':
         specifier: workspace:*
         version: link:../types
+      p-retry:
+        specifier: 'catalog:'
+        version: 6.2.1
       postcss-selector-parser:
         specifier: ^6.1.2
         version: 6.1.2
@@ -12564,7 +12567,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.0(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.7.0)(eslint@9.20.0(jiti@2.4.2)):
+  eslint-module-utils@2.12.0(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.7.0(eslint-plugin-import@2.31.0)(eslint@9.20.0(jiti@2.4.2)))(eslint@9.20.0(jiti@2.4.2)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
@@ -12585,7 +12588,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.20.0(jiti@2.4.2)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.0(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.7.0)(eslint@9.20.0(jiti@2.4.2))
+      eslint-module-utils: 2.12.0(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.7.0(eslint-plugin-import@2.31.0)(eslint@9.20.0(jiti@2.4.2)))(eslint@9.20.0(jiti@2.4.2))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3

--- a/src/query/package.json
+++ b/src/query/package.json
@@ -25,6 +25,7 @@
     "@vltpkg/security-archive": "workspace:*",
     "@vltpkg/semver": "workspace:*",
     "@vltpkg/types": "workspace:*",
+    "p-retry": "catalog:",
     "postcss-selector-parser": "^6.1.2"
   },
   "devDependencies": {

--- a/src/query/src/index.ts
+++ b/src/query/src/index.ts
@@ -115,6 +115,7 @@ export const walk = async (
 
 export type QueryOptions = {
   graph: GraphLike
+  retries?: number
   specOptions: SpecOptions
   securityArchive: SecurityArchiveLike | undefined
 }
@@ -159,6 +160,7 @@ const securitySelectors = new Set([
 export class Query {
   #cache: Map<string, QueryResponse>
   #graph: GraphLike
+  #retries: number
   #specOptions: SpecOptions
   #securityArchive: SecurityArchiveLike | undefined
 
@@ -176,9 +178,15 @@ export class Query {
     return false
   }
 
-  constructor({ graph, specOptions, securityArchive }: QueryOptions) {
+  constructor({
+    graph,
+    retries,
+    specOptions,
+    securityArchive,
+  }: QueryOptions) {
     this.#cache = new Map()
     this.#graph = graph
+    this.#retries = retries ?? 3
     this.#specOptions = specOptions
     this.#securityArchive = securityArchive
   }
@@ -393,6 +401,7 @@ export class Query {
         edges: new Set<EdgeLike>(),
       },
       partial: { nodes, edges },
+      retries: this.#retries,
       signal,
       securityArchive: this.#securityArchive,
       specOptions: this.#specOptions,

--- a/src/query/src/pseudo.ts
+++ b/src/query/src/pseudo.ts
@@ -87,6 +87,7 @@ const has = async (state: ParserState) => {
           edges: new Set(state.partial.edges),
           nodes: new Set(state.partial.nodes),
         },
+        retries: state.retries,
         securityArchive: state.securityArchive,
         specOptions: state.specOptions,
       })
@@ -169,6 +170,7 @@ const is = async (state: ParserState) => {
           edges: new Set(state.partial.edges),
         },
         walk: state.walk,
+        retries: state.retries,
         securityArchive: state.securityArchive,
         specOptions: state.specOptions,
       })
@@ -222,6 +224,7 @@ const not = async (state: ParserState) => {
           edges: new Set(state.partial.edges),
         },
         walk: state.walk,
+        retries: state.retries,
         securityArchive: state.securityArchive,
         specOptions: state.specOptions,
       })

--- a/src/query/src/pseudo/outdated.ts
+++ b/src/query/src/pseudo/outdated.ts
@@ -82,6 +82,7 @@ export const asOutdatedKind = (value: string): OutdatedKinds => {
 export const retrieveRemoteVersions = async (
   node: NodeLike,
   specOptions: SpecOptions,
+  signal?: AbortSignal,
 ): Promise<string[]> => {
   const spec = hydrate(node.id, String(node.name), specOptions)
   if (!spec.registry || !node.name) {
@@ -95,6 +96,7 @@ export const retrieveRemoteVersions = async (
     headers: {
       Accept: 'application/vnd.npm.install-v1+json',
     },
+    signal,
   })
   // on missing valid auth or API, it should abort the retry logic
   if (response.status === 404) {
@@ -154,9 +156,11 @@ export const queueNode = async (
   let versions: string[]
   try {
     versions = await pRetry(
-      () => retrieveRemoteVersions(node, state.specOptions),
+      () =>
+        retrieveRemoteVersions(node, state.specOptions, state.signal),
       {
         retries: state.retries,
+        signal: state.signal,
       },
     )
   } catch (err) {

--- a/src/query/src/pseudo/outdated.ts
+++ b/src/query/src/pseudo/outdated.ts
@@ -1,3 +1,4 @@
+import pRetry, { AbortError } from 'p-retry'
 import { hydrate, splitDepID } from '@vltpkg/dep-id/browser'
 import { error } from '@vltpkg/error-cause'
 import type { NodeLike } from '@vltpkg/graph'
@@ -90,38 +91,25 @@ export const retrieveRemoteVersions = async (
   const url = new URL(spec.registry)
   url.pathname = `/${node.name}`
 
-  try {
-    const response = await fetch(String(url), {
-      headers: {
-        Accept: 'application/vnd.npm.install-v1+json',
-      },
-    })
-    if (!response.ok) {
-      // eslint-disable-next-line no-console
-      console.warn(
-        error('Failed to fetch packument', {
-          name: String(node.name),
-          spec,
-          response,
-        }),
-      )
-      return []
-    }
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-    const packument: Packument = await response.json()
-    return Object.keys(packument.versions).sort(compare)
-  } catch (e) {
-    const err = e as Error
-    // eslint-disable-next-line no-console
-    console.warn(
-      error('Could not retrieve registry versions', {
-        name: String(node.name),
-        spec,
-        cause: err,
-      }),
-    )
-    return []
+  const response = await fetch(String(url), {
+    headers: {
+      Accept: 'application/vnd.npm.install-v1+json',
+    },
+  })
+  // on missing valid auth or API, it should abort the retry logic
+  if (response.status === 404) {
+    throw new AbortError('Missing API')
   }
+  if (!response.ok) {
+    throw error('Failed to fetch packument', {
+      name: String(node.name),
+      spec,
+      response,
+    })
+  }
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+  const packument: Packument = await response.json()
+  return Object.keys(packument.versions).sort(compare)
 }
 
 /**
@@ -163,10 +151,24 @@ export const queueNode = async (
   }
 
   const nodeVersion: string = node.version
-  const versions = await retrieveRemoteVersions(
-    node,
-    state.specOptions,
-  )
+  let versions: string[]
+  try {
+    versions = await pRetry(
+      () => retrieveRemoteVersions(node, state.specOptions),
+      {
+        retries: state.retries,
+      },
+    )
+  } catch (err) {
+    // eslint-disable-next-line no-console
+    console.warn(
+      error('Could not retrieve registry versions', {
+        name: String(node.name),
+        cause: err,
+      }),
+    )
+    versions = []
+  }
 
   const greaterVersions = versions.filter((version: string) =>
     gt(version, nodeVersion),

--- a/src/query/src/types.ts
+++ b/src/query/src/types.ts
@@ -50,6 +50,7 @@ export type ParserState = {
   signal?: AbortSignal
   walk: ParserFn
   partial: GraphSelectionState
+  retries: number
   securityArchive: SecurityArchiveLike | undefined
   specOptions: SpecOptions
 }

--- a/src/query/tap-snapshots/test/pseudo/outdated.ts.test.cjs
+++ b/src/query/tap-snapshots/test/pseudo/outdated.ts.test.cjs
@@ -5,6 +5,22 @@
  * Make sure to inspect the output below.  Do not ignore changes!
  */
 'use strict'
+exports[`test/pseudo/outdated.ts > TAP > select from outdated definition > missing package response > should log a warning for missing package response 1`] = `
+Array [
+  Array [
+    Error: Could not retrieve registry versions {
+      "cause": Object {
+        "cause": Error: Missing API {
+          "attemptNumber": 1,
+          "retriesLeft": 0,
+        },
+        "name": "c",
+      },
+    },
+  ],
+]
+`
+
 exports[`test/pseudo/outdated.ts > TAP > select from outdated definition > outdated kind any > must match snapshot 1`] = `
 Object {
   "edges": Array [

--- a/src/query/test/attribute.ts
+++ b/src/query/test/attribute.ts
@@ -239,6 +239,7 @@ t.test('filterAttributes', async t => {
     partial: all,
     loose: false,
     walk: async (state: ParserState) => state,
+    retries: 0,
     securityArchive: undefined,
     specOptions: {},
   }

--- a/src/query/test/fixtures/selector.ts
+++ b/src/query/test/fixtures/selector.ts
@@ -87,6 +87,7 @@ export const selectorFixture =
       initial,
       partial,
       walk,
+      retries: 0,
       securityArchive: undefined,
       specOptions: {},
     }

--- a/src/query/test/index.ts
+++ b/src/query/test/index.ts
@@ -38,6 +38,7 @@ const testBrokenState = (): ParserState => {
     initial: copyGraphSelectionState(initial),
     partial: copyGraphSelectionState(initial),
     walk,
+    retries: 0,
     securityArchive: undefined,
     specOptions,
   }

--- a/src/query/test/pseudo/abandoned.ts
+++ b/src/query/test/pseudo/abandoned.ts
@@ -26,6 +26,7 @@ t.test('selects packages with an abandoned alert', async t => {
       },
       cancellable: async () => {},
       walk: async i => i,
+      retries: 0,
       securityArchive: asSecurityArchiveLike(
         new Map([
           [
@@ -76,6 +77,7 @@ t.test('missing security archive', async t => {
       },
       cancellable: async () => {},
       walk: async i => i,
+      retries: 0,
       securityArchive: undefined,
       specOptions: {},
     }

--- a/src/query/test/pseudo/confused.ts
+++ b/src/query/test/pseudo/confused.ts
@@ -26,6 +26,7 @@ t.test('selects packages with a manifestConfusion alert', async t => {
       },
       cancellable: async () => {},
       walk: async i => i,
+      retries: 0,
       securityArchive: asSecurityArchiveLike(
         new Map([
           [
@@ -76,6 +77,7 @@ t.test('missing security archive', async t => {
       },
       cancellable: async () => {},
       walk: async i => i,
+      retries: 0,
       securityArchive: undefined,
       specOptions: {},
     }

--- a/src/query/test/pseudo/cve.ts
+++ b/src/query/test/pseudo/cve.ts
@@ -29,6 +29,7 @@ t.test('selects packages with a CVE alert', async t => {
       },
       cancellable: async () => {},
       walk: async i => i,
+      retries: 0,
       securityArchive: asSecurityArchiveLike(
         new Map([
           [
@@ -128,6 +129,7 @@ t.test('missing security archive', async t => {
       },
       cancellable: async () => {},
       walk: async i => i,
+      retries: 0,
       securityArchive: undefined,
       specOptions: {},
     }
@@ -161,6 +163,7 @@ t.test('missing CVE ID', async t => {
       },
       cancellable: async () => {},
       walk: async i => i,
+      retries: 0,
       securityArchive: asSecurityArchiveLike(new Map()),
       specOptions: {},
     }

--- a/src/query/test/pseudo/cwe.ts
+++ b/src/query/test/pseudo/cwe.ts
@@ -27,6 +27,7 @@ t.test('selects packages with a CWE alert', async t => {
       },
       cancellable: async () => {},
       walk: async i => i,
+      retries: 0,
       securityArchive: asSecurityArchiveLike(
         new Map([
           [
@@ -130,6 +131,7 @@ t.test('missing security archive', async t => {
       },
       cancellable: async () => {},
       walk: async i => i,
+      retries: 0,
       securityArchive: undefined,
       specOptions: {},
     }
@@ -163,6 +165,7 @@ t.test('missing CWE ID', async t => {
       },
       cancellable: async () => {},
       walk: async i => i,
+      retries: 0,
       securityArchive: asSecurityArchiveLike(new Map()),
       specOptions: {},
     }

--- a/src/query/test/pseudo/debug.ts
+++ b/src/query/test/pseudo/debug.ts
@@ -26,6 +26,7 @@ t.test('selects packages with a debugAccess alert', async t => {
       },
       cancellable: async () => {},
       walk: async i => i,
+      retries: 0,
       securityArchive: asSecurityArchiveLike(
         new Map([
           [
@@ -76,6 +77,7 @@ t.test('missing security archive', async t => {
       },
       cancellable: async () => {},
       walk: async i => i,
+      retries: 0,
       securityArchive: undefined,
       specOptions: {},
     }

--- a/src/query/test/pseudo/deprecated.ts
+++ b/src/query/test/pseudo/deprecated.ts
@@ -26,6 +26,7 @@ t.test('selects packages with a deprecated alert', async t => {
       },
       cancellable: async () => {},
       walk: async i => i,
+      retries: 0,
       securityArchive: asSecurityArchiveLike(
         new Map([
           [
@@ -76,6 +77,7 @@ t.test('missing security archive', async t => {
       },
       cancellable: async () => {},
       walk: async i => i,
+      retries: 0,
       securityArchive: undefined,
       specOptions: {},
     }

--- a/src/query/test/pseudo/dynamic.ts
+++ b/src/query/test/pseudo/dynamic.ts
@@ -26,6 +26,7 @@ t.test('selects packages with a dynamicRequire alert', async t => {
       },
       cancellable: async () => {},
       walk: async i => i,
+      retries: 0,
       securityArchive: asSecurityArchiveLike(
         new Map([
           [
@@ -76,6 +77,7 @@ t.test('missing security archive', async t => {
       },
       cancellable: async () => {},
       walk: async i => i,
+      retries: 0,
       securityArchive: undefined,
       specOptions: {},
     }

--- a/src/query/test/pseudo/entropic.ts
+++ b/src/query/test/pseudo/entropic.ts
@@ -28,6 +28,7 @@ t.test(
         },
         cancellable: async () => {},
         walk: async i => i,
+        retries: 0,
         securityArchive: asSecurityArchiveLike(
           new Map([
             [
@@ -79,6 +80,7 @@ t.test('missing security archive', async t => {
       },
       cancellable: async () => {},
       walk: async i => i,
+      retries: 0,
       securityArchive: undefined,
       specOptions: {},
     }

--- a/src/query/test/pseudo/env.ts
+++ b/src/query/test/pseudo/env.ts
@@ -26,6 +26,7 @@ t.test('selects packages with a envVars alert', async t => {
       },
       cancellable: async () => {},
       walk: async i => i,
+      retries: 0,
       securityArchive: asSecurityArchiveLike(
         new Map([
           [
@@ -76,6 +77,7 @@ t.test('missing security archive', async t => {
       },
       cancellable: async () => {},
       walk: async i => i,
+      retries: 0,
       securityArchive: undefined,
       specOptions: {},
     }

--- a/src/query/test/pseudo/eval.ts
+++ b/src/query/test/pseudo/eval.ts
@@ -26,6 +26,7 @@ t.test('selects packages with an eval alert', async t => {
       },
       cancellable: async () => {},
       walk: async i => i,
+      retries: 0,
       securityArchive: asSecurityArchiveLike(
         new Map([
           [
@@ -76,6 +77,7 @@ t.test('missing security archive', async t => {
       },
       cancellable: async () => {},
       walk: async i => i,
+      retries: 0,
       securityArchive: undefined,
       specOptions: {},
     }

--- a/src/query/test/pseudo/fs.ts
+++ b/src/query/test/pseudo/fs.ts
@@ -26,6 +26,7 @@ t.test('selects packages with a filesystemAccess alert', async t => {
       },
       cancellable: async () => {},
       walk: async i => i,
+      retries: 0,
       securityArchive: asSecurityArchiveLike(
         new Map([
           [
@@ -76,6 +77,7 @@ t.test('missing security archive', async t => {
       },
       cancellable: async () => {},
       walk: async i => i,
+      retries: 0,
       securityArchive: undefined,
       specOptions: {},
     }

--- a/src/query/test/pseudo/helpers.ts
+++ b/src/query/test/pseudo/helpers.ts
@@ -143,6 +143,7 @@ t.test('selects packages with an unmaintained alert', async t => {
         ]),
       ),
       specOptions: {},
+      retries: 0,
     }
     return state
   }
@@ -190,6 +191,7 @@ t.test('missing security archive', async t => {
       walk: async i => i,
       securityArchive: undefined,
       specOptions: {},
+      retries: 0,
     }
     return state
   }

--- a/src/query/test/pseudo/license.ts
+++ b/src/query/test/pseudo/license.ts
@@ -30,6 +30,7 @@ t.test('selects packages with a specific license kind', async t => {
       },
       cancellable: async () => {},
       walk: async i => i,
+      retries: 0,
       securityArchive: asSecurityArchiveLike(
         new Map([
           [
@@ -111,6 +112,7 @@ t.test('missing security archive', async t => {
       },
       cancellable: async () => {},
       walk: async i => i,
+      retries: 0,
       securityArchive: undefined,
       specOptions: {},
     }

--- a/src/query/test/pseudo/malware.ts
+++ b/src/query/test/pseudo/malware.ts
@@ -49,6 +49,7 @@ t.test('selects packages with a specific malware kind', async t => {
         ]),
       ),
       specOptions: {},
+      retries: 0,
     }
     return state
   }
@@ -126,6 +127,7 @@ t.test('missing security archive', async t => {
       walk: async i => i,
       securityArchive: undefined,
       specOptions: {},
+      retries: 0,
     }
     return state
   }

--- a/src/query/test/pseudo/minified.ts
+++ b/src/query/test/pseudo/minified.ts
@@ -35,6 +35,7 @@ t.test('selects packages with a minifiedFile alert', async t => {
         ]),
       ),
       specOptions: {},
+      retries: 0,
     }
     return state
   }
@@ -78,6 +79,7 @@ t.test('missing security archive', async t => {
       walk: async i => i,
       securityArchive: undefined,
       specOptions: {},
+      retries: 0,
     }
     return state
   }

--- a/src/query/test/pseudo/native.ts
+++ b/src/query/test/pseudo/native.ts
@@ -35,6 +35,7 @@ t.test('selects packages with a hasNativeCode alert', async t => {
         ]),
       ),
       specOptions: {},
+      retries: 0,
     }
     return state
   }
@@ -78,6 +79,7 @@ t.test('missing security archive', async t => {
       walk: async i => i,
       securityArchive: undefined,
       specOptions: {},
+      retries: 0,
     }
     return state
   }

--- a/src/query/test/pseudo/network.ts
+++ b/src/query/test/pseudo/network.ts
@@ -35,6 +35,7 @@ t.test('selects packages with a networkAccess alert', async t => {
         ]),
       ),
       specOptions: {},
+      retries: 0,
     }
     return state
   }
@@ -78,6 +79,7 @@ t.test('missing security archive', async t => {
       walk: async i => i,
       securityArchive: undefined,
       specOptions: {},
+      retries: 0,
     }
     return state
   }

--- a/src/query/test/pseudo/obfuscated.ts
+++ b/src/query/test/pseudo/obfuscated.ts
@@ -35,6 +35,7 @@ t.test('selects packages with an obfuscated alert', async t => {
         ]),
       ),
       specOptions: {},
+      retries: 0,
     }
     return state
   }
@@ -78,6 +79,7 @@ t.test('missing security archive', async t => {
       walk: async i => i,
       securityArchive: undefined,
       specOptions: {},
+      retries: 0,
     }
     return state
   }

--- a/src/query/test/pseudo/scanned.ts
+++ b/src/query/test/pseudo/scanned.ts
@@ -48,6 +48,7 @@ t.test('scanned selector', async t => {
       walk: async i => i,
       securityArchive,
       specOptions: {},
+      retries: 0,
     }
     return state
   }

--- a/src/query/test/pseudo/scripts.ts
+++ b/src/query/test/pseudo/scripts.ts
@@ -35,6 +35,7 @@ t.test('selects packages with an installScripts alert', async t => {
         ]),
       ),
       specOptions: {},
+      retries: 0,
     }
     return state
   }
@@ -78,6 +79,7 @@ t.test('missing security archive', async t => {
       walk: async i => i,
       securityArchive: undefined,
       specOptions: {},
+      retries: 0,
     }
     return state
   }

--- a/src/query/test/pseudo/semver.ts
+++ b/src/query/test/pseudo/semver.ts
@@ -31,6 +31,7 @@ t.test('select from semver definition', async t => {
         edges: new Set(),
         nodes: new Set(),
       },
+      retries: 0,
       cancellable: async () => {},
       walk: async i => i,
       securityArchive: undefined,

--- a/src/query/test/pseudo/severity.ts
+++ b/src/query/test/pseudo/severity.ts
@@ -49,6 +49,7 @@ t.test('selects packages with a specific severity kind', async t => {
         ]),
       ),
       specOptions: {},
+      retries: 0,
     }
     return state
   }
@@ -126,6 +127,7 @@ t.test('missing security archive', async t => {
       walk: async i => i,
       securityArchive: undefined,
       specOptions: {},
+      retries: 0,
     }
     return state
   }

--- a/src/query/test/pseudo/shell.ts
+++ b/src/query/test/pseudo/shell.ts
@@ -35,6 +35,7 @@ t.test('selects packages with a shellAccess alert', async t => {
         ]),
       ),
       specOptions: {},
+      retries: 0,
     }
     return state
   }
@@ -78,6 +79,7 @@ t.test('missing security archive', async t => {
       walk: async i => i,
       securityArchive: undefined,
       specOptions: {},
+      retries: 0,
     }
     return state
   }

--- a/src/query/test/pseudo/shrinkwrap.ts
+++ b/src/query/test/pseudo/shrinkwrap.ts
@@ -35,6 +35,7 @@ t.test('selects packages with a shrinkwrap alert', async t => {
         ]),
       ),
       specOptions: {},
+      retries: 0,
     }
     return state
   }
@@ -78,6 +79,7 @@ t.test('missing security archive', async t => {
       walk: async i => i,
       securityArchive: undefined,
       specOptions: {},
+      retries: 0,
     }
     return state
   }

--- a/src/query/test/pseudo/squat.ts
+++ b/src/query/test/pseudo/squat.ts
@@ -49,6 +49,7 @@ t.test('selects packages with a specific squat kind', async t => {
         ]),
       ),
       specOptions: {},
+      retries: 0,
     }
     return state
   }
@@ -126,6 +127,7 @@ t.test('missing security archive', async t => {
       walk: async i => i,
       securityArchive: undefined,
       specOptions: {},
+      retries: 0,
     }
     return state
   }

--- a/src/query/test/pseudo/suspicious.ts
+++ b/src/query/test/pseudo/suspicious.ts
@@ -35,6 +35,7 @@ t.test('selects packages with a suspicious alert', async t => {
         ]),
       ),
       specOptions: {},
+      retries: 0,
     }
     return state
   }
@@ -78,6 +79,7 @@ t.test('missing security archive', async t => {
       walk: async i => i,
       securityArchive: undefined,
       specOptions: {},
+      retries: 0,
     }
     return state
   }

--- a/src/query/test/pseudo/tracker.ts
+++ b/src/query/test/pseudo/tracker.ts
@@ -35,6 +35,7 @@ t.test('selects packages with a tracker alert', async t => {
         ]),
       ),
       specOptions: {},
+      retries: 0,
     }
     return state
   }
@@ -78,6 +79,7 @@ t.test('missing security archive', async t => {
       walk: async i => i,
       securityArchive: undefined,
       specOptions: {},
+      retries: 0,
     }
     return state
   }

--- a/src/query/test/pseudo/trivial.ts
+++ b/src/query/test/pseudo/trivial.ts
@@ -35,6 +35,7 @@ t.test('selects packages with a trivial alert', async t => {
         ]),
       ),
       specOptions: {},
+      retries: 0,
     }
     return state
   }
@@ -78,6 +79,7 @@ t.test('missing security archive', async t => {
       walk: async i => i,
       securityArchive: undefined,
       specOptions: {},
+      retries: 0,
     }
     return state
   }

--- a/src/query/test/pseudo/undesirable.ts
+++ b/src/query/test/pseudo/undesirable.ts
@@ -35,6 +35,7 @@ t.test('selects packages with an undesirable alert', async t => {
         ]),
       ),
       specOptions: {},
+      retries: 0,
     }
     return state
   }
@@ -78,6 +79,7 @@ t.test('missing security archive', async t => {
       walk: async i => i,
       securityArchive: undefined,
       specOptions: {},
+      retries: 0,
     }
     return state
   }

--- a/src/query/test/pseudo/unknown.ts
+++ b/src/query/test/pseudo/unknown.ts
@@ -35,6 +35,7 @@ t.test('selects packages with an unknown alert', async t => {
         ]),
       ),
       specOptions: {},
+      retries: 0,
     }
     return state
   }
@@ -78,6 +79,7 @@ t.test('missing security archive', async t => {
       walk: async i => i,
       securityArchive: undefined,
       specOptions: {},
+      retries: 0,
     }
     return state
   }

--- a/src/query/test/pseudo/unmaintained.ts
+++ b/src/query/test/pseudo/unmaintained.ts
@@ -35,6 +35,7 @@ t.test('selects packages with an unmaintained alert', async t => {
         ]),
       ),
       specOptions: {},
+      retries: 0,
     }
     return state
   }
@@ -78,6 +79,7 @@ t.test('missing security archive', async t => {
       walk: async i => i,
       securityArchive: undefined,
       specOptions: {},
+      retries: 0,
     }
     return state
   }

--- a/src/query/test/pseudo/unpopular.ts
+++ b/src/query/test/pseudo/unpopular.ts
@@ -35,6 +35,7 @@ t.test('selects packages with an unpopular alert', async t => {
         ]),
       ),
       specOptions: {},
+      retries: 0,
     }
     return state
   }
@@ -78,6 +79,7 @@ t.test('missing security archive', async t => {
       walk: async i => i,
       securityArchive: undefined,
       specOptions: {},
+      retries: 0,
     }
     return state
   }

--- a/src/query/test/pseudo/unstable.ts
+++ b/src/query/test/pseudo/unstable.ts
@@ -35,6 +35,7 @@ t.test('selects packages with an unstable alert', async t => {
         ]),
       ),
       specOptions: {},
+      retries: 0,
     }
     return state
   }
@@ -78,6 +79,7 @@ t.test('missing security archive', async t => {
       walk: async i => i,
       securityArchive: undefined,
       specOptions: {},
+      retries: 0,
     }
     return state
   }


### PR DESCRIPTION
Currently the `:outdated()` selector will only try fetching data from the packument in order to check version values. This change adds a retry mechanism to ensure requests are retried in case of network failure.

Fixes: https://github.com/vltpkg/vltpkg/issues/525