### PR TITLE
cache: handle all integrity cases when writing cache entry to disk

### DIFF
--- a/src/cache/src/index.ts
+++ b/src/cache/src/index.ts
@@ -55,10 +55,11 @@ export type BooleanOrVoid = boolean | void
 const hash = (s: string) =>
   createHash('sha512').update(s).digest('hex')
 
-const success = <T>(p: Promise<T>): Promise<T | null> =>
+const FAILURE = null
+const success = <T>(p: Promise<T>): Promise<T | typeof FAILURE> =>
   p.then(
     result => result,
-    () => null,
+    () => FAILURE,
   )
 
 export class Cache extends LRUCache<
@@ -413,7 +414,7 @@ export class Cache extends LRUCache<
       // Path doesn't exist but integrity is already what we want
       // Try to link integrity file to val file
       // If linking fails, continue on
-      if ((await success(link(intFile, valFile))) !== null) {
+      if ((await success(link(intFile, valFile))) !== FAILURE) {
         await writeKeyP
         return
       }
@@ -434,7 +435,8 @@ export class Cache extends LRUCache<
       // so its likely the same content so force link them
       // because thats faster than writing the value file.
       if (
-        (await success(this.#linkAtomic(intFile, valFile))) !== null
+        (await success(this.#linkAtomic(intFile, valFile))) !==
+        FAILURE
       ) {
         await writeKeyP
         return

--- a/src/cache/src/index.ts
+++ b/src/cache/src/index.ts
@@ -440,7 +440,7 @@ export class Cache extends LRUCache<
 
     // If files are not same size or something went wrong with the previous link
     // operations then fallback to doing everything:
-    // - write the write the key/value files
+    // - write the key/value files
     // - unlink integrity and then re-link it to the value file
     await Promise.all([
       writeKeyP,

--- a/src/cache/src/index.ts
+++ b/src/cache/src/index.ts
@@ -419,11 +419,6 @@ export class Cache extends LRUCache<
 
     // We now know that both the value and integrity files exist.
 
-    // TODO: we are handling different registries here which will likely
-    // return different headers so the file sizes will be different even
-    // if the content is the same. This should be updated to check based
-    // on the size of the response body, not the size of the file on disk.
-
     if (
       intStats.ino === valStats.ino &&
       intStats.dev === valStats.dev

--- a/src/cache/src/index.ts
+++ b/src/cache/src/index.ts
@@ -352,7 +352,7 @@ export class Cache extends LRUCache<
     // ensure we get a different random key for every write,
     // just in case the same file tries to write multiple times,
     // it'll still be atomic.
-    const tmp = `${file}.${this.#random}${this.#i++}`
+    const tmp = `${file}.${this.#random}.${this.#i++}`
     await writeFile(tmp, data)
     await rename(tmp, file)
   }

--- a/src/cache/test/index.ts
+++ b/src/cache/test/index.ts
@@ -1,23 +1,35 @@
 import { createHash } from 'node:crypto'
 import { readdirSync } from 'node:fs'
+import type { Stats } from 'node:fs'
+import { readFile, stat, writeFile } from 'node:fs/promises'
 import { resolve } from 'node:path'
 import t from 'tap'
 import { Cache } from '../src/index.ts'
+import type { Integrity } from '@vltpkg/types'
+
+const makeValueIntegrity = (
+  str: string,
+  fakeIntegrity?: Integrity,
+): [Buffer, Integrity] => {
+  const value = Buffer.from(str)
+  const integrity: Integrity =
+    fakeIntegrity ??
+    (`sha512-${createHash('sha512')
+      .update(value)
+      .digest('base64')}` as const)
+  return [value, integrity]
+}
 
 t.test('basic cache operation', async t => {
+  const hash =
+    '4a3ed8147e37876adc8f76328e5abcc1b470e6acfc18efea0135f983604953a5' +
+    '8e183c1a6086e91ba3e821d926f5fdeb37761c7ca0328a963f5e92870675b728'
   let odwCalled = false
   const c = new Cache({
     path: t.testdir(),
     onDiskWrite(path, key, data) {
       odwCalled = true
-      t.equal(
-        path,
-        resolve(
-          t.testdirName,
-          '4a3ed8147e37876adc8f76328e5abcc1b470e6acfc18efea0135f983604953a5' +
-            '8e183c1a6086e91ba3e821d926f5fdeb37761c7ca0328a963f5e92870675b728',
-        ),
-      )
+      t.equal(path, resolve(t.testdirName, hash))
       t.equal(key, 'xyz')
       t.same(data, Buffer.from('hello, world'))
     },
@@ -28,12 +40,7 @@ t.test('basic cache operation', async t => {
   await c.promise()
   t.equal(odwCalled, true)
   t.same([...c.keys()], ['xyz'])
-  t.same(readdirSync(t.testdirName), [
-    '4a3ed8147e37876adc8f76328e5abcc1b470e6acfc18efea0135f983604953a5' +
-      '8e183c1a6086e91ba3e821d926f5fdeb37761c7ca0328a963f5e92870675b728',
-    '4a3ed8147e37876adc8f76328e5abcc1b470e6acfc18efea0135f983604953a5' +
-      '8e183c1a6086e91ba3e821d926f5fdeb37761c7ca0328a963f5e92870675b728.key',
-  ])
+  t.same(readdirSync(t.testdirName), [hash, `${hash}.key`])
 
   const reader = new Cache({
     path: t.testdirName,
@@ -71,19 +78,15 @@ t.test('basic cache operation', async t => {
 })
 
 t.test('delete from disk', async t => {
+  const hash =
+    '4a3ed8147e37876adc8f76328e5abcc1b470e6acfc18efea0135f983604953a5' +
+    '8e183c1a6086e91ba3e821d926f5fdeb37761c7ca0328a963f5e92870675b728'
   let oddCalled = false
   const c = new Cache({
     path: t.testdir(),
     onDiskDelete(path, key, deleted) {
       oddCalled = true
-      t.equal(
-        path,
-        resolve(
-          t.testdirName,
-          '4a3ed8147e37876adc8f76328e5abcc1b470e6acfc18efea0135f983604953a5' +
-            '8e183c1a6086e91ba3e821d926f5fdeb37761c7ca0328a963f5e92870675b728',
-        ),
-      )
+      t.equal(path, resolve(t.testdirName, hash))
       t.equal(key, 'xyz')
       t.equal(deleted, true)
     },
@@ -92,36 +95,22 @@ t.test('delete from disk', async t => {
   c.set('xyz', Buffer.from('hello, world'))
   await c.promise()
   t.same([...c.keys()], ['xyz'])
-  t.same(readdirSync(t.testdirName), [
-    '4a3ed8147e37876adc8f76328e5abcc1b470e6acfc18efea0135f983604953a5' +
-      '8e183c1a6086e91ba3e821d926f5fdeb37761c7ca0328a963f5e92870675b728',
-    '4a3ed8147e37876adc8f76328e5abcc1b470e6acfc18efea0135f983604953a5' +
-      '8e183c1a6086e91ba3e821d926f5fdeb37761c7ca0328a963f5e92870675b728.key',
-  ])
+  t.same(readdirSync(t.testdirName), [hash, `${hash}.key`])
   c.delete('xyz')
   t.strictSame([...c.keys()], [])
   await c.promise()
   t.equal(oddCalled, false, 'does not call diskDelete by default')
-  t.same(readdirSync(t.testdirName), [
-    '4a3ed8147e37876adc8f76328e5abcc1b470e6acfc18efea0135f983604953a5' +
-      '8e183c1a6086e91ba3e821d926f5fdeb37761c7ca0328a963f5e92870675b728',
-    '4a3ed8147e37876adc8f76328e5abcc1b470e6acfc18efea0135f983604953a5' +
-      '8e183c1a6086e91ba3e821d926f5fdeb37761c7ca0328a963f5e92870675b728.key',
-  ])
-  c.delete(
-    'xyz',
-    true,
-    `sha512-${createHash('sha512').update('hello, world').digest('base64')}`,
-  )
+  t.same(readdirSync(t.testdirName), [hash, `${hash}.key`])
+
+  const [, integrity] = makeValueIntegrity('hello, world')
+  c.delete('xyz', true, integrity)
   await c.promise()
   t.equal(oddCalled, true, 'diskDelete has now been called')
   t.strictSame(readdirSync(t.testdirName), [])
 })
 
 t.test('walk over cached items', async t => {
-  const c = new Cache({
-    path: t.testdir(),
-  })
+  const c = new Cache({ path: t.testdir() })
   t.equal(c.max, Cache.defaultMax)
   c.set('xyz', Buffer.from('hello, world'))
   await c.promise()
@@ -140,56 +129,178 @@ t.test('walk over cached items', async t => {
 })
 
 t.test('integrity', async t => {
-  const c = new Cache({ path: t.testdir() })
-  const value = Buffer.from('hello, world')
-  const integrity = `sha512-${createHash('sha512')
-    .update(value)
-    .digest('base64')}` as const
-  c.set('key', value, { integrity })
-  await c.promise()
+  // Set a value in the cache, with a possible integrity value.
+  // Then wait for the cache to be written and clear the in-memory cache
+  // so the value is only persisted to disk.
+  const cacheSet = async (
+    c: Cache,
+    k: string,
+    v: Buffer,
+    integrity?: Integrity,
+  ) => {
+    c.set(k, v, { integrity })
+    await c.promise()
+    c.clear()
+  }
 
-  const sameInt = await c.fetch('otherkey', {
-    context: { integrity },
+  const statKeys = async (path: string | undefined) => {
+    const stats = path ? await stat(path) : ({} as Stats)
+    return {
+      dev: stats.dev,
+      ino: stats.ino,
+      size: stats.size,
+      nlink: stats.nlink,
+    }
+  }
+
+  t.test('fetch by integrity (sync and async)', async t => {
+    const cache = new Cache({ path: t.testdir() })
+    const [value, integrity] = makeValueIntegrity('hello, world')
+
+    await cacheSet(cache, 'key', value, integrity)
+
+    t.strictSame(
+      await cache.fetch('otherkey', { context: { integrity } }),
+      value,
+    )
+    t.strictSame(
+      cache.fetchSync('yolo', { context: { integrity } }),
+      value,
+    )
   })
-  t.strictSame(sameInt, value)
-  const sameSync = c.fetchSync('yolo', { context: { integrity } })
-  t.strictSame(sameSync, value)
 
-  // if we fetch with integrity, and the key exists
-  // but not the integrity, then link integrity.
-  c.set('apple', Buffer.from('red'))
-  await c.promise()
-  const red = Buffer.from('red')
-  const redInt = `sha512-${createHash('sha512')
-    .update(red)
-    .digest('base64')}` as const
+  t.test('fetch with missing integrity', async t => {
+    const cache = new Cache({ path: t.testdir() })
+    const [value, integrity] = makeValueIntegrity('red')
 
-  const d = new Cache({ path: t.testdirName })
-  t.strictSame(
-    await d.fetch('apple', { context: { integrity: redInt } }),
-    red,
-  )
-  t.strictSame(
-    await d.fetch('red things', { context: { integrity: redInt } }),
-    red,
-  )
+    await cacheSet(cache, 'apple', value, undefined)
 
-  const b = Buffer.from('b')
-  //@ts-expect-error
-  d.set('a', b, { integrity: 'yolo' })
-  //@ts-expect-error
-  t.throws(() => d.integrityPath('yolo'))
-  await d.promise()
-  const e = new Cache({ path: t.testdirName })
-  // it should have written the file, but the integrity didn't get written
-  t.strictSame(
-    //@ts-expect-error
-    await e.fetch('a', { context: { integrity: 'yolo' } }),
-    b,
-  )
-  t.equal(
-    //@ts-expect-error
-    await e.fetch('x', { context: { integrity: 'yolo' } }),
-    undefined,
-  )
+    // if we fetch with integrity, and the key exists
+    // but not the integrity, then link integrity.
+    t.strictSame(
+      await cache.fetch('apple', { context: { integrity } }),
+      value,
+    )
+    t.strictSame(
+      await cache.fetch('red things', { context: { integrity } }),
+      value,
+    )
+  })
+
+  t.test('set with bad integrity', async t => {
+    const cache = new Cache({ path: t.testdir() })
+    const [value, integrity] = makeValueIntegrity(
+      'b',
+      'yolo' as Integrity,
+    )
+
+    await cacheSet(cache, 'a', value, integrity)
+
+    t.throws(() => cache.integrityPath(integrity))
+
+    // it should have written the file, but the integrity didn't get written
+    t.strictSame(
+      await cache.fetch('a', { context: { integrity } }),
+      value,
+    )
+    t.equal(
+      await cache.fetch('x', { context: { integrity } }),
+      undefined,
+    )
+  })
+
+  t.test('linked integrity file exists', async t => {
+    const cache = new Cache({ path: t.testdir() })
+    const [value, integrity] = makeValueIntegrity('content')
+    const key = 'key'
+    const key2 = 'key2'
+
+    // Set first time to create files
+    await cacheSet(cache, key, value, integrity)
+    // Set again with same key and integrity
+    // Should detect they're already linked and same size
+    await cacheSet(cache, key, value, integrity)
+    // Now set with a different key but same integrity
+    // Should link the new key to existing integrity file
+    await cacheSet(cache, key2, value, integrity)
+
+    const valStats1 = await statKeys(cache.path(key))
+    t.strictSame(
+      valStats1,
+      await statKeys(cache.path(key2)),
+      'file 1 and file 2 are linked',
+    )
+    t.strictSame(
+      valStats1,
+      await statKeys(cache.integrityPath(integrity)),
+      'file 1 and integrity are linked',
+    )
+    t.equal(valStats1.size, value.length, 'file has correct size')
+    t.equal(valStats1.nlink, 3, 'nlink=3 (2 keys + integrity)')
+  })
+
+  t.test('integrity file exists with different content', async t => {
+    const cache = new Cache({ path: t.testdir() })
+    const [value1, integrity1] = makeValueIntegrity('content')
+    const [value2, integrity2] = makeValueIntegrity('not content')
+    const key1 = 'key1'
+    const key2 = 'key2'
+
+    // Create first integrity file
+    await cacheSet(cache, key1, value1, integrity1)
+    // Create new file with different integrity
+    await cacheSet(cache, key2, value2, integrity2)
+    // Now set with key1 but integrity2
+    // Should link to integrity2
+    await cacheSet(cache, key1, value2, integrity2)
+
+    t.strictSame(
+      await readFile(cache.path(key1)),
+      value2,
+      'key1 now has value2 content',
+    )
+    t.strictSame(
+      await readFile(cache.path(key2)),
+      value2,
+      'key2 has correct content',
+    )
+    // Check stats - key1 should be linked to integrity2
+    t.strictSame(
+      await statKeys(cache.path(key1)),
+      await statKeys(cache.integrityPath(integrity2)),
+      'key1 and integrity2 are linked',
+    )
+  })
+
+  t.test('messed up integrity file', async t => {
+    const cache = new Cache({ path: t.testdir() })
+    const [value, integrity] = makeValueIntegrity('content')
+    const key = 'key'
+
+    // Set first time to create files
+    await cacheSet(cache, key, value, integrity)
+    // Something (maybe another cache-unzip process) wrote something
+    // else to the integrity file
+    await writeFile(cache.integrityPath(integrity)!, 'im a bad guy')
+    // Set again with same key and integrity
+    // Should detect that something is wrong with the integrity file
+    // and rewrite it
+    await cacheSet(cache, key, value, integrity)
+
+    t.strictSame(
+      await readFile(cache.path(key)),
+      value,
+      'value has correct content',
+    )
+    t.strictSame(
+      await readFile(cache.integrityPath(integrity)!),
+      value,
+      'integrity has correct content',
+    )
+    t.strictSame(
+      await statKeys(cache.path(key)),
+      await statKeys(cache.integrityPath(integrity)),
+      'value and integrity are linked',
+    )
+  })
 })


### PR DESCRIPTION
Also update cache-unzip to use the reworked `cache.set` method with the
`integrity` option.

Fixes #627
