### PR TITLE
gui: fix query highlight

### DIFF
--- a/src/gui/src/components/query-bar/index.tsx
+++ b/src/gui/src/components/query-bar/index.tsx
@@ -33,7 +33,7 @@ export const QueryBar = ({
       return
     }
     try {
-      const tokens = Query.parse(query)
+      const tokens = Query.getQueryTokens(query)
       setParsedTokens(tokens)
     } catch (error) {
       console.error(`Error parsing query: ${error}`)

--- a/src/gui/src/components/query-bar/query-token.tsx
+++ b/src/gui/src/components/query-bar/query-token.tsx
@@ -6,6 +6,11 @@ import type { ParsedSelectorToken } from '@vltpkg/query'
 
 type TokenType = ParsedSelectorToken['type']
 
+const defaultVariant = {
+  light: 'text-gray-800 after:bg-gray-500/20',
+  dark: 'dark:text-gray-300 after:dark:bg-gray-500/20',
+}
+
 export const tokenVariantClasses = {
   pseudo: {
     light: 'text-purple-800 after:bg-purple-600/20',
@@ -27,10 +32,6 @@ export const tokenVariantClasses = {
     light: 'text-pink-800 after:bg-pink-600/20',
     dark: 'dark:text-pink-400 after:dark:bg-pink-600/15',
   },
-  combinator: {
-    light: 'text-gray-800 after:bg-gray-500/20',
-    dark: 'dark:text-gray-300 after:dark:bg-gray-500/20',
-  },
   string: {
     light: 'text-violet-800 after:bg-violet-500/20',
     dark: 'dark:text-violet-300 after:dark:bg-violet-500/20',
@@ -39,6 +40,9 @@ export const tokenVariantClasses = {
     light: 'text-fuchsia-800 after:bg-fuchsia-600/20',
     dark: 'dark:text-fuchsia-400 after:dark:bg-fuchsia-600/20',
   },
+  combinator: defaultVariant,
+  comment: defaultVariant,
+  selector: defaultVariant,
 }
 
 const variantMap: Record<TokenType, string> = Object.fromEntries(

--- a/src/gui/test/components/query-bar/__snapshots__/query-highlighter.tsx.snap
+++ b/src/gui/test/components/query-bar/__snapshots__/query-highlighter.tsx.snap
@@ -16,7 +16,7 @@ exports[`query-highlighter render default 1`] = `
     <gui-query-token variant="id">
       #react
     </gui-query-token>
-    <gui-query-token variant="string">
+    <gui-query-token variant="selector">
       ,
     </gui-query-token>
     <gui-query-token variant="attribute">

--- a/src/gui/test/components/query-bar/query-highlighter.tsx
+++ b/src/gui/test/components/query-bar/query-highlighter.tsx
@@ -22,7 +22,7 @@ afterEach(() => {
 
 test('query-highlighter render default', () => {
   const mockQuery = ':root > :not(#react, [name="react-sass"])'
-  const mockParsedTokens = Query.parse(mockQuery)
+  const mockParsedTokens = Query.getQueryTokens(mockQuery)
 
   const Container = () => {
     return (

--- a/src/query/src/index.ts
+++ b/src/query/src/index.ts
@@ -12,8 +12,8 @@ import {
   asPostcssNodeWithChildren,
   isSelectorNode,
   isPseudoNode,
-  isTagNode,
-  isStringNode,
+  isIdentifierNode,
+  isAttributeNode,
 } from './types.ts'
 import type {
   PostcssNode,
@@ -427,9 +427,9 @@ export class Query {
   }
 
   /**
-   * Parses a query into an array of tokens
+   * Parses a query string in order to retrieve an array of tokens.
    */
-  static parse(query: string): ParsedSelectorToken[] {
+  static getQueryTokens(query: string): ParsedSelectorToken[] {
     if (!query) return []
 
     const tokens: ParsedSelectorToken[] = []
@@ -444,23 +444,19 @@ export class Query {
 
     const processNode = (node: PostcssNode) => {
       for (const key of selectorsMap.keys()) {
-        if (
-          node.type === key &&
-          node.type !== 'root' &&
-          node.type !== 'selector'
-        ) {
-          let token = String(
-            node.source?.start?.column &&
-              node.source.end?.column &&
-              `${node.spaces.before}${query.slice(node.source.start.column - 1, node.source.end.column)}${node.spaces.after}`,
-          )
+        if (node.type === key && node.type !== 'root') {
+          let token = `${node.spaces.before}${node.value}${node.spaces.after}`
 
-          if (isTagNode(node)) {
-            token = node.value
-          }
-
-          if (isStringNode(node)) {
-            token = node.value
+          if (isIdentifierNode(node)) {
+            token = `${node.spaces.before}#${node.value}${node.spaces.after}`
+          } else if (isSelectorNode(node)) {
+            token = `${node.spaces.before},${node.spaces.after}`
+          } else if (isAttributeNode(node)) {
+            token = String(
+              node.source?.start?.column &&
+                node.source.end?.column &&
+                `${node.spaces.before}${query.slice(node.source.start.column - 1, node.source.end.column)}${node.spaces.after}`,
+            )
           }
 
           if (
@@ -472,10 +468,15 @@ export class Query {
             token += '('
           }
 
-          tokens.push({
-            ...node,
-            token,
-          } as ParsedSelectorToken)
+          if (
+            !isSelectorNode(node) ||
+            node.parent?.nodes.indexOf(node) !== 0
+          ) {
+            tokens.push({
+              ...node,
+              token,
+            } as ParsedSelectorToken)
+          }
         }
       }
       if (isPostcssNodeWithChildren(node)) {
@@ -485,7 +486,7 @@ export class Query {
         if (isPseudoNode(node) && node.nodes.length) {
           tokens.push({
             ...node,
-            token: ')',
+            token: ')' + node.spaces.after,
             type: 'pseudo',
           } as ParsedSelectorToken)
         }

--- a/src/query/src/parser.ts
+++ b/src/query/src/parser.ts
@@ -1,6 +1,6 @@
 import postcssSelectorParser from 'postcss-selector-parser'
 import type { Root } from 'postcss-selector-parser'
-import { isStringNode } from './types.ts'
+import { isIdentifierNode, isStringNode } from './types.ts'
 import type { PostcssNode } from './types.ts'
 
 /**
@@ -28,7 +28,7 @@ export const parse = (query: string): Root => {
   const escapedQuery = escapeDots(escapeScopedNamesSlashes(query))
   const transformAst = (root: Root) => {
     root.walk((node: PostcssNode) => {
-      if (isStringNode(node)) {
+      if (isIdentifierNode(node) || isStringNode(node)) {
         node.value = unescapeDots(node.value)
       }
     })

--- a/src/query/test/index.ts
+++ b/src/query/test/index.ts
@@ -306,7 +306,7 @@ t.test('Query.hasSecuritySelectors', async t => {
   t.notOk(Query.hasSecuritySelectors(':has'), 'should return false')
 })
 
-t.test('parse', t => {
+t.test('getQueryTokens', t => {
   const normalizeParseOutput = (nodes: ParsedSelectorToken[]) => {
     return nodes.map(node => {
       return {
@@ -316,25 +316,28 @@ t.test('parse', t => {
     })
   }
 
-  t.test('should parse empty query', t => {
-    t.strictSame(normalizeParseOutput(Query.parse('')), [])
+  t.test('should getQueryTokens empty query', t => {
+    t.strictSame(normalizeParseOutput(Query.getQueryTokens('')), [])
     t.end()
   })
 
-  t.test('should parse pseudo selector', t => {
-    t.strictSame(normalizeParseOutput(Query.parse(':root')), [
-      {
-        type: 'pseudo',
-        token: ':root',
-      },
-    ])
+  t.test('should getQueryTokens pseudo selector', t => {
+    t.strictSame(
+      normalizeParseOutput(Query.getQueryTokens(':root')),
+      [
+        {
+          type: 'pseudo',
+          token: ':root',
+        },
+      ],
+    )
     t.end()
   })
 
-  t.test('should parse attribute selector', t => {
+  t.test('should getQueryTokens attribute selector', t => {
     t.test('with value', t => {
       t.strictSame(
-        normalizeParseOutput(Query.parse('[name="react"]')),
+        normalizeParseOutput(Query.getQueryTokens('[name="react"]')),
         [
           {
             type: 'attribute',
@@ -347,7 +350,7 @@ t.test('parse', t => {
 
     t.test('with operator', t => {
       t.strictSame(
-        normalizeParseOutput(Query.parse('[name^="react"]')),
+        normalizeParseOutput(Query.getQueryTokens('[name^="react"]')),
         [
           {
             type: 'attribute',
@@ -359,64 +362,152 @@ t.test('parse', t => {
     })
 
     t.test('without value', t => {
-      t.strictSame(normalizeParseOutput(Query.parse('[name]')), [
-        {
-          type: 'attribute',
-          token: '[name]',
-        },
-      ])
+      t.strictSame(
+        normalizeParseOutput(Query.getQueryTokens('[name]')),
+        [
+          {
+            type: 'attribute',
+            token: '[name]',
+          },
+        ],
+      )
       t.end()
     })
     t.end()
   })
 
-  t.test('should parse class selector', t => {
-    t.strictSame(normalizeParseOutput(Query.parse('.container')), [
-      {
-        type: 'tag',
-        token: '.container',
-      },
-    ])
+  t.test('should getQueryTokens class selector', t => {
+    t.strictSame(
+      normalizeParseOutput(Query.getQueryTokens('.container')),
+      [
+        {
+          type: 'tag',
+          token: '.container',
+        },
+      ],
+    )
     t.end()
   })
 
-  t.test('should parse id selector', t => {
-    t.strictSame(normalizeParseOutput(Query.parse('#main')), [
-      {
-        type: 'id',
-        token: '#main',
+  t.test('should getQueryTokens id selector', t => {
+    t.strictSame(
+      normalizeParseOutput(Query.getQueryTokens('#main')),
+      [
+        {
+          type: 'id',
+          token: '#main',
+        },
+      ],
+    )
+
+    t.test('should getQueryTokens scoped-name id selector', t => {
+      t.strictSame(
+        normalizeParseOutput(Query.getQueryTokens('#@scoped/name')),
+        [
+          {
+            type: 'id',
+            token: '#@scoped/name',
+          },
+        ],
+      )
+      t.end()
+    })
+
+    t.test(
+      'should getQueryTokens dash-separated-scoped-name id selector',
+      t => {
+        t.strictSame(
+          normalizeParseOutput(
+            Query.getQueryTokens('#@scoped-org/name'),
+          ),
+          [
+            {
+              type: 'id',
+              token: '#@scoped-org/name',
+            },
+          ],
+        )
+        t.end()
       },
-    ])
+    )
+
+    t.test(
+      'should getQueryTokens dot-separated-scoped-name id selector',
+      t => {
+        t.strictSame(
+          normalizeParseOutput(
+            Query.getQueryTokens('#@scoped.org/name'),
+          ),
+          [
+            {
+              type: 'id',
+              token: '#@scoped.org/name',
+            },
+          ],
+        )
+        t.end()
+      },
+    )
     t.end()
   })
 
-  t.test('should parse tags', t => {
-    t.strictSame(normalizeParseOutput(Query.parse('name=test')), [
-      {
-        type: 'tag',
-        token: 'name=test',
-      },
-    ])
+  t.test(
+    'should getQueryTokens simple comma separated selector',
+    t => {
+      t.strictSame(
+        normalizeParseOutput(Query.getQueryTokens('#a, #b')),
+        [
+          {
+            type: 'id',
+            token: '#a',
+          },
+          {
+            type: 'selector',
+            token: ',',
+          },
+          {
+            type: 'id',
+            token: ' #b',
+          },
+        ],
+      )
+      t.end()
+    },
+  )
+
+  t.test('should getQueryTokens tags', t => {
+    t.strictSame(
+      normalizeParseOutput(Query.getQueryTokens('name=test')),
+      [
+        {
+          type: 'tag',
+          token: 'name=test',
+        },
+      ],
+    )
     t.end()
   })
 
-  t.test('should parse strings', t => {
-    t.strictSame(normalizeParseOutput(Query.parse('name="test"')), [
-      {
-        type: 'tag',
-        token: 'name=',
-      },
-      {
-        type: 'string',
-        token: '"test"',
-      },
-    ])
+  t.test('should getQueryTokens strings', t => {
+    t.strictSame(
+      normalizeParseOutput(Query.getQueryTokens('name="test"')),
+      [
+        {
+          type: 'tag',
+          token: 'name=',
+        },
+        {
+          type: 'string',
+          token: '"test"',
+        },
+      ],
+    )
     t.end()
   })
 
-  t.test('should parse combinator', t => {
+  t.test('should getQueryTokens combinator', t => {
     t.test('non-whitespace', t => {
-      t.strictSame(normalizeParseOutput(Query.parse('>')), [
+      t.strictSame(normalizeParseOutput(Query.getQueryTokens('>')), [
         {
           type: 'combinator',
           token: '>',
@@ -426,17 +517,17 @@ t.test('parse', t => {
     })
 
     t.test('whitespace', t => {
-      t.strictSame(Query.parse(' '), [])
+      t.strictSame(Query.getQueryTokens(' '), [])
       t.end()
     })
     t.end()
   })
 
-  t.test('should parse complex selector', t => {
+  t.test('should getQueryTokens complex selector', t => {
     t.test('with nested selectors', t => {
       t.strictSame(
         normalizeParseOutput(
-          Query.parse(':root > [name="react"] .container'),
+          Query.getQueryTokens(':root > [name="react"] .container'),
         ),
         [
           {
@@ -466,7 +557,7 @@ t.test('parse', t => {
 
     t.test('with nested pseudo selectors', t => {
       t.strictSame(
-        normalizeParseOutput(Query.parse(':not(#react)')),
+        normalizeParseOutput(Query.getQueryTokens(':not(#react)')),
         [
           {
             type: 'pseudo',
@@ -482,13 +573,59 @@ t.test('parse', t => {
           },
         ],
       )
+      t.test('with nested comma separated selectors', t => {
+        t.strictSame(
+          normalizeParseOutput(
+            Query.getQueryTokens(':not(#a, #b), :is(#c)'),
+          ),
+          [
+            {
+              type: 'pseudo',
+              token: ':not(',
+            },
+            {
+              type: 'id',
+              token: '#a',
+            },
+            {
+              type: 'selector',
+              token: ',',
+            },
+            {
+              type: 'id',
+              token: ' #b',
+            },
+            {
+              type: 'pseudo',
+              token: ')',
+            },
+            {
+              type: 'selector',
+              token: ',',
+            },
+            {
+              type: 'pseudo',
+              token: ' :is(',
+            },
+            {
+              type: 'id',
+              token: '#c',
+            },
+            {
+              type: 'pseudo',
+              token: ')',
+            },
+          ],
+        )
+        t.end()
+      })
       t.end()
     })
 
     t.test('with malformed queries', t => {
       t.test('should handle unclosed brackets', t => {
         t.strictSame(
-          normalizeParseOutput(Query.parse('[name="react"')),
+          normalizeParseOutput(Query.getQueryTokens('[name="react"')),
           [],
         )
         t.end()
@@ -496,7 +633,7 @@ t.test('parse', t => {
 
       t.test('should handle unclosed pseudo selectors', t => {
         t.strictSame(
-          normalizeParseOutput(Query.parse(':not(#react')),
+          normalizeParseOutput(Query.getQueryTokens(':not(#react')),
           [
             {
               type: 'pseudo',
@@ -512,7 +649,7 @@ t.test('parse', t => {
     t.test('with multiple attributes', t => {
       t.strictSame(
         normalizeParseOutput(
-          Query.parse('[name="react"][version="18"]'),
+          Query.getQueryTokens('[name="react"][version="18"]'),
         ),
         [
           {


### PR DESCRIPTION
In order to more easily account for escaped characters the token creation is now done at the parser module that handles the escaping and unescaping of reserved characters.