### PR TITLE
cli-sdk: more comprehensive error messaging

### DIFF
--- a/src/cli-sdk/src/commands/cache.ts
+++ b/src/cli-sdk/src/commands/cache.ts
@@ -27,9 +27,6 @@ export class CacheView extends ViewClass {
   stdout(...args: unknown[]) {
     stdout(...args)
   }
-  error(e: unknown) {
-    throw e
-  }
 }
 
 export const views: Views<void | CacheMap> = {

--- a/src/cli-sdk/src/config/index.ts
+++ b/src/cli-sdk/src/config/index.ts
@@ -26,9 +26,9 @@ import { PackageInfoClient } from '@vltpkg/package-info'
 import { PackageJson } from '@vltpkg/package-json'
 import { Monorepo } from '@vltpkg/workspaces'
 import { XDG } from '@vltpkg/xdg'
+import type { Jack, OptionsResults, Unwrap } from 'jackspeak'
 import { readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { lstat, mkdir, readFile, writeFile } from 'node:fs/promises'
-import type { Jack, OptionsResults, Unwrap } from 'jackspeak'
 import { homedir } from 'node:os'
 import { dirname, resolve } from 'node:path'
 import { PathScurry } from 'path-scurry'
@@ -56,6 +56,8 @@ export {
   recordFields,
   type Commands,
 }
+
+export const kCustomInspect = Symbol.for('nodejs.util.inspect.custom')
 
 export type RecordPairs = Record<string, unknown>
 export type RecordString = Record<string, string>
@@ -251,6 +253,17 @@ export class Config {
     )
     this.#options = Object.assign(options, {
       packageInfo: new PackageInfoClient(options),
+      [kCustomInspect]() {
+        return Object.fromEntries(
+          Object.entries(options).filter(
+            ([k]) =>
+              k !== 'monorepo' &&
+              k !== 'scurry' &&
+              k !== 'packageJson' &&
+              k !== 'packageInfo',
+          ),
+        )
+      },
     })
     return this.#options
   }

