### PR TITLE
query: add published selector

### DIFF
--- a/src/query/README.md
+++ b/src/query/README.md
@@ -139,6 +139,17 @@ e.g: `#foo` is the same as `[name=foo]`
     current one
 - `:private` Matches packages that have the property `private` set on
   their `package.json` file.
+- `:published(<date>)` Matches packages based on their publication
+  date. The date parameter can be prefixed with a comparator (`>`,
+  `<`, `>=`, `<=`). If no comparator is provided, it will match exact
+  dates. Please note that the value parameter needs to be quoted if
+  using a comparator. Examples:
+  - `:published(2024-01-01)` - Matches packages published exactly on
+    January 1st, 2024
+  - `:published(">2024-01-01")` - Matches packages published after
+    January 1st, 2024
+  - `:published("<=2023-12-31")` - Matches packages published on or
+    before December 31st, 2023
 - `:semver(<value>, <function>, <custom-attribute-selector>)` Matches
   packages based on a semver value, e.g, to retrieve all packages that
   have a `version` satisfied by the semver value `^1.0.0`:

--- a/src/query/src/pseudo.ts
+++ b/src/query/src/pseudo.ts
@@ -32,6 +32,7 @@ import { nativeParser } from './pseudo/native.ts'
 import { network } from './pseudo/network.ts'
 import { obfuscated } from './pseudo/obfuscated.ts'
 import { outdated } from './pseudo/outdated.ts'
+import { published } from './pseudo/published.ts'
 import { scanned } from './pseudo/scanned.ts'
 import { scripts } from './pseudo/scripts.ts'
 import { shell } from './pseudo/shell.ts'
