### PR TITLE
query: add v as shortcut to semver

### DIFF
--- a/src/query/src/pseudo.ts
+++ b/src/query/src/pseudo.ts
@@ -395,6 +395,7 @@ const pseudoSelectors = new Map<string, ParserFn>(
     unmaintained,
     unpopular,
     unstable,
+    v: semver,
   }),
 )
 

--- a/src/query/test/index.ts
+++ b/src/query/test/index.ts
@@ -81,6 +81,8 @@ t.test('simple graph', async t => {
       ['a', 'b', 'e', '@x/y', 'my-project', 'd'],
     ],
     ['#a', ['a']], // identifier
+    ['#a:v(1)', ['a']], // matches identifier + semver
+    ['#a:v(2)', []], // fails to match identifier + semver
   ])
 
   const query = new Query({


### PR DESCRIPTION
So that you can do stuff like:

```
#minimatch:v(3)
#abbrev:v(3.0.0)
#react:v(17 || 18)
```