--- a/src/cli-sdk/src/view.ts
+++ b/src/cli-sdk/src/view.ts
@@ -27,7 +27,7 @@ export class ViewClass<T = unknown> {
   // run the command", for example to have the gui just open a web browser
   // to the page relevant to a given thing, rather than computing it twice
   start() {}
-  done(_result: T, _opts: { time: number }): undefined | string {
+  done(_result: T, _opts: { time: number }): unknown {
     return
   }
   error(_err: unknown) {}

--- a/src/cli-sdk/tap-snapshots/test/config/index.ts.test.cjs
+++ b/src/cli-sdk/tap-snapshots/test/config/index.ts.test.cjs
@@ -1,0 +1,13 @@
+/* IMPORTANT
+ * This snapshot file is auto-generated, but designed for humans.
+ * It should be checked into source control and tracked carefully.
+ * Re-generate by setting TAP_SNAPSHOT=1 and running tests.
+ * Make sure to inspect the output below.  Do not ignore changes!
+ */
+'use strict'
+exports[`test/config/index.ts > TAP > load both configs, project writes over userconfig > formatted options uses custom inspect 1`] = `
+{
+  'git-hosts': { asdfasdf: 'https://example.com', github: 'https://github' },
+  projectRoot: '{CWD}/.tap/fixtures/test-config-index.ts-load-both-configs-project-writes-over-userconfig'
+}
+`

--- a/src/cli-sdk/test/commands/cache.ts
+++ b/src/cli-sdk/test/commands/cache.ts
@@ -394,5 +394,4 @@ t.test('human view coverage bits', async t => {
   )
 
   view.stdout('hello', 'world')
-  t.throws(() => view.error(new Error('hello')), new Error('hello'))
 })

--- a/src/cli-sdk/test/output.ts
+++ b/src/cli-sdk/test/output.ts
@@ -120,7 +120,7 @@ t.test('startView', async t => {
   t.test('using a view function for JSON', async t => {
     const { onDone, onError } = startView(confJson, views)
     t.equal(onError, undefined)
-    t.equal(await onDone(true), 'true')
+    t.equal(await onDone(true), true)
     t.equal(await onDone(undefined as unknown as true), undefined)
     t.end()
   })
@@ -128,7 +128,7 @@ t.test('startView', async t => {
   t.test('using a view function not json', async t => {
     const { onDone, onError } = startView(confMermaid, views)
     t.equal(onError, undefined)
-    t.equal(await onDone(true), '{ underthesea: true }')
+    t.strictSame(await onDone(true), { underthesea: true })
     t.equal(await onDone(undefined as unknown as true), undefined)
     t.end()
   })

--- a/src/cli-sdk/test/print-err.ts
+++ b/src/cli-sdk/test/print-err.ts
@@ -1,13 +1,15 @@
 import t from 'tap'
 
 import { error } from '@vltpkg/error-cause'
+import type { Codes } from '@vltpkg/error-cause'
 import type { CommandUsage } from '../src/index.ts'
 import { printErr } from '../src/print-err.ts'
 
-const printed: unknown[][] = []
-const stderr = (...a: unknown[]) => {
-  printed.push(a)
+const printed: string[] = []
+const stderr = (...a: string[]) => {
+  printed.push(a.join(' '))
 }
+const formatter = { colors: false }
 
 t.beforeEach(() => (printed.length = 0))
 
@@ -15,33 +17,92 @@ const usage = (() => ({
   usage: () => 'usage',
 })) as CommandUsage
 
-t.test('if not root error, print nothing', t => {
-  printErr(false, usage, stderr)
-  t.strictSame(printed, [])
+t.test('not an error', t => {
+  printErr(false, usage, stderr, formatter)
+  t.strictSame(printed, ['Unknown Error: false'])
   t.end()
 })
 
-t.test('print usage if a usage error', t => {
-  const er = error('bloopy doop', { code: 'EUSAGE' })
-  printErr(er, usage, stderr)
-  t.strictSame(printed, [['usage'], ['Error: bloopy doop']])
-  printed.length = 0
-  er.cause.validOptions = ['a', 'b']
-  er.cause.found = 'x'
-  printErr(er, usage, stderr)
-  t.strictSame(printed, [
-    ['usage'],
-    ['Error: bloopy doop'],
-    ['  Found: x'],
-    ['  Valid options: a, b'],
+t.test('regular error with weird cause', t => {
+  printErr(
+    new Error('foo bar', { cause: false }),
+    usage,
+    stderr,
+    formatter,
+  )
+  t.match(printed, [
+    'Error: foo bar',
+    'Cause:',
+    '  false',
+    'Stack:',
+    /^\s{2}/,
   ])
   t.end()
 })
 
-t.test('print helpful info for ERESOLVE', t => {
+t.test('regular error with no cause', t => {
+  printErr(new Error('foo bar'), usage, stderr, formatter)
+  t.match(printed, ['Error: foo bar', 'Stack:', /^\s{2}/])
+  t.end()
+})
+
+t.test('regular error with cause', t => {
+  printErr(
+    new Error('foo bar', { cause: { this_is_why_i_errored: true } }),
+    usage,
+    stderr,
+    formatter,
+  )
+  t.match(printed, [
+    'Error: foo bar',
+    'Cause:',
+    '  this_is_why_i_errored: true',
+    'Stack:',
+    /^\s{2}/,
+  ])
+  t.end()
+})
+
+t.test('regular error with regular error cause', t => {
+  printErr(
+    new Error('foo bar', {
+      cause: new Error('this_is_why_i_errored'),
+    }),
+    usage,
+    stderr,
+    formatter,
+  )
+  t.match(printed, [
+    'Error: foo bar',
+    'Cause:',
+    'Error: this_is_why_i_errored',
+    'Stack:',
+    /^\s{2}/,
+  ])
+  t.end()
+})
+
+t.test('EUSAGE', t => {
+  const er = error('bloopy doop', { code: 'EUSAGE' })
+  printErr(er, usage, stderr, formatter)
+  t.strictSame(printed, ['usage', 'Usage Error: bloopy doop'])
+  printed.length = 0
+  er.cause.validOptions = ['a', 'b']
+  er.cause.found = 'x'
+  printErr(er, usage, stderr, formatter)
+  t.strictSame(printed, [
+    'usage',
+    'Usage Error: bloopy doop',
+    '  Found: x',
+    '  Valid options: a, b',
+  ])
+  t.end()
+})
+
+t.test('ERESOLVE', t => {
   const er = error('bloopy doop', { code: 'ERESOLVE' })
-  printErr(er, usage, stderr)
-  t.strictSame(printed, [['Resolve Error: bloopy doop']])
+  printErr(er, usage, stderr, formatter)
+  t.strictSame(printed, ['Resolve Error: bloopy doop'])
   printed.length = 0
   er.cause.url = new URL('https://x.y/')
   er.cause.spec = 'x@1.x'
@@ -49,20 +110,53 @@ t.test('print helpful info for ERESOLVE', t => {
   er.cause.response = {
     statusCode: 200,
   } as unknown as Response
-  printErr(er, usage, stderr)
+  printErr(er, usage, stderr, formatter)
   t.strictSame(printed, [
-    ['Resolve Error: bloopy doop'],
-    ['  While fetching: https://x.y/'],
-    ['  To satisfy: x@1.x'],
-    ['  From: /home/base'],
-    ['Response:', er.cause.response],
+    'Resolve Error: bloopy doop',
+    '  While fetching: https://x.y/',
+    '  To satisfy: x@1.x',
+    '  From: /home/base',
+    '  Response: { statusCode: 200 }',
   ])
   t.end()
 })
 
-t.test('unknown error', t => {
-  const er = error('unknown', { found: 'wat' })
-  printErr(er, usage, stderr)
-  t.strictSame(printed, [[er]])
+t.test('error with an unknown code', t => {
+  const er = error('this is an error', {
+    code: 'ENOTACODEWEKNOWABOUT' as Codes,
+    wanted: Object.fromEntries(
+      Array.from({ length: 100 }, (_, i) => [`__${i}__`, i]),
+    ),
+  })
+  printErr(er, usage, stderr, {
+    ...formatter,
+    maxLines: 5,
+  })
+  t.matchStrict(printed, [
+    'Error: this is an error',
+    'Cause:',
+    `  code: ENOTACODEWEKNOWABOUT`,
+    `  wanted: {
+    __0__: 0,
+    __1__: 1,
+    __2__: 2,
+    __3__: 3,
+  ... 97 lines hidden ...`,
+    'Stack:',
+    /^\s{2}/,
+  ])
+  t.end()
+})
+
+t.test('error with a missing code', t => {
+  const er = error('this is an error', { found: 'wat' })
+  printErr(er, usage, stderr, formatter)
+  t.matchStrict(printed, [
+    'Error: this is an error',
+    'Cause:',
+    '  found: wat',
+    'Stack:',
+    /^\s{2}/,
+  ])
   t.end()
 })


### PR DESCRIPTION
#579 without any of the significant changes to `error-cause`.

If we are printing any `Error` without a handled code (whether from `error-cause` or not), we now print all the information from the error including the stack. But we cap each printed bit of information at 200 lines to avoid blowing up the terminal.

Also uses `util.format` everywhere with common options from `view` so we get colors.