### PR TITLE
gui: selected item tabs consistent render

### DIFF
--- a/src/gui/src/components/explorer-grid/selected-item/tabs-insight.tsx
+++ b/src/gui/src/components/explorer-grid/selected-item/tabs-insight.tsx
@@ -8,13 +8,9 @@ import {
 } from '@/components/explorer-grid/selected-item/insight-badge.jsx'
 import type { SocketSecurityDetails } from '@/lib/constants/index.js'
 import type { PackageAlert } from '@vltpkg/security-archive'
-import { ArrowUpDown } from 'lucide-react'
+import { ArrowUpDown, BadgeInfo } from 'lucide-react'
 
 export const InsightTabButton = () => {
-  const { insights } = useSelectedItem()
-
-  if (!insights || insights.length === 0) return null
-
   return (
     <TabsTrigger
       variant="ghost"
@@ -125,28 +121,39 @@ export const InsightTabContent = () => {
 
   return (
     <TabsContent value="insights">
-      <section className="mt-2 flex flex-col px-6 py-4">
-        {filteredInsights && filteredInsights.length > 0 && (
-          <>
-            <InsightHeader
-              items={filteredInsights}
-              setItems={setFilteredInsights}
-            />
+      {filteredInsights && filteredInsights.length > 0 ?
+        <section className="mt-2 flex flex-col px-6 py-4">
+          <InsightHeader
+            items={filteredInsights}
+            setItems={setFilteredInsights}
+          />
 
-            <div className="flex flex-col divide-y-[1px] divide-muted">
-              {filteredInsights.map((insight, idx) => (
-                <InsightItem
-                  key={idx}
-                  selector={insight.selector}
-                  severity={insight.severity}
-                  description={insight.description}
-                  category={insight.category}
-                />
-              ))}
+          <div className="flex flex-col divide-y-[1px] divide-muted">
+            {filteredInsights.map((insight, idx) => (
+              <InsightItem
+                key={idx}
+                selector={insight.selector}
+                severity={insight.severity}
+                description={insight.description}
+                category={insight.category}
+              />
+            ))}
+          </div>
+        </section>
+      : <div className="flex h-64 w-full items-center justify-center px-6 py-4">
+          <div className="flex flex-col items-center justify-center gap-3 text-center">
+            <div className="relative flex size-32 items-center justify-center rounded-full bg-secondary/60">
+              <BadgeInfo
+                className="absolute z-[3] size-14 text-neutral-500"
+                strokeWidth={1}
+              />
             </div>
-          </>
-        )}
-      </section>
+            <p className="w-2/3 text-pretty text-sm text-muted-foreground">
+              There are no insights for this package
+            </p>
+          </div>
+        </div>
+      }
 
       <div className="w-full px-6 py-4">
         <Link

--- a/src/gui/src/components/explorer-grid/selected-item/tabs-manifest.tsx
+++ b/src/gui/src/components/explorer-grid/selected-item/tabs-manifest.tsx
@@ -1,12 +1,9 @@
 import { TabsContent, TabsTrigger } from '@/components/ui/tabs.jsx'
 import { CodeBlock } from '@/components/ui/shiki.jsx'
 import { useSelectedItem } from '@/components/explorer-grid/selected-item/context.jsx'
+import { FileJson } from 'lucide-react'
 
 export const TabsManifestButton = () => {
-  const { selectedItem } = useSelectedItem()
-
-  if (!selectedItem.to?.manifest) return null
-
   return (
     <TabsTrigger
       variant="ghost"
@@ -20,16 +17,29 @@ export const TabsManifestButton = () => {
 export const TabsManifestContent = () => {
   const { selectedItem } = useSelectedItem()
 
-  if (!selectedItem.to?.manifest) return null
-
   return (
     <TabsContent
       value="package.json"
       className="h-full rounded-b-lg bg-white dark:bg-black">
-      <CodeBlock
-        code={JSON.stringify(selectedItem.to.manifest, null, 2)}
-        lang="json"
-      />
+      {selectedItem.to && selectedItem.to.manifest ?
+        <CodeBlock
+          code={JSON.stringify(selectedItem.to.manifest, null, 2)}
+          lang="json"
+        />
+      : <div className="flex h-64 items-center justify-center px-6 py-4">
+          <div className="flex flex-col items-center justify-center gap-3 text-center">
+            <div className="relative flex size-32 items-center justify-center rounded-full bg-secondary/60">
+              <FileJson
+                className="absolute z-[3] size-14 text-neutral-500"
+                strokeWidth={1}
+              />
+            </div>
+            <p className="w-2/3 text-pretty text-sm text-muted-foreground">
+              We couldn't find a manifest for this project
+            </p>
+          </div>
+        </div>
+      }
     </TabsContent>
   )
 }

--- a/src/gui/src/components/explorer-grid/selected-item/tabs-versions.tsx
+++ b/src/gui/src/components/explorer-grid/selected-item/tabs-versions.tsx
@@ -1,12 +1,9 @@
 import { TabsTrigger, TabsContent } from '@/components/ui/tabs.jsx'
+import { History } from 'lucide-react'
 import { useSelectedItem } from '@/components/explorer-grid/selected-item/context.jsx'
 import { rcompare } from '@vltpkg/semver'
 
 export const VersionsTabButton = () => {
-  const { selectedItemDetails } = useSelectedItem()
-
-  if (!selectedItemDetails.versions) return null
-
   return (
     <TabsTrigger
       variant="ghost"
@@ -20,26 +17,37 @@ export const VersionsTabButton = () => {
 export const VersionsTabContent = () => {
   const { selectedItemDetails } = useSelectedItem()
 
-  if (
-    (!selectedItemDetails.versions ||
-      selectedItemDetails.versions.length === 0) &&
-    (!selectedItemDetails.greaterVersions ||
-      selectedItemDetails.greaterVersions.length === 0)
-  ) {
-    return null
-  }
+  const versions = selectedItemDetails.versions || []
+  const greaterVersions = selectedItemDetails.greaterVersions || []
+
+  const isEmpty =
+    versions.length === 0 && greaterVersions.length === 0
 
   return (
-    <TabsContent value="versions" className="px-6 py-4">
-      <section className="flex flex-col gap-4">
-        {selectedItemDetails.greaterVersions &&
-          selectedItemDetails.greaterVersions.length > 0 && (
+    <TabsContent value="versions">
+      {isEmpty ?
+        <div className="flex h-64 w-full items-center justify-center px-6 py-4">
+          <div className="flex flex-col items-center justify-center gap-3 text-center">
+            <div className="relative flex size-32 items-center justify-center rounded-full bg-secondary/60">
+              <History
+                className="absolute z-[4] size-14 text-neutral-500"
+                strokeWidth={1}
+              />
+            </div>
+            <p className="w-2/3 text-pretty text-sm text-muted-foreground">
+              There is no versioning information about this package
+              yet
+            </p>
+          </div>
+        </div>
+      : <section className="flex flex-col gap-4 px-6 py-4">
+          {greaterVersions.length > 0 && (
             <div className="flex flex-col gap-2">
               <p className="text-sm font-medium text-muted-foreground">
                 Greater Versions
               </p>
               <ul className="flex flex-col divide-y-[1px] divide-border">
-                {selectedItemDetails.greaterVersions
+                {greaterVersions
                   .sort((a, b) => rcompare(a, b))
                   .map((version, idx) => (
                     <li
@@ -52,14 +60,13 @@ export const VersionsTabContent = () => {
             </div>
           )}
 
-        {selectedItemDetails.versions &&
-          selectedItemDetails.versions.length > 0 && (
+          {versions.length > 0 && (
             <div className="flex flex-col gap-2">
               <p className="text-sm font-medium text-muted-foreground">
                 All Versions
               </p>
               <ul className="flex flex-col divide-y-[1px] divide-border">
-                {selectedItemDetails.versions
+                {versions
                   .sort((a, b) => rcompare(a, b))
                   .map((version, idx) => (
                     <li
@@ -71,7 +78,8 @@ export const VersionsTabContent = () => {
               </ul>
             </div>
           )}
-      </section>
+        </section>
+      }
     </TabsContent>
   )
 }

--- a/src/gui/src/components/explorer-grid/selected-item/tabs-versions.tsx
+++ b/src/gui/src/components/explorer-grid/selected-item/tabs-versions.tsx
@@ -17,8 +17,8 @@ export const VersionsTabButton = () => {
 export const VersionsTabContent = () => {
   const { selectedItemDetails } = useSelectedItem()
 
-  const versions = selectedItemDetails.versions || []
-  const greaterVersions = selectedItemDetails.greaterVersions || []
+  const versions = selectedItemDetails.versions ?? []
+  const greaterVersions = selectedItemDetails.greaterVersions ?? []
 
   const isEmpty =
     versions.length === 0 && greaterVersions.length === 0

--- a/src/gui/test/components/explorer-grid/selected-item/__snapshots__/tabs-insight.tsx.snap
+++ b/src/gui/test/components/explorer-grid/selected-item/__snapshots__/tabs-insight.tsx.snap
@@ -2,14 +2,33 @@
 
 exports[`InsightTabButton renders default 1`] = `
 
+<gui-tabs-trigger
+  variant="ghost"
+  value="insights"
+  classname="w-fit px-2"
+>
+  Insights
+</gui-tabs-trigger>
 
 `;
 
-exports[`InsightTabContent renders default 1`] = `
+exports[`InsightTabContent renders an empty state 1`] = `
 
 <gui-tabs-content value="insights">
-  <section class="mt-2 flex flex-col px-6 py-4">
-  </section>
+  <div class="flex h-64 w-full items-center justify-center px-6 py-4">
+    <div class="flex flex-col items-center justify-center gap-3 text-center">
+      <div class="relative flex size-32 items-center justify-center rounded-full bg-secondary/60">
+        <gui-badge-info-icon
+          classname="absolute z-[3] size-14 text-neutral-500"
+          strokewidth="1"
+        >
+        </gui-badge-info-icon>
+      </div>
+      <p class="w-2/3 text-pretty text-sm text-muted-foreground">
+        There are no insights for this package
+      </p>
+    </div>
+  </div>
   <div class="w-full px-6 py-4">
     <gui-link
       to="/help/selectors"

--- a/src/gui/test/components/explorer-grid/selected-item/__snapshots__/tabs-manifest.tsx.snap
+++ b/src/gui/test/components/explorer-grid/selected-item/__snapshots__/tabs-manifest.tsx.snap
@@ -12,7 +12,31 @@ exports[`TabsManifestButton renders default 1`] = `
 
 `;
 
-exports[`TabsManifestContent renders default 1`] = `
+exports[`TabsManifestContent renders an empty state 1`] = `
+
+<gui-tabs-content
+  value="package.json"
+  classname="h-full rounded-b-lg bg-white dark:bg-black"
+>
+  <div class="flex h-64 items-center justify-center px-6 py-4">
+    <div class="flex flex-col items-center justify-center gap-3 text-center">
+      <div class="relative flex size-32 items-center justify-center rounded-full bg-secondary/60">
+        <gui-file-json-icon
+          classname="absolute z-[3] size-14 text-neutral-500"
+          strokewidth="1"
+        >
+        </gui-file-json-icon>
+      </div>
+      <p class="w-2/3 text-pretty text-sm text-muted-foreground">
+        We couldn't find a manifest for this project
+      </p>
+    </div>
+  </div>
+</gui-tabs-content>
+
+`;
+
+exports[`TabsManifestContent renders with a manifest 1`] = `
 
 <gui-tabs-content
   value="package.json"

--- a/src/gui/test/components/explorer-grid/selected-item/__snapshots__/tabs-versions.tsx.snap
+++ b/src/gui/test/components/explorer-grid/selected-item/__snapshots__/tabs-versions.tsx.snap
@@ -12,13 +12,31 @@ exports[`VersionsTabButton renders default 1`] = `
 
 `;
 
-exports[`VersionsTabContent renders default 1`] = `
+exports[`VersionsTabContent renders an empty state 1`] = `
 
-<gui-tabs-content
-  value="versions"
-  classname="px-6 py-4"
->
-  <section class="flex flex-col gap-4">
+<gui-tabs-content value="versions">
+  <div class="flex h-64 w-full items-center justify-center px-6 py-4">
+    <div class="flex flex-col items-center justify-center gap-3 text-center">
+      <div class="relative flex size-32 items-center justify-center rounded-full bg-secondary/60">
+        <gui-history-icon
+          classname="absolute z-[4] size-14 text-neutral-500"
+          strokewidth="1"
+        >
+        </gui-history-icon>
+      </div>
+      <p class="w-2/3 text-pretty text-sm text-muted-foreground">
+        There is no versioning information about this package yet
+      </p>
+    </div>
+  </div>
+</gui-tabs-content>
+
+`;
+
+exports[`VersionsTabContent renders with versions 1`] = `
+
+<gui-tabs-content value="versions">
+  <section class="flex flex-col gap-4 px-6 py-4">
     <div class="flex flex-col gap-2">
       <p class="text-sm font-medium text-muted-foreground">
         Greater Versions

--- a/src/gui/test/components/explorer-grid/selected-item/tabs-insight.tsx
+++ b/src/gui/test/components/explorer-grid/selected-item/tabs-insight.tsx
@@ -52,6 +52,7 @@ vi.mock(
 
 vi.mock('lucide-react', () => ({
   ArrowUpDown: 'gui-arrow-up-down-icon',
+  BadgeInfo: 'gui-badge-info-icon',
 }))
 
 expect.addSnapshotSerializer({
@@ -77,7 +78,7 @@ afterEach(() => {
   cleanup()
 })
 
-test('InsightTabContent renders default', () => {
+test('InsightTabContent renders an empty state', () => {
   const Container = () => {
     return <InsightTabContent />
   }

--- a/src/gui/test/components/explorer-grid/selected-item/tabs-manifest.tsx
+++ b/src/gui/test/components/explorer-grid/selected-item/tabs-manifest.tsx
@@ -14,6 +14,10 @@ import {
 import type { GridItemData } from '@/components/explorer-grid/types.js'
 import type { Manifest } from '@vltpkg/types'
 
+vi.mock('lucide-react', () => ({
+  FileJson: 'gui-file-json-icon',
+}))
+
 vi.mock(
   '@/components/explorer-grid/selected-item/context.jsx',
   () => ({
@@ -44,23 +48,6 @@ afterEach(() => {
   const CleanUp = () => (useStore(state => state.reset)(), '')
   render(<CleanUp />)
   cleanup()
-})
-
-test('TabsManifestButton does not render when manifest is not available', () => {
-  vi.mocked(useSelectedItem).mockReturnValue({
-    selectedItem: SELECTED_ITEM,
-    selectedItemDetails: SELECTED_ITEM_DETAILS,
-    insights: undefined,
-    activeTab: 'manifest',
-    setActiveTab: vi.fn(),
-  })
-
-  const Container = () => {
-    return <TabsManifestButton />
-  }
-
-  const { container } = render(<Container />)
-  expect(container.innerHTML).toBe('')
 })
 
 test('TabsManifestButton renders default', () => {
@@ -100,7 +87,7 @@ test('TabsManifestButton renders default', () => {
   expect(container.innerHTML).toMatchSnapshot()
 })
 
-test('TabsManifestContent does not render when manifest is not available', () => {
+test('TabsManifestContent renders an empty state', () => {
   vi.mocked(useSelectedItem).mockReturnValue({
     selectedItem: SELECTED_ITEM,
     selectedItemDetails: SELECTED_ITEM_DETAILS,
@@ -114,10 +101,10 @@ test('TabsManifestContent does not render when manifest is not available', () =>
   }
 
   const { container } = render(<Container />)
-  expect(container.innerHTML).toBe('')
+  expect(container.innerHTML).toMatchSnapshot()
 })
 
-test('TabsManifestContent renders default', () => {
+test('TabsManifestContent renders with a manifest', () => {
   const ITEM_WITH_MANIFEST = {
     ...SELECTED_ITEM,
     to: {

--- a/src/gui/test/components/explorer-grid/selected-item/tabs-versions.tsx
+++ b/src/gui/test/components/explorer-grid/selected-item/tabs-versions.tsx
@@ -13,6 +13,10 @@ import {
 } from './__fixtures__/item.ts'
 import type { DetailsInfo } from '@/lib/external-info.js'
 
+vi.mock('lucide-react', () => ({
+  History: 'gui-history-icon',
+}))
+
 vi.mock(
   '@/components/explorer-grid/selected-item/context.jsx',
   () => ({
@@ -57,24 +61,7 @@ test('VersionsTabButton renders default', () => {
   expect(container.innerHTML).toMatchSnapshot()
 })
 
-test('VersionsTabButton does not render when any verions are not available', () => {
-  vi.mocked(useSelectedItem).mockReturnValue({
-    selectedItem: SELECTED_ITEM,
-    selectedItemDetails: {
-      ...SELECTED_ITEM_DETAILS,
-      greaterVersions: undefined,
-      versions: undefined,
-    } as DetailsInfo,
-    insights: undefined,
-    activeTab: 'versions',
-    setActiveTab: vi.fn(),
-  })
-
-  const { container } = render(<VersionsTabButton />)
-  expect(container.innerHTML).toBe('')
-})
-
-test('VersionsTabContent renders default', () => {
+test('VersionsTabContent renders with versions', () => {
   vi.mocked(useSelectedItem).mockReturnValue({
     selectedItem: SELECTED_ITEM,
     selectedItemDetails: {
@@ -90,7 +77,7 @@ test('VersionsTabContent renders default', () => {
   expect(container.innerHTML).toMatchSnapshot()
 })
 
-test('VersionsTabContent does not render when any versions are not available', () => {
+test('VersionsTabContent renders an empty state', () => {
   vi.mocked(useSelectedItem).mockReturnValue({
     selectedItem: SELECTED_ITEM,
     selectedItemDetails: {
@@ -104,5 +91,5 @@ test('VersionsTabContent does not render when any versions are not available', (
   })
 
   const { container } = render(<VersionsTabContent />)
-  expect(container.innerHTML).toBe('')
+  expect(container.innerHTML).toMatchSnapshot()
 })


### PR DESCRIPTION
<img width="620" alt="Screenshot 2025-04-04 at 16 48 40" src="https://github.com/user-attachments/assets/f4490758-ccef-4f88-9e65-b849a9d9daae" />

Consistently renders a button for each `tab-content` on the selected item in the gui, and renders an empty state when applicable.

Closes vltpkg/statusboard#99

- **`tabs-insights`** consistent render with empty state
- **`tabs-manifest`** consistent render with empty state
- **`tabs-versions`** consistent render with empty state