### PR TITLE
cache-unzip: properly read length/encoding headers

### DIFF
--- a/src/cache-unzip/src/unzip.ts
+++ b/src/cache-unzip/src/unzip.ts
@@ -85,7 +85,7 @@ const main = async (
             i += size
             continue
           } else {
-            if (i % 2 === 0) {
+            if (headers.length % 2 === 0) {
               // it's a key
               if (h.toString().toLowerCase() === 'content-length') {
                 isContentLength = true

--- a/src/cache-unzip/test/unzip.ts
+++ b/src/cache-unzip/test/unzip.ts
@@ -133,6 +133,10 @@ t.test('unzip an entry that had headers', async t => {
   const unz = '{"hello":"world"}'
   const z = gzipSync(unz)
   const zheaders = Buffer.concat([
+    Buffer.from([0, 0, 0, 'even'.length + 4]),
+    Buffer.from('even'),
+    Buffer.from([0, 0, 0, 'odd'.length + 4]),
+    Buffer.from('odd'),
     Buffer.from([0, 0, 0, 'content-encoding'.length + 4]),
     Buffer.from('content-encoding'),
     Buffer.from([0, 0, 0, 'gzip'.length + 4]),
@@ -149,6 +153,10 @@ t.test('unzip an entry that had headers', async t => {
   )
 
   const resultHead = Buffer.concat([
+    Buffer.from([0, 0, 0, 'even'.length + 4]),
+    Buffer.from('even'),
+    Buffer.from([0, 0, 0, 'odd'.length + 4]),
+    Buffer.from('odd'),
     Buffer.from([0, 0, 0, 'content-encoding'.length + 4]),
     Buffer.from('content-encoding'),
     Buffer.from([0, 0, 0, 'identity'.length + 4]),


### PR DESCRIPTION
When unzipping cache entries we use the modulo operator to know when we are reading a header key or value.

Previously this operation was accidentally being performed on the offset which was only passing tests by coincidence that the keys and values were even lengths.

This commit makes sure we are checking the length of the headers array instead and adds some oddly length-ed headers to the test.