### PR TITLE
graph: properly save dependency types to manifests

### DIFF
--- a/src/cli-sdk/src/parse-add-remove-args.ts
+++ b/src/cli-sdk/src/parse-add-remove-args.ts
@@ -1,16 +1,16 @@
-import { joinDepIDTuple } from '@vltpkg/dep-id'
 import type { DepID } from '@vltpkg/dep-id'
-import type { DependencyTypeShort } from '@vltpkg/types'
-import { asDependency } from '@vltpkg/graph'
+import { joinDepIDTuple } from '@vltpkg/dep-id'
 import type {
   AddImportersDependenciesMap,
   Dependency,
   RemoveImportersDependenciesMap,
 } from '@vltpkg/graph'
-import type { LoadedConfig } from './config/index.ts'
-import { Spec } from '@vltpkg/spec'
+import { asDependency } from '@vltpkg/graph'
 import type { SpecOptions } from '@vltpkg/spec'
+import { Spec } from '@vltpkg/spec'
+import type { DependencySaveType } from '@vltpkg/types'
 import type { Monorepo } from '@vltpkg/workspaces'
+import type { LoadedConfig } from './config/index.ts'
 
 export type ParsedAddArgs = {
   add: AddImportersDependenciesMap
@@ -59,7 +59,7 @@ const getImporters = (
   return res
 }
 
-const getType = (opts: SaveTypes): DependencyTypeShort =>
+const getType = (opts: SaveTypes): DependencySaveType =>
   opts['save-prod'] ? 'prod'
   : opts['save-dev'] ? 'dev'
   : opts['save-peer'] ?
@@ -67,7 +67,7 @@ const getType = (opts: SaveTypes): DependencyTypeShort =>
       'peerOptional'
     : 'peer'
   : opts['save-optional'] ? 'optional'
-  : 'prod'
+  : 'implicit'
 
 class AddImportersDependenciesMapImpl
   extends Map

--- a/src/cli-sdk/tap-snapshots/test/parse-add-remove-args.ts.test.cjs
+++ b/src/cli-sdk/tap-snapshots/test/parse-add-remove-args.ts.test.cjs
@@ -56,11 +56,11 @@ exports[`test/parse-add-remove-args.ts > TAP > parseAddArgs > multiple items > s
 {
   add: AddImportersDependenciesMapImpl(1) [Map] {
     'file·.' => Map(5) {
-      'foo' => { spec: Spec {foo@^1}, type: 'prod' },
-      'bar' => { spec: Spec {bar@latest}, type: 'prod' },
-      'baz' => { spec: Spec {baz@1.0.0}, type: 'prod' },
-      '(unknown)@github:a/b' => { spec: Spec {(unknown)@github:a/b}, type: 'prod' },
-      '(unknown)@file:./a' => { spec: Spec {(unknown)@file:./a}, type: 'prod' }
+      'foo' => { spec: Spec {foo@^1}, type: 'implicit' },
+      'bar' => { spec: Spec {bar@latest}, type: 'implicit' },
+      'baz' => { spec: Spec {baz@1.0.0}, type: 'implicit' },
+      '(unknown)@github:a/b' => { spec: Spec {(unknown)@github:a/b}, type: 'implicit' },
+      '(unknown)@file:./a' => { spec: Spec {(unknown)@file:./a}, type: 'implicit' }
     },
     modifiedDependencies: true
   }
@@ -79,7 +79,7 @@ exports[`test/parse-add-remove-args.ts > TAP > parseAddArgs > no item > should r
 exports[`test/parse-add-remove-args.ts > TAP > parseAddArgs > single item > should return a single dependency item 1`] = `
 {
   add: AddImportersDependenciesMapImpl(1) [Map] {
-    'file·.' => Map(1) { 'foo' => { spec: Spec {foo@}, type: 'prod' } },
+    'file·.' => Map(1) { 'foo' => { spec: Spec {foo@}, type: 'implicit' } },
     modifiedDependencies: true
   }
 }
@@ -89,11 +89,11 @@ exports[`test/parse-add-remove-args.ts > TAP > parseAddArgs > workspaces > defin
 {
   add: AddImportersDependenciesMapImpl(1) [Map] {
     'workspace·utils§c' => Map(5) {
-      'foo' => { spec: Spec {foo@^1}, type: 'prod' },
-      'bar' => { spec: Spec {bar@latest}, type: 'prod' },
-      'baz' => { spec: Spec {baz@1.0.0}, type: 'prod' },
-      '(unknown)@github:a/b' => { spec: Spec {(unknown)@github:a/b}, type: 'prod' },
-      '(unknown)@file:./a' => { spec: Spec {(unknown)@file:./a}, type: 'prod' }
+      'foo' => { spec: Spec {foo@^1}, type: 'implicit' },
+      'bar' => { spec: Spec {bar@latest}, type: 'implicit' },
+      'baz' => { spec: Spec {baz@1.0.0}, type: 'implicit' },
+      '(unknown)@github:a/b' => { spec: Spec {(unknown)@github:a/b}, type: 'implicit' },
+      '(unknown)@file:./a' => { spec: Spec {(unknown)@file:./a}, type: 'implicit' }
     },
     modifiedDependencies: true
   }
@@ -104,25 +104,25 @@ exports[`test/parse-add-remove-args.ts > TAP > parseAddArgs > workspaces > defin
 {
   add: AddImportersDependenciesMapImpl(3) [Map] {
     'workspace·utils§c' => Map(5) {
-      'foo' => { spec: Spec {foo@^1}, type: 'prod' },
-      'bar' => { spec: Spec {bar@latest}, type: 'prod' },
-      'baz' => { spec: Spec {baz@1.0.0}, type: 'prod' },
-      '(unknown)@github:a/b' => { spec: Spec {(unknown)@github:a/b}, type: 'prod' },
-      '(unknown)@file:./a' => { spec: Spec {(unknown)@file:./a}, type: 'prod' }
+      'foo' => { spec: Spec {foo@^1}, type: 'implicit' },
+      'bar' => { spec: Spec {bar@latest}, type: 'implicit' },
+      'baz' => { spec: Spec {baz@1.0.0}, type: 'implicit' },
+      '(unknown)@github:a/b' => { spec: Spec {(unknown)@github:a/b}, type: 'implicit' },
+      '(unknown)@file:./a' => { spec: Spec {(unknown)@file:./a}, type: 'implicit' }
     },
     'workspace·foo' => Map(5) {
-      'foo' => { spec: Spec {foo@^1}, type: 'prod' },
-      'bar' => { spec: Spec {bar@latest}, type: 'prod' },
-      'baz' => { spec: Spec {baz@1.0.0}, type: 'prod' },
-      '(unknown)@github:a/b' => { spec: Spec {(unknown)@github:a/b}, type: 'prod' },
-      '(unknown)@file:./a' => { spec: Spec {(unknown)@file:./a}, type: 'prod' }
+      'foo' => { spec: Spec {foo@^1}, type: 'implicit' },
+      'bar' => { spec: Spec {bar@latest}, type: 'implicit' },
+      'baz' => { spec: Spec {baz@1.0.0}, type: 'implicit' },
+      '(unknown)@github:a/b' => { spec: Spec {(unknown)@github:a/b}, type: 'implicit' },
+      '(unknown)@file:./a' => { spec: Spec {(unknown)@file:./a}, type: 'implicit' }
     },
     'workspace·bar' => Map(5) {
-      'foo' => { spec: Spec {foo@^1}, type: 'prod' },
-      'bar' => { spec: Spec {bar@latest}, type: 'prod' },
-      'baz' => { spec: Spec {baz@1.0.0}, type: 'prod' },
-      '(unknown)@github:a/b' => { spec: Spec {(unknown)@github:a/b}, type: 'prod' },
-      '(unknown)@file:./a' => { spec: Spec {(unknown)@file:./a}, type: 'prod' }
+      'foo' => { spec: Spec {foo@^1}, type: 'implicit' },
+      'bar' => { spec: Spec {bar@latest}, type: 'implicit' },
+      'baz' => { spec: Spec {baz@1.0.0}, type: 'implicit' },
+      '(unknown)@github:a/b' => { spec: Spec {(unknown)@github:a/b}, type: 'implicit' },
+      '(unknown)@file:./a' => { spec: Spec {(unknown)@file:./a}, type: 'implicit' }
     },
     modifiedDependencies: true
   }
@@ -133,25 +133,25 @@ exports[`test/parse-add-remove-args.ts > TAP > parseAddArgs > workspaces > defin
 {
   add: AddImportersDependenciesMapImpl(3) [Map] {
     'workspace·app§b' => Map(5) {
-      'foo' => { spec: Spec {foo@^1}, type: 'prod' },
-      'bar' => { spec: Spec {bar@latest}, type: 'prod' },
-      'baz' => { spec: Spec {baz@1.0.0}, type: 'prod' },
-      '(unknown)@github:a/b' => { spec: Spec {(unknown)@github:a/b}, type: 'prod' },
-      '(unknown)@file:./a' => { spec: Spec {(unknown)@file:./a}, type: 'prod' }
+      'foo' => { spec: Spec {foo@^1}, type: 'implicit' },
+      'bar' => { spec: Spec {bar@latest}, type: 'implicit' },
+      'baz' => { spec: Spec {baz@1.0.0}, type: 'implicit' },
+      '(unknown)@github:a/b' => { spec: Spec {(unknown)@github:a/b}, type: 'implicit' },
+      '(unknown)@file:./a' => { spec: Spec {(unknown)@file:./a}, type: 'implicit' }
     },
     'workspace·app§a' => Map(5) {
-      'foo' => { spec: Spec {foo@^1}, type: 'prod' },
-      'bar' => { spec: Spec {bar@latest}, type: 'prod' },
-      'baz' => { spec: Spec {baz@1.0.0}, type: 'prod' },
-      '(unknown)@github:a/b' => { spec: Spec {(unknown)@github:a/b}, type: 'prod' },
-      '(unknown)@file:./a' => { spec: Spec {(unknown)@file:./a}, type: 'prod' }
+      'foo' => { spec: Spec {foo@^1}, type: 'implicit' },
+      'bar' => { spec: Spec {bar@latest}, type: 'implicit' },
+      'baz' => { spec: Spec {baz@1.0.0}, type: 'implicit' },
+      '(unknown)@github:a/b' => { spec: Spec {(unknown)@github:a/b}, type: 'implicit' },
+      '(unknown)@file:./a' => { spec: Spec {(unknown)@file:./a}, type: 'implicit' }
     },
     'workspace·utils§c' => Map(5) {
-      'foo' => { spec: Spec {foo@^1}, type: 'prod' },
-      'bar' => { spec: Spec {bar@latest}, type: 'prod' },
-      'baz' => { spec: Spec {baz@1.0.0}, type: 'prod' },
-      '(unknown)@github:a/b' => { spec: Spec {(unknown)@github:a/b}, type: 'prod' },
-      '(unknown)@file:./a' => { spec: Spec {(unknown)@file:./a}, type: 'prod' }
+      'foo' => { spec: Spec {foo@^1}, type: 'implicit' },
+      'bar' => { spec: Spec {bar@latest}, type: 'implicit' },
+      'baz' => { spec: Spec {baz@1.0.0}, type: 'implicit' },
+      '(unknown)@github:a/b' => { spec: Spec {(unknown)@github:a/b}, type: 'implicit' },
+      '(unknown)@file:./a' => { spec: Spec {(unknown)@file:./a}, type: 'implicit' }
     },
     modifiedDependencies: true
   }
@@ -161,7 +161,7 @@ exports[`test/parse-add-remove-args.ts > TAP > parseAddArgs > workspaces > defin
 exports[`test/parse-add-remove-args.ts > TAP > parseAddArgs > workspaces > define root dep if no workspace config defined > should return dependency of root 1`] = `
 {
   add: AddImportersDependenciesMapImpl(1) [Map] {
-    'file·.' => Map(1) { 'foo' => { spec: Spec {foo@}, type: 'prod' } },
+    'file·.' => Map(1) { 'foo' => { spec: Spec {foo@}, type: 'implicit' } },
     modifiedDependencies: true
   }
 }
@@ -170,7 +170,7 @@ exports[`test/parse-add-remove-args.ts > TAP > parseAddArgs > workspaces > defin
 exports[`test/parse-add-remove-args.ts > TAP > parseAddArgs > workspaces > define single dep of a single workspace > should return dependency of a workspace 1`] = `
 {
   add: AddImportersDependenciesMapImpl(1) [Map] {
-    'workspace·app§a' => Map(1) { 'foo' => { spec: Spec {foo@}, type: 'prod' } },
+    'workspace·app§a' => Map(1) { 'foo' => { spec: Spec {foo@}, type: 'implicit' } },
     modifiedDependencies: true
   }
 }
@@ -179,8 +179,8 @@ exports[`test/parse-add-remove-args.ts > TAP > parseAddArgs > workspaces > defin
 exports[`test/parse-add-remove-args.ts > TAP > parseAddArgs > workspaces > define single dep to a group of workspaces > should return dependency to a group of workspaces 1`] = `
 {
   add: AddImportersDependenciesMapImpl(2) [Map] {
-    'workspace·foo' => Map(1) { 'foo' => { spec: Spec {foo@}, type: 'prod' } },
-    'workspace·bar' => Map(1) { 'foo' => { spec: Spec {foo@}, type: 'prod' } },
+    'workspace·foo' => Map(1) { 'foo' => { spec: Spec {foo@}, type: 'implicit' } },
+    'workspace·bar' => Map(1) { 'foo' => { spec: Spec {foo@}, type: 'implicit' } },
     modifiedDependencies: true
   }
 }
@@ -189,9 +189,9 @@ exports[`test/parse-add-remove-args.ts > TAP > parseAddArgs > workspaces > defin
 exports[`test/parse-add-remove-args.ts > TAP > parseAddArgs > workspaces > define single dep to multiple groups of workspaces > should return dependency to many groups of workspaces 1`] = `
 {
   add: AddImportersDependenciesMapImpl(3) [Map] {
-    'workspace·utils§c' => Map(1) { 'foo' => { spec: Spec {foo@}, type: 'prod' } },
-    'workspace·foo' => Map(1) { 'foo' => { spec: Spec {foo@}, type: 'prod' } },
-    'workspace·bar' => Map(1) { 'foo' => { spec: Spec {foo@}, type: 'prod' } },
+    'workspace·utils§c' => Map(1) { 'foo' => { spec: Spec {foo@}, type: 'implicit' } },
+    'workspace·foo' => Map(1) { 'foo' => { spec: Spec {foo@}, type: 'implicit' } },
+    'workspace·bar' => Map(1) { 'foo' => { spec: Spec {foo@}, type: 'implicit' } },
     modifiedDependencies: true
   }
 }

--- a/src/graph/src/dependencies.ts
+++ b/src/graph/src/dependencies.ts
@@ -1,21 +1,28 @@
 import type { DepID } from '@vltpkg/dep-id'
 import { error } from '@vltpkg/error-cause'
 import type { Spec } from '@vltpkg/spec'
-import {
-  longDependencyTypes,
-  shortDependencyTypes,
-  dependencyTypes,
-} from '@vltpkg/types'
 import type {
-  Manifest,
+  DependencySaveType,
   DependencyTypeLong,
   DependencyTypeShort,
+  Manifest,
+} from '@vltpkg/types'
+import {
+  dependencyTypes,
+  longDependencyTypes,
+  shortDependencyTypes,
 } from '@vltpkg/types'
 
 export const isDependencyTypeShort = (
   obj: unknown,
 ): obj is DependencyTypeShort =>
   shortDependencyTypes.has(obj as DependencyTypeShort)
+
+export const isDependencySaveType = (
+  obj: unknown,
+): obj is DependencyTypeShort =>
+  shortDependencyTypes.has(obj as DependencyTypeShort) ||
+  obj === 'implicit'
 
 export const asDependencyTypeShort = (
   obj: unknown,
@@ -48,9 +55,10 @@ export type Dependency = {
    */
   spec: Spec
   /**
-   * The {@link DependencyTypeShort}, describing the type of dependency.
+   * The {@link DependencySaveType}, describing the way this dependency should
+   * be saved back to the manifest.
    */
-  type: DependencyTypeShort
+  type: DependencySaveType
 }
 
 /**
@@ -89,7 +97,7 @@ export const isDependency = (o: unknown): o is Dependency =>
   isObj(o) &&
   isObj(o.spec) &&
   !!o.spec.type &&
-  isDependencyTypeShort(o.type)
+  isDependencySaveType(o.type)
 
 export const asDependency = (obj: unknown): Dependency => {
   if (!isDependency(obj)) {

--- a/src/graph/src/graph.ts
+++ b/src/graph/src/graph.ts
@@ -4,7 +4,7 @@ import { error } from '@vltpkg/error-cause'
 import { satisfies } from '@vltpkg/satisfies'
 import { Spec } from '@vltpkg/spec'
 import type { SpecOptions } from '@vltpkg/spec'
-import type { Manifest, DependencyTypeShort } from '@vltpkg/types'
+import type { Manifest, DependencySaveType } from '@vltpkg/types'
 import type { Monorepo } from '@vltpkg/workspaces'
 import { inspect } from 'node:util'
 import type { InspectOptions } from 'node:util'
@@ -13,6 +13,7 @@ import { lockfileData } from './lockfile/save.ts'
 import { Node } from './node.ts'
 import type { NodeOptions } from './node.ts'
 import type { GraphLike, NodeLike } from './types.ts'
+import { resolveSaveType } from './resolve-save-type.ts'
 
 const kCustomInspect = Symbol.for('nodejs.util.inspect.custom')
 
@@ -191,7 +192,7 @@ export class Graph implements GraphLike {
    * pointing to nothing will be created to represent that missing dependency.
    */
   addEdge(
-    type: DependencyTypeShort,
+    type: DependencySaveType,
     spec: Spec,
     from: NodeLike,
     to?: NodeLike,
@@ -224,7 +225,11 @@ export class Graph implements GraphLike {
       this.edges.delete(edge)
     }
     const f = from as Node
-    const edgeOut = f.addEdgesTo(type, spec, to as Node | undefined)
+    const edgeOut = f.addEdgesTo(
+      resolveSaveType(from, spec.name, type),
+      spec,
+      to as Node | undefined,
+    )
     this.edges.add(edgeOut)
     return edgeOut
   }
@@ -309,7 +314,7 @@ export class Graph implements GraphLike {
    */
   placePackage(
     fromNode: Node,
-    depType: DependencyTypeShort,
+    depType: DependencySaveType,
     spec: Spec,
     manifest?: Manifest,
     id?: DepID,

--- a/src/graph/src/ideal/add-nodes.ts
+++ b/src/graph/src/ideal/add-nodes.ts
@@ -8,6 +8,7 @@ import type {
   BuildIdealAddOptions,
   BuildIdealFromGraphOptions,
 } from './types.ts'
+import { resolveSaveType } from '../resolve-save-type.ts'
 
 export type AddNodesOptions = BuildIdealAddOptions &
   BuildIdealFromGraphOptions &
@@ -45,8 +46,11 @@ export const addNodes = async ({
     // Removes any edges and nodes that are currently part of the
     // graph but are also in the list of dependencies to be installed
     const deps = [...dependencies.values()]
-    for (const { spec } of deps) {
-      const node = importer.edgesOut.get(spec.name)?.to
+    for (const dep of deps) {
+      const { spec } = dep
+      const existingEdge = importer.edgesOut.get(spec.name)
+      dep.type = resolveSaveType(importer, spec.name, dep.type)
+      const node = existingEdge?.to
       if (node) graph.removeNode(node)
     }
 

--- a/src/graph/src/resolve-save-type.ts
+++ b/src/graph/src/resolve-save-type.ts
@@ -1,0 +1,17 @@
+import type {
+  DependencySaveType,
+  DependencyTypeShort,
+} from '@vltpkg/types'
+import type { NodeLike } from './types.ts'
+
+/**
+ * Resolve a {@link DependencySaveType} to a {@link DependencyTypeShort}
+ */
+export const resolveSaveType = (
+  node: NodeLike,
+  name: string,
+  saveType: DependencySaveType,
+): DependencyTypeShort =>
+  saveType !== 'implicit' ? saveType : (
+    (node.edgesOut.get(name)?.type ?? 'prod')
+  )

--- a/src/graph/tap-snapshots/test/ideal/add-nodes.ts.test.cjs
+++ b/src/graph/tap-snapshots/test/ideal/add-nodes.ts.test.cjs
@@ -24,7 +24,7 @@ exports[`test/ideal/add-nodes.ts > TAP > addNodes > graph after adding a previou
           }
         ]
       },
-      Edge spec(bar@^1.0.0) -prod-> to: Node { ref: '··bar@1.0.0' }
+      Edge spec(bar@^1.0.0) -dev-> to: Node { ref: '··bar@1.0.0' }
     ]
   }
 ]

--- a/src/graph/tap-snapshots/test/reify/update-importers-package-json.ts.test.cjs
+++ b/src/graph/tap-snapshots/test/reify/update-importers-package-json.ts.test.cjs
@@ -10,6 +10,7 @@ Array [
   Object {
     "dependencies": Object {
       "b": "npm:a@1.0.0",
+      "becomeprod": "1.0.0",
       "git": "github:a/b",
     },
     "devDependencies": Object {
@@ -18,6 +19,10 @@ Array [
       "range": "~1.1.0",
     },
     "name": "root",
+    "peerDependencies": Object {
+      "pdep": "1.2.3",
+    },
+    "peerDependenciesMeta": Object {},
     "version": "1.0.0",
   },
 ]
@@ -28,6 +33,7 @@ Array [
   Object {
     "dependencies": Object {
       "b": "npm:a@^1.0.0",
+      "becomeprod": "1.0.0",
       "git": "github:a/b",
     },
     "devDependencies": Object {
@@ -36,6 +42,10 @@ Array [
       "range": "~1.1.0",
     },
     "name": "root",
+    "peerDependencies": Object {
+      "pdep": "1.2.3",
+    },
+    "peerDependenciesMeta": Object {},
     "version": "1.0.0",
   },
 ]
@@ -46,6 +56,7 @@ Array [
   Object {
     "dependencies": Object {
       "b": "custom:a@^1.0.0",
+      "becomeprod": "1.0.0",
       "git": "github:a/b",
     },
     "devDependencies": Object {
@@ -54,6 +65,10 @@ Array [
       "range": "~1.1.0",
     },
     "name": "root",
+    "peerDependencies": Object {
+      "pdep": "1.2.3",
+    },
+    "peerDependenciesMeta": Object {},
     "version": "1.0.0",
   },
 ]
@@ -63,6 +78,7 @@ exports[`test/reify/update-importers-package-json.ts > TAP > updatePackageJson >
 Array [
   Object {
     "dependencies": Object {
+      "becomeprod": "1.0.0",
       "foo": "1.0.0",
       "git": "github:a/b",
     },
@@ -71,6 +87,15 @@ Array [
       "range": "~1.1.0",
     },
     "name": "root",
+    "peerDependencies": Object {
+      "newpeeroptional": "1.0.0",
+      "pdep": "1.2.3",
+    },
+    "peerDependenciesMeta": Object {
+      "newpeeroptional": Object {
+        "optional": true,
+      },
+    },
     "version": "1.0.0",
   },
 ]
@@ -80,10 +105,20 @@ exports[`test/reify/update-importers-package-json.ts > TAP > updatePackageJson >
 Array [
   Object {
     "dependencies": Object {
+      "becomeprod": "1.0.0",
       "foo": "1.0.0",
       "git": "github:a/b",
     },
     "name": "root",
+    "peerDependencies": Object {
+      "newpeeroptional": "1.0.0",
+      "pdep": "1.2.3",
+    },
+    "peerDependenciesMeta": Object {
+      "newpeeroptional": Object {
+        "optional": true,
+      },
+    },
     "version": "1.0.0",
   },
 ]
@@ -93,6 +128,7 @@ exports[`test/reify/update-importers-package-json.ts > TAP > updatePackageJson >
 Array [
   Object {
     "dependencies": Object {
+      "becomeprod": "1.0.0",
       "git": "github:a/b",
     },
     "devDependencies": Object {
@@ -101,6 +137,10 @@ Array [
       "range": "~1.1.0",
     },
     "name": "root",
+    "peerDependencies": Object {
+      "pdep": "1.2.3",
+    },
+    "peerDependenciesMeta": Object {},
     "version": "1.0.0",
   },
 ]
@@ -110,6 +150,7 @@ exports[`test/reify/update-importers-package-json.ts > TAP > updatePackageJson >
 Array [
   Object {
     "dependencies": Object {
+      "becomeprod": "1.0.0",
       "foo": "1.0.0",
       "git": "github:a/b",
     },
@@ -117,6 +158,15 @@ Array [
       "range": "~1.1.0",
     },
     "name": "root",
+    "peerDependencies": Object {
+      "newpeeroptional": "1.0.0",
+      "pdep": "1.2.3",
+    },
+    "peerDependenciesMeta": Object {
+      "newpeeroptional": Object {
+        "optional": true,
+      },
+    },
     "version": "1.0.0",
   },
 ]
@@ -126,6 +176,7 @@ exports[`test/reify/update-importers-package-json.ts > TAP > updatePackageJson >
 Array [
   Object {
     "dependencies": Object {
+      "becomeprod": "1.0.0",
       "git": "github:a/b",
     },
     "devDependencies": Object {
@@ -133,6 +184,10 @@ Array [
       "range": "~1.1.0",
     },
     "name": "root",
+    "peerDependencies": Object {
+      "pdep": "1.2.3",
+    },
+    "peerDependenciesMeta": Object {},
     "version": "1.0.0",
   },
 ]
@@ -142,9 +197,19 @@ exports[`test/reify/update-importers-package-json.ts > TAP > updatePackageJson >
 Array [
   Object {
     "dependencies": Object {
+      "becomeprod": "1.0.0",
       "foo": "1.0.0",
     },
     "name": "root",
+    "peerDependencies": Object {
+      "newpeeroptional": "1.0.0",
+      "pdep": "1.2.3",
+    },
+    "peerDependenciesMeta": Object {
+      "newpeeroptional": Object {
+        "optional": true,
+      },
+    },
     "version": "1.0.0",
   },
 ]

--- a/src/graph/test/dependencies.ts
+++ b/src/graph/test/dependencies.ts
@@ -4,6 +4,7 @@ import {
   asDependencyTypeShort,
   isDependency,
   isDependencyTypeShort,
+  isDependencySaveType,
   shorten,
 } from '../src/dependencies.ts'
 import { Spec } from '@vltpkg/spec'
@@ -105,6 +106,21 @@ t.test('isDependencyTypeShort', async t => {
   )
   t.notOk(
     isDependencyTypeShort('unknown'),
+    'should not be ok if type is not a valid short type',
+  )
+})
+
+t.test('isDependencySaveType', async t => {
+  t.ok(
+    isDependencySaveType('prod'),
+    'should be ok if type is a valid save type',
+  )
+  t.ok(
+    isDependencySaveType('implicit'),
+    'should be ok if type is a valid save type',
+  )
+  t.notOk(
+    isDependencySaveType('unknown'),
     'should not be ok if type is not a valid short type',
   )
 })

--- a/src/graph/test/ideal/add-nodes.ts
+++ b/src/graph/test/ideal/add-nodes.ts
@@ -1,8 +1,8 @@
 import { joinDepIDTuple } from '@vltpkg/dep-id'
-import type { DependencyTypeShort } from '@vltpkg/types'
 import type { PackageInfoClient } from '@vltpkg/package-info'
-import { kCustomInspect, Spec } from '@vltpkg/spec'
 import type { SpecOptions } from '@vltpkg/spec'
+import { kCustomInspect, Spec } from '@vltpkg/spec'
+import type { DependencySaveType } from '@vltpkg/types'
 import { PathScurry } from 'path-scurry'
 import t from 'tap'
 import type {
@@ -59,7 +59,7 @@ t.test('addNodes', async t => {
   } as PackageInfoClient
   const addEntry = (
     name: string,
-    type: DependencyTypeShort = 'prod',
+    type: DependencySaveType = 'implicit',
   ) =>
     new Map(
       Object.entries({
@@ -122,7 +122,7 @@ t.test('addNodes', async t => {
   // now it should install the package bar to the main importer
   await addNodes({
     add: new Map([
-      [joinDepIDTuple(['file', '.']), addEntry('bar')],
+      [joinDepIDTuple(['file', '.']), addEntry('bar', 'dev')],
     ]) as AddImportersDependenciesMap,
     scurry: new PathScurry(t.testdirName),
     graph,

--- a/src/graph/test/resolve-save-type.ts
+++ b/src/graph/test/resolve-save-type.ts
@@ -1,0 +1,33 @@
+import { Spec } from '@vltpkg/spec'
+import t from 'tap'
+import type { Edge } from '../src/edge.ts'
+import type { Node } from '../src/node.ts'
+import { resolveSaveType } from '../src/resolve-save-type.ts'
+
+const node = {
+  edgesOut: new Map(),
+} as unknown as Node
+
+const fooEdge = {
+  type: 'dev',
+  from: node,
+  spec: Spec.parse('foo@1.2.3'),
+} as unknown as Edge
+
+node.edgesOut.set('foo', fooEdge)
+
+t.equal(
+  resolveSaveType(node, 'foo', 'implicit'),
+  'dev',
+  'preserved if found',
+)
+t.equal(
+  resolveSaveType(node, 'bar', 'implicit'),
+  'prod',
+  'prod if not found',
+)
+t.equal(
+  resolveSaveType(node, 'foo', 'optional'),
+  'optional',
+  'respected if not implicit',
+)

--- a/src/types/src/index.ts
+++ b/src/types/src/index.ts
@@ -390,6 +390,17 @@ export type DependencyTypeShort =
   | 'prod'
 
 /**
+ * Unique keys that indicate how a new or updated dependency should be saved
+ * back to a manifest.
+ *
+ * `'implicit'` is used to indicate that a dependency should be saved as
+ * whatever type it already exists as. If the dependency does not exist,
+ * then `'implicit'` is equivalent to `'prod'`, as that is the default
+ * save type.
+ */
+export type DependencySaveType = DependencyTypeShort | 'implicit'
+
+/**
  * A set of the possible long dependency type names,
  * as used in `package.json` files.
  */


### PR DESCRIPTION
- When a `--save-*` config is not provided, deps will be saved to either
  their current state, or `'prod'` if they are not already a dependency.
- Handling of `peerOptional` dependencies is added.

Fix: #552

cc: @ejkorol 