### PR TITLE
gui: bugfix `selected-item` no insights with a package score

### DIFF
--- a/src/gui/src/components/explorer-grid/selected-item/tabs-insight.tsx
+++ b/src/gui/src/components/explorer-grid/selected-item/tabs-insight.tsx
@@ -222,7 +222,7 @@ export const InsightTabContent = () => {
               {!packageScore && !filteredInsights ?
                 <BadgeInfo
                   className="absolute z-[3] size-14 text-neutral-500"
-                  strokeWidth={1}
+                  strokeWidth={1.25}
                 />
               : <BadgeCheck
                   className="absolute z-[3] size-14 text-emerald-500"

--- a/src/gui/src/components/explorer-grid/selected-item/tabs-manifest.tsx
+++ b/src/gui/src/components/explorer-grid/selected-item/tabs-manifest.tsx
@@ -31,7 +31,7 @@ export const TabsManifestContent = () => {
             <div className="relative flex size-32 items-center justify-center rounded-full bg-secondary/60">
               <FileJson
                 className="absolute z-[3] size-14 text-neutral-500"
-                strokeWidth={1}
+                strokeWidth={1.25}
               />
             </div>
             <p className="w-2/3 text-pretty text-sm text-muted-foreground">

--- a/src/gui/src/components/explorer-grid/selected-item/tabs-versions.tsx
+++ b/src/gui/src/components/explorer-grid/selected-item/tabs-versions.tsx
@@ -31,7 +31,7 @@ export const VersionsTabContent = () => {
             <div className="relative flex size-32 items-center justify-center rounded-full bg-secondary/60">
               <History
                 className="absolute z-[4] size-14 text-neutral-500"
-                strokeWidth={1}
+                strokeWidth={1.25}
               />
             </div>
             <p className="w-2/3 text-pretty text-sm text-muted-foreground">

--- a/src/gui/test/components/explorer-grid/selected-item/__snapshots__/tabs-insight.tsx.snap
+++ b/src/gui/test/components/explorer-grid/selected-item/__snapshots__/tabs-insight.tsx.snap
@@ -20,7 +20,7 @@ exports[`InsightTabContent renders an empty state 1`] = `
       <div class="relative flex size-32 items-center justify-center rounded-full bg-secondary/60">
         <gui-badge-info-icon
           classname="absolute z-[3] size-14 text-neutral-500"
-          strokewidth="1"
+          strokewidth="1.25"
         >
         </gui-badge-info-icon>
       </div>

--- a/src/gui/test/components/explorer-grid/selected-item/__snapshots__/tabs-insight.tsx.snap
+++ b/src/gui/test/components/explorer-grid/selected-item/__snapshots__/tabs-insight.tsx.snap
@@ -25,7 +25,7 @@ exports[`InsightTabContent renders an empty state 1`] = `
         </gui-badge-info-icon>
       </div>
       <p class="w-2/3 text-pretty text-sm text-muted-foreground">
-        There are no insights for this package
+        This package has not been scanned for insights.
       </p>
     </div>
   </div>
@@ -93,6 +93,123 @@ exports[`InsightTabContent renders with insights 1`] = `
       </div>
     </div>
   </section>
+  <div class="w-full px-6 py-4">
+    <gui-link
+      to="/help/selectors"
+      classname="group relative z-[1] inline-flex w-fit cursor-default items-center justify-center text-sm text-muted-foreground transition-all duration-300 after:absolute after:left-[-0.75rem] after:z-[-1] after:h-[calc(100%+0.5rem)] after:w-[calc(100%+1.5rem)] after:rounded-sm after:bg-transparent after:content-[''] hover:text-foreground hover:after:bg-muted"
+    >
+      See all Selectors &amp; Insights
+    </gui-link>
+  </div>
+</gui-tabs-content>
+
+`;
+
+exports[`InsightTabContent renders with no insights but a package score 1`] = `
+
+<gui-tabs-content value="insights">
+  <section class="mt-6 border-b-[1px] border-muted pb-6">
+    <div class="grid grid-cols-6 gap-2 px-6">
+      <div class="flex flex-col items-center justify-center gap-2 text-center">
+        <gui-progress-circle
+          variant="success"
+          strokewidth="4"
+          value="9000"
+        >
+          9000
+        </gui-progress-circle>
+        <p class="text-sm capitalize">
+          overall
+        </p>
+      </div>
+      <div class="flex flex-col items-center justify-center gap-2 text-center">
+        <gui-progress-circle
+          variant="success"
+          strokewidth="4"
+          value="9000"
+        >
+          9000
+        </gui-progress-circle>
+        <p class="text-sm capitalize">
+          quality
+        </p>
+      </div>
+      <div class="flex flex-col items-center justify-center gap-2 text-center">
+        <gui-progress-circle
+          variant="success"
+          strokewidth="4"
+          value="400"
+        >
+          400
+        </gui-progress-circle>
+        <p class="text-sm capitalize">
+          supply chain
+        </p>
+      </div>
+      <div class="flex flex-col items-center justify-center gap-2 text-center">
+        <gui-progress-circle
+          variant="success"
+          strokewidth="4"
+          value="8500"
+        >
+          8500
+        </gui-progress-circle>
+        <p class="text-sm capitalize">
+          maintenance
+        </p>
+      </div>
+      <div class="flex flex-col items-center justify-center gap-2 text-center">
+        <gui-progress-circle
+          variant="success"
+          strokewidth="4"
+          value="200"
+        >
+          200
+        </gui-progress-circle>
+        <p class="text-sm capitalize">
+          vulnerability
+        </p>
+      </div>
+      <div class="flex flex-col items-center justify-center gap-2 text-center">
+        <gui-progress-circle
+          variant="success"
+          strokewidth="4"
+          value="10000"
+        >
+          10000
+        </gui-progress-circle>
+        <p class="text-sm capitalize">
+          license
+        </p>
+      </div>
+    </div>
+    <div class="px-6 pt-6">
+      <p class="w-2/3 text-sm text-muted-foreground">
+        Package Insight Scores are powered by
+        <gui-link
+          href="https://socket.dev/npm/package/item"
+          target="_blank"
+        >
+          Socket
+        </gui-link>
+        , providing reliable and up-to-date security intelligence.
+      </p>
+    </div>
+  </section>
+  <div class="flex h-64 w-full items-center justify-center px-6 py-4">
+    <div class="flex flex-col items-center justify-center gap-3 text-center">
+      <div class="relative flex size-32 items-center justify-center rounded-full bg-emerald-500/20">
+        <gui-badge-check-icon
+          classname="absolute z-[3] size-14 text-emerald-500"
+          strokewidth="1.25"
+        >
+        </gui-badge-check-icon>
+      </div>
+      <p class="w-2/3 text-pretty text-sm text-muted-foreground">
+        This package has no insights available.
+      </p>
+    </div>
+  </div>
   <div class="w-full px-6 py-4">
     <gui-link
       to="/help/selectors"

--- a/src/gui/test/components/explorer-grid/selected-item/__snapshots__/tabs-manifest.tsx.snap
+++ b/src/gui/test/components/explorer-grid/selected-item/__snapshots__/tabs-manifest.tsx.snap
@@ -23,7 +23,7 @@ exports[`TabsManifestContent renders an empty state 1`] = `
       <div class="relative flex size-32 items-center justify-center rounded-full bg-secondary/60">
         <gui-file-json-icon
           classname="absolute z-[3] size-14 text-neutral-500"
-          strokewidth="1"
+          strokewidth="1.25"
         >
         </gui-file-json-icon>
       </div>

--- a/src/gui/test/components/explorer-grid/selected-item/__snapshots__/tabs-versions.tsx.snap
+++ b/src/gui/test/components/explorer-grid/selected-item/__snapshots__/tabs-versions.tsx.snap
@@ -20,7 +20,7 @@ exports[`VersionsTabContent renders an empty state 1`] = `
       <div class="relative flex size-32 items-center justify-center rounded-full bg-secondary/60">
         <gui-history-icon
           classname="absolute z-[4] size-14 text-neutral-500"
-          strokewidth="1"
+          strokewidth="1.25"
         >
         </gui-history-icon>
       </div>

--- a/src/gui/test/components/explorer-grid/selected-item/tabs-insight.tsx
+++ b/src/gui/test/components/explorer-grid/selected-item/tabs-insight.tsx
@@ -53,6 +53,7 @@ vi.mock(
 vi.mock('lucide-react', () => ({
   ArrowUpDown: 'gui-arrow-up-down-icon',
   BadgeInfo: 'gui-badge-info-icon',
+  BadgeCheck: 'gui-badge-check-icon',
 }))
 
 vi.mock('@/components/ui/progress-circle.jsx', () => ({
@@ -110,6 +111,31 @@ test('InsightTabContent renders with insights', () => {
     selectedItemDetails: SELECTED_ITEM_DETAILS,
     insights: mockedInsights,
     activeTab: 'insights',
+    setActiveTab: vi.fn(),
+  })
+
+  const Container = () => {
+    return <InsightTabContent />
+  }
+  const { container } = render(<Container />)
+
+  expect(container.innerHTML).toMatchSnapshot()
+})
+
+test('InsightTabContent renders with no insights but a package score', () => {
+  vi.mocked(useSelectedItem).mockReturnValue({
+    selectedItem: SELECTED_ITEM,
+    selectedItemDetails: SELECTED_ITEM_DETAILS,
+    insights: undefined,
+    activeTab: 'insights',
+    packageScore: {
+      overall: 90,
+      maintenance: 85,
+      vulnerability: 2,
+      license: 100,
+      quality: 90,
+      supplyChain: 4,
+    },
     setActiveTab: vi.fn(),
   })
 


### PR DESCRIPTION
### With no insights yet a package score
<img width="737" alt="Screenshot 2025-04-10 at 13 46 20" src="https://github.com/user-attachments/assets/05d1c33a-7d03-458d-8377-85aab949d00c" />

### With neither
<img width="737" alt="Screenshot 2025-04-10 at 13 58 37" src="https://github.com/user-attachments/assets/a8e51e3e-975e-4876-b2de-8abef1afb705" />

Fixes a bug where the `selected-item` may have no insights, yet have a package score.

Creates an explicit message on the empty state, where the package could either be `scanned` with no insights, or the package may not have any insights available.

Creates snapshot tests for this state

Also, links the socket external link to the actual package