### PR TITLE
query: fix metadata for published selector

### DIFF
--- a/src/query/src/pseudo/published.ts
+++ b/src/query/src/pseudo/published.ts
@@ -12,7 +12,11 @@ import {
   isTagNode,
 } from '../types.ts'
 import type { ParserState, PostcssNode } from '../types.ts'
-import { removeNode, removeQuotes } from './helpers.ts'
+import {
+  removeDanglingEdges,
+  removeNode,
+  removeQuotes,
+} from './helpers.ts'
 
 /**
  * The possible comparator values accepted by the :published() pseudo selector.
@@ -44,9 +48,6 @@ export const retrieveRemoteDate = async (
   url.pathname = `/${node.name}`
 
   const response = await fetch(String(url), {
-    headers: {
-      Accept: 'application/vnd.npm.install-v1+json',
-    },
     signal,
   })
   // on missing valid auth or API, it should abort the retry logic
@@ -218,6 +219,8 @@ export const published = async (state: ParserState) => {
       removeNode(state, node)
     }
   }
+
+  removeDanglingEdges(state)
 
   return state
 }

--- a/src/query/tap-snapshots/test/pseudo/missing.ts.test.cjs
+++ b/src/query/tap-snapshots/test/pseudo/missing.ts.test.cjs
@@ -5,16 +5,6 @@
  * Make sure to inspect the output below.  Do not ignore changes!
  */
 'use strict'
-exports[`test/pseudo/missing.ts > TAP > selects edges with no linked node > handles a mixed state with some linked and some unlinked edges > must match snapshot 1`] = `
-Object {
-  "edges": Array [
-    "a",
-    "b",
-  ],
-  "nodes": Array [],
-}
-`
-
 exports[`test/pseudo/missing.ts > TAP > selects edges with no linked node > handles an empty partial state > must match snapshot 1`] = `
 Object {
   "edges": Array [],


### PR DESCRIPTION
The `:published` selector needs the full packument in order to retrieve the publish date / time.