### PR TITLE
query: add score selector

### DIFF
--- a/src/query/README.md
+++ b/src/query/README.md
@@ -240,6 +240,18 @@ security data needs to be fetched prior to a `Query` instantiation.
   intentionally packed to hide their behavior. This could be a sign of
   malware.
 - `:scanned` Matches packages that have insight security metadata.
+- `:score(<rate>, <kind>)` Matches packages based on their security
+  score. The rate parameter is required and should be a value between
+  0 and 100 (or 0 and 1). The rate parameter can be prefixed with a
+  comparator (`>`, `<`, `>=`, `<=`). If no comparator is provided, it
+  will match exact scores. The kind parameter is optional and defaults
+  to 'overall'. Valid kinds are: 'overall', 'license', 'maintenance',
+  'quality', 'supplyChain', and 'vulnerability'. Examples:
+  - `:score(80)` - Matches packages with exactly 0.8 overall score
+  - `:score(">0.8")` - Matches packages with overall score greater
+    than 0.8
+  - `:score("<=0.5", "maintenance")` - Matches packages with
+    maintenance score less than or equal to 0.5
 - `:scripts` Matches packages that have scripts that are run when the
   package is installed. The majority of malware in npm is hidden in
   install scripts.

--- a/src/query/src/index.ts
+++ b/src/query/src/index.ts
@@ -141,6 +141,7 @@ const securitySelectors = new Set([
   ':network',
   ':obfuscated',
   ':scanned',
+  ':score',
   ':scripts',
   ':sev',
   ':severity',

--- a/src/query/src/pseudo.ts
+++ b/src/query/src/pseudo.ts
@@ -34,6 +34,7 @@ import { obfuscated } from './pseudo/obfuscated.ts'
 import { outdated } from './pseudo/outdated.ts'
 import { published } from './pseudo/published.ts'
 import { scanned } from './pseudo/scanned.ts'
+import { score } from './pseudo/score.ts'
 import { scripts } from './pseudo/scripts.ts'
 import { shell } from './pseudo/shell.ts'
 import { semverParser as semver } from './pseudo/semver.ts'
@@ -384,6 +385,7 @@ const pseudoSelectors = new Map<string, ParserFn>(
     root,
     scanned,
     scope,
+    score,
     scripts,
     semver,
     sev: severity,

--- a/src/query/src/pseudo/score.ts
+++ b/src/query/src/pseudo/score.ts
@@ -1,0 +1,176 @@
+import { error } from '@vltpkg/error-cause'
+import {
+  asPostcssNodeWithChildren,
+  asStringNode,
+  asTagNode,
+  isStringNode,
+  isTagNode,
+} from '../types.ts'
+import type { ParserState, PostcssNode } from '../types.ts'
+import {
+  assertSecurityArchive,
+  removeDanglingEdges,
+  removeNode,
+  removeQuotes,
+} from './helpers.ts'
+import type { PackageScore } from '@vltpkg/security-archive'
+
+export type ScoreKinds = keyof PackageScore
+
+export type ScoreComparator =
+  | '>'
+  | '<'
+  | '>='
+  | '<='
+  | '='
+  | undefined
+
+const kinds = new Set<ScoreKinds | undefined>([
+  'overall',
+  'license',
+  'maintenance',
+  'quality',
+  'supplyChain',
+  'vulnerability',
+  undefined,
+])
+
+export const isScoreKind = (value?: string): value is ScoreKinds =>
+  kinds.has(value as ScoreKinds)
+
+export const asScoreKind = (value?: string): ScoreKinds => {
+  if (!isScoreKind(value)) {
+    throw error('Expected a valid score kind', {
+      found: value,
+      validOptions: Array.from(kinds),
+    })
+  }
+  return value
+}
+
+export const parseInternals = (
+  nodes: PostcssNode[],
+): {
+  comparator: ScoreComparator
+  rate: number
+  kind: ScoreKinds
+} => {
+  let rateStr = ''
+  let comparator: ScoreComparator = '='
+  let kind: ScoreKinds = 'overall'
+
+  // Parse the first parameter (rate with optional comparator)
+  if (isStringNode(asPostcssNodeWithChildren(nodes[0]).nodes[0])) {
+    rateStr = removeQuotes(
+      asStringNode(asPostcssNodeWithChildren(nodes[0]).nodes[0])
+        .value,
+    )
+  } else if (
+    isTagNode(asPostcssNodeWithChildren(nodes[0]).nodes[0])
+  ) {
+    rateStr = asTagNode(
+      asPostcssNodeWithChildren(nodes[0]).nodes[0],
+    ).value
+  }
+
+  // Extract comparator if present
+  if (rateStr.startsWith('>=')) {
+    comparator = '>='
+    rateStr = rateStr.substring(2)
+  } else if (rateStr.startsWith('<=')) {
+    comparator = '<='
+    rateStr = rateStr.substring(2)
+  } else if (rateStr.startsWith('>')) {
+    comparator = '>'
+    rateStr = rateStr.substring(1)
+  } else if (rateStr.startsWith('<')) {
+    comparator = '<'
+    rateStr = rateStr.substring(1)
+  }
+
+  // Parse rate as number
+  let rate = parseFloat(rateStr)
+
+  // Normalize to 0-1 range if needed
+  if (rate > 1) {
+    rate = rate / 100
+  }
+
+  // Validate rate is in acceptable range
+  if (rate < 0 || rate > 1) {
+    throw error('Expected rate to be between 0 and 100', {
+      found: rateStr,
+    })
+  }
+
+  // Parse the second parameter (kind) if present
+  if (nodes.length > 1) {
+    if (isStringNode(asPostcssNodeWithChildren(nodes[1]).nodes[0])) {
+      kind = asScoreKind(
+        removeQuotes(
+          asStringNode(asPostcssNodeWithChildren(nodes[1]).nodes[0])
+            .value,
+        ),
+      )
+    } else if (
+      isTagNode(asPostcssNodeWithChildren(nodes[1]).nodes[0])
+    ) {
+      kind = asScoreKind(
+        asTagNode(asPostcssNodeWithChildren(nodes[1]).nodes[0]).value,
+      )
+    }
+  }
+
+  return { comparator, rate, kind }
+}
+
+export const score = async (state: ParserState) => {
+  assertSecurityArchive(state, 'score')
+
+  let internals
+  try {
+    internals = parseInternals(
+      asPostcssNodeWithChildren(state.current).nodes,
+    )
+  } catch (err) {
+    throw error('Failed to parse :score selector', { cause: err })
+  }
+
+  const { comparator, rate, kind } = internals
+  for (const node of state.partial.nodes) {
+    const report = state.securityArchive.get(node.id)
+    if (!report) {
+      removeNode(state, node)
+      continue
+    }
+
+    const scoreValue = report.score[kind]
+
+    let exclude = false
+    switch (comparator) {
+      case '>':
+        exclude = scoreValue <= rate
+        break
+      case '<':
+        exclude = scoreValue >= rate
+        break
+      case '>=':
+        exclude = scoreValue < rate
+        break
+      case '<=':
+        exclude = scoreValue > rate
+        break
+      default: // '='
+        exclude = scoreValue !== rate
+        break
+    }
+
+    if (exclude) {
+      removeNode(state, node)
+    }
+  }
+
+  removeDanglingEdges(state)
+
+  return state
+}

--- a/src/query/tap-snapshots/test/pseudo/score.ts.test.cjs
+++ b/src/query/tap-snapshots/test/pseudo/score.ts.test.cjs
@@ -1,0 +1,163 @@
+/* IMPORTANT
+ * This snapshot file is auto-generated, but designed for humans.
+ * It should be checked into source control and tracked carefully.
+ * Re-generate by setting TAP_SNAPSHOT=1 and running tests.
+ * Make sure to inspect the output below.  Do not ignore changes!
+ */
+'use strict'
+exports[`test/pseudo/score.ts > TAP > selects packages based on their security score > exact match on overall score > must match snapshot 1`] = `
+Object {
+  "edges": Array [
+    "a",
+  ],
+  "nodes": Array [
+    "a",
+  ],
+}
+`
+
+exports[`test/pseudo/score.ts > TAP > selects packages based on their security score > exact match with percentage value > must match snapshot 1`] = `
+Object {
+  "edges": Array [
+    "e",
+    "e",
+  ],
+  "nodes": Array [
+    "e",
+  ],
+}
+`
+
+exports[`test/pseudo/score.ts > TAP > selects packages based on their security score > exact match with perfect score > must match snapshot 1`] = `
+Object {
+  "edges": Array [
+    "d",
+  ],
+  "nodes": Array [
+    "d",
+  ],
+}
+`
+
+exports[`test/pseudo/score.ts > TAP > selects packages based on their security score > exact match with quoted value > must match snapshot 1`] = `
+Object {
+  "edges": Array [
+    "f",
+  ],
+  "nodes": Array [
+    "f",
+  ],
+}
+`
+
+exports[`test/pseudo/score.ts > TAP > selects packages based on their security score > greater than comparator > must match snapshot 1`] = `
+Object {
+  "edges": Array [
+    "a",
+    "d",
+  ],
+  "nodes": Array [
+    "a",
+    "d",
+  ],
+}
+`
+
+exports[`test/pseudo/score.ts > TAP > selects packages based on their security score > greater than or equal comparator > must match snapshot 1`] = `
+Object {
+  "edges": Array [
+    "a",
+    "d",
+  ],
+  "nodes": Array [
+    "a",
+    "d",
+  ],
+}
+`
+
+exports[`test/pseudo/score.ts > TAP > selects packages based on their security score > less than comparator > must match snapshot 1`] = `
+Object {
+  "edges": Array [
+    "e",
+    "c",
+    "e",
+  ],
+  "nodes": Array [
+    "c",
+    "e",
+  ],
+}
+`
+
+exports[`test/pseudo/score.ts > TAP > selects packages based on their security score > less than or equal comparator > must match snapshot 1`] = `
+Object {
+  "edges": Array [
+    "e",
+    "c",
+    "e",
+  ],
+  "nodes": Array [
+    "c",
+    "e",
+  ],
+}
+`
+
+exports[`test/pseudo/score.ts > TAP > selects packages based on their security score > with less than comparator and vulnerability kind > must match snapshot 1`] = `
+Object {
+  "edges": Array [
+    "b",
+    "e",
+    "c",
+    "e",
+    "f",
+  ],
+  "nodes": Array [
+    "b",
+    "c",
+    "e",
+    "f",
+  ],
+}
+`
+
+exports[`test/pseudo/score.ts > TAP > selects packages based on their security score > with percentage rate and maintenance kind > must match snapshot 1`] = `
+Object {
+  "edges": Array [
+    "e",
+    "c",
+    "e",
+    "f",
+  ],
+  "nodes": Array [
+    "c",
+    "e",
+    "f",
+  ],
+}
+`
+
+exports[`test/pseudo/score.ts > TAP > selects packages based on their security score > with specific kind and quoted parameters > must match snapshot 1`] = `
+Object {
+  "edges": Array [
+    "a",
+    "d",
+  ],
+  "nodes": Array [
+    "a",
+    "d",
+  ],
+}
+`
+
+exports[`test/pseudo/score.ts > TAP > selects packages based on their security score > with specific kind parameter > must match snapshot 1`] = `
+Object {
+  "edges": Array [
+    "a",
+  ],
+  "nodes": Array [
+    "a",
+  ],
+}
+`

--- a/src/query/test/pseudo/score.ts
+++ b/src/query/test/pseudo/score.ts
@@ -1,0 +1,475 @@
+import t from 'tap'
+import postcssSelectorParser from 'postcss-selector-parser'
+import { joinDepIDTuple } from '@vltpkg/dep-id'
+import { asSecurityArchiveLike } from '@vltpkg/security-archive'
+import { getSimpleGraph } from '../fixtures/graph.ts'
+import type { ParserState } from '../../src/types.ts'
+import {
+  score,
+  isScoreKind,
+  asScoreKind,
+} from '../../src/pseudo/score.ts'
+import type { PackageScore } from '@vltpkg/security-archive'
+
+// Create a function to generate a security archive with varied scores for testing
+const createTestSecurityArchive = () => {
+  // Define different scores for each package in the test graph
+  const scores: Record<string, PackageScore> = {
+    a: {
+      overall: 0.85,
+      license: 0.95,
+      maintenance: 0.8,
+      quality: 0.75,
+      supplyChain: 0.9,
+      vulnerability: 0.7,
+    },
+    b: {
+      overall: 0.65,
+      license: 0.5,
+      maintenance: 0.7,
+      quality: 0.6,
+      supplyChain: 0.8,
+      vulnerability: 0.45,
+    },
+    c: {
+      overall: 0.4,
+      license: 0.3,
+      maintenance: 0.5,
+      quality: 0.45,
+      supplyChain: 0.35,
+      vulnerability: 0.25,
+    },
+    d: {
+      overall: 0.95,
+      license: 1.0,
+      maintenance: 0.9,
+      quality: 0.85,
+      supplyChain: 0.95,
+      vulnerability: 0.9,
+    },
+    e: {
+      overall: 0.2,
+      license: 0.15,
+      maintenance: 0.3,
+      quality: 0.25,
+      supplyChain: 0.1,
+      vulnerability: 0.05,
+    },
+    f: {
+      overall: 0.5,
+      license: 0.55,
+      maintenance: 0.45,
+      quality: 0.5,
+      supplyChain: 0.6,
+      vulnerability: 0.4,
+    },
+  }
+
+  // Create a map of package IDs to security data
+  const securityMap = new Map()
+  Object.entries(scores).forEach(([name, score]) => {
+    securityMap.set(
+      joinDepIDTuple(['registry', '', `${name}@1.0.0`]),
+      {
+        id: joinDepIDTuple(['registry', '', `${name}@1.0.0`]),
+        author: [],
+        size: 0,
+        type: 'npm',
+        name,
+        version: '1.0.0',
+        license: 'MIT',
+        score,
+        alerts: [],
+      },
+    )
+  })
+
+  return asSecurityArchiveLike(securityMap)
+}
+
+t.test('selects packages based on their security score', async t => {
+  const getState = (query: string, graph = getSimpleGraph()) => {
+    const ast = postcssSelectorParser().astSync(query)
+    const current = ast.first.first
+    const state: ParserState = {
+      current,
+      initial: {
+        edges: new Set(graph.edges.values()),
+        nodes: new Set(graph.nodes.values()),
+      },
+      partial: {
+        edges: new Set(graph.edges.values()),
+        nodes: new Set(graph.nodes.values()),
+      },
+      collect: {
+        edges: new Set(),
+        nodes: new Set(),
+      },
+      cancellable: async () => {},
+      walk: async i => i,
+      securityArchive: createTestSecurityArchive(),
+      specOptions: {},
+      retries: 0,
+    }
+    return state
+  }
+
+  await t.test('exact match on overall score', async t => {
+    const res = await score(getState(':score("0.85")'))
+    t.strictSame(
+      [...res.partial.nodes].map(n => n.name),
+      ['a'],
+      'should select packages with exactly 0.85 overall score',
+    )
+    t.matchSnapshot({
+      nodes: [...res.partial.nodes].map(n => n.name),
+      edges: [...res.partial.edges].map(e => e.name),
+    })
+  })
+
+  await t.test('exact match with percentage value', async t => {
+    const res = await score(getState(':score(20)'))
+    t.strictSame(
+      [...res.partial.nodes].map(n => n.name),
+      ['e'],
+      'should select packages with exactly 0.2 (20%) overall score',
+    )
+    t.matchSnapshot({
+      nodes: [...res.partial.nodes].map(n => n.name),
+      edges: [...res.partial.edges].map(e => e.name),
+    })
+  })
+
+  await t.test('exact match with quoted value', async t => {
+    const res = await score(getState(':score("0.5")'))
+    t.strictSame(
+      [...res.partial.nodes].map(n => n.name),
+      ['f'],
+      'should select packages with exactly 0.5 overall score',
+    )
+    t.matchSnapshot({
+      nodes: [...res.partial.nodes].map(n => n.name),
+      edges: [...res.partial.edges].map(e => e.name),
+    })
+  })
+
+  await t.test('greater than comparator', async t => {
+    const res = await score(getState(':score(">0.8")'))
+    t.strictSame(
+      [...res.partial.nodes].map(n => n.name),
+      ['a', 'd'],
+      'should select packages with overall score greater than 0.8',
+    )
+    t.matchSnapshot({
+      nodes: [...res.partial.nodes].map(n => n.name),
+      edges: [...res.partial.edges].map(e => e.name),
+    })
+  })
+
+  await t.test('less than comparator', async t => {
+    const res = await score(getState(':score("<0.5")'))
+    t.strictSame(
+      [...res.partial.nodes].map(n => n.name),
+      ['c', 'e'],
+      'should select packages with overall score less than 0.5',
+    )
+    t.matchSnapshot({
+      nodes: [...res.partial.nodes].map(n => n.name),
+      edges: [...res.partial.edges].map(e => e.name),
+    })
+  })
+
+  await t.test('greater than or equal comparator', async t => {
+    const res = await score(getState(':score(">=0.75")'))
+    t.strictSame(
+      [...res.partial.nodes].map(n => n.name),
+      ['a', 'd'],
+      'should select packages with overall score greater than or equal to 0.75',
+    )
+    t.matchSnapshot({
+      nodes: [...res.partial.nodes].map(n => n.name),
+      edges: [...res.partial.edges].map(e => e.name),
+    })
+  })
+
+  await t.test('less than or equal comparator', async t => {
+    const res = await score(getState(':score(<=40)'))
+    t.strictSame(
+      [...res.partial.nodes].map(n => n.name),
+      ['c', 'e'],
+      'should select packages with overall score less than or equal to 0.4 (40%)',
+    )
+    t.matchSnapshot({
+      nodes: [...res.partial.nodes].map(n => n.name),
+      edges: [...res.partial.edges].map(e => e.name),
+    })
+  })
+
+  await t.test('with specific kind parameter', async t => {
+    const res = await score(getState(':score("0.95", license)'))
+    t.strictSame(
+      [...res.partial.nodes].map(n => n.name),
+      ['a'],
+      'should select packages with license score of exactly 0.95',
+    )
+    t.matchSnapshot({
+      nodes: [...res.partial.nodes].map(n => n.name),
+      edges: [...res.partial.edges].map(e => e.name),
+    })
+  })
+
+  await t.test(
+    'with specific kind and quoted parameters',
+    async t => {
+      const res = await score(
+        getState(':score(">0.8", "supplyChain")'),
+      )
+      t.strictSame(
+        [...res.partial.nodes].map(n => n.name),
+        ['a', 'd'],
+        'should select packages with supplyChain score greater than 0.8',
+      )
+      t.matchSnapshot({
+        nodes: [...res.partial.nodes].map(n => n.name),
+        edges: [...res.partial.edges].map(e => e.name),
+      })
+    },
+  )
+
+  await t.test(
+    'with less than comparator and vulnerability kind',
+    async t => {
+      const res = await score(
+        getState(':score("<0.5", vulnerability)'),
+      )
+      t.strictSame(
+        [...res.partial.nodes].map(n => n.name),
+        ['b', 'c', 'e', 'f'],
+        'should select packages with vulnerability score less than 0.5',
+      )
+      t.matchSnapshot({
+        nodes: [...res.partial.nodes].map(n => n.name),
+        edges: [...res.partial.edges].map(e => e.name),
+      })
+    },
+  )
+
+  await t.test(
+    'with percentage rate and maintenance kind',
+    async t => {
+      const res = await score(getState(':score(<=50, maintenance)'))
+      t.strictSame(
+        [...res.partial.nodes].map(n => n.name),
+        ['c', 'e', 'f'],
+        'should select packages with maintenance score less than or equal to 0.5 (50%)',
+      )
+      t.matchSnapshot({
+        nodes: [...res.partial.nodes].map(n => n.name),
+        edges: [...res.partial.edges].map(e => e.name),
+      })
+    },
+  )
+
+  await t.test('exact match with perfect score', async t => {
+    const res = await score(getState(':score(1, license)'))
+    t.strictSame(
+      [...res.partial.nodes].map(n => n.name),
+      ['d'],
+      'should select packages with license score of exactly 1.0',
+    )
+    t.matchSnapshot({
+      nodes: [...res.partial.nodes].map(n => n.name),
+      edges: [...res.partial.edges].map(e => e.name),
+    })
+  })
+})
+
+t.test('error cases', async t => {
+  // Test with missing security archive
+  await t.test('missing security archive', async t => {
+    const getState = (query: string) => {
+      const ast = postcssSelectorParser().astSync(query)
+      const current = ast.first.first
+      const state: ParserState = {
+        current,
+        initial: {
+          edges: new Set(),
+          nodes: new Set(),
+        },
+        partial: {
+          edges: new Set(),
+          nodes: new Set(),
+        },
+        collect: {
+          edges: new Set(),
+          nodes: new Set(),
+        },
+        cancellable: async () => {},
+        walk: async i => i,
+        securityArchive: undefined,
+        specOptions: {},
+        retries: 0,
+      }
+      return state
+    }
+
+    await t.rejects(
+      score(getState(':score(0.8)')),
+      { message: /Missing security archive/ },
+      'should throw an error when security archive is missing',
+    )
+  })
+
+  // Test with invalid rate value
+  await t.test('invalid rate value - too high', async t => {
+    const getState = (query: string) => {
+      const ast = postcssSelectorParser().astSync(query)
+      const current = ast.first.first
+      const state: ParserState = {
+        current,
+        initial: {
+          edges: new Set(),
+          nodes: new Set(),
+        },
+        partial: {
+          edges: new Set(),
+          nodes: new Set(),
+        },
+        collect: {
+          edges: new Set(),
+          nodes: new Set(),
+        },
+        cancellable: async () => {},
+        walk: async i => i,
+        securityArchive: createTestSecurityArchive(),
+        specOptions: {},
+        retries: 0,
+      }
+      return state
+    }
+
+    await t.rejects(
+      score(getState(':score(101)')),
+      { message: /Failed to parse :score selector/ },
+      'should throw an error when rate value is greater than 100',
+    )
+  })
+
+  // Test with invalid rate value - negative
+  await t.test('invalid rate value - negative', async t => {
+    const getState = (query: string) => {
+      const ast = postcssSelectorParser().astSync(query)
+      const current = ast.first.first
+      const state: ParserState = {
+        current,
+        initial: {
+          edges: new Set(),
+          nodes: new Set(),
+        },
+        partial: {
+          edges: new Set(),
+          nodes: new Set(),
+        },
+        collect: {
+          edges: new Set(),
+          nodes: new Set(),
+        },
+        cancellable: async () => {},
+        walk: async i => i,
+        securityArchive: createTestSecurityArchive(),
+        specOptions: {},
+        retries: 0,
+      }
+      return state
+    }
+
+    await t.rejects(
+      score(getState(':score("-0.5")')),
+      { message: /Failed to parse :score selector/ },
+      'should throw an error when rate value is negative',
+    )
+  })
+
+  // Test with invalid kind
+  await t.test('invalid kind parameter', async t => {
+    const getState = (query: string) => {
+      const ast = postcssSelectorParser().astSync(query)
+      const current = ast.first.first
+      const state: ParserState = {
+        current,
+        initial: {
+          edges: new Set(),
+          nodes: new Set(),
+        },
+        partial: {
+          edges: new Set(),
+          nodes: new Set(),
+        },
+        collect: {
+          edges: new Set(),
+          nodes: new Set(),
+        },
+        cancellable: async () => {},
+        walk: async i => i,
+        securityArchive: createTestSecurityArchive(),
+        specOptions: {},
+        retries: 0,
+      }
+      return state
+    }
+
+    await t.rejects(
+      score(getState(':score(0.8, invalid)')),
+      { message: /Failed to parse :score selector/ },
+      'should throw an error when kind parameter is invalid',
+    )
+  })
+})
+
+t.test('utility functions', async t => {
+  // Test isScoreKind function
+  await t.test('isScoreKind', async t => {
+    t.ok(
+      isScoreKind('overall'),
+      'should return true for valid score kind "overall"',
+    )
+    t.ok(
+      isScoreKind('license'),
+      'should return true for valid score kind "license"',
+    )
+    t.ok(
+      isScoreKind('maintenance'),
+      'should return true for valid score kind "maintenance"',
+    )
+    t.ok(
+      isScoreKind('quality'),
+      'should return true for valid score kind "quality"',
+    )
+    t.ok(
+      isScoreKind('supplyChain'),
+      'should return true for valid score kind "supplyChain"',
+    )
+    t.ok(
+      isScoreKind('vulnerability'),
+      'should return true for valid score kind "vulnerability"',
+    )
+    t.notOk(
+      isScoreKind('invalid'),
+      'should return false for invalid score kind',
+    )
+  })
+
+  // Test asScoreKind function
+  await t.test('asScoreKind', async t => {
+    t.equal(
+      asScoreKind('overall'),
+      'overall',
+      'should return the score kind for valid input',
+    )
+    t.throws(
+      () => asScoreKind('invalid'),
+      { message: /Expected a valid score kind/ },
+      'should throw an error for invalid score kind',
+    )
+  })
+})


### PR DESCRIPTION
Adds a `:score("<rate>", [kind])` pseudo selector that matches packages based on the scores rated found in the insights data.

The `rate` parameter can be prefixed with a comparator (>, < , >=, <=, similar to the `:published` selector in order to compare against a range instead of comparing exact values. If no comparator is provided, it will match exact scores.

Note that `rate` values are percentual values and can be either 0-1 or 0-100 and will be normalized prior to comparison.

Examples:

    /* Matches packages with exactly 0.8 overall score */
    :score(80)

    /* Matches packages with overall score greater than 0.8 */
    :score(">0.8")

    /* Matches maintenance score less than or equal to 0.5 */
    :score("<=0.5", "maintenance")