### PR TITLE
cache-unzip: write unzipped result to existing integrity files

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -402,6 +402,9 @@ importers:
       '@vltpkg/error-cause':
         specifier: workspace:*
         version: link:../error-cause
+      '@vltpkg/types':
+        specifier: workspace:*
+        version: link:../types
     devDependencies:
       '@eslint/js':
         specifier: 'catalog:'

--- a/src/cache-unzip/package.json
+++ b/src/cache-unzip/package.json
@@ -20,7 +20,8 @@
   },
   "dependencies": {
     "@vltpkg/cache": "workspace:*",
-    "@vltpkg/error-cause": "workspace:*"
+    "@vltpkg/error-cause": "workspace:*",
+    "@vltpkg/types": "workspace:*"
   },
   "devDependencies": {
     "@eslint/js": "catalog:",

--- a/src/cache-unzip/test/unzip.ts
+++ b/src/cache-unzip/test/unzip.ts
@@ -3,6 +3,9 @@ import { spawnSync } from 'node:child_process'
 import t from 'tap'
 import { gzipSync } from 'node:zlib'
 import { __CODE_SPLIT_SCRIPT_NAME } from '../src/unzip.ts'
+import { createHash } from 'node:crypto'
+import { readFile } from 'node:fs/promises'
+import type { Integrity } from '@vltpkg/types'
 
 const ENV = {
   NODE_OPTIONS: '--no-warnings --experimental-strip-types',
@@ -199,4 +202,82 @@ t.test('unzip an entry that had headers', async t => {
   })
   const c = new Cache({ path: t.testdirName })
   t.same(await c.fetch('gz1'), result)
+})
+
+t.test('unzip an entry with integrity', async t => {
+  const integrity: Integrity = `sha512-${createHash('sha512').update('just a random integrity value').digest('base64')}`
+  const unz = '{"hello":"world"}'
+  const z = gzipSync(unz)
+  const zheaders = Buffer.concat([
+    Buffer.from([0, 0, 0, 'integrity'.length + 4]),
+    Buffer.from('integrity'),
+    Buffer.from([0, 0, 0, integrity.length + 4]),
+    Buffer.from(integrity),
+    Buffer.from([0, 0, 0, 'content-encoding'.length + 4]),
+    Buffer.from('content-encoding'),
+    Buffer.from([0, 0, 0, 'identity'.length + 4]),
+    Buffer.from('identity'),
+    Buffer.from([0, 0, 0, 'content-length'.length + 4]),
+    Buffer.from('content-length'),
+    Buffer.from([0, 0, 0, String(z.byteLength).length + 4]),
+    Buffer.from(String(z.byteLength)),
+  ])
+  const zlen = zheaders.byteLength + 7
+  const zipped = Buffer.concat(
+    [Buffer.from([0, 0, 0, zlen]), Buffer.from('200'), zheaders, z],
+    zlen + z.byteLength,
+  )
+
+  const resultHead = Buffer.concat([
+    Buffer.from([0, 0, 0, 'integrity'.length + 4]),
+    Buffer.from('integrity'),
+    Buffer.from([0, 0, 0, integrity.length + 4]),
+    Buffer.from(integrity),
+    Buffer.from([0, 0, 0, 'content-encoding'.length + 4]),
+    Buffer.from('content-encoding'),
+    Buffer.from([0, 0, 0, 'identity'.length + 4]),
+    Buffer.from('identity'),
+    Buffer.from([0, 0, 0, 'content-length'.length + 4]),
+    Buffer.from('content-length'),
+    Buffer.from([0, 0, 0, String(unz.length).length + 4]),
+    Buffer.from(String(unz.length)),
+  ])
+  const rlen = resultHead.byteLength + 7
+  const result = Buffer.concat(
+    [
+      Buffer.from([0, 0, 0, rlen]),
+      Buffer.from('200'),
+      resultHead,
+      Buffer.from(unz),
+    ],
+    rlen + unz.length,
+  )
+
+  const cache = new Cache({ path: t.testdir() })
+  cache.set('gz1', zipped, { integrity })
+  await cache.promise()
+  const res = spawnSync(
+    process.execPath,
+    [__CODE_SPLIT_SCRIPT_NAME, t.testdirName],
+    {
+      stdio: ['pipe', 'inherit', 'inherit'],
+      input: 'gz1\0',
+      env: ENV,
+    },
+  )
+  t.matchOnlyStrict(res, {
+    status: 0,
+    signal: null,
+    output: [null, null, null],
+    pid: Number,
+    stdout: null,
+    stderr: null,
+  })
+  const c = new Cache({ path: t.testdirName })
+  t.same(await c.fetch('gz1'), result)
+  t.strictSame(
+    await readFile(c.path('gz1'), 'utf-8'),
+    await readFile(c.integrityPath(integrity)!, 'utf-8'),
+    'cache file and integrity are the same',
+  )
 })


### PR DESCRIPTION
With this change the `cache-unzip` process will now link any existing integrity files to the unzipped cache entry.

I tried a different approach to this originally where `@vltpkg/cache.set` was responsible for updating the integrity files. But we already use `cache.set(key, val, { integrity })` to mean "write this value to the cache, first linking *from* the integrity file if it exists" which is the behavior we want everywhere else.

So rather than make a new method/option on `@vltpkg/cache` for this less used behavior, `cache-unzip` uses the `cache.path()` and `cache.integrityPath()` methods to manually re-link any integrity files.

Fixes #617 