### PR TITLE
gui: fixes side item info

### DIFF
--- a/src/gui/src/components/explorer-grid/index.tsx
+++ b/src/gui/src/components/explorer-grid/index.tsx
@@ -221,6 +221,7 @@ const getDependencyItems = (
     const title = `${edge.name}@${edge.spec.bareSpec}`
     items.push({
       ...edge,
+      depName: edge.name,
       depIndex: count.currIndex++,
       id: edge.to.id,
       title,
@@ -259,6 +260,8 @@ const getUninstalledDependencyItems = (
     if (edge?.to) continue
     const title = `${name}@${version}`
     items.push({
+      spec: Spec.parse(name, version),
+      depName: edge?.name,
       depIndex: count.currIndex++,
       id: `uninstalled-dep:${title}`,
       title,

--- a/src/gui/src/components/explorer-grid/side-item.tsx
+++ b/src/gui/src/components/explorer-grid/side-item.tsx
@@ -88,9 +88,11 @@ export const SideItem = ({
                 </span>
               )}
               <span className="font-medium">{item.name}</span>
-              <InlineCode variant="monoGhost">
-                {`v${item.version}`}
-              </InlineCode>
+              {!item.id.startsWith('uninstalled-dep:') && (
+                <InlineCode variant="monoGhost">
+                  {`v${item.version}`}
+                </InlineCode>
+              )}
             </CardTitle>
             {uninstallAvailable && (
               <DropdownMenu>

--- a/src/gui/src/components/explorer-grid/side-item.tsx
+++ b/src/gui/src/components/explorer-grid/side-item.tsx
@@ -9,10 +9,10 @@ import {
   DropdownMenuContent,
   DropdownMenuItem,
 } from '@/components/ui/dropdown-menu.jsx'
+import { InlineCode } from '@/components/ui/inline-code.jsx'
 import { labelClassNamesMap } from './label-helper.js'
 import type { GridItemData, GridItemOptions } from './types.js'
 import { useGraphStore } from '@/state/index.js'
-import { InlineCode } from '../ui/inline-code.tsx'
 
 export type SideItemOptions = GridItemOptions & {
   parent?: boolean

--- a/src/gui/src/components/explorer-grid/side-item.tsx
+++ b/src/gui/src/components/explorer-grid/side-item.tsx
@@ -58,13 +58,6 @@ export const SideItem = ({
 
   const uninstallAvailable = !!onUninstall && item.from?.importer
 
-  const parseItem = (title: string) => {
-    const parsed = title.split('@')
-    return parsed.length >= 3 ?
-        parsed.slice(2).join('@')
-      : parsed.slice(1).join('@')
-  }
-
   return (
     <div className="group relative z-10" ref={divRef}>
       {item.stacked ?
@@ -86,6 +79,14 @@ export const SideItem = ({
         <CardHeader className="relative flex w-full flex-col rounded-t-lg p-0">
           <div className="flex items-center px-3 py-2">
             <CardTitle className="align-baseline text-sm">
+              {item.depName && item.depName !== item.name && (
+                <span className="font-light">
+                  <InlineCode variant="mono" className="-mx-1">
+                    {item.depName}
+                  </InlineCode>
+                  <InlineCode variant="monoGhost">as</InlineCode>
+                </span>
+              )}
               <span className="font-medium">{item.name}</span>
               <InlineCode variant="monoGhost">
                 {`v${item.version}`}
@@ -114,12 +115,22 @@ export const SideItem = ({
 
           {!isWorkspace && (
             <div className="flex flex-row flex-wrap items-center justify-between gap-2 border-t-[1px] border-muted px-3 py-2">
-              <p className="flex items-center gap-2 text-sm text-muted-foreground">
-                Spec:{' '}
-                <InlineCode variant="mono">
-                  {parseItem(item.title)}
-                </InlineCode>
-              </p>
+              {item.spec?.bareSpec && (
+                <p className="flex items-center gap-2 text-sm text-muted-foreground">
+                  Spec:{' '}
+                  <InlineCode variant="mono">
+                    {(
+                      item.spec.type === 'registry' &&
+                      item.spec.semver
+                    ) ?
+                      item.spec.semver
+                    : item.spec.bareSpec}
+                  </InlineCode>
+                  {item.size > 1 && (
+                    <span>and {item.size - 1} more.</span>
+                  )}
+                </p>
+              )}
               {item.labels?.map(i => (
                 <div key={i}>
                   <Badge

--- a/src/gui/src/components/explorer-grid/types.ts
+++ b/src/gui/src/components/explorer-grid/types.ts
@@ -17,6 +17,10 @@ export type EdgeLoose = Pick<QueryResponseEdge, 'name'> & {
  */
 export type GridItemData = EdgeLoose & {
   /**
+   * The original dependency name as defined in its parent manifest.
+   */
+  depName?: string
+  /**
    * An index value shared between installed and uninstalled dependencies
    * to keep track of the order they were added to the UI.
    */

--- a/src/gui/test/components/explorer-grid/__snapshots__/side-item.tsx.snap
+++ b/src/gui/test/components/explorer-grid/__snapshots__/side-item.tsx.snap
@@ -12,27 +12,30 @@ exports[`SideItem render as aliased dependency 1`] = `
         <div class="flex items-center px-3 py-2">
           <gui-card-title classname="align-baseline text-sm">
             <span class="font-light">
-              <span class="rounded-sm px-1.5 py-1 pt-1.5 text-xs font-normal font-courier text-muted-foreground dark:bg-neutral-700/50 bg-neutral-700/5 border-none -mx-1">
+              <gui-inline-code
+                variant="mono"
+                classname="-mx-1"
+              >
                 aliased-item
-              </span>
-              <span class="mx-1 rounded-sm px-1.5 py-1 pt-1.5 text-xs font-normal font-courier text-muted-foreground bg-transparent">
+              </gui-inline-code>
+              <gui-inline-code variant="monoGhost">
                 as
-              </span>
+              </gui-inline-code>
             </span>
             <span class="font-medium">
               item
             </span>
-            <span class="mx-1 rounded-sm px-1.5 py-1 pt-1.5 text-xs font-normal font-courier text-muted-foreground bg-transparent">
+            <gui-inline-code variant="monoGhost">
               v1.0.0
-            </span>
+            </gui-inline-code>
           </gui-card-title>
         </div>
         <div class="flex flex-row flex-wrap items-center justify-between gap-2 border-t-[1px] border-muted px-3 py-2">
           <p class="flex items-center gap-2 text-sm text-muted-foreground">
             Spec:
-            <span class="mx-1 rounded-sm px-1.5 py-1 pt-1.5 text-xs font-normal font-courier text-muted-foreground dark:bg-neutral-700/50 bg-neutral-700/5 border-none">
+            <gui-inline-code variant="mono">
               npm:item@^1.0.0
-            </span>
+            </gui-inline-code>
           </p>
           <div>
             <gui-badge classname="grow-0 border-transparent bg-cyan-100 text-neutral-900 hover:bg-cyan-100/80">
@@ -66,17 +69,17 @@ exports[`SideItem render as dependency 1`] = `
             <span class="font-medium">
               item
             </span>
-            <span class="mx-1 rounded-sm px-1.5 py-1 pt-1.5 text-xs font-normal font-courier text-muted-foreground bg-transparent">
+            <gui-inline-code variant="monoGhost">
               v1.0.0
-            </span>
+            </gui-inline-code>
           </gui-card-title>
         </div>
         <div class="flex flex-row flex-wrap items-center justify-between gap-2 border-t-[1px] border-muted px-3 py-2">
           <p class="flex items-center gap-2 text-sm text-muted-foreground">
             Spec:
-            <span class="mx-1 rounded-sm px-1.5 py-1 pt-1.5 text-xs font-normal font-courier text-muted-foreground dark:bg-neutral-700/50 bg-neutral-700/5 border-none">
+            <gui-inline-code variant="mono">
               ^1.0.0
-            </span>
+            </gui-inline-code>
           </p>
           <div>
             <gui-badge classname="grow-0 border-transparent bg-lime-100 text-neutral-900 hover:bg-lime-100/80">
@@ -110,17 +113,17 @@ exports[`SideItem render as dependency with long name 1`] = `
             <span class="font-medium">
               lorem-ipsum-dolor-sit-amet-consectetur-adipiscing-elit-sed-do-eiusmod-tempor-incididunt-ut-labore-et-dolore-magna-aliqua-ut-enim-ad-minim-veniam-quis-nostrud-exercitation
             </span>
-            <span class="mx-1 rounded-sm px-1.5 py-1 pt-1.5 text-xs font-normal font-courier text-muted-foreground bg-transparent">
+            <gui-inline-code variant="monoGhost">
               v1.0.0
-            </span>
+            </gui-inline-code>
           </gui-card-title>
         </div>
         <div class="flex flex-row flex-wrap items-center justify-between gap-2 border-t-[1px] border-muted px-3 py-2">
           <p class="flex items-center gap-2 text-sm text-muted-foreground">
             Spec:
-            <span class="mx-1 rounded-sm px-1.5 py-1 pt-1.5 text-xs font-normal font-courier text-muted-foreground dark:bg-neutral-700/50 bg-neutral-700/5 border-none">
+            <gui-inline-code variant="mono">
               ^1.0.0
-            </span>
+            </gui-inline-code>
           </p>
           <div>
             <gui-badge classname="grow-0 border-transparent bg-lime-100 text-neutral-900 hover:bg-lime-100/80">
@@ -154,17 +157,17 @@ exports[`SideItem render as dependent 1`] = `
             <span class="font-medium">
               item
             </span>
-            <span class="mx-1 rounded-sm px-1.5 py-1 pt-1.5 text-xs font-normal font-courier text-muted-foreground bg-transparent">
+            <gui-inline-code variant="monoGhost">
               v1.0.0
-            </span>
+            </gui-inline-code>
           </gui-card-title>
         </div>
         <div class="flex flex-row flex-wrap items-center justify-between gap-2 border-t-[1px] border-muted px-3 py-2">
           <p class="flex items-center gap-2 text-sm text-muted-foreground">
             Spec:
-            <span class="mx-1 rounded-sm px-1.5 py-1 pt-1.5 text-xs font-normal font-courier text-muted-foreground dark:bg-neutral-700/50 bg-neutral-700/5 border-none">
+            <gui-inline-code variant="mono">
               ^1.0.0
-            </span>
+            </gui-inline-code>
           </p>
           <div>
             <gui-badge classname="grow-0 border-transparent bg-cyan-100 text-neutral-900 hover:bg-cyan-100/80">
@@ -193,17 +196,17 @@ exports[`SideItem render as git dependency 1`] = `
             <span class="font-medium">
               item
             </span>
-            <span class="mx-1 rounded-sm px-1.5 py-1 pt-1.5 text-xs font-normal font-courier text-muted-foreground bg-transparent">
+            <gui-inline-code variant="monoGhost">
               v1.0.0
-            </span>
+            </gui-inline-code>
           </gui-card-title>
         </div>
         <div class="flex flex-row flex-wrap items-center justify-between gap-2 border-t-[1px] border-muted px-3 py-2">
           <p class="flex items-center gap-2 text-sm text-muted-foreground">
             Spec:
-            <span class="mx-1 rounded-sm px-1.5 py-1 pt-1.5 text-xs font-normal font-courier text-muted-foreground dark:bg-neutral-700/50 bg-neutral-700/5 border-none">
+            <gui-inline-code variant="mono">
               github:vltpkg/item
-            </span>
+            </gui-inline-code>
           </p>
           <div>
             <gui-badge classname="grow-0 border-transparent bg-cyan-100 text-neutral-900 hover:bg-cyan-100/80">
@@ -241,17 +244,17 @@ exports[`SideItem render as multi-stacked dependent 1`] = `
             <span class="font-medium">
               item
             </span>
-            <span class="mx-1 rounded-sm px-1.5 py-1 pt-1.5 text-xs font-normal font-courier text-muted-foreground bg-transparent">
+            <gui-inline-code variant="monoGhost">
               v1.0.0
-            </span>
+            </gui-inline-code>
           </gui-card-title>
         </div>
         <div class="flex flex-row flex-wrap items-center justify-between gap-2 border-t-[1px] border-muted px-3 py-2">
           <p class="flex items-center gap-2 text-sm text-muted-foreground">
             Spec:
-            <span class="mx-1 rounded-sm px-1.5 py-1 pt-1.5 text-xs font-normal font-courier text-muted-foreground dark:bg-neutral-700/50 bg-neutral-700/5 border-none">
+            <gui-inline-code variant="mono">
               ^1.0.0
-            </span>
+            </gui-inline-code>
             <span>
               and 4 more.
             </span>
@@ -283,17 +286,17 @@ exports[`SideItem render as parent 1`] = `
             <span class="font-medium">
               item
             </span>
-            <span class="mx-1 rounded-sm px-1.5 py-1 pt-1.5 text-xs font-normal font-courier text-muted-foreground bg-transparent">
+            <gui-inline-code variant="monoGhost">
               v1.0.0
-            </span>
+            </gui-inline-code>
           </gui-card-title>
         </div>
         <div class="flex flex-row flex-wrap items-center justify-between gap-2 border-t-[1px] border-muted px-3 py-2">
           <p class="flex items-center gap-2 text-sm text-muted-foreground">
             Spec:
-            <span class="mx-1 rounded-sm px-1.5 py-1 pt-1.5 text-xs font-normal font-courier text-muted-foreground dark:bg-neutral-700/50 bg-neutral-700/5 border-none">
+            <gui-inline-code variant="mono">
               ^1.0.0
-            </span>
+            </gui-inline-code>
           </p>
           <div>
             <gui-badge classname="grow-0 border-transparent bg-cyan-100 text-neutral-900 hover:bg-cyan-100/80">
@@ -326,17 +329,17 @@ exports[`SideItem render as two-stacked dependent 1`] = `
             <span class="font-medium">
               item
             </span>
-            <span class="mx-1 rounded-sm px-1.5 py-1 pt-1.5 text-xs font-normal font-courier text-muted-foreground bg-transparent">
+            <gui-inline-code variant="monoGhost">
               v1.0.0
-            </span>
+            </gui-inline-code>
           </gui-card-title>
         </div>
         <div class="flex flex-row flex-wrap items-center justify-between gap-2 border-t-[1px] border-muted px-3 py-2">
           <p class="flex items-center gap-2 text-sm text-muted-foreground">
             Spec:
-            <span class="mx-1 rounded-sm px-1.5 py-1 pt-1.5 text-xs font-normal font-courier text-muted-foreground dark:bg-neutral-700/50 bg-neutral-700/5 border-none">
+            <gui-inline-code variant="mono">
               ^1.0.0
-            </span>
+            </gui-inline-code>
             <span>
               and 1 more.
             </span>

--- a/src/gui/test/components/explorer-grid/__snapshots__/side-item.tsx.snap
+++ b/src/gui/test/components/explorer-grid/__snapshots__/side-item.tsx.snap
@@ -1,5 +1,57 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`SideItem render as aliased dependency 1`] = `
+
+<div>
+  <div class="group relative z-10">
+    <gui-card
+      role="article"
+      classname="relative my-4 transition-all  group-hover:bg-card-accent"
+    >
+      <gui-card-header classname="relative flex w-full flex-col rounded-t-lg p-0">
+        <div class="flex items-center px-3 py-2">
+          <gui-card-title classname="align-baseline text-sm">
+            <span class="font-light">
+              <span class="rounded-sm px-1.5 py-1 pt-1.5 text-xs font-normal font-courier text-muted-foreground dark:bg-neutral-700/50 bg-neutral-700/5 border-none -mx-1">
+                aliased-item
+              </span>
+              <span class="mx-1 rounded-sm px-1.5 py-1 pt-1.5 text-xs font-normal font-courier text-muted-foreground bg-transparent">
+                as
+              </span>
+            </span>
+            <span class="font-medium">
+              item
+            </span>
+            <span class="mx-1 rounded-sm px-1.5 py-1 pt-1.5 text-xs font-normal font-courier text-muted-foreground bg-transparent">
+              v1.0.0
+            </span>
+          </gui-card-title>
+        </div>
+        <div class="flex flex-row flex-wrap items-center justify-between gap-2 border-t-[1px] border-muted px-3 py-2">
+          <p class="flex items-center gap-2 text-sm text-muted-foreground">
+            Spec:
+            <span class="mx-1 rounded-sm px-1.5 py-1 pt-1.5 text-xs font-normal font-courier text-muted-foreground dark:bg-neutral-700/50 bg-neutral-700/5 border-none">
+              npm:item@^1.0.0
+            </span>
+          </p>
+          <div>
+            <gui-badge classname="grow-0 border-transparent bg-cyan-100 text-neutral-900 hover:bg-cyan-100/80">
+              prod
+            </gui-badge>
+          </div>
+        </div>
+      </gui-card-header>
+    </gui-card>
+    <div
+      class="absolute -left-[9px] bottom-[62px] z-0 h-[13.35rem] h-[5px] w-[9px] rounded-bl-sm border-b border-l border-solid border-muted group-[&amp;:nth-child(2)]:hidden group-[&amp;:nth-child(3)]:h-24"
+      style="height: -258px;"
+    >
+    </div>
+  </div>
+</div>
+
+`;
+
 exports[`SideItem render as dependency 1`] = `
 
 <div>
@@ -23,6 +75,7 @@ exports[`SideItem render as dependency 1`] = `
           <p class="flex items-center gap-2 text-sm text-muted-foreground">
             Spec:
             <span class="mx-1 rounded-sm px-1.5 py-1 pt-1.5 text-xs font-normal font-courier text-muted-foreground dark:bg-neutral-700/50 bg-neutral-700/5 border-none">
+              ^1.0.0
             </span>
           </p>
           <div>
@@ -66,6 +119,7 @@ exports[`SideItem render as dependency with long name 1`] = `
           <p class="flex items-center gap-2 text-sm text-muted-foreground">
             Spec:
             <span class="mx-1 rounded-sm px-1.5 py-1 pt-1.5 text-xs font-normal font-courier text-muted-foreground dark:bg-neutral-700/50 bg-neutral-700/5 border-none">
+              ^1.0.0
             </span>
           </p>
           <div>
@@ -109,6 +163,7 @@ exports[`SideItem render as dependent 1`] = `
           <p class="flex items-center gap-2 text-sm text-muted-foreground">
             Spec:
             <span class="mx-1 rounded-sm px-1.5 py-1 pt-1.5 text-xs font-normal font-courier text-muted-foreground dark:bg-neutral-700/50 bg-neutral-700/5 border-none">
+              ^1.0.0
             </span>
           </p>
           <div>
@@ -119,6 +174,50 @@ exports[`SideItem render as dependent 1`] = `
         </div>
       </gui-card-header>
     </gui-card>
+  </div>
+</div>
+
+`;
+
+exports[`SideItem render as git dependency 1`] = `
+
+<div>
+  <div class="group relative z-10">
+    <gui-card
+      role="article"
+      classname="relative my-4 transition-all  group-hover:bg-card-accent"
+    >
+      <gui-card-header classname="relative flex w-full flex-col rounded-t-lg p-0">
+        <div class="flex items-center px-3 py-2">
+          <gui-card-title classname="align-baseline text-sm">
+            <span class="font-medium">
+              item
+            </span>
+            <span class="mx-1 rounded-sm px-1.5 py-1 pt-1.5 text-xs font-normal font-courier text-muted-foreground bg-transparent">
+              v1.0.0
+            </span>
+          </gui-card-title>
+        </div>
+        <div class="flex flex-row flex-wrap items-center justify-between gap-2 border-t-[1px] border-muted px-3 py-2">
+          <p class="flex items-center gap-2 text-sm text-muted-foreground">
+            Spec:
+            <span class="mx-1 rounded-sm px-1.5 py-1 pt-1.5 text-xs font-normal font-courier text-muted-foreground dark:bg-neutral-700/50 bg-neutral-700/5 border-none">
+              github:vltpkg/item
+            </span>
+          </p>
+          <div>
+            <gui-badge classname="grow-0 border-transparent bg-cyan-100 text-neutral-900 hover:bg-cyan-100/80">
+              prod
+            </gui-badge>
+          </div>
+        </div>
+      </gui-card-header>
+    </gui-card>
+    <div
+      class="absolute -left-[9px] bottom-[62px] z-0 h-[13.35rem] h-[5px] w-[9px] rounded-bl-sm border-b border-l border-solid border-muted group-[&amp;:nth-child(2)]:hidden group-[&amp;:nth-child(3)]:h-24"
+      style="height: -258px;"
+    >
+    </div>
   </div>
 </div>
 
@@ -151,6 +250,10 @@ exports[`SideItem render as multi-stacked dependent 1`] = `
           <p class="flex items-center gap-2 text-sm text-muted-foreground">
             Spec:
             <span class="mx-1 rounded-sm px-1.5 py-1 pt-1.5 text-xs font-normal font-courier text-muted-foreground dark:bg-neutral-700/50 bg-neutral-700/5 border-none">
+              ^1.0.0
+            </span>
+            <span>
+              and 4 more.
             </span>
           </p>
           <div>
@@ -189,6 +292,7 @@ exports[`SideItem render as parent 1`] = `
           <p class="flex items-center gap-2 text-sm text-muted-foreground">
             Spec:
             <span class="mx-1 rounded-sm px-1.5 py-1 pt-1.5 text-xs font-normal font-courier text-muted-foreground dark:bg-neutral-700/50 bg-neutral-700/5 border-none">
+              ^1.0.0
             </span>
           </p>
           <div>
@@ -231,6 +335,10 @@ exports[`SideItem render as two-stacked dependent 1`] = `
           <p class="flex items-center gap-2 text-sm text-muted-foreground">
             Spec:
             <span class="mx-1 rounded-sm px-1.5 py-1 pt-1.5 text-xs font-normal font-courier text-muted-foreground dark:bg-neutral-700/50 bg-neutral-700/5 border-none">
+              ^1.0.0
+            </span>
+            <span>
+              and 1 more.
             </span>
           </p>
           <div>

--- a/src/gui/test/components/explorer-grid/side-item.tsx
+++ b/src/gui/test/components/explorer-grid/side-item.tsx
@@ -15,6 +15,19 @@ vi.mock('@/components/ui/card.jsx', () => ({
   CardHeader: 'gui-card-header',
   CardTitle: 'gui-card-title',
 }))
+vi.mock('@/components/ui/dropdown-menu.jsx', () => ({
+  DropdownMenu: 'gui-dropdown-menu',
+  DropdownMenuTrigger: 'gui-dropdown-menu-trigger',
+  DropdownMenuContent: 'gui-dropdown-menu-content',
+  DropdownMenuItem: 'gui-dropdown-menu-item',
+}))
+vi.mock('@/components/ui/inline-code.jsx', () => ({
+  InlineCode: 'gui-inline-code',
+}))
+vi.mock('lucide-react', async () => ({
+  Ellipsis: 'gui-ellipsis',
+  PackageMinus: 'gui-package-minus',
+}))
 
 expect.addSnapshotSerializer({
   serialize: v => html(v),

--- a/src/gui/test/components/explorer-grid/side-item.tsx
+++ b/src/gui/test/components/explorer-grid/side-item.tsx
@@ -1,6 +1,7 @@
 import { test, expect, vi, afterEach } from 'vitest'
 import { cleanup, render } from '@testing-library/react'
 import html from 'diffable-html'
+import { Spec } from '@vltpkg/spec/browser'
 import { useGraphStore as useStore } from '@/state/index.js'
 import type { GridItemData } from '@/components/explorer-grid/types.js'
 import { SideItem } from '@/components/explorer-grid/side-item.jsx'
@@ -35,6 +36,7 @@ test('SideItem render as dependent', async () => {
     version: '1.0.0',
     stacked: false,
     size: 1,
+    spec: Spec.parse('item', '^1.0.0'),
   } satisfies GridItemData
   render(
     <SideItem item={item} dependencies={false} onSelect={() => {}} />,
@@ -51,6 +53,7 @@ test('SideItem render as parent', async () => {
     version: '1.0.0',
     stacked: false,
     size: 1,
+    spec: Spec.parse('item', '^1.0.0'),
   } satisfies GridItemData
   render(
     <SideItem
@@ -72,6 +75,7 @@ test('SideItem render as two-stacked dependent', async () => {
     version: '1.0.0',
     stacked: true,
     size: 2,
+    spec: Spec.parse('item', '^1.0.0'),
   } satisfies GridItemData
   render(
     <SideItem item={item} dependencies={false} onSelect={() => {}} />,
@@ -88,6 +92,7 @@ test('SideItem render as multi-stacked dependent', async () => {
     version: '1.0.0',
     stacked: true,
     size: 5,
+    spec: Spec.parse('item', '^1.0.0'),
   } satisfies GridItemData
   render(
     <SideItem item={item} dependencies={false} onSelect={() => {}} />,
@@ -104,6 +109,42 @@ test('SideItem render as dependency', async () => {
     version: '1.0.0',
     stacked: false,
     size: 1,
+    spec: Spec.parse('item', '^1.0.0'),
+  } satisfies GridItemData
+  render(
+    <SideItem item={item} dependencies={true} onSelect={() => {}} />,
+  )
+  expect(window.document.body.innerHTML).toMatchSnapshot()
+})
+
+test('SideItem render as aliased dependency', async () => {
+  const item = {
+    id: '1',
+    labels: ['prod'],
+    depName: 'aliased-item',
+    name: 'item',
+    title: 'item',
+    version: '1.0.0',
+    stacked: false,
+    size: 1,
+    spec: Spec.parse('aliased-item', 'npm:item@^1.0.0'),
+  } satisfies GridItemData
+  render(
+    <SideItem item={item} dependencies={true} onSelect={() => {}} />,
+  )
+  expect(window.document.body.innerHTML).toMatchSnapshot()
+})
+
+test('SideItem render as git dependency', async () => {
+  const item = {
+    id: '1',
+    labels: ['prod'],
+    name: 'item',
+    title: 'item',
+    version: '1.0.0',
+    stacked: false,
+    size: 1,
+    spec: Spec.parse('aliased-item', 'github:vltpkg/item'),
   } satisfies GridItemData
   render(
     <SideItem item={item} dependencies={true} onSelect={() => {}} />,
@@ -121,6 +162,10 @@ test('SideItem render as dependency with long name', async () => {
     version: '1.0.0',
     stacked: false,
     size: 1,
+    spec: Spec.parse(
+      'lorem-ipsum-dolor-sit-amet-consectetur-adipiscing-elit-sed-do-eiusmod-tempor-incididunt-ut-labore-et-dolore-magna-aliqua-ut-enim-ad-minim-veniam-quis-nostrud-exercitation',
+      '^1.0.0',
+    ),
   } satisfies GridItemData
   render(
     <SideItem item={item} dependencies={true} onSelect={() => {}} />,


### PR DESCRIPTION
Fixes displays spec info on side items for dependencies types other than registry (namely: git, file, remote & workspaces) and adds a new interface for displaying the proper dependency name of aliased dependencies.

### Preview:
![Screenshot 2025-04-04 at 10 21 22 AM](https://github.com/user-attachments/assets/298caaad-22a7-4c4c-8f57-e3957e666ed1)

![Screenshot 2025-04-04 at 10 43 00 AM](https://github.com/user-attachments/assets/a9589122-a243-430f-bf48-68cbeba3b88f)

![Screenshot 2025-04-04 at 10 20 06 AM](https://github.com/user-attachments/assets/7a280bd0-4cf1-45dc-88f7-7b0938ea4e45)

Fixes: https://github.com/vltpkg/vltpkg/issues/352