### PR TITLE
query: fix `vlt query` cli output

### DIFF
--- a/src/cli-sdk/tap-snapshots/test/commands/list.ts.test.cjs
+++ b/src/cli-sdk/tap-snapshots/test/commands/list.ts.test.cjs
@@ -94,7 +94,10 @@ exports[`test/commands/list.ts > TAP > list > should list all pkgs in json forma
       },
       "projectRoot": "{ROOT}",
       "dev": false,
-      "optional": false
+      "optional": false,
+      "insights": {
+        "scanned": false
+      }
     }
   },
   {
@@ -114,7 +117,10 @@ exports[`test/commands/list.ts > TAP > list > should list all pkgs in json forma
       },
       "projectRoot": "{ROOT}",
       "dev": false,
-      "optional": false
+      "optional": false,
+      "insights": {
+        "scanned": false
+      }
     }
   },
   {
@@ -137,7 +143,10 @@ exports[`test/commands/list.ts > TAP > list > should list all pkgs in json forma
       },
       "projectRoot": "{ROOT}",
       "dev": false,
-      "optional": false
+      "optional": false,
+      "insights": {
+        "scanned": false
+      }
     }
   },
   {
@@ -160,7 +169,10 @@ exports[`test/commands/list.ts > TAP > list > should list all pkgs in json forma
       },
       "projectRoot": "{ROOT}",
       "dev": false,
-      "optional": false
+      "optional": false,
+      "insights": {
+        "scanned": false
+      }
     }
   },
   {
@@ -186,7 +198,10 @@ exports[`test/commands/list.ts > TAP > list > should list all pkgs in json forma
       },
       "projectRoot": "{ROOT}",
       "dev": false,
-      "optional": false
+      "optional": false,
+      "insights": {
+        "scanned": false
+      }
     }
   }
 ]
@@ -248,7 +263,10 @@ exports[`test/commands/list.ts > TAP > list > should list pkgs in json format 1`
       },
       "projectRoot": "{ROOT}",
       "dev": false,
-      "optional": false
+      "optional": false,
+      "insights": {
+        "scanned": false
+      }
     }
   },
   {
@@ -268,7 +286,10 @@ exports[`test/commands/list.ts > TAP > list > should list pkgs in json format 1`
       },
       "projectRoot": "{ROOT}",
       "dev": false,
-      "optional": false
+      "optional": false,
+      "insights": {
+        "scanned": false
+      }
     }
   },
   {
@@ -291,7 +312,10 @@ exports[`test/commands/list.ts > TAP > list > should list pkgs in json format 1`
       },
       "projectRoot": "{ROOT}",
       "dev": false,
-      "optional": false
+      "optional": false,
+      "insights": {
+        "scanned": false
+      }
     }
   }
 ]
@@ -325,7 +349,10 @@ exports[`test/commands/list.ts > TAP > list > workspaces > should list workspace
       },
       "projectRoot": "{ROOT}",
       "dev": false,
-      "optional": false
+      "optional": false,
+      "insights": {
+        "scanned": false
+      }
     }
   },
   {
@@ -342,7 +369,10 @@ exports[`test/commands/list.ts > TAP > list > workspaces > should list workspace
       },
       "projectRoot": "{ROOT}",
       "dev": false,
-      "optional": false
+      "optional": false,
+      "insights": {
+        "scanned": false
+      }
     }
   },
   {
@@ -359,7 +389,10 @@ exports[`test/commands/list.ts > TAP > list > workspaces > should list workspace
       },
       "projectRoot": "{ROOT}",
       "dev": false,
-      "optional": false
+      "optional": false,
+      "insights": {
+        "scanned": false
+      }
     }
   }
 ]

--- a/src/cli-sdk/tap-snapshots/test/commands/query.ts.test.cjs
+++ b/src/cli-sdk/tap-snapshots/test/commands/query.ts.test.cjs
@@ -118,7 +118,10 @@ exports[`test/commands/query.ts > TAP > query > should list pkgs in json format 
       },
       "projectRoot": "{ROOT}",
       "dev": false,
-      "optional": false
+      "optional": false,
+      "insights": {
+        "scanned": false
+      }
     }
   },
   {
@@ -138,7 +141,10 @@ exports[`test/commands/query.ts > TAP > query > should list pkgs in json format 
       },
       "projectRoot": "{ROOT}",
       "dev": false,
