### PR TITLE
cli-sdk: add expect-results config

### DIFF
--- a/src/cli-sdk/src/commands/query.ts
+++ b/src/cli-sdk/src/commands/query.ts
@@ -25,7 +25,7 @@ export const usage: CommandUsage = () =>
     command: 'query',
     usage: [
       '',
-      '<query> --view=[human | json | mermaid | gui]',
+      '<query> --view=<human | json | mermaid | gui>',
       '<query> --expect-results=<comparison string>',
     ],
     description:

--- a/src/cli-sdk/src/commands/query.ts
+++ b/src/cli-sdk/src/commands/query.ts
@@ -26,7 +26,7 @@ export const usage: CommandUsage = () =>
     usage: [
       '',
       '<query> --view=[human | json | mermaid | gui]',
-      '<query> --expect=[number | boolean | string]',
+      '<query> --expect-results=[number | string]',
     ],
     description:
       'List installed dependencies matching the provided query.',
@@ -51,7 +51,7 @@ export const usage: CommandUsage = () =>
     },
     options: {
       'expect-results': {
-        value: '[number | boolean | string]',
+        value: '[number | string]',
         description:
           'Sets an expected number of resulting items. Errors if the number of resulting items does not match the set value. Accepts a specific numeric value, "true" (same as "> 0"), "false" (same as 0) or a string value starting with either ">", "<", ">=" or "<=" followed by a numeric value to be compared.',
       },
@@ -80,10 +80,6 @@ const validateExpectedResult = (
     return edges.length > parseInt(expectResults.slice(1).trim(), 10)
   } else if (expectResults?.startsWith('<')) {
     return edges.length < parseInt(expectResults.slice(1).trim(), 10)
-  } else if (expectResults === 'true') {
-    return edges.length > 0
-  } else if (expectResults === 'false') {
-    return edges.length === 0
   } else if (expectResults) {
     return edges.length === parseInt(expectResults.trim(), 10)
   }
@@ -147,14 +143,9 @@ export const command: CommandFn<QueryResult> = async conf => {
   }
 
   if (!validateExpectedResult(conf, edges)) {
-    const expectResults = conf.values['expect-results']
-    const wanted =
-      expectResults === 'true' ? '> 0'
-      : expectResults === 'false' ? 0
-      : expectResults
     throw error('Unexpected number of items', {
       found: edges.length,
-      wanted,
+      wanted: conf.values['expect-results'],
     })
   }
 

--- a/src/cli-sdk/src/commands/query.ts
+++ b/src/cli-sdk/src/commands/query.ts
@@ -53,7 +53,7 @@ export const usage: CommandUsage = () =>
       'expect-results': {
         value: '[number | string]',
         description:
-          'Sets an expected number of resulting items. Errors if the number of resulting items does not match the set value. Accepts a specific numeric value, "true" (same as "> 0"), "false" (same as 0) or a string value starting with either ">", "<", ">=" or "<=" followed by a numeric value to be compared.',
+          'Sets an expected number of resulting items. Errors if the number of resulting items does not match the set value. Accepts a specific numeric value or a string value starting with either ">", "<", ">=" or "<=" followed by a numeric value to be compared.',
       },
       view: {
         value: '[human | json | mermaid | gui]',

--- a/src/cli-sdk/src/commands/query.ts
+++ b/src/cli-sdk/src/commands/query.ts
@@ -26,7 +26,7 @@ export const usage: CommandUsage = () =>
     usage: [
       '',
       '<query> --view=[human | json | mermaid | gui]',
-      '<query> --expected-results=[number | boolean | string]',
+      '<query> --expect=[number | boolean | string]',
     ],
     description:
       'List installed dependencies matching the provided query.',

--- a/src/cli-sdk/src/commands/query.ts
+++ b/src/cli-sdk/src/commands/query.ts
@@ -26,7 +26,7 @@ export const usage: CommandUsage = () =>
     usage: [
       '',
       '<query> --view=[human | json | mermaid | gui]',
-      '<query> --expect-results=[number | string]',
+      '<query> --expect-results=<comparison string>',
     ],
     description:
       'List installed dependencies matching the provided query.',

--- a/src/cli-sdk/src/config/definition.ts
+++ b/src/cli-sdk/src/config/definition.ts
@@ -550,12 +550,12 @@ export const definition = j
   .opt({
     'expect-results': {
       hint: 'value',
+      validate: (v: unknown) =>
+        typeof v === 'string' && /^([<>]=?)?[0-9]+$/.test(v),
       description: `When running \`vlt query\`, this option allows you to
                     set a expected number of resulting items.
 
-                    Accepted values are numbers, booleans: true (to expect at
-                    least one result), false (to expect no results) and
-                    strings.
+                    Accepted values are numbers and strings.
 
                     Strings starting with \`>\`, \`<\`, \`>=\` or \`<=\`
                     followed by a number can be used to check if the result

--- a/src/cli-sdk/src/config/definition.ts
+++ b/src/cli-sdk/src/config/definition.ts
@@ -546,3 +546,19 @@ export const definition = j
       description: 'Print helpful information',
     },
   })
+
+  .opt({
+    'expect-results': {
+      hint: 'value',
+      description: `When running \`vlt query\`, this option allows you to
+                    set a expected number of resulting items.
+
+                    Accepted values are numbers, booleans: true (to expect at
+                    least one result), false (to expect no results) and
+                    strings.
+
+                    Strings starting with \`>\`, \`<\`, \`>=\` or \`<=\`
+                    followed by a number can be used to check if the result
+                    is greater than or less than a specific number.`,
+    },
+  })

--- a/src/cli-sdk/tap-snapshots/test/commands/query.ts.test.cjs
+++ b/src/cli-sdk/tap-snapshots/test/commands/query.ts.test.cjs
@@ -60,9 +60,8 @@ List installed dependencies matching the provided query.
     expect-results
       Sets an expected number of resulting items. Errors if the number of
       resulting items does not match the set value. Accepts a specific numeric
-      value, "true" (same as "> 0"), "false" (same as 0) or a string value
-      starting with either ">", "<", ">=" or "<=" followed by a numeric value to
-      be compared.
+      value or a string value starting with either ">", "<", ">=" or "<="
+      followed by a numeric value to be compared.
 
       ​--expect-results=[number | string]
 

--- a/src/cli-sdk/tap-snapshots/test/commands/query.ts.test.cjs
+++ b/src/cli-sdk/tap-snapshots/test/commands/query.ts.test.cjs
@@ -29,7 +29,7 @@ exports[`test/commands/query.ts > TAP > query > should have usage 1`] = `
 Usage:
   vlt query
   vlt query <query> --view=[human | json | mermaid | gui]
-  vlt query <query> --expected-results=[number | boolean | string]
+  vlt query <query> --expect=[number | boolean | string]
 
 List installed dependencies matching the provided query.
 

--- a/src/cli-sdk/tap-snapshots/test/commands/query.ts.test.cjs
+++ b/src/cli-sdk/tap-snapshots/test/commands/query.ts.test.cjs
@@ -15,10 +15,21 @@ exports[`test/commands/query.ts > TAP > query > colors > should use colors when 
 [0m[0m
 `
 
+exports[`test/commands/query.ts > TAP > query > expect-results option > should return items when expect-results check passes 1`] = `
+my-project
+├── foo@1.0.0
+├─┬ bar@1.0.0
+│ └─┬ custom:baz@1.0.0
+│   └── foo@1.0.0 (deduped)
+└── missing@^1.0.0 (missing)
+
+`
+
 exports[`test/commands/query.ts > TAP > query > should have usage 1`] = `
 Usage:
   vlt query
   vlt query <query> --view=[human | json | mermaid | gui]
+  vlt query <query> --expected-results=[number | boolean | string]
 
 List installed dependencies matching the provided query.
 
@@ -40,7 +51,20 @@ List installed dependencies matching the provided query.
 
     ​vlt query '[name^="@vltpkg"]'
 
+    Errors if a copyleft licensed package is found
+
+    ​vlt query '*:license(copyleft) --expect-results=0'
+
   Options
+
+    expect-results
+      Sets an expected number of resulting items. Errors if the number of
+      resulting items does not match the set value. Accepts a specific numeric
+      value, "true" (same as "> 0"), "false" (same as 0) or a string value
+      starting with either ">", "<", ">=" or "<=" followed by a numeric value to
+      be compared.
+
+      ​--expect-results=[number | boolean | string]
 
     view
       Output format. Defaults to human-readable or json if no tty.

--- a/src/cli-sdk/tap-snapshots/test/commands/query.ts.test.cjs
+++ b/src/cli-sdk/tap-snapshots/test/commands/query.ts.test.cjs
@@ -28,8 +28,8 @@ my-project
 exports[`test/commands/query.ts > TAP > query > should have usage 1`] = `
 Usage:
   vlt query
-  vlt query <query> --view=[human | json | mermaid | gui]
-  vlt query <query> --expect-results=[number | string]
+  vlt query <query> --view=<human | json | mermaid | gui>
+  vlt query <query> --expect-results=<comparison string>
 
 List installed dependencies matching the provided query.
 

--- a/src/cli-sdk/tap-snapshots/test/commands/query.ts.test.cjs
+++ b/src/cli-sdk/tap-snapshots/test/commands/query.ts.test.cjs
@@ -29,7 +29,7 @@ exports[`test/commands/query.ts > TAP > query > should have usage 1`] = `
 Usage:
   vlt query
   vlt query <query> --view=[human | json | mermaid | gui]
-  vlt query <query> --expect=[number | boolean | string]
+  vlt query <query> --expect-results=[number | string]
 
 List installed dependencies matching the provided query.
 
@@ -64,7 +64,7 @@ List installed dependencies matching the provided query.
       starting with either ">", "<", ">=" or "<=" followed by a numeric value to
       be compared.
 
-      ​--expect-results=[number | boolean | string]
+      ​--expect-results=[number | string]
 
     view
       Output format. Defaults to human-readable or json if no tty.

--- a/src/cli-sdk/tap-snapshots/test/commands/query.ts.test.cjs
+++ b/src/cli-sdk/tap-snapshots/test/commands/query.ts.test.cjs
@@ -19,7 +19,7 @@ exports[`test/commands/query.ts > TAP > query > expect-results option > should r
 my-project
 ├── foo@1.0.0
 ├─┬ bar@1.0.0
-│ └─┬ custom:baz@1.0.0
+│ └─┬ baz (custom:baz@1.0.0)
 │   └── foo@1.0.0 (deduped)
 └── missing@^1.0.0 (missing)
 

--- a/src/cli-sdk/tap-snapshots/test/config/definition.ts.test.cjs
+++ b/src/cli-sdk/tap-snapshots/test/config/definition.ts.test.cjs
@@ -91,6 +91,17 @@ Object {
     "hint": "program",
     "type": "string",
   },
+  "expect-results": Object {
+    "description": String(
+      When running \`vlt query\`, this option allows you to set a expected number of resulting items.
+      
+      Accepted values are numbers, booleans: true (to expect at least one result), false (to expect no results) and strings.
+      
+      Strings starting with \`>\`, \`<\`, \`>=\` or \`<=\` followed by a number can be used to check if the result is greater than or less than a specific number.
+    ),
+    "hint": "value",
+    "type": "string",
+  },
   "fallback-command": Object {
     "description": String(
       The command to run when the first argument doesn't match any known commands.

--- a/src/cli-sdk/tap-snapshots/test/config/definition.ts.test.cjs
+++ b/src/cli-sdk/tap-snapshots/test/config/definition.ts.test.cjs
@@ -95,12 +95,13 @@ Object {
     "description": String(
       When running \`vlt query\`, this option allows you to set a expected number of resulting items.
       
-      Accepted values are numbers, booleans: true (to expect at least one result), false (to expect no results) and strings.
+      Accepted values are numbers and strings.
       
       Strings starting with \`>\`, \`<\`, \`>=\` or \`<=\` followed by a number can be used to check if the result is greater than or less than a specific number.
     ),
     "hint": "value",
     "type": "string",
+    "validate": Function validate(v),
   },
   "fallback-command": Object {
     "description": String(

--- a/src/cli-sdk/test/commands/query.ts
+++ b/src/cli-sdk/test/commands/query.ts
@@ -209,7 +209,7 @@ t.test('query', async t => {
       await runCommand({
         positionals: ['*'],
         values: {
-          'expect-results': 'true',
+          'expect-results': '>0',
           view: 'human',
         },
         options,
@@ -227,37 +227,6 @@ t.test('query', async t => {
         options,
       }),
       'should pass gte checks',
-    )
-
-    await t.rejects(
-      Command.command({
-        positionals: ['*'],
-        values: {
-          'expect-results': 'false',
-          view: 'human',
-        },
-        options,
-      } as LoadedConfig),
-      /Unexpected number of items/,
-      'should fail validation for boolean check',
-    )
-
-    await t.rejects(
-      Command.command({
-        positionals: ['*[version="2.0.0"]'],
-        values: {
-          'expect-results': 'true',
-          view: 'human',
-        },
-        options,
-      } as LoadedConfig),
-      {
-        cause: {
-          found: 0,
-          wanted: '> 0',
-        },
-      },
-      'should convert wanted values from boolean check',
     )
 
     await t.rejects(

--- a/src/cli-sdk/test/commands/query.ts
+++ b/src/cli-sdk/test/commands/query.ts
@@ -204,6 +204,128 @@ t.test('query', async t => {
     'should fail to run with no security archive',
   )
 
+  await t.test('expect-results option', async t => {
+    t.matchSnapshot(
+      await runCommand({
+        positionals: ['*'],
+        values: {
+          'expect-results': 'true',
+          view: 'human',
+        },
+        options,
+      }),
+      'should return items when expect-results check passes',
+    )
+
+    t.ok(
+      await runCommand({
+        positionals: ['*'],
+        values: {
+          'expect-results': '>=  5',
+          view: 'human',
+        },
+        options,
+      }),
+      'should pass gte checks',
+    )
+
+    await t.rejects(
+      Command.command({
+        positionals: ['*'],
+        values: {
+          'expect-results': 'false',
+          view: 'human',
+        },
+        options,
+      } as LoadedConfig),
+      /Unexpected number of items/,
+      'should fail validation for boolean check',
+    )
+
+    await t.rejects(
+      Command.command({
+        positionals: ['*[version="2.0.0"]'],
+        values: {
+          'expect-results': 'true',
+          view: 'human',
+        },
+        options,
+      } as LoadedConfig),
+      {
+        cause: {
+          found: 0,
+          wanted: '> 0',
+        },
+      },
+      'should convert wanted values from boolean check',
+    )
+
+    await t.rejects(
+      Command.command({
+        positionals: ['[version="2.0.0"]'],
+        values: {
+          'expect-results': '>1',
+          view: 'human',
+        },
+        options,
+      } as LoadedConfig),
+      /Unexpected number of items/,
+      'should fail validation for gt check',
+    )
+
+    await t.rejects(
+      Command.command({
+        positionals: ['*'],
+        values: {
+          'expect-results': '>=1000',
+          view: 'human',
+        },
+        options,
+      } as LoadedConfig),
+      /Unexpected number of items/,
+      'should fail validation for gte check',
+    )
+
+    await t.rejects(
+      Command.command({
+        positionals: ['*'],
+        values: {
+          'expect-results': '<3',
+          view: 'human',
+        },
+        options,
+      } as LoadedConfig),
+      /Unexpected number of items/,
+      'should fail validation for lt check',
+    )
+
+    await t.rejects(
+      Command.command({
+        positionals: ['*'],
+        values: {
+          'expect-results': '<=1',
+          view: 'human',
+        },
+        options,
+      } as LoadedConfig),
+      /Unexpected number of items/,
+      'should fail validation for lte check',
+    )
+
+    await t.rejects(
+      Command.command({
+        positionals: ['*'],
+        values: {
+          'expect-results': '500',
+          view: 'human',
+        },
+        options,
+      } as LoadedConfig),
+      /Unexpected number of items/,
+      'should fail validation for exact numeric value check',
+    )
+  })
+
   await t.test('workspaces', async t => {
     const mainManifest = {
       name: 'my-project',

--- a/src/cli-sdk/test/config/definition.ts
+++ b/src/cli-sdk/test/config/definition.ts
@@ -50,6 +50,14 @@ t.test('identity can only be lowercase alphanum', async t => {
   t.equal(values.identity, 'asdf123')
 })
 
+t.test('expect-results validation', async t => {
+  t.throws(() => {
+    definition.parse(['--expect-results', 'foobar'])
+  })
+  const { values } = definition.parse(['--expect-results', '>=5000'])
+  t.equal(values['expect-results'], '>=5000')
+})
+
 t.test('default view depends on stdout TTY status', t => {
   t.test('tty true', async t => {
     delete process.env.VLT_VIEW


### PR DESCRIPTION
Add a new `--expect-results` config value that when used with the `vlt query` command allows for validation of the result values of a query.

Example:

    vlt query --expect-results=">=1"
    my-project
    └── a@1.0.0

    vlt query --expect-results=false
    Error: Unexpected number of items
        at ...
      [cause]: { found: 1, wanted: 0 }
    }

Fixes: https://github.com/vltpkg/vltpkg/issues/592