### PR TITLE
gui: bugfix initial header load

### DIFF
--- a/src/gui/src/app/explorer.tsx
+++ b/src/gui/src/app/explorer.tsx
@@ -95,6 +95,7 @@ const ExplorerContent = () => {
   const query = useGraphStore(state => state.query)
   const q = useGraphStore(state => state.q)
   const ac = useRef<AbortController>(new AbortController())
+  const navigate = useNavigate()
 
   // updates the query response state anytime the query changes
   // by defining query and q as dependencies of `useEffect` we
@@ -118,12 +119,7 @@ const ExplorerContent = () => {
         query !== state.query ||
         state.route !== '/explore'
       ) {
-        history.pushState(
-          { query, route: '/explore' },
-          '',
-          '/explore?query=' + encodeURIComponent(query),
-        )
-        window.scrollTo(0, 0)
+        void navigate('/explore?query=' + encodeURIComponent(query))
       }
     }
     void updateQueryData().catch(() => {})

--- a/src/gui/src/components/navigation/header.tsx
+++ b/src/gui/src/components/navigation/header.tsx
@@ -1,5 +1,5 @@
 import { useLocation } from 'react-router'
-import { useEffect, useState } from 'react'
+import { useMemo } from 'react'
 import { useGraphStore } from '@/state/index.js'
 
 const routeNames = new Map<string, string>([
@@ -13,26 +13,19 @@ const routeNames = new Map<string, string>([
 ])
 
 const Header = () => {
-  const [routeName, setRouteName] = useState<string>('')
   const { pathname } = useLocation()
   const projectInfo = useGraphStore(state => state.projectInfo)
 
-  useEffect(() => {
-    /**
-     * Set a clean route on the state for display
-     */
-    const mappedName = routeNames.get(pathname)
-    if (mappedName) {
-      setRouteName(mappedName)
-    } else {
-      setRouteName('VLT /vōlt/')
-    }
-  }, [pathname])
+  const routeName = useMemo(() => {
+    if (pathname.includes('error')) return null
+    if (pathname === '/create-new-project') return null
+    if (projectInfo.vltInstalled === false && pathname === '/explore')
+      return null
 
-  if (pathname.includes('error')) return null
-  if (pathname === '/create-new-project') return null
+    return routeNames.get(pathname) || 'VLT /vōlt/'
+  }, [pathname, projectInfo.vltInstalled])
 
-  if (projectInfo.vltInstalled === false) return null
+  if (!routeName) return null
 
   return (
     <div className="flex h-[65px] w-full items-center rounded-t-lg border-x-[1px] border-t-[1px] px-8 py-3">


### PR DESCRIPTION
- Fixes a bug where the header title is not immediately visible when starting the gui on the `explore` route,
the cause was a check for if the project was installed with vlt.

- Optimizes the header component by removing state and useEffect, and using a useMemo instead, which improves re-rendering on the header component itself.