-      "optional": false
+      "optional": false,
+      "insights": {
+        "scanned": false
+      }
     }
   },
   {
@@ -161,7 +167,10 @@ exports[`test/commands/query.ts > TAP > query > should list pkgs in json format 
       },
       "projectRoot": "{ROOT}",
       "dev": false,
-      "optional": false
+      "optional": false,
+      "insights": {
+        "scanned": false
+      }
     }
   },
   {
@@ -184,7 +193,10 @@ exports[`test/commands/query.ts > TAP > query > should list pkgs in json format 
       },
       "projectRoot": "{ROOT}",
       "dev": false,
-      "optional": false
+      "optional": false,
+      "insights": {
+        "scanned": false
+      }
     }
   },
   {
@@ -210,7 +222,10 @@ exports[`test/commands/query.ts > TAP > query > should list pkgs in json format 
       },
       "projectRoot": "{ROOT}",
       "dev": false,
-      "optional": false
+      "optional": false,
+      "insights": {
+        "scanned": false
+      }
     }
   }
 ]
@@ -244,7 +259,10 @@ exports[`test/commands/query.ts > TAP > query > workspaces > should list workspa
       },
       "projectRoot": "{ROOT}",
       "dev": false,
-      "optional": false
+      "optional": false,
+      "insights": {
+        "scanned": false
+      }
     }
   },
   {
@@ -261,7 +279,10 @@ exports[`test/commands/query.ts > TAP > query > workspaces > should list workspa
       },
       "projectRoot": "{ROOT}",
       "dev": false,
-      "optional": false
+      "optional": false,
+      "insights": {
+        "scanned": false
+      }
     }
   },
   {
@@ -278,7 +299,10 @@ exports[`test/commands/query.ts > TAP > query > workspaces > should list workspa
       },
       "projectRoot": "{ROOT}",
       "dev": false,
-      "optional": false
+      "optional": false,
+      "insights": {
+        "scanned": false
+      }
     }
   }
 ]

--- a/src/graph/src/types.ts
+++ b/src/graph/src/types.ts
@@ -49,6 +49,20 @@ export type NodeLike = {
   projectRoot: string
   dev: boolean
   optional: boolean
+  toJSON: () => Pick<
+    NodeLike,
+    | 'id'
+    | 'name'
+    | 'version'
+    | 'location'
+    | 'importer'
+    | 'manifest'
+    | 'projectRoot'
+    | 'integrity'
+    | 'resolved'
+    | 'dev'
+    | 'optional'
+  >
   toString(): string
   setResolved(): void
 }

