### PR TITLE
windows smoke test fixes

### DIFF
--- a/infra/smoke-test/test/fixtures/variants.ts
+++ b/infra/smoke-test/test/fixtures/variants.ts
@@ -9,23 +9,31 @@ import t from 'tap'
 // this makes the tests run faster
 export const Bins = ['vlt'] as const
 
-export const allVariants = [
-  'source',
-  'denoSource',
-  'bundle',
-  'denoBundle',
-  'compile',
-] as const
+const ALL_VARIANTS = {
+  source: 'source',
+  denoSource: 'denoSource',
+  bundle: 'bundle',
+  denoBundle: 'denoBundle',
+  compile: 'compile',
+} as const
 
-export type VariantType = (typeof allVariants)[number]
+export type VariantType = keyof typeof ALL_VARIANTS
 
-export const publishedVariant: VariantType = 'compile'
+export const publishedVariant: VariantType = ALL_VARIANTS.compile
+
+const filterVariants =
+  process.env.SMOKE_TEST_VARIANTS?.split(',') ??
+  Object.values(ALL_VARIANTS)
+
+export const allVariants = Object.values(ALL_VARIANTS).filter(k =>
+  filterVariants.includes(k),
+)
 
 export const defaultVariants: VariantType[] = [
-  'source',
-  'bundle',
-  'compile',
-] as const
+  ALL_VARIANTS.source,
+  ALL_VARIANTS.bundle,
+  ALL_VARIANTS.compile,
+].filter(k => filterVariants.includes(k))
 
 export type Variant = {
   args: (bin: Bin) => string[]

--- a/scripts/bins/vlr.ps1
+++ b/scripts/bins/vlr.ps1
@@ -1,0 +1,6 @@
+$ScriptDir = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
+$nodeArgs = $args
+& { 
+  $env:NODE_OPTIONS = "--no-warnings --experimental-strip-types --enable-source-maps"
+  node "$ScriptDir\infra\build\src\bins\vlr.ts" @nodeArgs
+}

--- a/scripts/bins/vlrx.ps1
+++ b/scripts/bins/vlrx.ps1
@@ -1,0 +1,6 @@
+$ScriptDir = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
+$nodeArgs = $args
+& { 
+  $env:NODE_OPTIONS = "--no-warnings --experimental-strip-types --enable-source-maps"
+  node "$ScriptDir\infra\build\src\bins\vlrx.ts" @nodeArgs
+}

--- a/scripts/bins/vlt.ps1
+++ b/scripts/bins/vlt.ps1
@@ -1,0 +1,6 @@
+$ScriptDir = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
+$nodeArgs = $args
+& { 
+  $env:NODE_OPTIONS = "--no-warnings --experimental-strip-types --enable-source-maps"
+  node "$ScriptDir\infra\build\src\bins\vlt.ts" @nodeArgs
+}

--- a/scripts/bins/vlx.ps1
+++ b/scripts/bins/vlx.ps1
@@ -1,0 +1,6 @@
+$ScriptDir = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
+$nodeArgs = $args
+& { 
+  $env:NODE_OPTIONS = "--no-warnings --experimental-strip-types --enable-source-maps"
+  node "$ScriptDir\infra\build\src\bins\vlx.ts" @nodeArgs
+}

--- a/scripts/bins/vlxl.ps1
+++ b/scripts/bins/vlxl.ps1
@@ -1,0 +1,6 @@
+$ScriptDir = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
+$nodeArgs = $args
+& { 
+  $env:NODE_OPTIONS = "--no-warnings --experimental-strip-types --enable-source-maps"
+  node "$ScriptDir\infra\build\src\bins\vlxl.ts" @nodeArgs
+}

--- a/src/rollback-remove/src/index.ts
+++ b/src/rollback-remove/src/index.ts
@@ -13,6 +13,7 @@ export class RollbackRemove {
   #paths = new Map<string, string>()
 
   async rm(path: string) {
+    if (this.#paths.has(path)) return
     const target = `${dirname(path)}/.VLT.DELETE.${this.#key}.${basename(path)}`
     this.#paths.set(path, target)
     await rename(path, target).catch((e: unknown) => {

--- a/src/rollback-remove/test/index.ts
+++ b/src/rollback-remove/test/index.ts
@@ -88,6 +88,7 @@ t.test('delete some stuff', async t => {
   t.strictSame(hasSpawned(), false)
 
   await remover.rm('a/b')
+  await remover.rm('a/b')
   await remover.rm('d')
   await remover.rm('noent')
   t.matchOnly(


### PR DESCRIPTION
08c61365a7f92472082987f358df7a6702e94c59 fixed a bug where edges in were not being deleted when their parent node was deleted. This caused the `rollback-remove` instance to attempt to rename the same path twice, which was causing `EPERM` errors on Windows the 2nd time.

I was able to reproduce this consistently by running (with no node_modules/cache/lockfile) `vlt i abbrev@2.0.0` followed by `vlt i abbrev@3.0.0`.

01e8a34776fc2714f749f33b10d01d14aab74dfc fixed this error by treating `EPERM` errors the same as `ENOENT` but this caused the temporary `.VLT.DELETE.*` rollback files to never be removed which was causing the smoke-test to fail.

This PR keeps the handling of EPERM errors, because without it we get a lot of flaky tests. But it avoids this specific cause of this EPERM error by using the map of pending rollbacks to ensure that the same path is not rolled back more than once.

---

This PR also includes a few commits that made this easier to debug:

- local `.ps1` scripts for easier running of our source on Windows
- A `SMOKE_TEST_VARIANTS` env var to filter which smoke test variants are run by default