### PR TITLE
query: refactor id selector parser

### DIFF
--- a/src/query/src/id.ts
+++ b/src/query/src/id.ts
@@ -1,26 +1,43 @@
 import { error } from '@vltpkg/error-cause'
 import { asIdentifierNode } from './types.ts'
 import type { ParserState } from './types.ts'
-import {
-  attributeSelectorsMap,
-  filterAttributes,
-} from './attribute.ts'
 
 /**
  * Parse ids, e.g: `#foo`
  */
-export const id = async (state: ParserState) => {
+export const id = async (
+  state: ParserState,
+): Promise<ParserState> => {
   const { value } = asIdentifierNode(state.current)
-  const comparator = attributeSelectorsMap.get('=')
 
   /* c8 ignore start - should not be possible */
   if (!value) {
     throw error('Missing identifier name')
   }
-  if (!comparator) {
-    throw error('Could not find attribute selector comparator')
-  }
   /* c8 ignore stop */
 
-  return filterAttributes(state, comparator, value, 'name', true)
+  // Filter out any edges and their linked
+  // nodes if they don't match the id value
+  for (const edge of state.partial.edges) {
+    if (edge.name !== value) {
+      state.partial.edges.delete(edge)
+      if (edge.to) {
+        state.partial.nodes.delete(edge.to)
+      }
+    }
+  }
+
+  // Filter out importer nodes, this extra step is needed
+  // to filter out nodes that have no edges linking to them
+  for (const node of state.partial.nodes) {
+    if (
+      node.edgesIn.size === 0 &&
+      node.name !== value &&
+      state.partial.nodes.has(node)
+    ) {
+      state.partial.nodes.delete(node)
+    }
+  }
+
+  return state
 }

--- a/src/query/src/index.ts
+++ b/src/query/src/index.ts
@@ -2,7 +2,7 @@ import { error } from '@vltpkg/error-cause'
 import type { EdgeLike, GraphLike, NodeLike } from '@vltpkg/graph'
 import type { SpecOptions } from '@vltpkg/spec/browser'
 import type { SecurityArchiveLike } from '@vltpkg/security-archive'
-import postcssSelectorParser from 'postcss-selector-parser'
+import { parse } from './parser.ts'
 import { attribute } from './attribute.ts'
 import { classFn } from './class.ts'
 import { combinator } from './combinator.ts'
@@ -398,7 +398,7 @@ export class Query {
         })
         signal?.throwIfAborted()
       },
