### PR TITLE
query: add link selector

### DIFF
--- a/src/query/README.md
+++ b/src/query/README.md
@@ -121,6 +121,7 @@ e.g: `#foo` is the same as `[name=foo]`
   of the same name, this selector has a forgiving behavior regarding
   its nested selector list ignoring any usage of non-existing ids,
   classes, combinators, operators and pseudo-selectors.
+- `:link` Matches linked packages only.
 - `:not(<selector-list>)` Negation pseudo-class, select packages that
   do not match a list of selectors.
 - `:outdated(<type>)` Matches packages that are outdated, the type

--- a/src/query/src/pseudo.ts
+++ b/src/query/src/pseudo.ts
@@ -27,6 +27,7 @@ import { env } from './pseudo/env.ts'
 import { evalParser } from './pseudo/eval.ts'
 import { fs } from './pseudo/fs.ts'
 import { license } from './pseudo/license.ts'
+import { link } from './pseudo/link.ts'
 import { malware } from './pseudo/malware.ts'
 import { minified } from './pseudo/minified.ts'
 import { nativeParser } from './pseudo/native.ts'
@@ -357,8 +358,8 @@ const pseudoSelectors = new Map<string, ParserFn>(
     fs,
     has,
     is,
-    // TODO: link
     license,
+    link,
     malware,
     minified,
     missing,

--- a/src/query/src/pseudo/link.ts
+++ b/src/query/src/pseudo/link.ts
@@ -1,0 +1,30 @@
+import { splitDepID } from '@vltpkg/dep-id/browser'
+import type { ParserState } from '../types.ts'
+import { removeNode } from './helpers.ts'
+
+/**
+ * :link Pseudo-Selector, matches only nodes that are file links.
+ *
+ * It filters out any node that is not of type 'file' or nodes of 'file'
+ * type that ends with 'tar.gz' since these are local tarballs.
+ */
+export const link = async (state: ParserState) => {
+  for (const node of state.partial.nodes) {
+    const [type, path] = splitDepID(node.id)
+    if (type !== 'file' || path.endsWith('tar.gz') || path === '.') {
+      removeNode(state, node)
+    }
+  }
+
+  for (const edge of state.partial.edges) {
+    if (
+      !edge.spec.file ||
+      edge.spec.file.endsWith('tar.gz') ||
+      edge.spec.file === '.'
+    ) {
+      state.partial.edges.delete(edge)
+    }
+  }
+
+  return state
+}

--- a/src/query/tap-snapshots/test/pseudo/link.ts.test.cjs
+++ b/src/query/tap-snapshots/test/pseudo/link.ts.test.cjs
@@ -1,0 +1,36 @@
+/* IMPORTANT
+ * This snapshot file is auto-generated, but designed for humans.
+ * It should be checked into source control and tracked carefully.
+ * Re-generate by setting TAP_SNAPSHOT=1 and running tests.
+ * Make sure to inspect the output below.  Do not ignore changes!
+ */
+'use strict'
+exports[`test/pseudo/link.ts > TAP > selects file links and tar.gz packages > handles an empty partial state > must match snapshot 1`] = `
+Object {
+  "edges": Array [],
+  "nodes": Array [],
+}
+`
+
+exports[`test/pseudo/link.ts > TAP > selects file links and tar.gz packages > selects nodes that are file links in simple graph > must match snapshot 1`] = `
+Object {
+  "edges": Array [
+    "@x/y",
+  ],
+  "nodes": Array [
+    "@x/y",
+  ],
+}
+`
+
+exports[`test/pseudo/link.ts > TAP > selects file links and tar.gz packages > selects nodes that are file links or tar.gz in linked graph > must match snapshot 1`] = `
+Object {
+  "edges": Array [
+    "a",
+    "d",
+  ],
+  "nodes": Array [
+    "a",
+  ],
+}
+`

--- a/src/query/test/fixtures/graph.ts
+++ b/src/query/test/fixtures/graph.ts
@@ -134,7 +134,7 @@ export const getSimpleGraph = (): GraphLike => {
   )
   newEdge(
     graph.mainImporter,
-    Spec.parse('@x/y', '^1.0.0', specOptions),
+    Spec.parse('@x/y', 'file:y', specOptions),
     'dev',
     y,
   )
@@ -441,5 +441,65 @@ export const getSemverRichGraph = (): GraphLike => {
     ...g.manifest,
     version: '1.2.3-rc.1+rev.2',
   }
+  return graph
+}
+
+// Returns a graph that looks like:
+//
+// link-project (#a.file, #b.registry, #c.tar.gz)
+// +-- a (file link)
+// +-- b (registry package)
+// +-- c (tar.gz archive)
+//
+export const getLinkedGraph = (): GraphLike => {
+  const graph = newGraph('link-project')
+  const addNode = newNode(graph)
+
+  // Create file link node 'a'
+  const a = addNode('a')
+  a.id = joinDepIDTuple(['file', 'a'])
+
+  // Create registry node 'b'
+  const b = addNode('b')
+
+  // Create tar.gz node 'c'
+  const c = addNode('c')
+  c.id = joinDepIDTuple(['file', 'package.tar.gz'])
+
+  // Add nodes to graph
+  ;[a, b, c].forEach(i => {
+    graph.nodes.set(i.id, i)
+  })
+
+  // Add edges from main importer to nodes
+  newEdge(
+    graph.mainImporter,
+    Spec.parse('a', 'file:a', specOptions),
+    'prod',
+    a,
+  )
+  newEdge(
+    graph.mainImporter,
+    Spec.parse('b', '^1.0.0', specOptions),
+    'prod',
+    b,
+  )
+  newEdge(
+    graph.mainImporter,
+    Spec.parse('c', 'file:package.tar.gz', specOptions),
+    'prod',
+    c,
+  )
+  newEdge(
+    graph.mainImporter,
+    Spec.parse('d', 'file:d', specOptions),
+    'prod',
+  )
+  newEdge(
+    graph.mainImporter,
+    Spec.parse('e', 'file:e.tar.gz', specOptions),
+    'prod',
+  )
+
   return graph
 }

