### PR TITLE
query: refactor private pseudo selector

### DIFF
--- a/src/query/src/pseudo.ts
+++ b/src/query/src/pseudo.ts
@@ -1,7 +1,6 @@
 import { splitDepID } from '@vltpkg/dep-id/browser'
 import { error } from '@vltpkg/error-cause'
 import type { EdgeLike, NodeLike } from '@vltpkg/graph'
-import { asManifest } from '@vltpkg/types'
 
 import { removeDanglingEdges, removeNode } from './pseudo/helpers.ts'
 import {
@@ -34,6 +33,7 @@ import { network } from './pseudo/network.ts'
 import { obfuscated } from './pseudo/obfuscated.ts'
 import { outdated } from './pseudo/outdated.ts'
 import { published } from './pseudo/published.ts'
+import { privateParser } from './pseudo/private.ts'
 import { scanned } from './pseudo/scanned.ts'
 import { score } from './pseudo/score.ts'
 import { scripts } from './pseudo/scripts.ts'
@@ -240,22 +240,6 @@ const not = async (state: ParserState) => {
 }
 
 /**
- * :private Pseudo-Selector will only match packages that have
- * a `private: true` key set in their `package.json` metadata.
- */
-const privateFn = async (state: ParserState) => {
-  for (const node of state.partial.nodes) {
-    if (!node.manifest || !asManifest(node.manifest).private) {
-      removeNode(state, node)
-    }
-  }
-
-  removeDanglingEdges(state)
-
-  return state
-}
-
-/**
  * :root Pseudo-Element will return the project root node for the graph.
  */
 const root = async (state: ParserState) => {
@@ -369,7 +353,7 @@ const pseudoSelectors = new Map<string, ParserFn>(
     outdated,
     published,
     // TODO: overridden
-    private: privateFn,
+    private: privateParser,
     project,
     root,
     scanned,

--- a/src/query/src/pseudo/private.ts
+++ b/src/query/src/pseudo/private.ts
@@ -1,0 +1,19 @@
+import { asManifest } from '@vltpkg/types'
+import type { ParserState } from '../types.ts'
+import { removeNode, removeDanglingEdges } from './helpers.ts'
+
+/**
+ * :private Pseudo-Selector will only match packages that have
+ * a `private: true` key set in their `package.json` metadata.
+ */
+export const privateParser = async (state: ParserState) => {
+  for (const node of state.partial.nodes) {
+    if (!node.manifest || !asManifest(node.manifest).private) {
+      removeNode(state, node)
+    }
+  }
+
+  removeDanglingEdges(state)
+
+  return state
+}

--- a/src/query/tap-snapshots/test/pseudo/private.ts.test.cjs
+++ b/src/query/tap-snapshots/test/pseudo/private.ts.test.cjs
@@ -1,0 +1,38 @@
+/* IMPORTANT
+ * This snapshot file is auto-generated, but designed for humans.
+ * It should be checked into source control and tracked carefully.
+ * Re-generate by setting TAP_SNAPSHOT=1 and running tests.
+ * Make sure to inspect the output below.  Do not ignore changes!
+ */
+'use strict'
+exports[`test/pseudo/private.ts > TAP > selects packages with private flag > handles an empty partial state > must match snapshot 1`] = `
+Object {
+  "edges": Array [],
+  "nodes": Array [],
+}
+`
+
+exports[`test/pseudo/private.ts > TAP > selects packages with private flag > selects no nodes in cycle graph > must match snapshot 1`] = `
+Object {
+  "edges": Array [],
+  "nodes": Array [],
+}
+`
+
+exports[`test/pseudo/private.ts > TAP > selects packages with private flag > selects no nodes with private flag in workspace graph > must match snapshot 1`] = `
+Object {
+  "edges": Array [],
+  "nodes": Array [],
+}
+`
+
+exports[`test/pseudo/private.ts > TAP > selects packages with private flag > selects nodes with private flag in simple graph > must match snapshot 1`] = `
+Object {
+  "edges": Array [
+    "d",
+  ],
+  "nodes": Array [
+    "d",
+  ],
+}
+`

--- a/src/query/test/pseudo/private.ts
+++ b/src/query/test/pseudo/private.ts
@@ -1,0 +1,105 @@
+import t from 'tap'
+import postcssSelectorParser from 'postcss-selector-parser'
+import type { ParserState } from '../../src/types.ts'
+import { privateParser } from '../../src/pseudo/private.ts'
+import {
+  getSimpleGraph,
+  getSingleWorkspaceGraph,
+  getCycleGraph,
+} from '../fixtures/graph.ts'
+
+t.test('selects packages with private flag', async t => {
+  const getState = (query: string, graph = getSimpleGraph()) => {
+    const ast = postcssSelectorParser().astSync(query)
+    const current = ast.first.first
+    const state: ParserState = {
+      current,
+      initial: {
+        edges: new Set(graph.edges.values()),
+        nodes: new Set(graph.nodes.values()),
+      },
+      partial: {
+        edges: new Set(graph.edges.values()),
+        nodes: new Set(graph.nodes.values()),
+      },
+      collect: {
+        edges: new Set(),
+        nodes: new Set(),
+      },
+      cancellable: async () => {},
+      walk: async i => i,
+      retries: 0,
+      securityArchive: undefined,
+      specOptions: {},
+    }
+    return state
+  }
+
+  await t.test(
+    'selects nodes with private flag in simple graph',
+    async t => {
+      // Based on the getSimpleGraph fixture, only the 'd' package has private: true
+      const res = await privateParser(getState(':private'))
+      t.strictSame(
+        [...res.partial.nodes].map(n => n.name),
+        ['d'],
+        'should select only packages with private flag set to true',
+      )
+      t.matchSnapshot({
+        nodes: [...res.partial.nodes].map(n => n.name).sort(),
+        edges: [...res.partial.edges].map(e => e.name).sort(),
+      })
+    },
+  )
+
+  await t.test(
+    'selects no nodes with private flag in workspace graph',
+    async t => {
+      // In getSingleWorkspaceGraph, no nodes have private flag
+      const wsGraph = getSingleWorkspaceGraph()
+      const res = await privateParser(getState(':private', wsGraph))
+      t.strictSame(
+        [...res.partial.nodes].map(n => n.name),
+        [],
+        'should not select any nodes in workspace graph as none have private flag',
+      )
+      t.matchSnapshot({
+        nodes: [...res.partial.nodes].map(n => n.name).sort(),
+        edges: [...res.partial.edges].map(e => e.name).sort(),
+      })
+    },
+  )
+
+  await t.test('selects no nodes in cycle graph', async t => {
+    // In getCycleGraph, no nodes have private flag
+    const cycleGraph = getCycleGraph()
+    const res = await privateParser(getState(':private', cycleGraph))
+    t.strictSame(
+      [...res.partial.nodes].map(n => n.name),
+      [],
+      'should not select any packages in a cycle graph as none have private flag',
+    )
+    t.matchSnapshot({
+      nodes: [...res.partial.nodes].map(n => n.name),
+      edges: [...res.partial.edges].map(e => e.name),
+    })
+  })
+
+  await t.test('handles an empty partial state', async t => {
+    // Create a state with empty partial nodes
+    const state = getState(':private')
+    state.partial.nodes.clear()
+    state.partial.edges.clear()
+
+    const res = await privateParser(state)
+    t.strictSame(
+      [...res.partial.nodes].map(n => n.name),
+      [],
+      'should return empty array when starting with empty partial state',
+    )
+    t.matchSnapshot({
+      nodes: [...res.partial.nodes].map(n => n.name),
+      edges: [...res.partial.edges].map(e => e.name),
+    })
+  })
+})


### PR DESCRIPTION
Refactor `:private` into its own file and add unit tests for it.