@@ -376,6 +377,7 @@ const pseudoSelectors = new Map<string, ParserFn>(
     not,
     obfuscated,
     outdated,
+    published,
     // TODO: overridden
     private: privateFn,
     project,

--- a/src/query/src/pseudo/published.ts
+++ b/src/query/src/pseudo/published.ts
@@ -1,0 +1,223 @@
+import pRetry, { AbortError } from 'p-retry'
+import { hydrate, splitDepID } from '@vltpkg/dep-id/browser'
+import { error } from '@vltpkg/error-cause'
+import type { NodeLike } from '@vltpkg/graph'
+import type { SpecOptions } from '@vltpkg/spec/browser'
+import type { Packument } from '@vltpkg/types'
+import {
+  asPostcssNodeWithChildren,
+  asStringNode,
+  asTagNode,
+  isStringNode,
+  isTagNode,
+} from '../types.ts'
+import type { ParserState, PostcssNode } from '../types.ts'
+import { removeNode, removeQuotes } from './helpers.ts'
+
+/**
+ * The possible comparator values accepted by the :published() pseudo selector.
+ */
+export type PublishedComparator = '>' | '<' | '>=' | '<=' | undefined
+
+/**
+ * Result of the internal parsing of the :published() pseudo selector.
+ */
+export type PublishedInternals = {
+  relativeDate: string
+  comparator: PublishedComparator
+}
+
+/**
+ * Fetches the published date of a package version from the npm registry.
+ */
+export const retrieveRemoteDate = async (
+  node: NodeLike,
+  specOptions: SpecOptions,
+  signal?: AbortSignal,
+): Promise<string | undefined> => {
+  const spec = hydrate(node.id, String(node.name), specOptions)
+  if (!spec.registry || !node.name || !node.version) {
+    return undefined
+  }
+
+  const url = new URL(spec.registry)
+  url.pathname = `/${node.name}`
+
+  const response = await fetch(String(url), {
+    headers: {
+      Accept: 'application/vnd.npm.install-v1+json',
+    },
+    signal,
+  })
+  // on missing valid auth or API, it should abort the retry logic
+  if (response.status === 404) {
+    throw new AbortError('Missing API')
+  }
+  if (!response.ok) {
+    throw error('Failed to fetch packument', {
+      name: String(node.name),
+      spec,
+      response,
+    })
+  }
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+  const packument: Packument = await response.json()
+  const res = packument.time?.[node.version]
+  return res
+}
+
+/**
+ * Retrieves what kind of check the :published selector should perform.
+ */
+export const parseInternals = (
+  nodes: PostcssNode[],
+): PublishedInternals => {
+  let value = ''
+
+  if (isStringNode(asPostcssNodeWithChildren(nodes[0]).nodes[0])) {
+    value = removeQuotes(
+      asStringNode(asPostcssNodeWithChildren(nodes[0]).nodes[0])
+        .value,
+    )
+  } else if (
+    isTagNode(asPostcssNodeWithChildren(nodes[0]).nodes[0])
+  ) {
+    value = asTagNode(
+      asPostcssNodeWithChildren(nodes[0]).nodes[0],
+    ).value
+  }
+
+  // Check if the value starts with a comparator
+  let comparator: PublishedComparator
+  let relativeDate = value
+
+  if (value.startsWith('>=')) {
+    comparator = '>='
+    relativeDate = value.slice(2)
+  } else if (value.startsWith('<=')) {
+    comparator = '<='
+    relativeDate = value.slice(2)
+  } else if (value.startsWith('>')) {
+    comparator = '>'
+    relativeDate = value.slice(1)
+  } else if (value.startsWith('<')) {
+    comparator = '<'
+    relativeDate = value.slice(1)
+  }
+
+  return { relativeDate, comparator }
+}
+
+/**
+ * Filter nodes by queueing up for removal those that don't match the date criteria.
+ */
+export const queueNode = async (
+  state: ParserState,
+  node: NodeLike,
+  relativeDate: string,
+  comparator: PublishedComparator,
+): Promise<NodeLike | undefined> => {
+  if (!node.name || !node.version) {
+    return node
+  }
+
+  let publishedDate: string | undefined
+  try {
+    publishedDate = await pRetry(
+      () => retrieveRemoteDate(node, state.specOptions, state.signal),
+      {
+        retries: state.retries,
+        signal: state.signal,
+      },
+    )
+  } catch (err) {
+    // eslint-disable-next-line no-console
+    console.warn(
+      error('Could not retrieve registry publish date', {
+        name: String(node.name),
+        cause: err,
+      }),
+    )
+    return node
+  }
+
+  if (!publishedDate) {
+    return node
+  }
+
+  // only matches the same amount of date information
+  // as provided in the relative date
+  const nodeDate = new Date(
+    publishedDate.slice(0, relativeDate.length),
+  )
+  const compareDate = new Date(relativeDate)
+
+  switch (comparator) {
+    case '>':
+      return nodeDate > compareDate ? undefined : node
+    case '<':
+      return nodeDate < compareDate ? undefined : node
+    case '>=':
+      return nodeDate >= compareDate ? undefined : node
+    case '<=':
+      return nodeDate <= compareDate ? undefined : node
+    default:
+      return nodeDate.getTime() === compareDate.getTime() ?
+          undefined
+        : node
+  }
+}
+
+/**
+ * Filters out nodes that don't match the published date criteria.
+ *
+ * The :published() pseudo selector supports a date parameter that can be prefixed
+ * with a comparator (>, <, >=, <=). If no comparator is provided, it will match
+ * exact dates.
+ *
+ * Examples:
+ * - :published("2024-01-01") - Matches packages published exactly on January 1st, 2024
+ * - :published(">2024-01-01") - Matches packages published after January 1st, 2024
+ * - :published("<=2023-12-31") - Matches packages published on or before December 31st, 2023
+ */
+export const published = async (state: ParserState) => {
+  let internals
+  try {
+    internals = parseInternals(
+      asPostcssNodeWithChildren(state.current).nodes,
+    )
+  } catch (err) {
+    throw error('Failed to parse :published selector', {
+      cause: err,
+    })
+  }
+
+  const { relativeDate, comparator } = internals
+  const queue = []
+
+  for (const node of state.partial.nodes) {
+    // filter out nodes that are always ignored by the published selector
+    if (
+      node.mainImporter ||
+      node.manifest?.private ||
+      splitDepID(node.id)[0] !== 'registry'
+    ) {
+      removeNode(state, node)
+      continue
+    }
+
+    // fetch published date info and perform checks to define
+    // whether or not a node should be filtered out
+    queue.push(queueNode(state, node, relativeDate, comparator))
+  }
+
+  // nodes queued for removal are then finally removed
+  const removeNodeQueue = await Promise.all(queue)
+  for (const node of removeNodeQueue) {
+    if (node) {
+      removeNode(state, node)
+    }
+  }
+
+  return state
+}

--- a/src/query/tap-snapshots/test/pseudo/published.ts.test.cjs
+++ b/src/query/tap-snapshots/test/pseudo/published.ts.test.cjs
@@ -1,0 +1,73 @@
+/* IMPORTANT
+ * This snapshot file is auto-generated, but designed for humans.
+ * It should be checked into source control and tracked carefully.
+ * Re-generate by setting TAP_SNAPSHOT=1 and running tests.
+ * Make sure to inspect the output below.  Do not ignore changes!
+ */
+'use strict'
+exports[`test/pseudo/published.ts > TAP > select from published definition > published exact date > must match snapshot 1`] = `
+Object {
+  "edges": Array [
+    "a",
+  ],
+  "nodes": Array [
+    "a",
+  ],
+}
+`
+
+exports[`test/pseudo/published.ts > TAP > select from published definition > published greater than date > must match snapshot 1`] = `
+Object {
+  "edges": Array [
+    "c",
+    "d",
+    "e",
+  ],
+  "nodes": Array [
+    "c",
+    "d",
+    "e",
+  ],
+}
+`
+
+exports[`test/pseudo/published.ts > TAP > select from published definition > published greater than or equal date > must match snapshot 1`] = `
+Object {
+  "edges": Array [
+    "b",
+    "c",
+    "d",
+    "e",
+  ],
+  "nodes": Array [
+    "b",
+    "c",
+    "d",
+    "e",
+  ],
+}
+`
+
+exports[`test/pseudo/published.ts > TAP > select from published definition > published less than date > must match snapshot 1`] = `
+Object {
+  "edges": Array [
+    "a",
+  ],
+  "nodes": Array [
+    "a",
+  ],
+}
+`
+
+exports[`test/pseudo/published.ts > TAP > select from published definition > published less than or equal date > must match snapshot 1`] = `
+Object {
+  "edges": Array [
+    "a",
+    "b",
+  ],
+  "nodes": Array [
+    "a",
+    "b",
+  ],
+}
+`

--- a/src/query/test/pseudo/published.ts
+++ b/src/query/test/pseudo/published.ts
@@ -1,0 +1,265 @@
+import t from 'tap'
+import type { SpecOptions } from '@vltpkg/spec/browser'
+import { joinDepIDTuple } from '@vltpkg/dep-id'
+import type { NodeLike } from '@vltpkg/graph'
+import postcssSelectorParser from 'postcss-selector-parser'
+import {
+  published,
+  parseInternals,
+  queueNode,
+  retrieveRemoteDate,
+} from '../../src/pseudo/published.ts'
+import { asPostcssNodeWithChildren } from '../../src/types.ts'
+import type { ParserState } from '../../src/types.ts'
+import { getSemverRichGraph } from '../fixtures/graph.ts'
+
+const specOptions = {
+  registry: 'https://registry.npmjs.org',
+  registries: {
+    custom: 'http://example.com',
+  },
+} as SpecOptions
+
+global.fetch = (async (url: string) => {
+  if (url === 'https://registry.npmjs.org/h') {
+    return {
+      ok: false,
+    }
+  } else if (url === 'https://registry.npmjs.org/i') {
+    throw new Error('ERR')
+  } else if (url === 'https://registry.npmjs.org/c') {
+    return {
+      status: 404,
+      ok: false,
+    }
+  }
+  return {
+    ok: true,
+    json: async () => {
+      switch (url) {
+        case 'https://registry.npmjs.org/a': {
+          return {
+            time: {
+              '1.0.1': '2024-01-01T11:11:11.111Z',
+            },
+          }
+        }
+        case 'https://registry.npmjs.org/b': {
+          return {
+            time: {
+              '2.2.1': '2024-02-01T00:00:00.000Z',
+            },
+          }
+        }
+        case 'http://example.com/c': {
+          return {
+            time: {
+              '3.4.0': '2024-03-01T00:00:00.000Z',
+            },
+          }
+        }
+        case 'https://registry.npmjs.org/d': {
+          return {
+            time: {
+              '2.3.4': '2024-04-01T00:00:00.000Z',
+            },
+          }
+        }
+        case 'https://registry.npmjs.org/e': {
+          return {
+            time: {
+              '120.0.0': '2024-05-01T00:00:00.000Z',
+            },
+          }
+        }
+      }
+    },
+  }
+}) as unknown as typeof global.fetch
+
+const getState = (query: string, graph = getSemverRichGraph()) => {
+  const ast = postcssSelectorParser().astSync(query)
+  const current = asPostcssNodeWithChildren(ast.first.first)
+  const state: ParserState = {
+    current,
+    initial: {
+      edges: new Set(graph.edges.values()),
+      nodes: new Set(graph.nodes.values()),
+    },
+    partial: {
+      edges: new Set(graph.edges.values()),
+      nodes: new Set(graph.nodes.values()),
+    },
+    collect: {
+      edges: new Set(),
+      nodes: new Set(),
+    },
+    cancellable: async () => {},
+    walk: async i => i,
+    retries: 0,
+    securityArchive: undefined,
+    specOptions,
+  }
+  return state
+}
+
+t.test('select from published definition', async t => {
+  t.capture(console, 'warn')
+
+  await t.test('published exact date', async t => {
+    const res = await published(getState(':published(2024-01-01)'))
+    t.strictSame(
+      [...res.partial.nodes].map(n => n.name),
+      ['a'],
+      'should have expected result using exact date match',
+    )
+    t.matchSnapshot({
+      nodes: [...res.partial.nodes].map(n => n.name),
+      edges: [...res.partial.edges].map(e => e.name),
+    })
+  })
+
+  await t.test('published greater than date', async t => {
+    const res = await published(getState(':published(">2024-02-01")'))
+    t.strictSame(
+      [...res.partial.nodes].map(n => n.name),
+      ['c', 'd', 'e'],
+      'should have expected result using greater than date',
+    )
+    t.matchSnapshot({
+      nodes: [...res.partial.nodes].map(n => n.name),
+      edges: [...res.partial.edges].map(e => e.name),
+    })
+  })
+
+  await t.test('published greater than or equal date', async t => {
+    const res = await published(
+      getState(':published(">=2024-02-01")'),
+    )
+    t.strictSame(
+      [...res.partial.nodes].map(n => n.name),
+      ['b', 'c', 'd', 'e'],
+      'should have expected result using greater than date',
+    )
+    t.matchSnapshot({
+      nodes: [...res.partial.nodes].map(n => n.name),
+      edges: [...res.partial.edges].map(e => e.name),
+    })
+  })
+
+  await t.test('published less than date', async t => {
+    const res = await published(getState(':published("<2024-02-01")'))
+    t.strictSame(
+      [...res.partial.nodes].map(n => n.name),
+      ['a'],
+      'should have expected result using less than or equal date',
+    )
+    t.matchSnapshot({
+      nodes: [...res.partial.nodes].map(n => n.name),
+      edges: [...res.partial.edges].map(e => e.name),
+    })
+  })
+
+  await t.test('published less than or equal date', async t => {
+    const res = await published(
+      getState(':published("<=2024-02-01")'),
+    )
+    t.strictSame(
+      [...res.partial.nodes].map(n => n.name),
+      ['a', 'b'],
+      'should have expected result using less than or equal date',
+    )
+    t.matchSnapshot({
+      nodes: [...res.partial.nodes].map(n => n.name),
+      edges: [...res.partial.edges].map(e => e.name),
+    })
+  })
+
+  await t.test('invalid pseudo selector usage', async t => {
+    await t.rejects(
+      published(getState(':semver')),
+      /Failed to parse :published selector/,
+      'should throw an error for invalid pseudo selector usage',
+    )
+  })
+})
+
+t.test('parseInternals', async t => {
+  const ast = postcssSelectorParser().astSync(
+    ':published(">2024-01-01")',
+  )
+  const nodes = asPostcssNodeWithChildren(ast.first.first).nodes
+  const internals = parseInternals(nodes)
+  t.strictSame(
+    internals,
+    { relativeDate: '2024-01-01', comparator: '>' },
+    'should correctly parse internals from published selector',
+  )
+})
+
+t.test('retrieveRemoteDate', async t => {
+  t.capture(console, 'warn')
+
+  const missingName = {
+    id: joinDepIDTuple(['registry', '', 'a@1.0.0']),
+  } as NodeLike
+  t.strictSame(
+    await retrieveRemoteDate(missingName, specOptions),
+    undefined,
+    'should return undefined if missing essential info',
+  )
+
+  await t.test('no response from registry', async t => {
+    const node = {
+      name: 'h',
+      version: '1.0.0',
+      id: joinDepIDTuple(['registry', '', 'h@1.0.0']),
+    } as NodeLike
+    await t.rejects(
+      retrieveRemoteDate(node, specOptions),
+      /Failed to fetch packument/,
+      'should throw an internal error so that it may be retried',
+    )
+  })
+
+  await t.test('fetch error', async t => {
+    const node = {
+      name: 'i',
+      id: joinDepIDTuple(['registry', '', 'i@1.0.0']),
+    } as NodeLike
+    t.strictSame(
+      await retrieveRemoteDate(node, specOptions),
+      undefined,
+      'should return undefined if fetch throws',
+    )
+  })
+
+  await t.test('404', async t => {
+    const node = {
+      name: 'c',
+      version: '1.0.0',
+      id: joinDepIDTuple(['registry', '', 'c@1.0.0']),
+    } as NodeLike
+    await t.rejects(
+      retrieveRemoteDate(node, specOptions),
+      /Missing API/,
+      'should throw an internal error that will not be retried',
+    )
+  })
+})
+
+t.test('queueNode', async t => {
+  const missingName = {
+    id: joinDepIDTuple(['registry', '', 'a@1.0.0']),
+  } as NodeLike
+  t.strictSame(
+    await queueNode(
+      getState(':published("2024-01-01")'),
+      missingName,
+      '2024-01-01',
+      undefined,
+    ),
+    missingName,
+    'should return node if missing essential info',
+  )
+})


### PR DESCRIPTION
Adds a `:published("<date>")` pseudo selector that matches packages based on their publication date.

The date parameter can be prefixed with a comparator (>, <, >=, <=). If no comparator is provided, it will match exact dates.

Examples:

    /* Matches packages published exactly on January 1st, 2024 */
    :published(2024-01-01)

    /* Matches packages published after January 1st, 2024 */
    :published(">2024-01-01")

    /* Matches packages published on or before December 31st, 2023 */
    :published("<=2023-12-31")

Fixes: https://github.com/vltpkg/statusboard/issues/107