### PR TITLE
query: refactor missing pseudo selector

### DIFF
--- a/src/query/src/pseudo.ts
+++ b/src/query/src/pseudo.ts
@@ -29,6 +29,7 @@ import { fs } from './pseudo/fs.ts'
 import { license } from './pseudo/license.ts'
 import { malware } from './pseudo/malware.ts'
 import { minified } from './pseudo/minified.ts'
+import { missing } from './pseudo/missing.ts'
 import { nativeParser } from './pseudo/native.ts'
 import { network } from './pseudo/network.ts'
 import { obfuscated } from './pseudo/obfuscated.ts'
@@ -175,20 +176,6 @@ const is = async (state: ParserState) => {
       removeNode(state, node)
     }
   }
-  return state
-}
-
-/**
- * :missing Pseudo-Selector, matches only
- * edges that are not linked to any node.
- */
-const missing = async (state: ParserState) => {
-  for (const edge of state.partial.edges) {
-    if (edge.to) {
-      state.partial.edges.delete(edge)
-    }
-  }
-  state.partial.nodes.clear()
   return state
 }
 

--- a/src/query/src/pseudo/missing.ts
+++ b/src/query/src/pseudo/missing.ts
@@ -1,0 +1,16 @@
+import type { ParserState } from '../types.ts'
+
+/**
+ * :missing Pseudo-Selector, matches only edges that are not linked to any node.
+ * It filters out any edges that have a 'to' property, keeping only dangling edges
+ * and clears all nodes from the result.
+ */
+export const missing = async (state: ParserState) => {
+  for (const edge of state.partial.edges) {
+    if (edge.to) {
+      state.partial.edges.delete(edge)
+    }
+  }
+  state.partial.nodes.clear()
+  return state
+}

--- a/src/query/tap-snapshots/test/pseudo/missing.ts.test.cjs
+++ b/src/query/tap-snapshots/test/pseudo/missing.ts.test.cjs
@@ -1,0 +1,40 @@
+/* IMPORTANT
+ * This snapshot file is auto-generated, but designed for humans.
+ * It should be checked into source control and tracked carefully.
+ * Re-generate by setting TAP_SNAPSHOT=1 and running tests.
+ * Make sure to inspect the output below.  Do not ignore changes!
+ */
+'use strict'
+exports[`test/pseudo/missing.ts > TAP > selects edges with no linked node > handles a mixed state with some linked and some unlinked edges > must match snapshot 1`] = `
+Object {
+  "edges": Array [
+    "a",
+    "b",
+  ],
+  "nodes": Array [],
+}
+`
+
+exports[`test/pseudo/missing.ts > TAP > selects edges with no linked node > handles an empty partial state > must match snapshot 1`] = `
+Object {
+  "edges": Array [],
+  "nodes": Array [],
+}
+`
+
+exports[`test/pseudo/missing.ts > TAP > selects edges with no linked node > returns no edges in simple graph (all edges have linked nodes) > must match snapshot 1`] = `
+Object {
+  "edges": Array [],
+  "nodes": Array [],
+}
+`
+
+exports[`test/pseudo/missing.ts > TAP > selects edges with no linked node > selects edges with no linked node in missing node graph > must match snapshot 1`] = `
+Object {
+  "edges": Array [
+    "a",
+    "b",
+  ],
+  "nodes": Array [],
+}
+`

--- a/src/query/test/pseudo/missing.ts
+++ b/src/query/test/pseudo/missing.ts
@@ -1,0 +1,108 @@
+import t from 'tap'
+import postcssSelectorParser from 'postcss-selector-parser'
+import type { ParserState } from '../../src/types.ts'
+import { missing } from '../../src/pseudo/missing.ts'
+import {
+  getSimpleGraph,
+  getMissingNodeGraph,
+} from '../fixtures/graph.ts'
+
+t.test('selects edges with no linked node', async t => {
+  const getState = (query: string, graph = getSimpleGraph()) => {
+    const ast = postcssSelectorParser().astSync(query)
+    const current = ast.first.first
+    const state: ParserState = {
+      current,
+      initial: {
+        edges: new Set(graph.edges.values()),
+        nodes: new Set(graph.nodes.values()),
+      },
+      partial: {
+        edges: new Set(graph.edges.values()),
+        nodes: new Set(graph.nodes.values()),
+      },
+      collect: {
+        edges: new Set(),
+        nodes: new Set(),
+      },
+      cancellable: async () => {},
+      walk: async i => i,
+      retries: 0,
+      securityArchive: undefined,
+      specOptions: {},
+    }
+    return state
+  }
+
+  await t.test(
+    'returns no edges in simple graph (all edges have linked nodes)',
+    async t => {
+      // In getSimpleGraph, all edges have linked nodes, so :missing should return no edges
+      const res = await missing(getState(':missing'))
+      t.strictSame(
+        [...res.partial.edges].map(e => e.name),
+        [],
+        'should not select any edges in a graph where all edges have linked nodes',
+      )
+      t.strictSame(
+        [...res.partial.nodes].map(n => n.name),
+        [],
+        'should always return an empty nodes set',
+      )
+      t.matchSnapshot({
+        nodes: [...res.partial.nodes].map(n => n.name).sort(),
+        edges: [...res.partial.edges].map(e => e.name).sort(),
+      })
+    },
+  )
+
+  await t.test(
+    'selects edges with no linked node in missing node graph',
+    async t => {
+      // In getMissingNodeGraph, there are edges without linked nodes
+      const missingNodeGraph = getMissingNodeGraph()
+      const res = await missing(
+        getState(':missing', missingNodeGraph),
+      )
+
+      // The getMissingNodeGraph has edges 'a' and 'b' without linked nodes
+      t.strictSame(
+        [...res.partial.edges].map(e => e.name).sort(),
+        ['a', 'b'].sort(),
+        'should select only edges without linked nodes',
+      )
+      t.strictSame(
+        [...res.partial.nodes],
+        [],
+        'should always return an empty nodes set',
+      )
+      t.matchSnapshot({
+        nodes: [...res.partial.nodes].map(n => n.name).sort(),
+        edges: [...res.partial.edges].map(e => e.name).sort(),
+      })
+    },
+  )
+
+  await t.test('handles an empty partial state', async t => {
+    // Create a state with empty partial edges and nodes
+    const state = getState(':missing')
+    state.partial.nodes.clear()
+    state.partial.edges.clear()
+
+    const res = await missing(state)
+    t.strictSame(
+      [...res.partial.edges],
+      [],
+      'should return empty array of edges when starting with empty partial state',
+    )
+    t.strictSame(
+      [...res.partial.nodes],
+      [],
+      'should return empty array of nodes when starting with empty partial state',
+    )
+    t.matchSnapshot({
+      nodes: [...res.partial.nodes].map(n => n.name),
+      edges: [...res.partial.edges].map(e => e.name),
+    })
+  })
+})


### PR DESCRIPTION
Refactor `:missing` into its own file and add unit tests for it.