--- a/src/gui/src/state/load-graph.ts
+++ b/src/gui/src/state/load-graph.ts
@@ -1,4 +1,4 @@
-import { lockfile } from '@vltpkg/graph/browser'
+import { lockfile, stringifyNode } from '@vltpkg/graph/browser'
 import { SecurityArchive } from '@vltpkg/security-archive/browser'
 import {
   defaultRegistry,
@@ -120,6 +120,24 @@ export const load = (transfered: TransferData): LoadResponse => {
         dev: false,
         optional: false,
         setResolved() {},
+        toJSON() {
+          return {
+            id: this.id,
+            name: this.name,
+            version: this.version,
+            location: this.location,
+            importer: this.importer,
+            manifest: this.manifest,
+            projectRoot: this.projectRoot,
+            integrity: this.integrity,
+            resolved: this.resolved,
+            dev: this.dev,
+            optional: this.optional,
+          }
+        },
+        toString() {
+          return stringifyNode(this)
+        },
       }
       this.nodes.set(node.id, node)
       return node
@@ -138,6 +156,20 @@ export const load = (transfered: TransferData): LoadResponse => {
     node.resolved = importer.resolved
     node.dev = importer.dev
     node.optional = importer.optional
+    node.toJSON = () => ({
+      id: node.id,
+      name: node.name,
+      version: node.version,
+      location: node.location,
+      importer: node.importer,
+      manifest: node.manifest,
+      projectRoot: node.projectRoot,
+      integrity: node.integrity,
+      resolved: node.resolved,
+      dev: node.dev,
+      optional: node.optional,
+    })
+    node.toString = () => stringifyNode(node)
     // should set the main importer in the first iteration
     if (!graph.mainImporter) {
       graph.mainImporter = node

--- a/src/gui/test/components/explorer-grid/index.tsx
+++ b/src/gui/test/components/explorer-grid/index.tsx
@@ -70,18 +70,21 @@ test('explorer-grid with results', async () => {
       name: 'root',
       version: '1.0.0',
       insights: {},
+      toJSON() {},
     } as QueryResponseNode
     const aNode = {
       id: joinDepIDTuple(['registry', '', 'a@1.0.0']),
       name: 'a',
       version: '1.0.0',
       insights: {},
+      toJSON() {},
     } as QueryResponseNode
     const bNode = {
       id: joinDepIDTuple(['registry', '', 'b@1.0.0']),
       name: 'b',
       version: '1.0.0',
       insights: {},
+      toJSON() {},
     } as QueryResponseNode
     const nodes = [rootNode, aNode, bNode]
     const edges: QueryResponseEdge[] = [
@@ -117,18 +120,21 @@ test('explorer-grid with stack', async () => {
       name: 'root',
       version: '1.0.0',
       insights: {},
+      toJSON() {},
     } as QueryResponseNode
     const aNode = {
       id: joinDepIDTuple(['registry', '', 'a@1.0.0']),
       name: 'a',
       version: '1.0.0',
       insights: {},
+      toJSON() {},
     } as QueryResponseNode
     const bNode = {
       id: joinDepIDTuple(['registry', '', 'b@1.0.0']),
       name: 'b',
       version: '1.0.0',
       insights: {},
+      toJSON() {},
     } as QueryResponseNode
     const nodes = [rootNode, aNode, bNode]
     const edges: QueryResponseEdge[] = [

--- a/src/gui/test/state/__snapshots__/load-graph.ts.snap
+++ b/src/gui/test/state/__snapshots__/load-graph.ts.snap
@@ -18,6 +18,8 @@ exports[`load graph 1`] = `
         dev: false,
         optional: false,
         setResolved: [Function: setResolved],
+        toJSON: [Function (anonymous)],
+        toString: [Function (anonymous)],
         location: '.',
         integrity: undefined,
         resolved: undefined
@@ -39,6 +41,8 @@ exports[`load graph 1`] = `
           dev: false,
           optional: false,
           setResolved: [Function: setResolved],
+          toJSON: [Function (anonymous)],
+          toString: [Function (anonymous)],
           location: '.',
           integrity: undefined,
           resolved: undefined
@@ -59,6 +63,8 @@ exports[`load graph 1`] = `
           dev: true,
           optional: false,
           setResolved: [Function: setResolved],
+          toJSON: [Function: toJSON],
+          toString: [Function: toString],
           integrity: 'sha512-6/mh1E2u2YgEsCHdY0Yx5oW+61gZU+1vXaoiHHrpKeuRNNgFvS+/jrwHiQhB5apAf5oB7UB7E19ol2R2LKH8hQ==',
           resolved: undefined,
           location: 'node_modules/.pnpm/foo@1.0.0/node_modules/foo'
@@ -80,6 +86,8 @@ exports[`load graph 1`] = `
           dev: false,
           optional: false,
           setResolved: [Function: setResolved],
+          toJSON: [Function (anonymous)],
+          toString: [Function (anonymous)],
           location: '.',
           integrity: undefined,
           resolved: undefined
@@ -100,6 +108,8 @@ exports[`load graph 1`] = `
           dev: false,
           optional: true,
           setResolved: [Function: setResolved],
+          toJSON: [Function: toJSON],
+          toString: [Function: toString],
           integrity: undefined,
           resolved: 'http://example.com/baz.tgz'
         },
@@ -120,6 +130,8 @@ exports[`load graph 1`] = `
           dev: true,
           optional: false,
           setResolved: [Function: setResolved],
+          toJSON: [Function: toJSON],
+          toString: [Function: toString],
           integrity: 'sha512-6/mh1E2u2YgEsCHdY0Yx5oW+61gZU+1vXaoiHHrpKeuRNNgFvS+/jrwHiQhB5apAf5oB7UB7E19ol2R2LKH8hQ==',
           resolved: undefined,
           location: 'node_modules/.pnpm/foo@1.0.0/node_modules/foo'
@@ -140,6 +152,8 @@ exports[`load graph 1`] = `
           dev: true,
           optional: true,
           setResolved: [Function: setResolved],
+          toJSON: [Function: toJSON],
+          toString: [Function: toString],
           integrity: undefined,
           resolved: undefined
         },
@@ -161,6 +175,8 @@ exports[`load graph 1`] = `
         dev: false,
         optional: false,
         setResolved: [Function: setResolved],
+        toJSON: [Function (anonymous)],
+        toString: [Function (anonymous)],
         location: '.',
         integrity: undefined,
         resolved: undefined
@@ -179,6 +195,8 @@ exports[`load graph 1`] = `
         dev: true,
         optional: true,
         setResolved: [Function: setResolved],
+        toJSON: [Function: toJSON],
+        toString: [Function: toString],
         integrity: undefined,
         resolved: undefined
       },
@@ -196,6 +214,8 @@ exports[`load graph 1`] = `
         dev: true,
         optional: false,
         setResolved: [Function: setResolved],
+        toJSON: [Function: toJSON],
+        toString: [Function: toString],
         integrity: 'sha512-6/mh1E2u2YgEsCHdY0Yx5oW+61gZU+1vXaoiHHrpKeuRNNgFvS+/jrwHiQhB5apAf5oB7UB7E19ol2R2LKH8hQ==',
         resolved: undefined,
         location: 'node_modules/.pnpm/foo@1.0.0/node_modules/foo'
@@ -214,6 +234,8 @@ exports[`load graph 1`] = `
         dev: false,
         optional: true,
         setResolved: [Function: setResolved],
+        toJSON: [Function: toJSON],
+        toString: [Function: toString],
         integrity: undefined,
         resolved: 'http://example.com/baz.tgz'
       }
@@ -250,6 +272,8 @@ exports[`load graph 1`] = `
       dev: false,
       optional: false,
       setResolved: [Function: setResolved],
+      toJSON: [Function (anonymous)],
+      toString: [Function (anonymous)],
       location: '.',
       integrity: undefined,
       resolved: undefined

--- a/src/query/src/index.ts
+++ b/src/query/src/index.ts
@@ -166,6 +166,15 @@ const securitySelectors = new Set([
   ':unstable',
 ])
 
+const setMethodToJSON = (node: QueryResponseNode) => {
+  const { toJSON } = node
+  const insights = node.insights
+  node.toJSON = () => ({
+    ...toJSON.call(node),
+    insights,
+  })
+}
+
 export class Query {
   #cache: Map<string, QueryResponse>
   #graph: GraphLike
@@ -215,6 +224,8 @@ export class Query {
         node.insights = {
           scanned: false,
         }
+
+        setMethodToJSON(node)
         continue
       }
 
@@ -369,6 +380,8 @@ export class Query {
           i => i.type === 'unstableOwnership',
         ),
       }
+
+      setMethodToJSON(node)
     }
     return nodes
   }

--- a/src/query/src/types.ts
+++ b/src/query/src/types.ts
@@ -75,6 +75,21 @@ export type QueryResponseNode = Omit<
   edgesIn: Set<QueryResponseEdge>
   edgesOut: Map<string, QueryResponseEdge>
   insights: Insights
+  toJSON: () => Pick<
+    QueryResponseNode,
+    | 'id'
+    | 'name'
+    | 'version'
+    | 'location'
+    | 'importer'
+    | 'manifest'
+    | 'projectRoot'
+    | 'integrity'
+    | 'resolved'
+    | 'dev'
+    | 'optional'
+    | 'insights'
+  >
 }
 
 export type Insights = {

--- a/src/query/test/fixtures/graph.ts
+++ b/src/query/test/fixtures/graph.ts
@@ -47,6 +47,21 @@ export const newNode =
     dev: false,
     optional: false,
     setResolved() {},
+    toJSON() {
+      return {
+        id: this.id,
+        name: this.name,
+        version: this.version,
+        location: this.location,
+        importer: this.importer,
+        manifest: this.manifest,
+        projectRoot: this.projectRoot,
+        integrity: this.integrity,
+        resolved: this.resolved,
+        dev: this.dev,
+        optional: this.optional,
+      }
+    },
   })
 const newEdge = (
   from: NodeLike,

--- a/src/security-archive/test/fixtures/graph.ts
+++ b/src/security-archive/test/fixtures/graph.ts
@@ -52,6 +52,21 @@ export const newNode =
     dev: false,
     optional: false,
     setResolved() {},
+    toJSON() {
+      return {
+        id: this.id,
+        name: this.name,
+        version: this.version,
+        location: this.location,
+        importer: this.importer,
+        manifest: this.manifest,
+        projectRoot: this.projectRoot,
+        integrity: this.integrity,
+        resolved: this.resolved,
+        dev: this.dev,
+        optional: this.optional,
+      }
+    },
   })
 const newEdge = (
   from: NodeLike,


### PR DESCRIPTION
Add a `node.toJSON` method defintion to the `QueryResponseNode`
object. This fixes properly output of insights data to stdout
when using `vlt query ...`.

graph, gui: Added a `node.toJSON` to the `NodeLike` type definition, also
updates `src/gui` to implement a proper `toJSON` and `toString`
methods for its internal `NodeLike` implementation.