--- a/src/query/test/pseudo/link.ts
+++ b/src/query/test/pseudo/link.ts
@@ -1,0 +1,91 @@
+import t from 'tap'
+import postcssSelectorParser from 'postcss-selector-parser'
+import type { ParserState } from '../../src/types.ts'
+import { link } from '../../src/pseudo/link.ts'
+import { getSimpleGraph, getLinkedGraph } from '../fixtures/graph.ts'
+
+t.test('selects file links and tar.gz packages', async t => {
+  const getState = (query: string, graph = getSimpleGraph()) => {
+    const ast = postcssSelectorParser().astSync(query)
+    const current = ast.first.first
+    const state: ParserState = {
+      current,
+      initial: {
+        edges: new Set(graph.edges.values()),
+        nodes: new Set(graph.nodes.values()),
+      },
+      partial: {
+        edges: new Set(graph.edges.values()),
+        nodes: new Set(graph.nodes.values()),
+      },
+      collect: {
+        edges: new Set(),
+        nodes: new Set(),
+      },
+      cancellable: async () => {},
+      walk: async i => i,
+      retries: 0,
+      securityArchive: undefined,
+      specOptions: {},
+    }
+    return state
+  }
+
+  await t.test(
+    'selects nodes that are file links in simple graph',
+    async t => {
+      // Based on the getSimpleGraph fixture, only '@x/y' is a file link
+      const res = await link(getState(':link'))
+      t.strictSame(
+        [...res.partial.nodes].map(n => n.name).sort(),
+        ['@x/y'].sort(),
+        'should select only file link packages in simple graph',
+      )
+      t.matchSnapshot({
+        nodes: [...res.partial.nodes].map(n => n.name).sort(),
+        edges: [...res.partial.edges].map(e => e.name).sort(),
+      })
+    },
+  )
+
+  await t.test(
+    'selects nodes that are file links or tar.gz in linked graph',
+    async t => {
+      // In getLinkedGraph, 'a' is a file
+      const linkedGraph = getLinkedGraph()
+      const res = await link(getState(':link', linkedGraph))
+      t.strictSame(
+        [...res.partial.nodes].map(n => n.name).sort(),
+        ['a'].sort(),
+        'should select file links packages',
+      )
+      t.strictSame(
+        [...res.partial.edges].map(e => e.name).sort(),
+        ['a', 'd'].sort(),
+        'should select file links edges including to missing packages',
+      )
+      t.matchSnapshot({
+        nodes: [...res.partial.nodes].map(n => n.name).sort(),
+        edges: [...res.partial.edges].map(e => e.name).sort(),
+      })
+    },
+  )
+
+  await t.test('handles an empty partial state', async t => {
+    // Create a state with empty partial nodes
+    const state = getState(':link')
+    state.partial.nodes.clear()
+    state.partial.edges.clear()
+
+    const res = await link(state)
+    t.strictSame(
+      [...res.partial.nodes].map(n => n.name),
+      [],
+      'should return empty array when starting with empty partial state',
+    )
+    t.matchSnapshot({
+      nodes: [...res.partial.nodes].map(n => n.name),
+      edges: [...res.partial.edges].map(e => e.name),
+    })
+  })
+})


### PR DESCRIPTION
Adds a `:link` pseudo selector that matches linked packages.

Fixes: https://github.com/vltpkg/statusboard/issues/109