### PR TITLE
query: refactor empty pseudo selector

### DIFF
--- a/src/query/src/pseudo.ts
+++ b/src/query/src/pseudo.ts
@@ -21,6 +21,7 @@ import { cwe } from './pseudo/cwe.ts'
 import { debug } from './pseudo/debug.ts'
 import { deprecated } from './pseudo/deprecated.ts'
 import { dynamic } from './pseudo/dynamic.ts'
+import { empty } from './pseudo/empty.ts'
 import { entropic } from './pseudo/entropic.ts'
 import { env } from './pseudo/env.ts'
 import { evalParser } from './pseudo/eval.ts'
@@ -48,18 +49,6 @@ import { unknown } from './pseudo/unknown.ts'
 import { unmaintained } from './pseudo/unmaintained.ts'
 import { unpopular } from './pseudo/unpopular.ts'
 import { unstable } from './pseudo/unstable.ts'
-
-/**
- * :empty Pseudo-Selector, matches only nodes that have no children.
- */
-const empty = async (state: ParserState) => {
-  for (const node of state.partial.nodes) {
-    if (node.edgesOut.size > 0) {
-      removeNode(state, node)
-    }
-  }
-  return state
-}
 
 /**
  * :has Pseudo-Selector, matches only nodes that have valid results

--- a/src/query/src/pseudo/empty.ts
+++ b/src/query/src/pseudo/empty.ts
@@ -1,0 +1,15 @@
+import type { ParserState } from '../types.ts'
+import { removeNode } from './helpers.ts'
+
+/**
+ * :empty Pseudo-Selector, matches only nodes that have no children.
+ * It filters out any node that has edges out, i.e., has dependencies.
+ */
+export const empty = async (state: ParserState) => {
+  for (const node of state.partial.nodes) {
+    if (node.edgesOut.size > 0) {
+      removeNode(state, node)
+    }
+  }
+  return state
+}

--- a/src/query/tap-snapshots/test/pseudo/empty.ts.test.cjs
+++ b/src/query/tap-snapshots/test/pseudo/empty.ts.test.cjs
@@ -1,0 +1,50 @@
+/* IMPORTANT
+ * This snapshot file is auto-generated, but designed for humans.
+ * It should be checked into source control and tracked carefully.
+ * Re-generate by setting TAP_SNAPSHOT=1 and running tests.
+ * Make sure to inspect the output below.  Do not ignore changes!
+ */
+'use strict'
+exports[`test/pseudo/empty.ts > TAP > selects packages with no dependencies > handles an empty partial state > must match snapshot 1`] = `
+Object {
+  "edges": Array [],
+  "nodes": Array [],
+}
+`
+
+exports[`test/pseudo/empty.ts > TAP > selects packages with no dependencies > returns no nodes in cycle graph > must match snapshot 1`] = `
+Object {
+  "edges": Array [],
+  "nodes": Array [],
+}
+`
+
+exports[`test/pseudo/empty.ts > TAP > selects packages with no dependencies > selects nodes with no outgoing edges in simple graph > must match snapshot 1`] = `
+Object {
+  "edges": Array [
+    "@x/y",
+    "a",
+    "c",
+    "e",
+    "e",
+    "f",
+  ],
+  "nodes": Array [
+    "@x/y",
+    "a",
+    "c",
+    "e",
+    "f",
+  ],
+}
+`
+
+exports[`test/pseudo/empty.ts > TAP > selects packages with no dependencies > selects nodes with no outgoing edges in workspace graph > must match snapshot 1`] = `
+Object {
+  "edges": Array [],
+  "nodes": Array [
+    "w",
+    "ws",
+  ],
+}
+`

--- a/src/query/test/pseudo/empty.ts
+++ b/src/query/test/pseudo/empty.ts
@@ -1,0 +1,105 @@
+import t from 'tap'
+import postcssSelectorParser from 'postcss-selector-parser'
+import type { ParserState } from '../../src/types.ts'
+import { empty } from '../../src/pseudo/empty.ts'
+import {
+  getSimpleGraph,
+  getSingleWorkspaceGraph,
+  getCycleGraph,
+} from '../fixtures/graph.ts'
+
+t.test('selects packages with no dependencies', async t => {
+  const getState = (query: string, graph = getSimpleGraph()) => {
+    const ast = postcssSelectorParser().astSync(query)
+    const current = ast.first.first
+    const state: ParserState = {
+      current,
+      initial: {
+        edges: new Set(graph.edges.values()),
+        nodes: new Set(graph.nodes.values()),
+      },
+      partial: {
+        edges: new Set(graph.edges.values()),
+        nodes: new Set(graph.nodes.values()),
+      },
+      collect: {
+        edges: new Set(),
+        nodes: new Set(),
+      },
+      cancellable: async () => {},
+      walk: async i => i,
+      retries: 0,
+      securityArchive: undefined,
+      specOptions: {},
+    }
+    return state
+  }
+
+  await t.test(
+    'selects nodes with no outgoing edges in simple graph',
+    async t => {
+      // Based on the getSimpleGraph fixture, packages a, c, e, f and @x/y have no dependencies
+      const res = await empty(getState(':empty'))
+      t.strictSame(
+        [...res.partial.nodes].map(n => n.name).sort(),
+        ['a', 'c', 'e', 'f', '@x/y'].sort(),
+        'should select only packages with no dependencies',
+      )
+      t.matchSnapshot({
+        nodes: [...res.partial.nodes].map(n => n.name).sort(),
+        edges: [...res.partial.edges].map(e => e.name).sort(),
+      })
+    },
+  )
+
+  await t.test(
+    'selects nodes with no outgoing edges in workspace graph',
+    async t => {
+      // In getSingleWorkspaceGraph, both 'ws' (root) and 'w' (workspace) have no dependencies
+      const wsGraph = getSingleWorkspaceGraph()
+      const res = await empty(getState(':empty', wsGraph))
+      t.strictSame(
+        [...res.partial.nodes].map(n => n.name).sort(),
+        ['ws', 'w'].sort(),
+        'should select all nodes in workspace graph as none have dependencies',
+      )
+      t.matchSnapshot({
+        nodes: [...res.partial.nodes].map(n => n.name).sort(),
+        edges: [...res.partial.edges].map(e => e.name).sort(),
+      })
+    },
+  )
+
+  await t.test('returns no nodes in cycle graph', async t => {
+    // In getCycleGraph, all nodes have dependencies (cycle)
+    const cycleGraph = getCycleGraph()
+    const res = await empty(getState(':empty', cycleGraph))
+    t.strictSame(
+      [...res.partial.nodes].map(n => n.name),
+      [],
+      'should not select any packages in a cycle graph as all have dependencies',
+    )
+    t.matchSnapshot({
+      nodes: [...res.partial.nodes].map(n => n.name),
+      edges: [...res.partial.edges].map(e => e.name),
+    })
+  })
+
+  await t.test('handles an empty partial state', async t => {
+    // Create a state with empty partial nodes
+    const state = getState(':empty')
+    state.partial.nodes.clear()
+    state.partial.edges.clear()
+
+    const res = await empty(state)
+    t.strictSame(
+      [...res.partial.nodes].map(n => n.name),
+      [],
+      'should return empty array when starting with empty partial state',
+    )
+    t.matchSnapshot({
+      nodes: [...res.partial.nodes].map(n => n.name),
+      edges: [...res.partial.edges].map(e => e.name),
+    })
+  })
+})


### PR DESCRIPTION
Refactor `:empty` into its own file and add unit tests for it.