-      current: postcssSelectorParser().astSync(query),
+      current: parse(query),
       initial: {
         nodes: new Set(nodes),
         edges: new Set(edges),

--- a/src/query/src/index.ts
+++ b/src/query/src/index.ts
@@ -433,7 +433,7 @@ export class Query {
 
     const ast = (q: string) => {
       try {
-        return postcssSelectorParser().astSync(q)
+        return parse(q)
       } catch (_e) {
         return ast(q.slice(0, -1))
       }

--- a/src/query/src/parser.ts
+++ b/src/query/src/parser.ts
@@ -1,0 +1,19 @@
+import postcssSelectorParser from 'postcss-selector-parser'
+import type { Root } from 'postcss-selector-parser'
+
+/**
+ * Escapes forward slashes in specific patterns matching @scoped/name paths
+ * This will allow usage of unescaped forward slashes necessary for scoped
+ * package names in the id selector.
+ */
+export const escapeScopedNamesSlashes = (query: string): string =>
+  query.replace(/(#@\w+)\//gm, (_, scope: string) => `${scope}\\/`)
+
+/**
+ * Parses a CSS selector string into an AST
+ * Handles escaping of forward slashes in specific patterns
+ */
+export const parse = (query: string): Root => {
+  const escapedQuery = escapeScopedNamesSlashes(query)
+  return postcssSelectorParser().astSync(escapedQuery)
+}

--- a/src/query/tap-snapshots/test/id.ts.test.cjs
+++ b/src/query/tap-snapshots/test/id.ts.test.cjs
@@ -5,6 +5,62 @@
  * Make sure to inspect the output below.  Do not ignore changes!
  */
 'use strict'
+exports[`test/id.ts > TAP > id > aliased graph > query > "#a" 1`] = `
+Object {
+  "edges": Array [
+    "a",
+  ],
+  "nodes": Array [
+    "a",
+  ],
+}
+`
+
+exports[`test/id.ts > TAP > id > aliased graph > query > "#a" 2`] = `
+Object {
+  "edges": Array [],
+  "nodes": Array [],
+}
+`
+
+exports[`test/id.ts > TAP > id > aliased graph > query > "#aliased-project" 1`] = `
+Object {
+  "edges": Array [],
+  "nodes": Array [
+    "aliased-project",
+  ],
+}
+`
+
+exports[`test/id.ts > TAP > id > aliased graph > query > "#b" 1`] = `
+Object {
+  "edges": Array [
+    "b",
+  ],
+  "nodes": Array [
+    "foo",
+  ],
+}
+`
+
+exports[`test/id.ts > TAP > id > aliased graph > query > "#bar" 1`] = `
+Object {
+  "edges": Array [
+    "bar",
+  ],
+  "nodes": Array [
+    "d",
+  ],
+}
+`
+
+exports[`test/id.ts > TAP > id > aliased graph > query > "#foo" 1`] = `
+Object {
+  "edges": Array [],
+  "nodes": Array [],
+}
+`
+
 exports[`test/id.ts > TAP > id > query > "#a" 1`] = `
 Object {
   "edges": Array [

--- a/src/query/tap-snapshots/test/pseudo/deprecated.ts.test.cjs
+++ b/src/query/tap-snapshots/test/pseudo/deprecated.ts.test.cjs
@@ -5,7 +5,7 @@
  * Make sure to inspect the output below.  Do not ignore changes!
  */
 'use strict'
-exports[`test/pseudo/deprecated.ts > TAP > selects packages with a deprecated alert > filter out any node that does not have the alert > must match snapshot 1`] = `
+exports[`test/pseudo/deprecated.ts > TAP > selects packages with deprecated alert > filter out any node that does not have the alert > must match snapshot 1`] = `
 Object {
   "edges": Array [
     "e",

--- a/src/query/test/fixtures/selector.ts
+++ b/src/query/test/fixtures/selector.ts
@@ -1,4 +1,4 @@
-import postcssSelectorParser from 'postcss-selector-parser'
+import { parse } from '../../src/parser.ts'
 import type { EdgeLike, GraphLike, NodeLike } from '@vltpkg/graph'
 import { joinDepIDTuple } from '@vltpkg/dep-id'
 import type {
@@ -66,7 +66,7 @@ export const selectorFixture =
     }
     let current: PostcssNode
     if (typeof query === 'string') {
-      const ast = postcssSelectorParser().astSync(query)
+      const ast = parse(query)
       // if the testing function handles a fully parsed
       // css ast then just use that instead
       current =

--- a/src/query/test/parser.ts
+++ b/src/query/test/parser.ts
@@ -1,0 +1,71 @@
+import t from 'tap'
+import postcssSelectorParser from 'postcss-selector-parser'
+import { parse, escapeScopedNamesSlashes } from '../src/parser.ts'
+
+t.test('escapeScopedNamesSlashes', async t => {
+  t.equal(
+    escapeScopedNamesSlashes('#@scope/package'),
+    '#@scope\\/package',
+    'should escape forward slash in #@scope/package pattern',
+  )
+
+  t.equal(
+    escapeScopedNamesSlashes('#@multiple/package #@another/pkg'),
+    '#@multiple\\/package #@another\\/pkg',
+    'should escape multiple instances of the pattern',
+  )
+
+  t.equal(
+    escapeScopedNamesSlashes('#@name/package[attr]'),
+    '#@name\\/package[attr]',
+    'should work with attribute selectors',
+  )
+
+  t.equal(
+    escapeScopedNamesSlashes('#regular #@123/456'),
+    '#regular #@123\\/456',
+    'should work with numeric components',
+  )
+
+  t.equal(
+    escapeScopedNamesSlashes('#regular-selector'),
+    '#regular-selector',
+    'should not modify strings without the specific pattern',
+  )
+
+  t.equal(
+    escapeScopedNamesSlashes('a > b #@xyz/abc'),
+    'a > b #@xyz\\/abc',
+    'should work with combinators',
+  )
+})
+
+t.test('parse', async t => {
+  // Test basic parsing
+  t.ok(parse(':root > *'), 'should parse simple selectors')
+
+  // Compare with direct postcss parser for equivalence (minus the escaping)
+  const simpleSelector = 'div > span'
+  const directAst = postcssSelectorParser().astSync(simpleSelector)
+  const ourAst = parse(simpleSelector)
+
+  t.same(
+    ourAst.toString(),
+    directAst.toString(),
+    'should produce equivalent AST to direct postcss parser',
+  )
+
+  // Test with a selector that needs escaping
+  const selectorWithScoped = '#@scope/package'
+  t.doesNotThrow(
+    () => parse(selectorWithScoped),
+    'should parse selectors with scoped packages without throwing',
+  )
+
+  // Test a complex selector
+  const complexSelector = 'a > #@scope/pkg.class:pseudo[attr=val]'
+  t.ok(
+    parse(complexSelector),
+    'should parse complex selectors with scoped packages',
+  )
+})

--- a/src/query/test/pseudo/abandoned.ts
+++ b/src/query/test/pseudo/abandoned.ts
@@ -1,14 +1,14 @@
 import t from 'tap'
-import postcssSelectorParser from 'postcss-selector-parser'
 import { joinDepIDTuple } from '@vltpkg/dep-id'
 import { asSecurityArchiveLike } from '@vltpkg/security-archive'
 import { getSimpleGraph } from '../fixtures/graph.ts'
 import type { ParserState } from '../../src/types.ts'
+import { parse } from '../../src/parser.ts'
 import { abandoned } from '../../src/pseudo/abandoned.ts'
 
 t.test('selects packages with an abandoned alert', async t => {
   const getState = (query: string, graph = getSimpleGraph()) => {
-    const ast = postcssSelectorParser().astSync(query)
+    const ast = parse(query)
     const current = ast.first.first
     const state: ParserState = {
       current,
@@ -59,7 +59,7 @@ t.test('selects packages with an abandoned alert', async t => {
 
 t.test('missing security archive', async t => {
   const getState = (query: string) => {
-    const ast = postcssSelectorParser().astSync(query)
+    const ast = parse(query)
     const current = ast.first.first
     const state: ParserState = {
       current,

--- a/src/query/test/pseudo/confused.ts
+++ b/src/query/test/pseudo/confused.ts
@@ -1,14 +1,14 @@
 import t from 'tap'
-import postcssSelectorParser from 'postcss-selector-parser'
 import { joinDepIDTuple } from '@vltpkg/dep-id'
 import { asSecurityArchiveLike } from '@vltpkg/security-archive'
 import { getSimpleGraph } from '../fixtures/graph.ts'
 import type { ParserState } from '../../src/types.ts'
+import { parse } from '../../src/parser.ts'
 import { confused } from '../../src/pseudo/confused.ts'
 
 t.test('selects packages with a manifestConfusion alert', async t => {
   const getState = (query: string, graph = getSimpleGraph()) => {
-    const ast = postcssSelectorParser().astSync(query)
+    const ast = parse(query)
     const current = ast.first.first
     const state: ParserState = {
       current,
@@ -59,7 +59,7 @@ t.test('selects packages with a manifestConfusion alert', async t => {
 
 t.test('missing security archive', async t => {
   const getState = (query: string) => {
-    const ast = postcssSelectorParser().astSync(query)
+    const ast = parse(query)
     const current = ast.first.first
     const state: ParserState = {
       current,

--- a/src/query/test/pseudo/cve.ts
+++ b/src/query/test/pseudo/cve.ts
@@ -1,5 +1,4 @@
 import t from 'tap'
-import postcssSelectorParser from 'postcss-selector-parser'
 import { joinDepIDTuple } from '@vltpkg/dep-id'
 import {
   asPackageReportData,
@@ -7,11 +6,12 @@ import {
 } from '@vltpkg/security-archive'
 import { getSimpleGraph } from '../fixtures/graph.ts'
 import type { ParserState } from '../../src/types.ts'
+import { parse } from '../../src/parser.ts'
 import { cve } from '../../src/pseudo/cve.ts'
 
 t.test('selects packages with a CVE alert', async t => {
   const getState = (query: string, graph = getSimpleGraph()) => {
-    const ast = postcssSelectorParser().astSync(query)
+    const ast = parse(query)
     const current = ast.first.first
     const state: ParserState = {
       current,
@@ -119,7 +119,7 @@ t.test('selects packages with a CVE alert', async t => {
 
 t.test('missing security archive', async t => {
   const getState = (query: string) => {
-    const ast = postcssSelectorParser().astSync(query)
+    const ast = parse(query)
     const current = ast.first.first
     const state: ParserState = {
       current,
@@ -153,7 +153,7 @@ t.test('missing security archive', async t => {
 
 t.test('missing CVE ID', async t => {
   const getState = (query: string) => {
-    const ast = postcssSelectorParser().astSync(query)
+    const ast = parse(query)
     const current = ast.first.first
     const state: ParserState = {
       current,

--- a/src/query/test/pseudo/cwe.ts
+++ b/src/query/test/pseudo/cwe.ts
@@ -1,15 +1,15 @@
 import t from 'tap'
-import postcssSelectorParser from 'postcss-selector-parser'
 import { joinDepIDTuple } from '@vltpkg/dep-id'
 import { asSecurityArchiveLike } from '@vltpkg/security-archive'
 import type { PackageReportData } from '@vltpkg/security-archive'
 import { getSimpleGraph } from '../fixtures/graph.ts'
 import type { ParserState } from '../../src/types.ts'
 import { cwe } from '../../src/pseudo/cwe.ts'
+import { parse } from '../../src/parser.ts'
 
 t.test('selects packages with a CWE alert', async t => {
   const getState = (query: string, graph = getSimpleGraph()) => {
-    const ast = postcssSelectorParser().astSync(query)
+    const ast = parse(query)
     const current = ast.first.first
     const state: ParserState = {
       current,
@@ -121,7 +121,7 @@ t.test('selects packages with a CWE alert', async t => {
 
 t.test('missing security archive', async t => {
   const getState = (query: string) => {
-    const ast = postcssSelectorParser().astSync(query)
+    const ast = parse(query)
     const current = ast.first.first
     const state: ParserState = {
       current,
@@ -155,7 +155,7 @@ t.test('missing security archive', async t => {
 
 t.test('missing CWE ID', async t => {
   const getState = (query: string) => {
-    const ast = postcssSelectorParser().astSync(query)
+    const ast = parse(query)
     const current = ast.first.first
     const state: ParserState = {
       current,

--- a/src/query/test/pseudo/debug.ts
+++ b/src/query/test/pseudo/debug.ts
@@ -1,14 +1,14 @@
 import t from 'tap'
-import postcssSelectorParser from 'postcss-selector-parser'
 import { joinDepIDTuple } from '@vltpkg/dep-id'
 import { asSecurityArchiveLike } from '@vltpkg/security-archive'
 import { getSimpleGraph } from '../fixtures/graph.ts'
 import type { ParserState } from '../../src/types.ts'
+import { parse } from '../../src/parser.ts'
 import { debug } from '../../src/pseudo/debug.ts'
 
 t.test('selects packages with a debugAccess alert', async t => {
   const getState = (query: string, graph = getSimpleGraph()) => {
-    const ast = postcssSelectorParser().astSync(query)
+    const ast = parse(query)
     const current = ast.first.first
     const state: ParserState = {
       current,
@@ -59,7 +59,7 @@ t.test('selects packages with a debugAccess alert', async t => {
 
 t.test('missing security archive', async t => {
   const getState = (query: string) => {
-    const ast = postcssSelectorParser().astSync(query)
+    const ast = parse(query)
     const current = ast.first.first
     const state: ParserState = {
       current,

--- a/src/query/test/pseudo/deprecated.ts
+++ b/src/query/test/pseudo/deprecated.ts
@@ -1,14 +1,14 @@
 import t from 'tap'
-import postcssSelectorParser from 'postcss-selector-parser'
 import { joinDepIDTuple } from '@vltpkg/dep-id'
 import { asSecurityArchiveLike } from '@vltpkg/security-archive'
 import { getSimpleGraph } from '../fixtures/graph.ts'
 import type { ParserState } from '../../src/types.ts'
+import { parse } from '../../src/parser.ts'
 import { deprecated } from '../../src/pseudo/deprecated.ts'
 
-t.test('selects packages with a deprecated alert', async t => {
+t.test('selects packages with deprecated alert', async t => {
   const getState = (query: string, graph = getSimpleGraph()) => {
-    const ast = postcssSelectorParser().astSync(query)
+    const ast = parse(query)
     const current = ast.first.first
     const state: ParserState = {
       current,
@@ -59,7 +59,7 @@ t.test('selects packages with a deprecated alert', async t => {
 
 t.test('missing security archive', async t => {
   const getState = (query: string) => {
-    const ast = postcssSelectorParser().astSync(query)
+    const ast = parse(query)
     const current = ast.first.first
     const state: ParserState = {
       current,

--- a/src/query/test/pseudo/dynamic.ts
+++ b/src/query/test/pseudo/dynamic.ts
@@ -1,14 +1,14 @@
 import t from 'tap'
-import postcssSelectorParser from 'postcss-selector-parser'
 import { joinDepIDTuple } from '@vltpkg/dep-id'
 import { asSecurityArchiveLike } from '@vltpkg/security-archive'
 import { getSimpleGraph } from '../fixtures/graph.ts'
 import type { ParserState } from '../../src/types.ts'
+import { parse } from '../../src/parser.ts'
 import { dynamic } from '../../src/pseudo/dynamic.ts'
 
 t.test('selects packages with a dynamicRequire alert', async t => {
   const getState = (query: string, graph = getSimpleGraph()) => {
-    const ast = postcssSelectorParser().astSync(query)
+    const ast = parse(query)
     const current = ast.first.first
     const state: ParserState = {
       current,
@@ -59,7 +59,7 @@ t.test('selects packages with a dynamicRequire alert', async t => {
 
 t.test('missing security archive', async t => {
   const getState = (query: string) => {
-    const ast = postcssSelectorParser().astSync(query)
+    const ast = parse(query)
     const current = ast.first.first
     const state: ParserState = {
       current,

--- a/src/query/test/pseudo/empty.ts
+++ b/src/query/test/pseudo/empty.ts
@@ -1,6 +1,6 @@
 import t from 'tap'
-import postcssSelectorParser from 'postcss-selector-parser'
 import type { ParserState } from '../../src/types.ts'
+import { parse } from '../../src/parser.ts'
 import { empty } from '../../src/pseudo/empty.ts'
 import {
   getSimpleGraph,
@@ -10,7 +10,7 @@ import {
 
 t.test('selects packages with no dependencies', async t => {
   const getState = (query: string, graph = getSimpleGraph()) => {
-    const ast = postcssSelectorParser().astSync(query)
+    const ast = parse(query)
     const current = ast.first.first
     const state: ParserState = {
       current,

--- a/src/query/test/pseudo/entropic.ts
+++ b/src/query/test/pseudo/entropic.ts
@@ -1,16 +1,16 @@
 import t from 'tap'
-import postcssSelectorParser from 'postcss-selector-parser'
 import { joinDepIDTuple } from '@vltpkg/dep-id'
 import { asSecurityArchiveLike } from '@vltpkg/security-archive'
 import { getSimpleGraph } from '../fixtures/graph.ts'
 import type { ParserState } from '../../src/types.ts'
+import { parse } from '../../src/parser.ts'
 import { entropic } from '../../src/pseudo/entropic.ts'
 
 t.test(
   'selects packages with a highEntropyStrings alert',
   async t => {
     const getState = (query: string, graph = getSimpleGraph()) => {
-      const ast = postcssSelectorParser().astSync(query)
+      const ast = parse(query)
       const current = ast.first.first
       const state: ParserState = {
         current,
@@ -62,7 +62,7 @@ t.test(
 
 t.test('missing security archive', async t => {
   const getState = (query: string) => {
-    const ast = postcssSelectorParser().astSync(query)
+    const ast = parse(query)
     const current = ast.first.first
     const state: ParserState = {
       current,

--- a/src/query/test/pseudo/env.ts
+++ b/src/query/test/pseudo/env.ts
@@ -1,14 +1,14 @@
 import t from 'tap'
-import postcssSelectorParser from 'postcss-selector-parser'
 import { joinDepIDTuple } from '@vltpkg/dep-id'
 import { asSecurityArchiveLike } from '@vltpkg/security-archive'
 import { getSimpleGraph } from '../fixtures/graph.ts'
 import type { ParserState } from '../../src/types.ts'
+import { parse } from '../../src/parser.ts'
 import { env } from '../../src/pseudo/env.ts'
 
 t.test('selects packages with a envVars alert', async t => {
   const getState = (query: string, graph = getSimpleGraph()) => {
-    const ast = postcssSelectorParser().astSync(query)
+    const ast = parse(query)
     const current = ast.first.first
     const state: ParserState = {
       current,
@@ -59,7 +59,7 @@ t.test('selects packages with a envVars alert', async t => {
 
 t.test('missing security archive', async t => {
   const getState = (query: string) => {
-    const ast = postcssSelectorParser().astSync(query)
+    const ast = parse(query)
     const current = ast.first.first
     const state: ParserState = {
       current,

--- a/src/query/test/pseudo/eval.ts
+++ b/src/query/test/pseudo/eval.ts
@@ -1,14 +1,14 @@
 import t from 'tap'
-import postcssSelectorParser from 'postcss-selector-parser'
 import { joinDepIDTuple } from '@vltpkg/dep-id'
 import { asSecurityArchiveLike } from '@vltpkg/security-archive'
 import { getSimpleGraph } from '../fixtures/graph.ts'
 import type { ParserState } from '../../src/types.ts'
+import { parse } from '../../src/parser.ts'
 import { evalParser } from '../../src/pseudo/eval.ts'
 
 t.test('selects packages with an eval alert', async t => {
   const getState = (query: string, graph = getSimpleGraph()) => {
-    const ast = postcssSelectorParser().astSync(query)
+    const ast = parse(query)
     const current = ast.first.first
     const state: ParserState = {
       current,
@@ -59,7 +59,7 @@ t.test('selects packages with an eval alert', async t => {
 
 t.test('missing security archive', async t => {
   const getState = (query: string) => {
-    const ast = postcssSelectorParser().astSync(query)
+    const ast = parse(query)
     const current = ast.first.first
     const state: ParserState = {
       current,

--- a/src/query/test/pseudo/fs.ts
+++ b/src/query/test/pseudo/fs.ts
@@ -1,14 +1,14 @@
 import t from 'tap'
-import postcssSelectorParser from 'postcss-selector-parser'
 import { joinDepIDTuple } from '@vltpkg/dep-id'
 import { asSecurityArchiveLike } from '@vltpkg/security-archive'
 import { getSimpleGraph } from '../fixtures/graph.ts'
 import type { ParserState } from '../../src/types.ts'
+import { parse } from '../../src/parser.ts'
 import { fs } from '../../src/pseudo/fs.ts'
 
 t.test('selects packages with a filesystemAccess alert', async t => {
   const getState = (query: string, graph = getSimpleGraph()) => {
-    const ast = postcssSelectorParser().astSync(query)
+    const ast = parse(query)
     const current = ast.first.first
     const state: ParserState = {
       current,
@@ -59,7 +59,7 @@ t.test('selects packages with a filesystemAccess alert', async t => {
 
 t.test('missing security archive', async t => {
   const getState = (query: string) => {
-    const ast = postcssSelectorParser().astSync(query)
+    const ast = parse(query)
     const current = ast.first.first
     const state: ParserState = {
       current,

--- a/src/query/test/pseudo/helpers.ts
+++ b/src/query/test/pseudo/helpers.ts
@@ -1,5 +1,4 @@
 import t from 'tap'
-import postcssSelectorParser from 'postcss-selector-parser'
 import { asSecurityArchiveLike } from '@vltpkg/security-archive'
 import {
   createSecuritySelectorFilter,
@@ -14,6 +13,7 @@ import {
 } from '../fixtures/graph.ts'
 import type { ParserState } from '../../src/types.ts'
 import { joinDepIDTuple } from '@vltpkg/dep-id/browser'
+import { parse } from '../../src/parser.ts'
 
 t.test('removeDanglingEdges', async t => {
   await t.test('graph with missing nodes', async t => {
@@ -116,7 +116,7 @@ t.test('removeQuotes', async t => {
 
 t.test('selects packages with an unmaintained alert', async t => {
   const getState = (query: string, graph = getSimpleGraph()) => {
-    const ast = postcssSelectorParser().astSync(query)
+    const ast = parse(query)
     const current = ast.first.first
     const state: ParserState = {
       current,
@@ -171,7 +171,7 @@ t.test('selects packages with an unmaintained alert', async t => {
 
 t.test('missing security archive', async t => {
   const getState = (query: string) => {
-    const ast = postcssSelectorParser().astSync(query)
+    const ast = parse(query)
     const current = ast.first.first
     const state: ParserState = {
       current,

--- a/src/query/test/pseudo/license.ts
+++ b/src/query/test/pseudo/license.ts
@@ -1,9 +1,9 @@
 import t from 'tap'
-import postcssSelectorParser from 'postcss-selector-parser'
 import { joinDepIDTuple } from '@vltpkg/dep-id'
 import { asSecurityArchiveLike } from '@vltpkg/security-archive'
 import { getSimpleGraph } from '../fixtures/graph.ts'
 import type { ParserState } from '../../src/types.ts'
+import { parse } from '../../src/parser.ts'
 import {
   license,
   isLicenseKind,
@@ -12,7 +12,7 @@ import {
 
 t.test('selects packages with a specific license kind', async t => {
   const getState = (query: string, graph = getSimpleGraph()) => {
-    const ast = postcssSelectorParser().astSync(query)
+    const ast = parse(query)
     const current = ast.first.first
     const state: ParserState = {
       current,
@@ -94,7 +94,7 @@ t.test('selects packages with a specific license kind', async t => {
 
 t.test('missing security archive', async t => {
   const getState = (query: string) => {
-    const ast = postcssSelectorParser().astSync(query)
+    const ast = parse(query)
     const current = ast.first.first
     const state: ParserState = {
       current,

--- a/src/query/test/pseudo/malware.ts
+++ b/src/query/test/pseudo/malware.ts
@@ -1,5 +1,4 @@
 import t from 'tap'
-import postcssSelectorParser from 'postcss-selector-parser'
 import { joinDepIDTuple } from '@vltpkg/dep-id'
 import { asSecurityArchiveLike } from '@vltpkg/security-archive'
 import { getSimpleGraph } from '../fixtures/graph.ts'
@@ -9,10 +8,11 @@ import {
   isMalwareKind,
   asMalwareKind,
 } from '../../src/pseudo/malware.ts'
+import { parse } from '../../src/parser.ts'
 
 t.test('selects packages with a specific malware kind', async t => {
   const getState = (query: string, graph = getSimpleGraph()) => {
-    const ast = postcssSelectorParser().astSync(query)
+    const ast = parse(query)
     const current = ast.first.first
     const state: ParserState = {
       current,
@@ -107,7 +107,7 @@ t.test('selects packages with a specific malware kind', async t => {
 
 t.test('missing security archive', async t => {
   const getState = (query: string) => {
-    const ast = postcssSelectorParser().astSync(query)
+    const ast = parse(query)
     const current = ast.first.first
     const state: ParserState = {
       current,

--- a/src/query/test/pseudo/minified.ts
+++ b/src/query/test/pseudo/minified.ts
@@ -1,14 +1,14 @@
 import t from 'tap'
-import postcssSelectorParser from 'postcss-selector-parser'
 import { joinDepIDTuple } from '@vltpkg/dep-id'
 import { asSecurityArchiveLike } from '@vltpkg/security-archive'
 import { getSimpleGraph } from '../fixtures/graph.ts'
 import type { ParserState } from '../../src/types.ts'
 import { minified } from '../../src/pseudo/minified.ts'
+import { parse } from '../../src/parser.ts'
 
 t.test('selects packages with a minifiedFile alert', async t => {
   const getState = (query: string, graph = getSimpleGraph()) => {
-    const ast = postcssSelectorParser().astSync(query)
+    const ast = parse(query)
     const current = ast.first.first
     const state: ParserState = {
       current,
@@ -59,7 +59,7 @@ t.test('selects packages with a minifiedFile alert', async t => {
 
 t.test('missing security archive', async t => {
   const getState = (query: string) => {
-    const ast = postcssSelectorParser().astSync(query)
+    const ast = parse(query)
     const current = ast.first.first
     const state: ParserState = {
       current,

--- a/src/query/test/pseudo/native.ts
+++ b/src/query/test/pseudo/native.ts
@@ -1,14 +1,14 @@
 import t from 'tap'
-import postcssSelectorParser from 'postcss-selector-parser'
 import { joinDepIDTuple } from '@vltpkg/dep-id'
 import { asSecurityArchiveLike } from '@vltpkg/security-archive'
 import { getSimpleGraph } from '../fixtures/graph.ts'
 import type { ParserState } from '../../src/types.ts'
 import { nativeParser } from '../../src/pseudo/native.ts'
+import { parse } from '../../src/parser.ts'
 
 t.test('selects packages with a hasNativeCode alert', async t => {
   const getState = (query: string, graph = getSimpleGraph()) => {
-    const ast = postcssSelectorParser().astSync(query)
+    const ast = parse(query)
     const current = ast.first.first
     const state: ParserState = {
       current,
@@ -59,7 +59,7 @@ t.test('selects packages with a hasNativeCode alert', async t => {
 
 t.test('missing security archive', async t => {
   const getState = (query: string) => {
-    const ast = postcssSelectorParser().astSync(query)
+    const ast = parse(query)
     const current = ast.first.first
     const state: ParserState = {
       current,

--- a/src/query/test/pseudo/network.ts
+++ b/src/query/test/pseudo/network.ts
@@ -1,14 +1,14 @@
 import t from 'tap'
-import postcssSelectorParser from 'postcss-selector-parser'
 import { joinDepIDTuple } from '@vltpkg/dep-id'
 import { asSecurityArchiveLike } from '@vltpkg/security-archive'
 import { getSimpleGraph } from '../fixtures/graph.ts'
 import type { ParserState } from '../../src/types.ts'
 import { network } from '../../src/pseudo/network.ts'
+import { parse } from '../../src/parser.ts'
 
 t.test('selects packages with a networkAccess alert', async t => {
   const getState = (query: string, graph = getSimpleGraph()) => {
-    const ast = postcssSelectorParser().astSync(query)
+    const ast = parse(query)
     const current = ast.first.first
     const state: ParserState = {
       current,
@@ -59,7 +59,7 @@ t.test('selects packages with a networkAccess alert', async t => {
 
 t.test('missing security archive', async t => {
   const getState = (query: string) => {
-    const ast = postcssSelectorParser().astSync(query)
+    const ast = parse(query)
     const current = ast.first.first
     const state: ParserState = {
       current,

--- a/src/query/test/pseudo/obfuscated.ts
+++ b/src/query/test/pseudo/obfuscated.ts
@@ -1,14 +1,14 @@
 import t from 'tap'
-import postcssSelectorParser from 'postcss-selector-parser'
 import { joinDepIDTuple } from '@vltpkg/dep-id'
 import { asSecurityArchiveLike } from '@vltpkg/security-archive'
 import { getSimpleGraph } from '../fixtures/graph.ts'
 import type { ParserState } from '../../src/types.ts'
 import { obfuscated } from '../../src/pseudo/obfuscated.ts'
+import { parse } from '../../src/parser.ts'
 
 t.test('selects packages with an obfuscated alert', async t => {
   const getState = (query: string, graph = getSimpleGraph()) => {
-    const ast = postcssSelectorParser().astSync(query)
+    const ast = parse(query)
     const current = ast.first.first
     const state: ParserState = {
       current,
@@ -59,7 +59,7 @@ t.test('selects packages with an obfuscated alert', async t => {
 
 t.test('missing security archive', async t => {
   const getState = (query: string) => {
-    const ast = postcssSelectorParser().astSync(query)
+    const ast = parse(query)
     const current = ast.first.first
     const state: ParserState = {
       current,

--- a/src/query/test/pseudo/outdated.ts
+++ b/src/query/test/pseudo/outdated.ts
@@ -2,7 +2,6 @@ import t from 'tap'
 import type { SpecOptions } from '@vltpkg/spec/browser'
 import { joinDepIDTuple } from '@vltpkg/dep-id'
 import type { NodeLike } from '@vltpkg/graph'
-import postcssSelectorParser from 'postcss-selector-parser'
 import {
   outdated,
   parseInternals,
@@ -15,6 +14,7 @@ import {
   getSemverRichGraph,
   getSimpleGraph,
 } from '../fixtures/graph.ts'
+import { parse } from '../../src/parser.ts'
 
 const specOptions = {
   registry: 'https://registry.npmjs.org',
@@ -113,7 +113,7 @@ global.fetch = (async (url: string) => {
 }) as unknown as typeof global.fetch
 
 const getState = (query: string, graph = getSemverRichGraph()) => {
-  const ast = postcssSelectorParser().astSync(query)
+  const ast = parse(query)
   const current = asPostcssNodeWithChildren(ast.first.first)
   const state: ParserState = {
     current,
@@ -245,7 +245,7 @@ t.test('select from outdated definition', async t => {
 })
 
 t.test('parseInternals', async t => {
-  const ast = postcssSelectorParser().astSync(':outdated(any)')
+  const ast = parse(':outdated(any)')
   const nodes = asPostcssNodeWithChildren(ast.first.first).nodes
   const internals = parseInternals(nodes)
   t.strictSame(
@@ -256,9 +256,7 @@ t.test('parseInternals', async t => {
 })
 
 t.test('invalid outdated kind', async t => {
-  const ast = postcssSelectorParser().astSync(
-    ':outdated(unsupported)',
-  )
+  const ast = parse(':outdated(unsupported)')
   const nodes = asPostcssNodeWithChildren(ast.first.first).nodes
   t.throws(
     () => parseInternals(nodes),

--- a/src/query/test/pseudo/published.ts
+++ b/src/query/test/pseudo/published.ts
@@ -2,7 +2,7 @@ import t from 'tap'
 import type { SpecOptions } from '@vltpkg/spec/browser'
 import { joinDepIDTuple } from '@vltpkg/dep-id'
 import type { NodeLike } from '@vltpkg/graph'
-import postcssSelectorParser from 'postcss-selector-parser'
+import { parse } from '../../src/parser.ts'
 import {
   published,
   parseInternals,
@@ -78,8 +78,8 @@ global.fetch = (async (url: string) => {
 }) as unknown as typeof global.fetch
 
 const getState = (query: string, graph = getSemverRichGraph()) => {
-  const ast = postcssSelectorParser().astSync(query)
-  const current = asPostcssNodeWithChildren(ast.first.first)
+  const ast = parse(query)
+  const current = ast.first.first
   const state: ParserState = {
     current,
     initial: {
@@ -185,9 +185,7 @@ t.test('select from published definition', async t => {
 })
 
 t.test('parseInternals', async t => {
-  const ast = postcssSelectorParser().astSync(
-    ':published(">2024-01-01")',
-  )
+  const ast = parse(':published(">2024-01-01")')
   const nodes = asPostcssNodeWithChildren(ast.first.first).nodes
   const internals = parseInternals(nodes)
   t.strictSame(

--- a/src/query/test/pseudo/scanned.ts
+++ b/src/query/test/pseudo/scanned.ts
@@ -1,16 +1,16 @@
 import t from 'tap'
-import postcssSelectorParser from 'postcss-selector-parser'
 import { joinDepIDTuple } from '@vltpkg/dep-id'
 import { asSecurityArchiveLike } from '@vltpkg/security-archive'
 import type { PackageReportData } from '@vltpkg/security-archive'
 import { scanned } from '../../src/pseudo/scanned.ts'
 import { getSimpleGraph } from '../fixtures/graph.ts'
 import type { ParserState } from '../../src/types.ts'
+import { parse } from '../../src/parser.ts'
 
 t.test('scanned selector', async t => {
   const getState = () => {
     const graph = getSimpleGraph()
-    const ast = postcssSelectorParser().astSync(':scanned')
+    const ast = parse(':scanned')
     const current = ast.first.first
     const testId = joinDepIDTuple(['registry', '', 'e@1.0.0'])
     const securityArchive = asSecurityArchiveLike(

--- a/src/query/test/pseudo/score.ts
+++ b/src/query/test/pseudo/score.ts
@@ -1,5 +1,4 @@
 import t from 'tap'
-import postcssSelectorParser from 'postcss-selector-parser'
 import { joinDepIDTuple } from '@vltpkg/dep-id'
 import { asSecurityArchiveLike } from '@vltpkg/security-archive'
 import { getSimpleGraph } from '../fixtures/graph.ts'
@@ -10,6 +9,7 @@ import {
   asScoreKind,
 } from '../../src/pseudo/score.ts'
 import type { PackageScore } from '@vltpkg/security-archive'
+import { parse } from '../../src/parser.ts'
 
 // Create a function to generate a security archive with varied scores for testing
 const createTestSecurityArchive = () => {
@@ -89,7 +89,7 @@ const createTestSecurityArchive = () => {
 
 t.test('selects packages based on their security score', async t => {
   const getState = (query: string, graph = getSimpleGraph()) => {
-    const ast = postcssSelectorParser().astSync(query)
+    const ast = parse(query)
     const current = ast.first.first
     const state: ParserState = {
       current,
@@ -288,7 +288,7 @@ t.test('error cases', async t => {
   // Test with missing security archive
   await t.test('missing security archive', async t => {
     const getState = (query: string) => {
-      const ast = postcssSelectorParser().astSync(query)
+      const ast = parse(query)
       const current = ast.first.first
       const state: ParserState = {
         current,
@@ -323,7 +323,7 @@ t.test('error cases', async t => {
   // Test with invalid rate value
   await t.test('invalid rate value - too high', async t => {
     const getState = (query: string) => {
-      const ast = postcssSelectorParser().astSync(query)
+      const ast = parse(query)
       const current = ast.first.first
       const state: ParserState = {
         current,
@@ -358,7 +358,7 @@ t.test('error cases', async t => {
   // Test with invalid rate value - negative
   await t.test('invalid rate value - negative', async t => {
     const getState = (query: string) => {
-      const ast = postcssSelectorParser().astSync(query)
+      const ast = parse(query)
       const current = ast.first.first
       const state: ParserState = {
         current,
@@ -393,7 +393,7 @@ t.test('error cases', async t => {
   // Test with invalid kind
   await t.test('invalid kind parameter', async t => {
     const getState = (query: string) => {
-      const ast = postcssSelectorParser().astSync(query)
+      const ast = parse(query)
       const current = ast.first.first
       const state: ParserState = {
         current,

--- a/src/query/test/pseudo/scripts.ts
+++ b/src/query/test/pseudo/scripts.ts
@@ -1,14 +1,14 @@
 import t from 'tap'
-import postcssSelectorParser from 'postcss-selector-parser'
 import { joinDepIDTuple } from '@vltpkg/dep-id'
 import { asSecurityArchiveLike } from '@vltpkg/security-archive'
 import { getSimpleGraph } from '../fixtures/graph.ts'
 import type { ParserState } from '../../src/types.ts'
 import { scripts } from '../../src/pseudo/scripts.ts'
+import { parse } from '../../src/parser.ts'
 
 t.test('selects packages with an installScripts alert', async t => {
   const getState = (query: string, graph = getSimpleGraph()) => {
-    const ast = postcssSelectorParser().astSync(query)
+    const ast = parse(query)
     const current = ast.first.first
     const state: ParserState = {
       current,
@@ -59,7 +59,7 @@ t.test('selects packages with an installScripts alert', async t => {
 
 t.test('missing security archive', async t => {
   const getState = (query: string) => {
-    const ast = postcssSelectorParser().astSync(query)
+    const ast = parse(query)
     const current = ast.first.first
     const state: ParserState = {
       current,

--- a/src/query/test/pseudo/semver.ts
+++ b/src/query/test/pseudo/semver.ts
@@ -1,5 +1,4 @@
 import t from 'tap'
-import postcssSelectorParser from 'postcss-selector-parser'
 import {
   asSemverFunctionName,
   isSemverFunctionName,
@@ -12,10 +11,11 @@ import {
   getSemverRichGraph,
   getSimpleGraph,
 } from '../fixtures/graph.ts'
+import { parse } from '../../src/parser.ts'
 
 t.test('select from semver definition', async t => {
   const getState = (query: string, graph = getSimpleGraph()) => {
-    const ast = postcssSelectorParser().astSync(query)
+    const ast = parse(query)
     const current = asPostcssNodeWithChildren(ast.first.first)
     const state: ParserState = {
       current,
@@ -508,7 +508,7 @@ t.test('asSemverFunctionName', async t => {
 })
 
 t.test('parse an element other than semver', async t => {
-  const ast = postcssSelectorParser().astSync(':root')
+  const ast = parse(':root')
   const notSemver = asPostcssNodeWithChildren(ast.first.first).nodes
   t.throws(
     () => parseInternals(notSemver, false),
@@ -518,9 +518,7 @@ t.test('parse an element other than semver', async t => {
 })
 
 t.test('parse an invalid semver function name', async t => {
-  const ast = postcssSelectorParser().astSync(
-    ':semver(^1.0.0, ":unsupported")',
-  )
+  const ast = parse(':semver(^1.0.0, ":unsupported")')
   const notSemver = asPostcssNodeWithChildren(ast.first.first).nodes
   t.throws(
     () => parseInternals(notSemver, false),

--- a/src/query/test/pseudo/severity.ts
+++ b/src/query/test/pseudo/severity.ts
@@ -1,5 +1,4 @@
 import t from 'tap'
-import postcssSelectorParser from 'postcss-selector-parser'
 import { joinDepIDTuple } from '@vltpkg/dep-id'
 import { asSecurityArchiveLike } from '@vltpkg/security-archive'
 import { getSimpleGraph } from '../fixtures/graph.ts'
@@ -9,10 +8,11 @@ import {
   isSeverityKind,
   asSeverityKind,
 } from '../../src/pseudo/severity.ts'
+import { parse } from '../../src/parser.ts'
 
 t.test('selects packages with a specific severity kind', async t => {
   const getState = (query: string, graph = getSimpleGraph()) => {
-    const ast = postcssSelectorParser().astSync(query)
+    const ast = parse(query)
     const current = ast.first.first
     const state: ParserState = {
       current,
@@ -107,7 +107,7 @@ t.test('selects packages with a specific severity kind', async t => {
 
 t.test('missing security archive', async t => {
   const getState = (query: string) => {
-    const ast = postcssSelectorParser().astSync(query)
+    const ast = parse(query)
     const current = ast.first.first
     const state: ParserState = {
       current,

--- a/src/query/test/pseudo/shell.ts
+++ b/src/query/test/pseudo/shell.ts
@@ -1,14 +1,14 @@
 import t from 'tap'
-import postcssSelectorParser from 'postcss-selector-parser'
 import { joinDepIDTuple } from '@vltpkg/dep-id'
 import { asSecurityArchiveLike } from '@vltpkg/security-archive'
 import { getSimpleGraph } from '../fixtures/graph.ts'
 import type { ParserState } from '../../src/types.ts'
 import { shell } from '../../src/pseudo/shell.ts'
+import { parse } from '../../src/parser.ts'
 
 t.test('selects packages with a shellAccess alert', async t => {
   const getState = (query: string, graph = getSimpleGraph()) => {
-    const ast = postcssSelectorParser().astSync(query)
+    const ast = parse(query)
     const current = ast.first.first
     const state: ParserState = {
       current,
@@ -59,7 +59,7 @@ t.test('selects packages with a shellAccess alert', async t => {
 
 t.test('missing security archive', async t => {
   const getState = (query: string) => {
-    const ast = postcssSelectorParser().astSync(query)
+    const ast = parse(query)
     const current = ast.first.first
     const state: ParserState = {
       current,

--- a/src/query/test/pseudo/shrinkwrap.ts
+++ b/src/query/test/pseudo/shrinkwrap.ts
@@ -1,14 +1,14 @@
 import t from 'tap'
-import postcssSelectorParser from 'postcss-selector-parser'
 import { joinDepIDTuple } from '@vltpkg/dep-id'
 import { asSecurityArchiveLike } from '@vltpkg/security-archive'
 import { getSimpleGraph } from '../fixtures/graph.ts'
 import type { ParserState } from '../../src/types.ts'
 import { shrinkwrap } from '../../src/pseudo/shrinkwrap.ts'
+import { parse } from '../../src/parser.ts'
 
 t.test('selects packages with a shrinkwrap alert', async t => {
   const getState = (query: string, graph = getSimpleGraph()) => {
-    const ast = postcssSelectorParser().astSync(query)
+    const ast = parse(query)
     const current = ast.first.first
     const state: ParserState = {
       current,
@@ -59,7 +59,7 @@ t.test('selects packages with a shrinkwrap alert', async t => {
 
 t.test('missing security archive', async t => {
   const getState = (query: string) => {
-    const ast = postcssSelectorParser().astSync(query)
+    const ast = parse(query)
     const current = ast.first.first
     const state: ParserState = {
       current,

--- a/src/query/test/pseudo/squat.ts
+++ b/src/query/test/pseudo/squat.ts
@@ -1,5 +1,4 @@
 import t from 'tap'
-import postcssSelectorParser from 'postcss-selector-parser'
 import { joinDepIDTuple } from '@vltpkg/dep-id'
 import { asSecurityArchiveLike } from '@vltpkg/security-archive'
 import { getSimpleGraph } from '../fixtures/graph.ts'
@@ -9,10 +8,11 @@ import {
   isSquatKind,
   asSquatKind,
 } from '../../src/pseudo/squat.ts'
+import { parse } from '../../src/parser.ts'
 
 t.test('selects packages with a specific squat kind', async t => {
   const getState = (query: string, graph = getSimpleGraph()) => {
-    const ast = postcssSelectorParser().astSync(query)
+    const ast = parse(query)
     const current = ast.first.first
     const state: ParserState = {
       current,
@@ -107,7 +107,7 @@ t.test('selects packages with a specific squat kind', async t => {
 
 t.test('missing security archive', async t => {
   const getState = (query: string) => {
-    const ast = postcssSelectorParser().astSync(query)
+    const ast = parse(query)
     const current = ast.first.first
     const state: ParserState = {
       current,

--- a/src/query/test/pseudo/suspicious.ts
+++ b/src/query/test/pseudo/suspicious.ts
@@ -1,14 +1,14 @@
 import t from 'tap'
-import postcssSelectorParser from 'postcss-selector-parser'
 import { joinDepIDTuple } from '@vltpkg/dep-id'
 import { asSecurityArchiveLike } from '@vltpkg/security-archive'
 import { getSimpleGraph } from '../fixtures/graph.ts'
 import type { ParserState } from '../../src/types.ts'
 import { suspicious } from '../../src/pseudo/suspicious.ts'
+import { parse } from '../../src/parser.ts'
 
 t.test('selects packages with a suspicious alert', async t => {
   const getState = (query: string, graph = getSimpleGraph()) => {
-    const ast = postcssSelectorParser().astSync(query)
+    const ast = parse(query)
     const current = ast.first.first
     const state: ParserState = {
       current,
@@ -59,7 +59,7 @@ t.test('selects packages with a suspicious alert', async t => {
 
 t.test('missing security archive', async t => {
   const getState = (query: string) => {
-    const ast = postcssSelectorParser().astSync(query)
+    const ast = parse(query)
     const current = ast.first.first
     const state: ParserState = {
       current,

--- a/src/query/test/pseudo/tracker.ts
+++ b/src/query/test/pseudo/tracker.ts
@@ -1,14 +1,14 @@
 import t from 'tap'
-import postcssSelectorParser from 'postcss-selector-parser'
 import { joinDepIDTuple } from '@vltpkg/dep-id'
 import { asSecurityArchiveLike } from '@vltpkg/security-archive'
 import { getSimpleGraph } from '../fixtures/graph.ts'
 import type { ParserState } from '../../src/types.ts'
 import { tracker } from '../../src/pseudo/tracker.ts'
+import { parse } from '../../src/parser.ts'
 
 t.test('selects packages with a tracker alert', async t => {
   const getState = (query: string, graph = getSimpleGraph()) => {
-    const ast = postcssSelectorParser().astSync(query)
+    const ast = parse(query)
     const current = ast.first.first
     const state: ParserState = {
       current,
@@ -59,7 +59,7 @@ t.test('selects packages with a tracker alert', async t => {
 
 t.test('missing security archive', async t => {
   const getState = (query: string) => {
-    const ast = postcssSelectorParser().astSync(query)
+    const ast = parse(query)
     const current = ast.first.first
     const state: ParserState = {
       current,

--- a/src/query/test/pseudo/trivial.ts
+++ b/src/query/test/pseudo/trivial.ts
@@ -1,14 +1,14 @@
 import t from 'tap'
-import postcssSelectorParser from 'postcss-selector-parser'
 import { joinDepIDTuple } from '@vltpkg/dep-id'
 import { asSecurityArchiveLike } from '@vltpkg/security-archive'
 import { getSimpleGraph } from '../fixtures/graph.ts'
 import type { ParserState } from '../../src/types.ts'
 import { trivial } from '../../src/pseudo/trivial.ts'
+import { parse } from '../../src/parser.ts'
 
 t.test('selects packages with a trivial alert', async t => {
   const getState = (query: string, graph = getSimpleGraph()) => {
-    const ast = postcssSelectorParser().astSync(query)
+    const ast = parse(query)
     const current = ast.first.first
     const state: ParserState = {
       current,
@@ -59,7 +59,7 @@ t.test('selects packages with a trivial alert', async t => {
 
 t.test('missing security archive', async t => {
   const getState = (query: string) => {
-    const ast = postcssSelectorParser().astSync(query)
+    const ast = parse(query)
     const current = ast.first.first
     const state: ParserState = {
       current,

--- a/src/query/test/pseudo/undesirable.ts
+++ b/src/query/test/pseudo/undesirable.ts
@@ -1,14 +1,14 @@
 import t from 'tap'
-import postcssSelectorParser from 'postcss-selector-parser'
 import { joinDepIDTuple } from '@vltpkg/dep-id'
 import { asSecurityArchiveLike } from '@vltpkg/security-archive'
 import { getSimpleGraph } from '../fixtures/graph.ts'
 import type { ParserState } from '../../src/types.ts'
 import { undesirable } from '../../src/pseudo/undesirable.ts'
+import { parse } from '../../src/parser.ts'
 
 t.test('selects packages with an undesirable alert', async t => {
   const getState = (query: string, graph = getSimpleGraph()) => {
-    const ast = postcssSelectorParser().astSync(query)
+    const ast = parse(query)
     const current = ast.first.first
     const state: ParserState = {
       current,
@@ -59,7 +59,7 @@ t.test('selects packages with an undesirable alert', async t => {
 
 t.test('missing security archive', async t => {
   const getState = (query: string) => {
-    const ast = postcssSelectorParser().astSync(query)
+    const ast = parse(query)
     const current = ast.first.first
     const state: ParserState = {
       current,

--- a/src/query/test/pseudo/unknown.ts
+++ b/src/query/test/pseudo/unknown.ts
@@ -1,14 +1,14 @@
 import t from 'tap'
-import postcssSelectorParser from 'postcss-selector-parser'
 import { joinDepIDTuple } from '@vltpkg/dep-id'
 import { asSecurityArchiveLike } from '@vltpkg/security-archive'
 import { getSimpleGraph } from '../fixtures/graph.ts'
 import type { ParserState } from '../../src/types.ts'
 import { unknown } from '../../src/pseudo/unknown.ts'
+import { parse } from '../../src/parser.ts'
 
 t.test('selects packages with an unknown alert', async t => {
   const getState = (query: string, graph = getSimpleGraph()) => {
-    const ast = postcssSelectorParser().astSync(query)
+    const ast = parse(query)
     const current = ast.first.first
     const state: ParserState = {
       current,
@@ -59,7 +59,7 @@ t.test('selects packages with an unknown alert', async t => {
 
 t.test('missing security archive', async t => {
   const getState = (query: string) => {
-    const ast = postcssSelectorParser().astSync(query)
+    const ast = parse(query)
     const current = ast.first.first
     const state: ParserState = {
       current,

--- a/src/query/test/pseudo/unmaintained.ts
+++ b/src/query/test/pseudo/unmaintained.ts
@@ -1,14 +1,14 @@
 import t from 'tap'
-import postcssSelectorParser from 'postcss-selector-parser'
 import { joinDepIDTuple } from '@vltpkg/dep-id'
 import { asSecurityArchiveLike } from '@vltpkg/security-archive'
 import { getSimpleGraph } from '../fixtures/graph.ts'
 import type { ParserState } from '../../src/types.ts'
 import { unmaintained } from '../../src/pseudo/unmaintained.ts'
+import { parse } from '../../src/parser.ts'
 
 t.test('selects packages with an unmaintained alert', async t => {
   const getState = (query: string, graph = getSimpleGraph()) => {
-    const ast = postcssSelectorParser().astSync(query)
+    const ast = parse(query)
     const current = ast.first.first
     const state: ParserState = {
       current,
@@ -59,7 +59,7 @@ t.test('selects packages with an unmaintained alert', async t => {
 
 t.test('missing security archive', async t => {
   const getState = (query: string) => {
-    const ast = postcssSelectorParser().astSync(query)
+    const ast = parse(query)
     const current = ast.first.first
     const state: ParserState = {
       current,

--- a/src/query/test/pseudo/unpopular.ts
+++ b/src/query/test/pseudo/unpopular.ts
@@ -1,14 +1,14 @@
 import t from 'tap'
-import postcssSelectorParser from 'postcss-selector-parser'
 import { joinDepIDTuple } from '@vltpkg/dep-id'
 import { asSecurityArchiveLike } from '@vltpkg/security-archive'
 import { getSimpleGraph } from '../fixtures/graph.ts'
 import type { ParserState } from '../../src/types.ts'
 import { unpopular } from '../../src/pseudo/unpopular.ts'
+import { parse } from '../../src/parser.ts'
 
 t.test('selects packages with an unpopular alert', async t => {
   const getState = (query: string, graph = getSimpleGraph()) => {
-    const ast = postcssSelectorParser().astSync(query)
+    const ast = parse(query)
     const current = ast.first.first
     const state: ParserState = {
       current,
@@ -59,7 +59,7 @@ t.test('selects packages with an unpopular alert', async t => {
 
 t.test('missing security archive', async t => {
   const getState = (query: string) => {
-    const ast = postcssSelectorParser().astSync(query)
+    const ast = parse(query)
     const current = ast.first.first
     const state: ParserState = {
       current,

--- a/src/query/test/pseudo/unstable.ts
+++ b/src/query/test/pseudo/unstable.ts
@@ -1,14 +1,14 @@
 import t from 'tap'
-import postcssSelectorParser from 'postcss-selector-parser'
 import { joinDepIDTuple } from '@vltpkg/dep-id'
 import { asSecurityArchiveLike } from '@vltpkg/security-archive'
 import { getSimpleGraph } from '../fixtures/graph.ts'
 import type { ParserState } from '../../src/types.ts'
 import { unstable } from '../../src/pseudo/unstable.ts'
+import { parse } from '../../src/parser.ts'
 
 t.test('selects packages with an unstable alert', async t => {
   const getState = (query: string, graph = getSimpleGraph()) => {
-    const ast = postcssSelectorParser().astSync(query)
+    const ast = parse(query)
     const current = ast.first.first
     const state: ParserState = {
       current,
@@ -59,7 +59,7 @@ t.test('selects packages with an unstable alert', async t => {
 
 t.test('missing security archive', async t => {
   const getState = (query: string) => {
-    const ast = postcssSelectorParser().astSync(query)
+    const ast = parse(query)
     const current = ast.first.first
     const state: ParserState = {
       current,


### PR DESCRIPTION
The id selector now selects and filter out items based on the edge name rather than looking at the node name, so that it's
capable of filtering aliased packages by their effectively defined alias name instead of only looking at the manifest value the way the attribute selector works.

Importer nodes need to have a special step to be filtered out when they don't have edges pointing to them.

This PR also adds an abstraction layer to parsing query strings in `src/query/src/parser.ts` that now will automatically escape forward slashes in order to support scoped package names in the id selector, e.g:

    #@vltpkg/dep-id

Refactor tests and other usages of the css lang parser to use the new abstraction method instead.

Refs: https://github.com/vltpkg/statusboard/issues/98
Refs: https://github.com/vltpkg/vltpkg/issues/357
Refs: https://github.com/vltpkg/statusboard/issues/102
Replaces: https://github.com/vltpkg/vltpkg/pull/612