### PR TITLE
query: fix unquoted comparisons

### DIFF
--- a/src/query/tap-snapshots/test/pseudo/published.ts.test.cjs
+++ b/src/query/tap-snapshots/test/pseudo/published.ts.test.cjs
@@ -16,7 +16,29 @@ Object {
 }
 `
 
-exports[`test/pseudo/published.ts > TAP > select from published definition > published greater than date > must match snapshot 1`] = `
+exports[`test/pseudo/published.ts > TAP > select from published definition > published exact time (quoted) > must match snapshot 1`] = `
+Object {
+  "edges": Array [
+    "a",
+  ],
+  "nodes": Array [
+    "a",
+  ],
+}
+`
+
+exports[`test/pseudo/published.ts > TAP > select from published definition > published exact time > must match snapshot 1`] = `
+Object {
+  "edges": Array [
+    "a",
+  ],
+  "nodes": Array [
+    "a",
+  ],
+}
+`
+
+exports[`test/pseudo/published.ts > TAP > select from published definition > published greater than date (quoted) > must match snapshot 1`] = `
 Object {
   "edges": Array [
     "c",
@@ -31,7 +53,22 @@ Object {
 }
 `
 
-exports[`test/pseudo/published.ts > TAP > select from published definition > published greater than or equal date > must match snapshot 1`] = `
+exports[`test/pseudo/published.ts > TAP > select from published definition > published greater than date (unquoted) > must match snapshot 1`] = `
+Object {
+  "edges": Array [
+    "c",
+    "d",
+    "e",
+  ],
+  "nodes": Array [
+    "c",
+    "d",
+    "e",
+  ],
+}
+`
+
+exports[`test/pseudo/published.ts > TAP > select from published definition > published greater than or equal date (quoted) > must match snapshot 1`] = `
 Object {
   "edges": Array [
     "b",
@@ -48,7 +85,24 @@ Object {
 }
 `
 
-exports[`test/pseudo/published.ts > TAP > select from published definition > published less than date > must match snapshot 1`] = `
+exports[`test/pseudo/published.ts > TAP > select from published definition > published greater than or equal date (unquoted) > must match snapshot 1`] = `
+Object {
+  "edges": Array [
+    "b",
+    "c",
+    "d",
+    "e",
+  ],
+  "nodes": Array [
+    "b",
+    "c",
+    "d",
+    "e",
+  ],
+}
+`
+
+exports[`test/pseudo/published.ts > TAP > select from published definition > published less than date (quoted) > must match snapshot 1`] = `
 Object {
   "edges": Array [
     "a",
@@ -59,7 +113,31 @@ Object {
 }
 `
 
-exports[`test/pseudo/published.ts > TAP > select from published definition > published less than or equal date > must match snapshot 1`] = `
+exports[`test/pseudo/published.ts > TAP > select from published definition > published less than date (unquoted) > must match snapshot 1`] = `
+Object {
+  "edges": Array [
+    "a",
+  ],
+  "nodes": Array [
+    "a",
+  ],
+}
+`
+
+exports[`test/pseudo/published.ts > TAP > select from published definition > published less than or equal date (quoted) > must match snapshot 1`] = `
+Object {
+  "edges": Array [
+    "a",
+    "b",
+  ],
+  "nodes": Array [
+    "a",
+    "b",
+  ],
+}
+`
+
+exports[`test/pseudo/published.ts > TAP > select from published definition > published less than or equal date (unquoted) > must match snapshot 1`] = `
 Object {
   "edges": Array [
     "a",

--- a/src/query/tap-snapshots/test/pseudo/score.ts.test.cjs
+++ b/src/query/tap-snapshots/test/pseudo/score.ts.test.cjs
@@ -50,7 +50,33 @@ Object {
 }
 `
 
+exports[`test/pseudo/score.ts > TAP > selects packages based on their security score > greater than comparator (unquoted) > must match snapshot 1`] = `
+Object {
+  "edges": Array [
+    "a",
+    "d",
+  ],
+  "nodes": Array [
+    "a",
+    "d",
+  ],
+}
+`
+
 exports[`test/pseudo/score.ts > TAP > selects packages based on their security score > greater than comparator > must match snapshot 1`] = `
+Object {
+  "edges": Array [
+    "a",
+    "d",
+  ],
+  "nodes": Array [
+    "a",
+    "d",
+  ],
+}
+`
+
+exports[`test/pseudo/score.ts > TAP > selects packages based on their security score > greater than or equal comparator (unquoted) > must match snapshot 1`] = `
 Object {
   "edges": Array [
     "a",
@@ -76,7 +102,35 @@ Object {
 }
 `
 
+exports[`test/pseudo/score.ts > TAP > selects packages based on their security score > less than comparator (unquoted) > must match snapshot 1`] = `
+Object {
+  "edges": Array [
+    "e",
+    "c",
+    "e",
+  ],
+  "nodes": Array [
+    "c",
+    "e",
+  ],
+}
+`
+
 exports[`test/pseudo/score.ts > TAP > selects packages based on their security score > less than comparator > must match snapshot 1`] = `
+Object {
+  "edges": Array [
+    "e",
+    "c",
+    "e",
+  ],
+  "nodes": Array [
+    "c",
+    "e",
+  ],
+}
+`
+
+exports[`test/pseudo/score.ts > TAP > selects packages based on their security score > less than or equal comparator (unquoted) > must match snapshot 1`] = `
 Object {
   "edges": Array [
     "e",

--- a/src/query/test/pseudo/published.ts
+++ b/src/query/test/pseudo/published.ts
@@ -106,6 +106,36 @@ const getState = (query: string, graph = getSemverRichGraph()) => {
 t.test('select from published definition', async t => {
   t.capture(console, 'warn')
 
+  await t.test('published exact time', async t => {
+    const res = await published(
+      getState(':published(2024-01-01T11:11:11.111Z)'),
+    )
+    t.strictSame(
+      [...res.partial.nodes].map(n => n.name),
+      ['a'],
+      'should have expected result using exact date match',
+    )
+    t.matchSnapshot({
+      nodes: [...res.partial.nodes].map(n => n.name),
+      edges: [...res.partial.edges].map(e => e.name),
+    })
+  })
+
+  await t.test('published exact time (quoted)', async t => {
+    const res = await published(
+      getState(':published("2024-01-01T11:11:11.111Z")'),
+    )
+    t.strictSame(
+      [...res.partial.nodes].map(n => n.name),
+      ['a'],
+      'should have expected result using greater than date',
+    )
+    t.matchSnapshot({
+      nodes: [...res.partial.nodes].map(n => n.name),
+      edges: [...res.partial.edges].map(e => e.name),
+    })
+  })
+
   await t.test('published exact date', async t => {
     const res = await published(getState(':published(2024-01-01)'))
     t.strictSame(
@@ -119,7 +149,7 @@ t.test('select from published definition', async t => {
     })
   })
 
-  await t.test('published greater than date', async t => {
+  await t.test('published greater than date (quoted)', async t => {
     const res = await published(getState(':published(">2024-02-01")'))
     t.strictSame(
       [...res.partial.nodes].map(n => n.name),
@@ -132,14 +162,12 @@ t.test('select from published definition', async t => {
     })
   })
 
-  await t.test('published greater than or equal date', async t => {
-    const res = await published(
-      getState(':published(">=2024-02-01")'),
-    )
+  await t.test('published greater than date (unquoted)', async t => {
+    const res = await published(getState(':published(>2024-02-01)'))
     t.strictSame(
       [...res.partial.nodes].map(n => n.name),
-      ['b', 'c', 'd', 'e'],
-      'should have expected result using greater than date',
+      ['c', 'd', 'e'],
+      'should have expected result using unquoted greater than date',
     )
     t.matchSnapshot({
       nodes: [...res.partial.nodes].map(n => n.name),
@@ -147,7 +175,43 @@ t.test('select from published definition', async t => {
     })
   })
 
-  await t.test('published less than date', async t => {
+  await t.test(
+    'published greater than or equal date (quoted)',
+    async t => {
+      const res = await published(
+        getState(':published(">=2024-02-01")'),
+      )
+      t.strictSame(
+        [...res.partial.nodes].map(n => n.name),
+        ['b', 'c', 'd', 'e'],
+        'should have expected result using greater than date',
+      )
+      t.matchSnapshot({
+        nodes: [...res.partial.nodes].map(n => n.name),
+        edges: [...res.partial.edges].map(e => e.name),
+      })
+    },
+  )
+
+  await t.test(
+    'published greater than or equal date (unquoted)',
+    async t => {
+      const res = await published(
+        getState(':published(>=2024-02-01)'),
+      )
+      t.strictSame(
+        [...res.partial.nodes].map(n => n.name),
+        ['b', 'c', 'd', 'e'],
+        'should have expected result using unquoted greater than or equal date',
+      )
+      t.matchSnapshot({
+        nodes: [...res.partial.nodes].map(n => n.name),
+        edges: [...res.partial.edges].map(e => e.name),
+      })
+    },
+  )
+
+  await t.test('published less than date (quoted)', async t => {
     const res = await published(getState(':published("<2024-02-01")'))
     t.strictSame(
       [...res.partial.nodes].map(n => n.name),
@@ -160,20 +224,54 @@ t.test('select from published definition', async t => {
     })
   })
 
-  await t.test('published less than or equal date', async t => {
-    const res = await published(
-      getState(':published("<=2024-02-01")'),
-    )
+  await t.test('published less than date (unquoted)', async t => {
+    const res = await published(getState(':published(<2024-02-01)'))
     t.strictSame(
       [...res.partial.nodes].map(n => n.name),
-      ['a', 'b'],
-      'should have expected result using less than or equal date',
+      ['a'],
+      'should have expected result using unquoted less than date',
     )
     t.matchSnapshot({
       nodes: [...res.partial.nodes].map(n => n.name),
       edges: [...res.partial.edges].map(e => e.name),
     })
   })
+
+  await t.test(
+    'published less than or equal date (quoted)',
+    async t => {
+      const res = await published(
+        getState(':published("<=2024-02-01")'),
+      )
+      t.strictSame(
+        [...res.partial.nodes].map(n => n.name),
+        ['a', 'b'],
+        'should have expected result using less than or equal date',
+      )
+      t.matchSnapshot({
+        nodes: [...res.partial.nodes].map(n => n.name),
+        edges: [...res.partial.edges].map(e => e.name),
+      })
+    },
+  )
+
+  await t.test(
+    'published less than or equal date (unquoted)',
+    async t => {
+      const res = await published(
+        getState(':published(<=2024-02-01)'),
+      )
+      t.strictSame(
+        [...res.partial.nodes].map(n => n.name),
+        ['a', 'b'],
+        'should have expected result using unquoted less than or equal date',
+      )
+      t.matchSnapshot({
+        nodes: [...res.partial.nodes].map(n => n.name),
+        edges: [...res.partial.edges].map(e => e.name),
+      })
+    },
+  )
 
   await t.test('invalid pseudo selector usage', async t => {
     await t.rejects(
@@ -185,15 +283,46 @@ t.test('select from published definition', async t => {
 })
 
 t.test('parseInternals', async t => {
-  const ast = postcssSelectorParser().astSync(
-    ':published(">2024-01-01")',
-  )
-  const nodes = asPostcssNodeWithChildren(ast.first.first).nodes
-  const internals = parseInternals(nodes)
-  t.strictSame(
-    internals,
-    { relativeDate: '2024-01-01', comparator: '>' },
-    'should correctly parse internals from published selector',
+  await t.test('with quoted parameter', async t => {
+    const ast = postcssSelectorParser().astSync(
+      ':published(">2024-01-01")',
+    )
+    const nodes = asPostcssNodeWithChildren(ast.first.first).nodes
+    const internals = parseInternals(nodes)
+    t.strictSame(
+      internals,
+      { relativeDate: '2024-01-01', comparator: '>' },
+      'should correctly parse internals from published selector with quoted parameter',
+    )
+  })
+
+  await t.test('with unquoted parameter', async t => {
+    const ast = postcssSelectorParser().astSync(
+      ':published(>2024-01-01)',
+    )
+    const nodes = asPostcssNodeWithChildren(ast.first.first).nodes
+    const internals = parseInternals(nodes)
+    t.strictSame(
+      internals,
+      { relativeDate: '2024-01-01', comparator: '>' },
+      'should correctly parse internals from published selector with unquoted parameter',
+    )
+  })
+
+  await t.test(
+    'with unquoted greater than or equal parameter',
+    async t => {
+      const ast = postcssSelectorParser().astSync(
+        ':published(>=2024-01-01)',
+      )
+      const nodes = asPostcssNodeWithChildren(ast.first.first).nodes
+      const internals = parseInternals(nodes)
+      t.strictSame(
+        internals,
+        { relativeDate: '2024-01-01', comparator: '>=' },
+        'should correctly parse internals from published selector with unquoted >= parameter',
+      )
+    },
   )
 })
 

--- a/src/query/test/pseudo/score.ts
+++ b/src/query/test/pseudo/score.ts
@@ -166,12 +166,38 @@ t.test('selects packages based on their security score', async t => {
     })
   })
 
+  await t.test('greater than comparator (unquoted)', async t => {
+    const res = await score(getState(':score(>0.8)'))
+    t.strictSame(
+      [...res.partial.nodes].map(n => n.name),
+      ['a', 'd'],
+      'should select packages with overall score greater than 0.8 using unquoted parameter',
+    )
+    t.matchSnapshot({
+      nodes: [...res.partial.nodes].map(n => n.name),
+      edges: [...res.partial.edges].map(e => e.name),
+    })
+  })
+
   await t.test('less than comparator', async t => {
     const res = await score(getState(':score("<0.5")'))
     t.strictSame(
       [...res.partial.nodes].map(n => n.name),
       ['c', 'e'],
       'should select packages with overall score less than 0.5',
+    )
+    t.matchSnapshot({
+      nodes: [...res.partial.nodes].map(n => n.name),
+      edges: [...res.partial.edges].map(e => e.name),
+    })
+  })
+
+  await t.test('less than comparator (unquoted)', async t => {
+    const res = await score(getState(':score(<0.5)'))
+    t.strictSame(
+      [...res.partial.nodes].map(n => n.name),
+      ['c', 'e'],
+      'should select packages with overall score less than 0.5 using unquoted parameter',
     )
     t.matchSnapshot({
       nodes: [...res.partial.nodes].map(n => n.name),
@@ -192,6 +218,22 @@ t.test('selects packages based on their security score', async t => {
     })
   })
 
+  await t.test(
+    'greater than or equal comparator (unquoted)',
+    async t => {
+      const res = await score(getState(':score(>=0.75)'))
+      t.strictSame(
+        [...res.partial.nodes].map(n => n.name),
+        ['a', 'd'],
+        'should select packages with overall score greater than or equal to 0.75 using unquoted parameter',
+      )
+      t.matchSnapshot({
+        nodes: [...res.partial.nodes].map(n => n.name),
+        edges: [...res.partial.edges].map(e => e.name),
+      })
+    },
+  )
+
   await t.test('less than or equal comparator', async t => {
     const res = await score(getState(':score(<=40)'))
     t.strictSame(
@@ -204,6 +246,22 @@ t.test('selects packages based on their security score', async t => {
       edges: [...res.partial.edges].map(e => e.name),
     })
   })
+
+  await t.test(
+    'less than or equal comparator (unquoted)',
+    async t => {
+      const res = await score(getState(':score(<=40)'))
+      t.strictSame(
+        [...res.partial.nodes].map(n => n.name),
+        ['c', 'e'],
+        'should select packages with overall score less than or equal to 0.4 (40%) using unquoted parameter',
+      )
+      t.matchSnapshot({
+        nodes: [...res.partial.nodes].map(n => n.name),
+        edges: [...res.partial.edges].map(e => e.name),
+      })
+    },
+  )
 
   await t.test('with specific kind parameter', async t => {
     const res = await score(getState(':score("0.95", license)'))


### PR DESCRIPTION
Fixes using unquoted values as parameters for both the `:published` and `:score` pseudo selectors.

Example:

    :score(>50)

    :published(>=2024)