### PR TITLE
query: fix parsing scope names with dashes in ids

### DIFF
--- a/src/query/src/parser.ts
+++ b/src/query/src/parser.ts
@@ -9,7 +9,10 @@ import type { PostcssNode } from './types.ts'
  * package names in the id selector.
  */
 export const escapeScopedNamesSlashes = (query: string): string =>
-  query.replace(/(#@\w+)\//gm, (_, scope: string) => `${scope}\\/`)
+  query.replace(
+    /(#@(\w|-|\.)+)\//gm,
+    (_, scope: string) => `${scope}\\/`,
+  )
 
 export const escapeDots = (query: string): string =>
   query.replaceAll('.', '\\.')

--- a/src/query/test/parser.ts
+++ b/src/query/test/parser.ts
@@ -10,6 +10,18 @@ t.test('escapeScopedNamesSlashes', async t => {
   )
 
   t.equal(
+    escapeScopedNamesSlashes('#@scope-dash-sep/package'),
+    '#@scope-dash-sep\\/package',
+    'should escape forward slash with dashes',
+  )
+
+  t.equal(
+    escapeScopedNamesSlashes('#@scope.dot.sep/package'),
+    '#@scope.dot.sep\\/package',
+    'should escape forward slash with dots',
+  )
+
+  t.equal(
     escapeScopedNamesSlashes('#@multiple/package #@another/pkg'),
     '#@multiple\\/package #@another\\/pkg',
     'should escape multiple instances of the pattern',


### PR DESCRIPTION
When escaping slashes for scoped names, we need to also take into account that names can contain dashes and dots, e.g:

    #@scope-name/pkg