### PR TITLE
fix `vlt query` results

### DIFF
--- a/src/query/src/index.ts
+++ b/src/query/src/index.ts
@@ -206,16 +206,15 @@ export class Query {
           i => i.type === 'manifestConfusion',
         ),
         cve: securityArchiveEntry.alerts
-          .filter(i => i.props.cveId)
-          // can not be undefined because of the filter above
-          // but TS doesn't know that
-          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-          .map(i => i.props.cveId!),
+          .filter(i => i.props?.cveId)
+          // can not be undefined because of the filter above but TS doesn't know that
+          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion, @typescript-eslint/no-non-null-asserted-optional-chain
+          .map(i => i.props?.cveId!),
         cwe: Array.from(
           new Set(
             securityArchiveEntry.alerts
-              .filter(i => i.props.cveId)
-              .flatMap(i => i.props.cwes?.map(j => j.id)),
+              .filter(i => i.props?.cveId)
+              .flatMap(i => i.props?.cwes?.map(j => j.id)),
           ),
         ) as `CWE-${string}`[],
         debug: securityArchiveEntry.alerts.some(

--- a/src/query/src/pseudo/cve.ts
+++ b/src/query/src/pseudo/cve.ts
@@ -65,7 +65,7 @@ export const cve = async (state: ParserState) => {
     const report = state.securityArchive.get(node.id)
     const exclude = !report?.alerts.some(
       alert =>
-        alert.props.cveId?.trim().toLowerCase() ===
+        alert.props?.cveId?.trim().toLowerCase() ===
         cveId.trim().toLowerCase(),
     )
     if (exclude) {

--- a/src/query/src/pseudo/cwe.ts
+++ b/src/query/src/pseudo/cwe.ts
@@ -64,7 +64,7 @@ export const cwe = async (state: ParserState) => {
   for (const node of state.partial.nodes) {
     const report = state.securityArchive.get(node.id)
     const exclude = !report?.alerts.some(alert =>
-      alert.props.cwes?.some(
+      alert.props?.cwes?.some(
         cwe =>
           cwe.id.trim().toLowerCase() === cweId.trim().toLowerCase(),
       ),

--- a/src/security-archive/src/types.ts
+++ b/src/security-archive/src/types.ts
@@ -67,7 +67,7 @@ export type PackageAlert = {
   type: string
   severity: 'low' | 'medium' | 'high' | 'critical'
   category: string
-  props: PackageAlertProps
+  props?: PackageAlertProps
 }
 
 /**


### PR DESCRIPTION
Fixes an issue with not being able to read results due to logic that tries to read properties from an undefined value. Type definition for the resulting package alert object is fixed and so its usage in `@vltpkg/query`.