### PR TITLE
query: fix query response types

### DIFF
--- a/src/query/src/index.ts
+++ b/src/query/src/index.ts
@@ -19,6 +19,7 @@ import type {
   ParserFn,
   QueryResponse,
   QueryResponseNode,
+  QueryResponseEdge,
 } from './types.ts'
 
 export * from './types.ts'
@@ -180,6 +181,10 @@ export class Query {
     this.#graph = graph
     this.#specOptions = specOptions
     this.#securityArchive = securityArchive
+  }
+
+  #getQueryResponseEdges(_edges: Set<EdgeLike>): QueryResponseEdge[] {
+    return Array.from(_edges) as QueryResponseEdge[]
   }
 
   #getQueryResponseNodes(_nodes: Set<NodeLike>): QueryResponseNode[] {
@@ -395,7 +400,7 @@ export class Query {
     })
 
     const res: QueryResponse = {
-      edges: Array.from(collect.edges),
+      edges: this.#getQueryResponseEdges(collect.edges),
       nodes: this.#getQueryResponseNodes(collect.nodes),
     }
     this.#cache.set(query, res)

--- a/src/query/src/types.ts
+++ b/src/query/src/types.ts
@@ -59,9 +59,16 @@ export type QueryResponse = {
   nodes: QueryResponseNode[]
 }
 
-export type QueryResponseNode = {
+export type QueryResponseEdge = EdgeLike & {
+  from: QueryResponseNode
+  to?: QueryResponseNode
+}
+
+export type QueryResponseNode = NodeLike & {
+  edgesIn: Set<QueryResponseEdge>
+  edgesOut: Map<string, QueryResponseEdge>
   insights: Insights
-} & NodeLike
+}
 
 export type Insights = {
   abandoned?: boolean


### PR DESCRIPTION
Adds a `QueryResponseEdge` type so that both the `nodes` and `edges` returned from `query.search()` can have a unified type definition.