### PR TITLE
graph: fix aliases in human readable output

### DIFF
--- a/src/cli-sdk/tap-snapshots/test/commands/list.ts.test.cjs
+++ b/src/cli-sdk/tap-snapshots/test/commands/list.ts.test.cjs
@@ -9,7 +9,7 @@ exports[`test/commands/list.ts > TAP > list > colors > should use colors when se
 [0m[33mmy-project[39m[0m
 [0m├── [33m@foo/bazz@1.0.0[39m[0m
 [0m├─┬ [33mbar@1.0.0[39m[0m
-[0m│ └─┬ [33mcustom:baz@1.0.0[39m[0m
+[0m│ └─┬ [33mbaz (custom:baz@1.0.0)[39m[0m
 [0m│   └── [33m@foo/bazz@1.0.0[39m [2m(deduped)[22m[0m
 [0m└── [33mmissing@^1.0.0[39m [31m(missing)[39m[0m
 [0m[0m
@@ -58,7 +58,7 @@ exports[`test/commands/list.ts > TAP > list > should list all pkgs in human form
 my-project
 ├── @foo/bazz@1.0.0
 └─┬ bar@1.0.0
-  └─┬ custom:baz@1.0.0
+  └─┬ baz (custom:baz@1.0.0)
     └── @foo/bazz@1.0.0 (deduped)
 
 `
@@ -67,7 +67,7 @@ exports[`test/commands/list.ts > TAP > list > should list all pkgs in human read
 my-project
 ├── @foo/bazz@1.0.0
 ├─┬ bar@1.0.0
-│ └─┬ custom:baz@1.0.0
+│ └─┬ baz (custom:baz@1.0.0)
 │   └── @foo/bazz@1.0.0 (deduped)
 └── missing@^1.0.0 (missing)
 

--- a/src/cli-sdk/tap-snapshots/test/commands/query.ts.test.cjs
+++ b/src/cli-sdk/tap-snapshots/test/commands/query.ts.test.cjs
@@ -9,7 +9,7 @@ exports[`test/commands/query.ts > TAP > query > colors > should use colors when 
 [0mmy-project[0m
 [0m├── foo@1.0.0[0m
 [0m├─┬ bar@1.0.0[0m
-[0m│ └─┬ custom:baz@1.0.0[0m
+[0m│ └─┬ baz (custom:baz@1.0.0)[0m
 [0m│   └── foo@1.0.0 [2m(deduped)[22m[0m
 [0m└── missing@^1.0.0 [31m(missing)[39m[0m
 [0m[0m
@@ -68,7 +68,7 @@ exports[`test/commands/query.ts > TAP > query > should list pkgs in human readab
 my-project
 ├── foo@1.0.0
 ├─┬ bar@1.0.0
-│ └─┬ custom:baz@1.0.0
+│ └─┬ baz (custom:baz@1.0.0)
 │   └── foo@1.0.0 (deduped)
 └── missing@^1.0.0 (missing)
 

--- a/src/graph/src/visualization/human-readable-output.ts
+++ b/src/graph/src/visualization/human-readable-output.ts
@@ -128,11 +128,7 @@ export function humanReadableOutput(
     let header = ''
     let content = ''
 
-    const depIdTuple = item.node?.id && splitDepID(item.node.id)
-    const hasCustomReg =
-      depIdTuple?.[0] === 'registry' && depIdTuple[1]
-    const name =
-      hasCustomReg ? `${depIdTuple[1]}:${item.name}` : item.name
+    const name = item.name
     const decoratedName =
       (
         options.highlightSelection &&
@@ -164,17 +160,26 @@ export function humanReadableOutput(
         const parent = item
         const isLast =
           includedItems.indexOf(nextItem) === includedItems.length - 1
+
+        // prefixes the node name with the registry name
+        // if a custom registry name is found
+        const depIdTuple =
+          nextItem.node?.id && splitDepID(nextItem.node.id)
+        const hasCustomReg =
+          depIdTuple?.[0] === 'registry' && depIdTuple[1]
+        const nodeName =
+          hasCustomReg ?
+            `${depIdTuple[1]}:${nextItem.node?.name}`
+          : nextItem.node?.name
+
         const toName =
           nextItem.node?.version ?
-            `${nextItem.node.name}@${nextItem.node.version}`
-          : nextItem.node?.name
+            `${nodeName}@${nextItem.node.version}`
+          : nodeName
         const nextChar = isLast ? 'last-child' : 'middle-child'
 
         nextItem.name =
-          (
-            nextItem.node?.name &&
-            nextItem.edge?.name !== nextItem.edge?.to?.name
-          ) ?
+          nextItem.node?.name && nextItem.edge?.name !== nodeName ?
             `${nextItem.edge?.name} (${toName})`
           : `${nextItem.edge?.name}@${nextItem.node?.version || nextItem.edge?.spec.bareSpec}`
         nextItem.padding =

--- a/src/graph/tap-snapshots/test/visualization/human-readable-output.ts.test.cjs
+++ b/src/graph/tap-snapshots/test/visualization/human-readable-output.ts.test.cjs
@@ -12,8 +12,8 @@ exports[`test/visualization/human-readable-output.ts > TAP > actual graph > colo
 [0m├── extraneous@1.0.0[0m
 [0m├─┬ bar@1.0.0[0m
 [0m│ ├── blooo@1.0.0[0m
-[0m│ └── custom:baz@1.0.0[0m
-[0m├── custom:aliased (foo@1.0.0)[0m
+[0m│ └── baz (custom:baz@1.0.0)[0m
+[0m├── aliased (custom:foo@1.0.0)[0m
 [0m├─┬ @scoped/b@1.0.0[0m
 [0m│ └── @scoped/c@1.0.0[0m
 [0m├── @scoped/a@1.0.0[0m
@@ -29,7 +29,7 @@ exports[`test/visualization/human-readable-output.ts > TAP > actual graph > colo
 exports[`test/visualization/human-readable-output.ts > TAP > actual graph > selected packages > should print selected packages 1`] = `
 my-project
 └─┬ bar@1.0.0
-  └── custom:baz@1.0.0
+  └── baz (custom:baz@1.0.0)
 
 `
 
@@ -40,8 +40,8 @@ my-project
 ├── extraneous@1.0.0
 ├─┬ bar@1.0.0
 │ ├── blooo@1.0.0
-│ └── custom:baz@1.0.0
-├── custom:aliased (foo@1.0.0)
+│ └── baz (custom:baz@1.0.0)
+├── aliased (custom:foo@1.0.0)
 ├─┬ @scoped/b@1.0.0
 │ └── @scoped/c@1.0.0
 ├── @scoped/a@1.0.0
@@ -56,7 +56,7 @@ workspace-a
 
 exports[`test/visualization/human-readable-output.ts > TAP > aliased package > should print both edge and node names 1`] = `
 my-project
-└── a (@myscope/foo@1.0.0)
+└── a (npm:@myscope/foo@1.0.0)
 
 `
 
@@ -72,7 +72,7 @@ exports[`test/visualization/human-readable-output.ts > TAP > human-readable-outp
 my-project
 ├── foo@1.0.0
 ├─┬ bar@1.0.0
-│ ├─┬ custom:baz@1.0.0
+│ ├─┬ baz (custom:baz@1.0.0)
 │ │ └── foo@1.0.0 (deduped)
 │ └── extraneous@1.0.0
 └── missing@^1.0.0 (missing)

--- a/src/graph/test/visualization/human-readable-output.ts
+++ b/src/graph/test/visualization/human-readable-output.ts
@@ -65,7 +65,7 @@ t.test('human-readable-output', async t => {
   const baz = graph.placePackage(
     bar,
     'dev',
-    Spec.parse('baz', 'custom:bar@^1.0.0', configData as SpecOptions),
+    Spec.parse('baz', 'custom:baz@^1.0.0', configData as SpecOptions),
     {
       name: 'baz',
       version: '1.0.0',
@@ -329,14 +329,14 @@ t.test('aliased package', async t => {
       name: 'my-project',
       version: '1.0.0',
       dependencies: {
-        a: '^1.0.0',
+        a: 'npm:@myscope/foo@^1.0.0',
       },
     },
   })
   graph.placePackage(
     graph.mainImporter,
     'optional',
-    Spec.parse('a', '^1.0.0'),
+    Spec.parse('a', 'npm:@myscope/foo@^1.0.0'),
     { name: '@myscope/foo', version: '1.0.0' },
   )
   t.matchSnapshot(


### PR DESCRIPTION
Fix the representation of aliased dependencies and custom registry prefixes in the human readable output.

The registry prefix now goes along with the node name/version instead of prefixing the dependency name.

## Example

For a given `package.json` file:

```json
{
  "name": "my-project",
  "dependencies": {
    "a": "npm:abbrev@^3.0.0"
  }
}
```

### Before:

```
    vlt ls
    my-project
    └── npm:a (abbrev@3.0.0)
```

### After:

```
    vlt ls
    my-project
    └── a (npm:abbrev@3.0.0)
```