### PR TITLE
query: pseudo element parameter escaping

### DIFF
--- a/src/query/src/parser.ts
+++ b/src/query/src/parser.ts
@@ -1,6 +1,11 @@
 import postcssSelectorParser from 'postcss-selector-parser'
-import type { Root } from 'postcss-selector-parser'
-import { isIdentifierNode, isStringNode } from './types.ts'
+import type { Pseudo, Root } from 'postcss-selector-parser'
+import {
+  asSelectorNode,
+  isCombinatorNode,
+  isPseudoNode,
+  isTagNode,
+} from './types.ts'
 import type { PostcssNode } from './types.ts'
 
 /**
@@ -20,6 +25,20 @@ export const escapeDots = (query: string): string =>
 export const unescapeDots = (query: string): string =>
   query.replaceAll('\\.', '.')
 
+const pseudoCleanUpNeeded = new Set([
+  ':published',
+  ':score',
+  ':malware',
+  ':severity',
+  ':sev',
+  ':squat',
+  ':semver',
+  ':v',
+])
+
+const hasParamsToEscape = (node: Pseudo) =>
+  pseudoCleanUpNeeded.has(node.value)
+
 /**
  * Parses a CSS selector string into an AST
  * Handles escaping of forward slashes in specific patterns
@@ -28,8 +47,72 @@ export const parse = (query: string): Root => {
   const escapedQuery = escapeDots(escapeScopedNamesSlashes(query))
   const transformAst = (root: Root) => {
     root.walk((node: PostcssNode) => {
-      if (isIdentifierNode(node) || isStringNode(node)) {
+      // clean up the escaped dots
+      if (node.value && typeof node.value === 'string') {
         node.value = unescapeDots(node.value)
+      }
+      if (isPseudoNode(node) && hasParamsToEscape(node)) {
+        // these are pseudo nodes that should only take strings as
+        // parameters, so in this preparse step we clean up anything
+        // that was recognized as a postcss node and transform that
+        // into something that can be most likely parsed as a string
+        for (const n of node.nodes) {
+          // the parameters have a selector node that wraps them up
+          const selector = asSelectorNode(n)
+          selector.nodes.forEach((currentNode, index, arr) => {
+            // get the next node, we'll update it later
+            const nextNode = arr[index + 1]
+            // if the current node is a combinator node, we'll need to
+            // escape it, we do so by removing the node entirely and
+            // updating the contents of the next node with its value
+            if (
+              isCombinatorNode(currentNode) &&
+              isTagNode(nextNode)
+            ) {
+              nextNode.value = `${currentNode.spaces.before}${currentNode.value}${currentNode.spaces.after}${nextNode.value}`
+              // make sure to also update the source position
+              // references, those are used by the syntax highlighter
+              if (
+                nextNode.source?.start?.line &&
+                currentNode.source?.start?.line
+              ) {
+                nextNode.source.start.line =
+                  currentNode.source.start.line
+              }
+              if (
+                nextNode.source?.start?.column &&
+                currentNode.source?.start?.column
+              ) {
+                nextNode.source.start.column =
+                  currentNode.source.start.column
+              }
+              // removes the current node from the selector node
+              arr.splice(index, 1)
+            }
+          })
+          // after removing combinator nodes, if we end up with multiple
+          // tags in the selector node, we need to smush them together
+          selector.nodes.reduce((acc, currentNode) => {
+            if (currentNode === acc) return acc
+            acc.value = `${acc.value}${currentNode.spaces.before}${currentNode.value}${currentNode.spaces.after}`
+            // make sure to also update the source position refs
+            if (
+              currentNode.source?.end?.line &&
+              acc.source?.end?.line
+            ) {
+              acc.source.end.line = currentNode.source.end.line
+            }
+            if (
+              currentNode.source?.end?.column &&
+              acc.source?.end?.column
+            ) {
+              acc.source.end.column = currentNode.source.end.column
+            }
+            return acc
+          }, selector.first)
+          // the selector wrapper node should have a single node
+          selector.nodes.length = 1
+        }
       }
     })
   }

--- a/src/query/src/pseudo/malware.ts
+++ b/src/query/src/pseudo/malware.ts
@@ -32,6 +32,8 @@ export type MalwareAlertTypes =
   | 'gptAnomaly'
   | undefined
 
+export type MalwareComparator = '>' | '<' | '>=' | '<=' | undefined
+
 const kindsMap = new Map<MalwareKinds, MalwareAlertTypes>([
   ['critical', 'malware'],
   ['high', 'gptMalware'],
@@ -42,6 +44,19 @@ const kindsMap = new Map<MalwareKinds, MalwareAlertTypes>([
   ['2', 'gptSecurity'],
   ['3', 'gptAnomaly'],
 ])
+
+// Map numerical values to their respective kinds for comparison operations
+const kindLevelMap = new Map<MalwareKinds, number>([
+  ['critical', 0],
+  ['high', 1],
+  ['medium', 2],
+  ['low', 3],
+  ['0', 0],
+  ['1', 1],
+  ['2', 2],
+  ['3', 3],
+])
+
 const kinds = new Set(kindsMap.keys())
 
 export const isMalwareKind = (
@@ -60,25 +75,58 @@ export const asMalwareKind = (value?: string): MalwareKinds => {
 
 export const parseInternals = (
   nodes: PostcssNode[],
-): { kind: MalwareKinds } => {
+): { kind: MalwareKinds; comparator: MalwareComparator } => {
+  let kindValue = ''
+  let comparator: MalwareComparator = undefined
   let kind: MalwareKinds
 
+  // Parse the parameter (kind with optional comparator)
   if (isStringNode(asPostcssNodeWithChildren(nodes[0]).nodes[0])) {
-    kind = asMalwareKind(
-      removeQuotes(
-        asStringNode(asPostcssNodeWithChildren(nodes[0]).nodes[0])
-          .value,
-      ),
+    kindValue = removeQuotes(
+      asStringNode(asPostcssNodeWithChildren(nodes[0]).nodes[0])
+        .value,
     )
   } else if (
     isTagNode(asPostcssNodeWithChildren(nodes[0]).nodes[0])
   ) {
-    kind = asMalwareKind(
-      asTagNode(asPostcssNodeWithChildren(nodes[0]).nodes[0]).value,
-    )
+    kindValue = asTagNode(
+      asPostcssNodeWithChildren(nodes[0]).nodes[0],
+    ).value
   }
 
-  return { kind }
+  // Extract comparator if present
+  if (kindValue.startsWith('>=')) {
+    comparator = '>='
+    kindValue = kindValue.substring(2)
+  } else if (kindValue.startsWith('<=')) {
+    comparator = '<='
+    kindValue = kindValue.substring(2)
+  } else if (kindValue.startsWith('>')) {
+    comparator = '>'
+    kindValue = kindValue.substring(1)
+  } else if (kindValue.startsWith('<')) {
+    comparator = '<'
+    kindValue = kindValue.substring(1)
+  }
+
+  // Validate the kind without comparator
+  if (!comparator) {
+    kind = asMalwareKind(kindValue)
+  } else {
+    // For comparisons, just make sure it's a valid numeric value or a valid kind
+    if (isMalwareKind(kindValue)) {
+      kind = kindValue
+    } else {
+      throw error(
+        'Expected a valid malware kind or number between 0-3',
+        {
+          found: kindValue,
+        },
+      )
+    }
+  }
+
+  return { kind, comparator }
 }
 
 export const malware = async (state: ParserState) => {
@@ -93,13 +141,84 @@ export const malware = async (state: ParserState) => {
     throw error('Failed to parse :malware selector', { cause: err })
   }
 
-  const { kind } = internals
-  const alertName = kindsMap.get(kind)
+  const { kind, comparator } = internals
+  const alertName = comparator ? undefined : kindsMap.get(kind)
+
   for (const node of state.partial.nodes) {
     const report = state.securityArchive.get(node.id)
-    const exclude = !report?.alerts.some(
-      alert => alert.type === alertName,
-    )
+    // Always exclude nodes that don't have security data or alerts
+    if (!report?.alerts || report.alerts.length === 0) {
+      removeNode(state, node)
+    }
+  }
+
+  for (const node of state.partial.nodes) {
+    const report = state.securityArchive.get(node.id)
+    let exclude = true
+
+    if (report) {
+      if (comparator) {
+        // retrieve the value to compare against
+        const kindLevel = kindLevelMap.get(kind)
+        // the kindLevel value has already been validated at this point
+        // and thus can never return an undefined/falsy value but ts doesn't
+        // know about that, so we have the extra check here
+        /* c8 ignore next - impossible */
+        if (!kindLevel) break
+
+        // Check each alert to find any that match our comparison criteria
+        for (const alert of report.alerts) {
+          // Get the numerical value of the alert type
+          const alertType = alert.type as MalwareAlertTypes
+
+          // retrieve a key to the current alert level to be compared against
+          const currentAlertLevelKey = [...kindsMap.entries()].find(
+            ([_, alertValue]) => alertValue === alertType,
+          )?.[0]
+
+          // perform the comparison based on the user-provided kindLevel
+          if (currentAlertLevelKey) {
+            const currentAlertLevel = kindLevelMap.get(
+              currentAlertLevelKey,
+            )
+            /* c8 ignore next - impossible but ts doesn't know */
+            if (currentAlertLevel == null) continue
+
+            switch (comparator) {
+              case '>':
+                if (currentAlertLevel > kindLevel) {
+                  exclude = false
+                }
+                break
+              case '<':
+                if (currentAlertLevel < kindLevel) {
+                  exclude = false
+                }
+                break
+              case '>=':
+                if (currentAlertLevel >= kindLevel) {
+                  exclude = false
+                }
+                break
+              case '<=':
+                if (currentAlertLevel <= kindLevel) {
+                  exclude = false
+                }
+                break
+            }
+
+            // If we've found a match, no need to check other alerts
+            if (!exclude) break
+          }
+        }
+      } else {
+        // Original exact match behavior
+        exclude = !report.alerts.some(
+          alert => alert.type === alertName,
+        )
+      }
+    }
+
     if (exclude) {
       removeNode(state, node)
     }

--- a/src/query/src/pseudo/malware.ts
+++ b/src/query/src/pseudo/malware.ts
@@ -169,7 +169,7 @@ export const malware = async (state: ParserState) => {
         // Check each alert to find any that match our comparison criteria
         for (const alert of report.alerts) {
           // Get the numerical value of the alert type
-          const alertType = alert.type as MalwareAlertTypes
+          const alertType = alert.type
 
           // retrieve a key to the current alert level to be compared against
           const currentAlertLevelKey = [...kindsMap.entries()].find(

--- a/src/query/src/pseudo/published.ts
+++ b/src/query/src/pseudo/published.ts
@@ -83,9 +83,10 @@ export const parseInternals = (
   } else if (
     isTagNode(asPostcssNodeWithChildren(nodes[0]).nodes[0])
   ) {
-    value = asTagNode(
+    const tagNode = asTagNode(
       asPostcssNodeWithChildren(nodes[0]).nodes[0],
-    ).value
+    )
+    value = tagNode.value
   }
 
   // Check if the value starts with a comparator

--- a/src/query/src/pseudo/score.ts
+++ b/src/query/src/pseudo/score.ts
@@ -68,9 +68,10 @@ export const parseInternals = (
   } else if (
     isTagNode(asPostcssNodeWithChildren(nodes[0]).nodes[0])
   ) {
-    rateStr = asTagNode(
+    const tagNode = asTagNode(
       asPostcssNodeWithChildren(nodes[0]).nodes[0],
-    ).value
+    )
+    rateStr = tagNode.value
   }
 
   // Extract comparator if present

--- a/src/query/src/pseudo/severity.ts
+++ b/src/query/src/pseudo/severity.ts
@@ -32,6 +32,8 @@ export type SeverityAlertTypes =
   | 'mildCVE'
   | undefined
 
+export type SeverityComparator = '>' | '<' | '>=' | '<=' | undefined
+
 const kindsMap = new Map<SeverityKinds, SeverityAlertTypes>([
   ['critical', 'criticalCVE'],
   ['high', 'cve'],
@@ -42,6 +44,19 @@ const kindsMap = new Map<SeverityKinds, SeverityAlertTypes>([
   ['2', 'potentialVulnerability'],
   ['3', 'mildCVE'],
 ])
+
+// Map numerical values to their respective kinds for comparison operations
+const kindLevelMap = new Map<SeverityKinds, number>([
+  ['critical', 0],
+  ['high', 1],
+  ['medium', 2],
+  ['low', 3],
+  ['0', 0],
+  ['1', 1],
+  ['2', 2],
+  ['3', 3],
+])
+
 const kinds = new Set(kindsMap.keys())
 
 export const isSeverityKind = (
@@ -60,25 +75,61 @@ export const asSeverityKind = (value?: string): SeverityKinds => {
 
 export const parseInternals = (
   nodes: PostcssNode[],
-): { kind: SeverityKinds } => {
+): {
+  kind: SeverityKinds
+  comparator: SeverityComparator
+} => {
   let kind: SeverityKinds
+  let comparator: SeverityComparator
 
+  if (nodes.length === 0) {
+    throw error('Missing severity kind parameter')
+  }
+
+  let kindValue = ''
   if (isStringNode(asPostcssNodeWithChildren(nodes[0]).nodes[0])) {
-    kind = asSeverityKind(
-      removeQuotes(
-        asStringNode(asPostcssNodeWithChildren(nodes[0]).nodes[0])
-          .value,
-      ),
+    kindValue = removeQuotes(
+      asStringNode(asPostcssNodeWithChildren(nodes[0]).nodes[0])
+        .value,
     )
   } else if (
     isTagNode(asPostcssNodeWithChildren(nodes[0]).nodes[0])
   ) {
-    kind = asSeverityKind(
-      asTagNode(asPostcssNodeWithChildren(nodes[0]).nodes[0]).value,
-    )
+    kindValue = asTagNode(
+      asPostcssNodeWithChildren(nodes[0]).nodes[0],
+    ).value
   }
 
-  return { kind }
+  // Extract comparator if present
+  if (kindValue.startsWith('>=')) {
+    comparator = '>='
+    kindValue = kindValue.substring(2)
+  } else if (kindValue.startsWith('<=')) {
+    comparator = '<='
+    kindValue = kindValue.substring(2)
+  } else if (kindValue.startsWith('>')) {
+    comparator = '>'
+    kindValue = kindValue.substring(1)
+  } else if (kindValue.startsWith('<')) {
+    comparator = '<'
+    kindValue = kindValue.substring(1)
+  }
+
+  // Parse kind value
+  if (kindValue) {
+    if (isSeverityKind(kindValue)) {
+      kind = kindValue
+    } else {
+      throw error(
+        'Expected a valid severity kind or number between 0-3',
+        {
+          found: kindValue,
+        },
+      )
+    }
+  }
+
+  return { kind, comparator }
 }
 
 export const severity = async (state: ParserState) => {
@@ -93,13 +144,81 @@ export const severity = async (state: ParserState) => {
     throw error('Failed to parse :severity selector', { cause: err })
   }
 
-  const { kind } = internals
-  const alertName = kindsMap.get(kind)
+  const { kind, comparator } = internals
+
   for (const node of state.partial.nodes) {
     const report = state.securityArchive.get(node.id)
-    const exclude = !report?.alerts.some(
-      alert => alert.type === alertName,
-    )
+    // Always exclude nodes that don't have security data or alerts
+    if (!report?.alerts || report.alerts.length === 0) {
+      removeNode(state, node)
+    }
+  }
+
+  for (const node of state.partial.nodes) {
+    const report = state.securityArchive.get(node.id)
+    let exclude = true
+
+    if (report) {
+      if (comparator) {
+        // retrieve the value to compare against
+        const kindLevel = kindLevelMap.get(kind)
+        // the kindLevel value has already been validated at this point
+        // and thus can never return an undefined/falsy value but ts doesn't
+        // know about that, so we have the extra check here
+        /* c8 ignore next - impossible */
+        if (!kindLevel) break
+
+        // Check each alert to find any that match our comparison criteria
+        for (const alert of report.alerts) {
+          // Get the numerical value of the alert type
+          const alertType = alert.type as SeverityAlertTypes
+
+          // retrieve a key to the current alert level to be compared against
+          const currentAlertLevelKey = [...kindsMap.entries()].find(
+            ([_, alertValue]) => alertValue === alertType,
+          )?.[0]
+
+          // perform the comparison based on the user-provided kindLevel
+          if (currentAlertLevelKey) {
+            const currentAlertLevel = kindLevelMap.get(
+              currentAlertLevelKey,
+            )
+            /* c8 ignore next - impossible but ts doesn't know */
+            if (currentAlertLevel == null) continue
+
+            switch (comparator) {
+              case '>':
+                if (currentAlertLevel > kindLevel) {
+                  exclude = false
+                }
+                break
+              case '<':
+                if (currentAlertLevel < kindLevel) {
+                  exclude = false
+                }
+                break
+              case '>=':
+                if (currentAlertLevel >= kindLevel) {
+                  exclude = false
+                }
+                break
+              case '<=':
+                if (currentAlertLevel <= kindLevel) {
+                  exclude = false
+                }
+                break
+            }
+          }
+        }
+      } else {
+        // Original exact match behavior
+        const alertName = kindsMap.get(kind)
+        exclude = !report.alerts.some(
+          alert => alert.type === alertName,
+        )
+      }
+    }
+
     if (exclude) {
       removeNode(state, node)
     }

--- a/src/query/src/pseudo/severity.ts
+++ b/src/query/src/pseudo/severity.ts
@@ -171,7 +171,7 @@ export const severity = async (state: ParserState) => {
         // Check each alert to find any that match our comparison criteria
         for (const alert of report.alerts) {
           // Get the numerical value of the alert type
-          const alertType = alert.type as SeverityAlertTypes
+          const alertType = alert.type
 
           // retrieve a key to the current alert level to be compared against
           const currentAlertLevelKey = [...kindsMap.entries()].find(

--- a/src/query/src/types.ts
+++ b/src/query/src/types.ts
@@ -221,6 +221,20 @@ export const asIdentifierNode = (node?: PostcssNode): Identifier => {
 export const isSelectorNode = (node: any): node is Selector =>
   isPostcssNodeWithChildren(node) && node.type === 'selector'
 
+export const asSelectorNode = (node?: PostcssNode): Selector => {
+  if (!node) {
+    throw error('Expected a query node')
+  }
+
+  if (!isSelectorNode(node)) {
+    throw error('Mismatching query node', {
+      wanted: 'selector',
+      found: node.type,
+    })
+  }
+  return node
+}
+
 export const isPseudoNode = (node: unknown): node is Pseudo =>
   isObj(node) && !!node.value && node.type === 'pseudo'
 

--- a/src/query/tap-snapshots/test/parser.ts.test.cjs
+++ b/src/query/tap-snapshots/test/parser.ts.test.cjs
@@ -1,0 +1,344 @@
+/* IMPORTANT
+ * This snapshot file is auto-generated, but designed for humans.
+ * It should be checked into source control and tracked carefully.
+ * Re-generate by setting TAP_SNAPSHOT=1 and running tests.
+ * Make sure to inspect the output below.  Do not ignore changes!
+ */
+'use strict'
+exports[`test/parser.ts > TAP > parse > should clean up usage of combinators params in pseudo selectors that accept only string values 1`] = `
+Array [
+  Object {
+    "source": Object {
+      "end": Object {
+        "column": 6,
+        "line": 1,
+      },
+      "start": Object {
+        "column": 1,
+        "line": 1,
+      },
+    },
+    "type": "selector",
+  },
+  Object {
+    "source": Object {
+      "end": Object {
+        "column": 6,
+        "line": 1,
+      },
+      "start": Object {
+        "column": 1,
+        "line": 1,
+      },
+    },
+    "type": "pseudo",
+    "value": ":v",
+  },
+  Object {
+    "source": Object {
+      "end": Object {
+        "column": 6,
+        "line": 1,
+      },
+      "start": Object {
+        "column": 4,
+        "line": 1,
+      },
+    },
+    "type": "selector",
+  },
+  Object {
+    "source": Object {
+      "end": Object {
+        "column": 5,
+        "line": 1,
+      },
+      "start": Object {
+        "column": 4,
+        "line": 1,
+      },
+    },
+    "type": "tag",
+    "value": ">2",
+  },
+]
+`
+
+exports[`test/parser.ts > TAP > parse > should clean up usage of multiple pseudo selectors requiring cleaning up 1`] = `
+Array [
+  Object {
+    "source": Object {
+      "end": Object {
+        "column": 129,
+        "line": 1,
+      },
+      "start": Object {
+        "column": 1,
+        "line": 1,
+      },
+    },
+    "type": "selector",
+  },
+  Object {
+    "source": Object {
+      "end": Object {
+        "column": 5,
+        "line": 1,
+      },
+      "start": Object {
+        "column": 1,
+        "line": 1,
+      },
+    },
+    "type": "pseudo",
+    "value": ":root",
+  },
+  Object {
+    "source": Object {
+      "end": Object {
+        "column": 7,
+        "line": 1,
+      },
+      "start": Object {
+        "column": 7,
+        "line": 1,
+      },
+    },
+    "type": "combinator",
+    "value": ">",
+  },
+  Object {
+    "source": Object {
+      "end": Object {
+        "column": 20,
+        "line": 1,
+      },
+      "start": Object {
+        "column": 9,
+        "line": 1,
+      },
+    },
+    "type": "pseudo",
+    "value": ":v",
+  },
+  Object {
+    "source": Object {
+      "end": Object {
+        "column": 20,
+        "line": 1,
+      },
+      "start": Object {
+        "column": 12,
+        "line": 1,
+      },
+    },
+    "type": "selector",
+  },
+  Object {
+    "source": Object {
+      "end": Object {
+        "column": 19,
+        "line": 1,
+      },
+      "start": Object {
+        "column": 12,
+        "line": 1,
+      },
+    },
+    "type": "tag",
+    "value": ">1 >2 >3",
+  },
+  Object {
+    "source": Object {
+      "end": Object {
+        "column": 58,
+        "line": 1,
+      },
+      "start": Object {
+        "column": 21,
+        "line": 1,
+      },
+    },
+    "type": "pseudo",
+    "value": ":not",
+  },
+  Object {
+    "source": Object {
+      "end": Object {
+        "column": 58,
+        "line": 1,
+      },
+      "start": Object {
+        "column": 26,
+        "line": 1,
+      },
+    },
+    "type": "selector",
+  },
+  Object {
+    "source": Object {
+      "end": Object {
+        "column": 57,
+        "line": 1,
+      },
+      "start": Object {
+        "column": 26,
+        "line": 1,
+      },
+    },
+    "type": "pseudo",
+    "value": ":v",
+  },
+  Object {
+    "source": Object {
+      "end": Object {
+        "column": 57,
+        "line": 1,
+      },
+      "start": Object {
+        "column": 29,
+        "line": 1,
+      },
+    },
+    "type": "selector",
+  },
+  Object {
+    "source": Object {
+      "end": Object {
+        "column": 56,
+        "line": 1,
+      },
+      "start": Object {
+        "column": 29,
+        "line": 1,
+      },
+    },
+    "type": "tag",
+    "value": "2.0.0-pre+build0.13adsfa1",
+  },
+  Object {
+    "source": Object {
+      "end": Object {
+        "column": 60,
+        "line": 1,
+      },
+      "start": Object {
+        "column": 60,
+        "line": 1,
+      },
+    },
+    "type": "combinator",
+    "value": ">",
+  },
+  Object {
+    "source": Object {
+      "end": Object {
+        "column": 70,
+        "line": 1,
+      },
+      "start": Object {
+        "column": 62,
+        "line": 1,
+      },
+    },
+    "type": "tag",
+    "value": "published(<=2024-01-01T11:11:11.111Z)",
+  },
+  Object {
+    "source": Object {
+      "end": Object {
+        "column": 100,
+        "line": 1,
+      },
+      "start": Object {
+        "column": 100,
+        "line": 1,
+      },
+    },
+    "type": "combinator",
+    "value": " ",
+  },
+  Object {
+    "source": Object {
+      "end": Object {
+        "column": 114,
+        "line": 1,
+      },
+      "start": Object {
+        "column": 101,
+        "line": 1,
+      },
+    },
+    "type": "pseudo",
+    "value": ":severity",
+  },
+  Object {
+    "source": Object {
+      "end": Object {
+        "column": 114,
+        "line": 1,
+      },
+      "start": Object {
+        "column": 111,
+        "line": 1,
+      },
+    },
+    "type": "selector",
+  },
+  Object {
+    "source": Object {
+      "end": Object {
+        "column": 114,
+        "line": 1,
+      },
+      "start": Object {
+        "column": 111,
+        "line": 1,
+      },
+    },
+    "type": "tag",
+    "value": ">=0",
+  },
+  Object {
+    "source": Object {
+      "end": Object {
+        "column": 129,
+        "line": 1,
+      },
+      "start": Object {
+        "column": 115,
+        "line": 1,
+      },
+    },
+    "type": "pseudo",
+    "value": ":score",
+  },
+  Object {
+    "source": Object {
+      "end": Object {
+        "column": 129,
+        "line": 1,
+      },
+      "start": Object {
+        "column": 122,
+        "line": 1,
+      },
+    },
+    "type": "selector",
+  },
+  Object {
+    "source": Object {
+      "end": Object {
+        "column": 128,
+        "line": 1,
+      },
+      "start": Object {
+        "column": 123,
+        "line": 1,
+      },
+    },
+    "type": "tag",
+    "value": " > 0.9",
+  },
+]
+`

--- a/src/query/tap-snapshots/test/pseudo/malware.ts.test.cjs
+++ b/src/query/tap-snapshots/test/pseudo/malware.ts.test.cjs
@@ -8,10 +8,12 @@
 exports[`test/pseudo/malware.ts > TAP > selects packages with a specific malware kind > filter out any node that does not have the malware alert > must match snapshot 1`] = `
 Object {
   "edges": Array [
+    "a",
     "e",
     "e",
   ],
   "nodes": Array [
+    "a",
     "e",
   ],
 }
@@ -20,9 +22,11 @@ Object {
 exports[`test/pseudo/malware.ts > TAP > selects packages with a specific malware kind > filter out using unquoted param > must match snapshot 1`] = `
 Object {
   "edges": Array [
+    "b",
     "f",
   ],
   "nodes": Array [
+    "b",
     "f",
   ],
 }
@@ -31,11 +35,137 @@ Object {
 exports[`test/pseudo/malware.ts > TAP > selects packages with a specific malware kind > filter using numbered param > must match snapshot 1`] = `
 Object {
   "edges": Array [
+    "a",
     "e",
     "e",
   ],
   "nodes": Array [
+    "a",
     "e",
+  ],
+}
+`
+
+exports[`test/pseudo/malware.ts > TAP > selects packages with a specific malware kind > greater than comparator with number (unquoted) > must match snapshot 1`] = `
+Object {
+  "edges": Array [
+    "c",
+    "d",
+  ],
+  "nodes": Array [
+    "c",
+    "d",
+  ],
+}
+`
+
+exports[`test/pseudo/malware.ts > TAP > selects packages with a specific malware kind > greater than comparator with string kind (quoted) > must match snapshot 1`] = `
+Object {
+  "edges": Array [
+    "c",
+    "d",
+  ],
+  "nodes": Array [
+    "c",
+    "d",
+  ],
+}
+`
+
+exports[`test/pseudo/malware.ts > TAP > selects packages with a specific malware kind > greater than or equal to comparator with number (unquoted) > must match snapshot 1`] = `
+Object {
+  "edges": Array [
+    "c",
+    "d",
+  ],
+  "nodes": Array [
+    "c",
+    "d",
+  ],
+}
+`
+
+exports[`test/pseudo/malware.ts > TAP > selects packages with a specific malware kind > greater than or equal to comparator with string kind (quoted) > must match snapshot 1`] = `
+Object {
+  "edges": Array [
+    "c",
+    "d",
+  ],
+  "nodes": Array [
+    "c",
+    "d",
+  ],
+}
+`
+
+exports[`test/pseudo/malware.ts > TAP > selects packages with a specific malware kind > less than comparator with number (unquoted) > must match snapshot 1`] = `
+Object {
+  "edges": Array [
+    "a",
+    "b",
+    "e",
+    "e",
+    "f",
+  ],
+  "nodes": Array [
+    "a",
+    "b",
+    "e",
+    "f",
+  ],
+}
+`
+
+exports[`test/pseudo/malware.ts > TAP > selects packages with a specific malware kind > less than comparator with string kind (quoted) > must match snapshot 1`] = `
+Object {
+  "edges": Array [
+    "a",
+    "b",
+    "e",
+    "e",
+    "f",
+  ],
+  "nodes": Array [
+    "a",
+    "b",
+    "e",
+    "f",
+  ],
+}
+`
+
+exports[`test/pseudo/malware.ts > TAP > selects packages with a specific malware kind > less than or equal to comparator with number (unquoted) > must match snapshot 1`] = `
+Object {
+  "edges": Array [
+    "a",
+    "b",
+    "e",
+    "e",
+    "f",
+  ],
+  "nodes": Array [
+    "a",
+    "b",
+    "e",
+    "f",
+  ],
+}
+`
+
+exports[`test/pseudo/malware.ts > TAP > selects packages with a specific malware kind > less than or equal to comparator with string kind (quoted) > must match snapshot 1`] = `
+Object {
+  "edges": Array [
+    "a",
+    "b",
+    "e",
+    "e",
+    "f",
+  ],
+  "nodes": Array [
+    "a",
+    "b",
+    "e",
+    "f",
   ],
 }
 `

--- a/src/query/tap-snapshots/test/pseudo/published.ts.test.cjs
+++ b/src/query/tap-snapshots/test/pseudo/published.ts.test.cjs
@@ -16,7 +16,29 @@ Object {
 }
 `
 
-exports[`test/pseudo/published.ts > TAP > select from published definition > published greater than date > must match snapshot 1`] = `
+exports[`test/pseudo/published.ts > TAP > select from published definition > published exact time (quoted) > must match snapshot 1`] = `
+Object {
+  "edges": Array [
+    "a",
+  ],
+  "nodes": Array [
+    "a",
+  ],
+}
+`
+
+exports[`test/pseudo/published.ts > TAP > select from published definition > published exact time > must match snapshot 1`] = `
+Object {
+  "edges": Array [
+    "a",
+  ],
+  "nodes": Array [
+    "a",
+  ],
+}
+`
+
+exports[`test/pseudo/published.ts > TAP > select from published definition > published greater than date (quoted) > must match snapshot 1`] = `
 Object {
   "edges": Array [
     "c",
@@ -31,7 +53,22 @@ Object {
 }
 `
 
-exports[`test/pseudo/published.ts > TAP > select from published definition > published greater than or equal date > must match snapshot 1`] = `
+exports[`test/pseudo/published.ts > TAP > select from published definition > published greater than date (unquoted) > must match snapshot 1`] = `
+Object {
+  "edges": Array [
+    "c",
+    "d",
+    "e",
+  ],
+  "nodes": Array [
+    "c",
+    "d",
+    "e",
+  ],
+}
+`
+
+exports[`test/pseudo/published.ts > TAP > select from published definition > published greater than or equal date (quoted) > must match snapshot 1`] = `
 Object {
   "edges": Array [
     "b",
@@ -48,7 +85,24 @@ Object {
 }
 `
 
-exports[`test/pseudo/published.ts > TAP > select from published definition > published less than date > must match snapshot 1`] = `
+exports[`test/pseudo/published.ts > TAP > select from published definition > published greater than or equal date (unquoted) > must match snapshot 1`] = `
+Object {
+  "edges": Array [
+    "b",
+    "c",
+    "d",
+    "e",
+  ],
+  "nodes": Array [
+    "b",
+    "c",
+    "d",
+    "e",
+  ],
+}
+`
+
+exports[`test/pseudo/published.ts > TAP > select from published definition > published less than date (quoted) > must match snapshot 1`] = `
 Object {
   "edges": Array [
     "a",
@@ -59,7 +113,31 @@ Object {
 }
 `
 
-exports[`test/pseudo/published.ts > TAP > select from published definition > published less than or equal date > must match snapshot 1`] = `
+exports[`test/pseudo/published.ts > TAP > select from published definition > published less than date (unquoted) > must match snapshot 1`] = `
+Object {
+  "edges": Array [
+    "a",
+  ],
+  "nodes": Array [
+    "a",
+  ],
+}
+`
+
+exports[`test/pseudo/published.ts > TAP > select from published definition > published less than or equal date (quoted) > must match snapshot 1`] = `
+Object {
+  "edges": Array [
+    "a",
+    "b",
+  ],
+  "nodes": Array [
+    "a",
+    "b",
+  ],
+}
+`
+
+exports[`test/pseudo/published.ts > TAP > select from published definition > published less than or equal date (unquoted) > must match snapshot 1`] = `
 Object {
   "edges": Array [
     "a",

--- a/src/query/tap-snapshots/test/pseudo/score.ts.test.cjs
+++ b/src/query/tap-snapshots/test/pseudo/score.ts.test.cjs
@@ -50,7 +50,33 @@ Object {
 }
 `
 
+exports[`test/pseudo/score.ts > TAP > selects packages based on their security score > greater than comparator (unquoted) > must match snapshot 1`] = `
+Object {
+  "edges": Array [
+    "a",
+    "d",
+  ],
+  "nodes": Array [
+    "a",
+    "d",
+  ],
+}
+`
+
 exports[`test/pseudo/score.ts > TAP > selects packages based on their security score > greater than comparator > must match snapshot 1`] = `
+Object {
+  "edges": Array [
+    "a",
+    "d",
+  ],
+  "nodes": Array [
+    "a",
+    "d",
+  ],
+}
+`
+
+exports[`test/pseudo/score.ts > TAP > selects packages based on their security score > greater than or equal comparator (unquoted) > must match snapshot 1`] = `
 Object {
   "edges": Array [
     "a",
@@ -76,7 +102,35 @@ Object {
 }
 `
 
+exports[`test/pseudo/score.ts > TAP > selects packages based on their security score > less than comparator (unquoted) > must match snapshot 1`] = `
+Object {
+  "edges": Array [
+    "e",
+    "c",
+    "e",
+  ],
+  "nodes": Array [
+    "c",
+    "e",
+  ],
+}
+`
+
 exports[`test/pseudo/score.ts > TAP > selects packages based on their security score > less than comparator > must match snapshot 1`] = `
+Object {
+  "edges": Array [
+    "e",
+    "c",
+    "e",
+  ],
+  "nodes": Array [
+    "c",
+    "e",
+  ],
+}
+`
+
+exports[`test/pseudo/score.ts > TAP > selects packages based on their security score > less than or equal comparator (unquoted) > must match snapshot 1`] = `
 Object {
   "edges": Array [
     "e",

--- a/src/query/tap-snapshots/test/pseudo/semver.ts.test.cjs
+++ b/src/query/tap-snapshots/test/pseudo/semver.ts.test.cjs
@@ -196,6 +196,35 @@ Object {
 }
 `
 
+exports[`test/pseudo/semver.ts > TAP > select from semver definition > unquoted complex semver with spaces > must match snapshot 1`] = `
+Object {
+  "edges": Array [
+    "a",
+    "b",
+    "d",
+  ],
+  "nodes": Array [
+    "semver-rich-project",
+    "a",
+    "b",
+    "d",
+  ],
+}
+`
+
+exports[`test/pseudo/semver.ts > TAP > select from semver definition > unquoted custom attribute property > must match snapshot 1`] = `
+Object {
+  "edges": Array [
+    "b",
+    "d",
+  ],
+  "nodes": Array [
+    "b",
+    "d",
+  ],
+}
+`
+
 exports[`test/pseudo/semver.ts > TAP > select from semver definition > unquoted custom semver function > must match snapshot 1`] = `
 Object {
   "edges": Array [
@@ -231,6 +260,44 @@ Object {
 }
 `
 
+exports[`test/pseudo/semver.ts > TAP > select from semver definition > unquoted greater than or equal semver > must match snapshot 1`] = `
+Object {
+  "edges": Array [
+    "b",
+    "c",
+    "d",
+    "e",
+    "f",
+  ],
+  "nodes": Array [
+    "b",
+    "c",
+    "d",
+    "e",
+    "f",
+  ],
+}
+`
+
+exports[`test/pseudo/semver.ts > TAP > select from semver definition > unquoted greater than semver > must match snapshot 1`] = `
+Object {
+  "edges": Array [
+    "b",
+    "c",
+    "d",
+    "e",
+    "f",
+  ],
+  "nodes": Array [
+    "b",
+    "c",
+    "d",
+    "e",
+    "f",
+  ],
+}
+`
+
 exports[`test/pseudo/semver.ts > TAP > select from semver definition > unquoted hyphen-separated semver > must match snapshot 1`] = `
 Object {
   "edges": Array [
@@ -238,6 +305,30 @@ Object {
   ],
   "nodes": Array [
     "e",
+  ],
+}
+`
+
+exports[`test/pseudo/semver.ts > TAP > select from semver definition > unquoted less than or equal semver > must match snapshot 1`] = `
+Object {
+  "edges": Array [
+    "a",
+  ],
+  "nodes": Array [
+    "semver-rich-project",
+    "a",
+  ],
+}
+`
+
+exports[`test/pseudo/semver.ts > TAP > select from semver definition > unquoted less than semver > must match snapshot 1`] = `
+Object {
+  "edges": Array [
+    "a",
+  ],
+  "nodes": Array [
+    "semver-rich-project",
+    "a",
   ],
 }
 `
@@ -285,6 +376,48 @@ Object {
   ],
   "nodes": Array [
     "e",
+  ],
+}
+`
+
+exports[`test/pseudo/semver.ts > TAP > select from semver definition > unquoted semver with +-. characters > must match snapshot 1`] = `
+Object {
+  "edges": Array [
+    "g",
+  ],
+  "nodes": Array [
+    "g",
+  ],
+}
+`
+
+exports[`test/pseudo/semver.ts > TAP > select from semver definition > unquoted semver with || (OR) operator > must match snapshot 1`] = `
+Object {
+  "edges": Array [
+    "e",
+    "f",
+  ],
+  "nodes": Array [
+    "semver-rich-project",
+    "e",
+    "f",
+  ],
+}
+`
+
+exports[`test/pseudo/semver.ts > TAP > select from semver definition > unquoted semver with multiple comparators > must match snapshot 1`] = `
+Object {
+  "edges": Array [
+    "a",
+    "b",
+    "e",
+    "f",
+  ],
+  "nodes": Array [
+    "a",
+    "b",
+    "e",
+    "f",
   ],
 }
 `

--- a/src/query/tap-snapshots/test/pseudo/severity.ts.test.cjs
+++ b/src/query/tap-snapshots/test/pseudo/severity.ts.test.cjs
@@ -39,3 +39,57 @@ Object {
   ],
 }
 `
+
+exports[`test/pseudo/severity.ts > TAP > selects packages with a specific severity kind > greater than comparator with number (unquoted) > must match snapshot 1`] = `
+Object {
+  "edges": Array [
+    "a",
+    "b",
+  ],
+  "nodes": Array [
+    "a",
+    "b",
+  ],
+}
+`
+
+exports[`test/pseudo/severity.ts > TAP > selects packages with a specific severity kind > greater than or equal to comparator with number (quoted) > must match snapshot 1`] = `
+Object {
+  "edges": Array [
+    "a",
+    "b",
+  ],
+  "nodes": Array [
+    "a",
+    "b",
+  ],
+}
+`
+
+exports[`test/pseudo/severity.ts > TAP > selects packages with a specific severity kind > less than comparator with number (quoted) > must match snapshot 1`] = `
+Object {
+  "edges": Array [
+    "e",
+    "e",
+    "f",
+  ],
+  "nodes": Array [
+    "e",
+    "f",
+  ],
+}
+`
+
+exports[`test/pseudo/severity.ts > TAP > selects packages with a specific severity kind > less than or equal to comparator with number (unquoted) > must match snapshot 1`] = `
+Object {
+  "edges": Array [
+    "e",
+    "e",
+    "f",
+  ],
+  "nodes": Array [
+    "e",
+    "f",
+  ],
+}
+`

--- a/src/query/tap-snapshots/test/pseudo/squat.ts.test.cjs
+++ b/src/query/tap-snapshots/test/pseudo/squat.ts.test.cjs
@@ -39,3 +39,77 @@ Object {
   ],
 }
 `
+
+exports[`test/pseudo/squat.ts > TAP > selects packages with a specific squat kind > greater than comparator with number (unquoted) > must match snapshot 1`] = `
+Object {
+  "edges": Array [
+    "f",
+  ],
+  "nodes": Array [
+    "f",
+  ],
+}
+`
+
+exports[`test/pseudo/squat.ts > TAP > selects packages with a specific squat kind > greater than or equal to comparator - exact match (unquoted) > must match snapshot 1`] = `
+Object {
+  "edges": Array [
+    "e",
+    "e",
+    "f",
+  ],
+  "nodes": Array [
+    "e",
+    "f",
+  ],
+}
+`
+
+exports[`test/pseudo/squat.ts > TAP > selects packages with a specific squat kind > greater than or equal to comparator with number (quoted) > must match snapshot 1`] = `
+Object {
+  "edges": Array [
+    "f",
+  ],
+  "nodes": Array [
+    "f",
+  ],
+}
+`
+
+exports[`test/pseudo/squat.ts > TAP > selects packages with a specific squat kind > less than comparator with number (quoted) > must match snapshot 1`] = `
+Object {
+  "edges": Array [
+    "e",
+    "e",
+  ],
+  "nodes": Array [
+    "e",
+  ],
+}
+`
+
+exports[`test/pseudo/squat.ts > TAP > selects packages with a specific squat kind > less than or equal to comparator - exact match (quoted) > must match snapshot 1`] = `
+Object {
+  "edges": Array [
+    "e",
+    "e",
+    "f",
+  ],
+  "nodes": Array [
+    "e",
+    "f",
+  ],
+}
+`
+
+exports[`test/pseudo/squat.ts > TAP > selects packages with a specific squat kind > less than or equal to comparator with number (unquoted) > must match snapshot 1`] = `
+Object {
+  "edges": Array [
+    "e",
+    "e",
+  ],
+  "nodes": Array [
+    "e",
+  ],
+}
+`

--- a/src/query/test/parser.ts
+++ b/src/query/test/parser.ts
@@ -86,4 +86,32 @@ t.test('parse', async t => {
     parse(':root > :v("2.0.0")'),
     'should parse dots in string parameters',
   )
+
+  const res: any[] = []
+  parse(':v(>2)').walk(node => {
+    res.push({
+      type: node.type,
+      source: node.source,
+      ...(node.value ? { value: node.value } : undefined),
+    })
+  })
+  t.matchSnapshot(
+    res,
+    'should clean up usage of combinators params in pseudo selectors that accept only string values',
+  )
+
+  res.length = 0
+  parse(
+    ':root > :v(>1 >2 >3):not(:v(2.0.0-pre+build0.13adsfa1)) > published(<=2024-01-01T11:11:11.111Z) :severity(>=0):score( > 0.9)',
+  ).walk(node => {
+    res.push({
+      type: node.type,
+      source: node.source,
+      ...(node.value ? { value: node.value } : undefined),
+    })
+  })
+  t.matchSnapshot(
+    res,
+    'should clean up usage of multiple pseudo selectors requiring cleaning up',
+  )
 })

--- a/src/query/test/pseudo/malware.ts
+++ b/src/query/test/pseudo/malware.ts
@@ -7,8 +7,10 @@ import {
   malware,
   isMalwareKind,
   asMalwareKind,
+  parseInternals,
 } from '../../src/pseudo/malware.ts'
 import { parse } from '../../src/parser.ts'
+import { asPostcssNodeWithChildren } from '../../src/types.ts'
 
 t.test('selects packages with a specific malware kind', async t => {
   const getState = (query: string, graph = getSimpleGraph()) => {
@@ -32,6 +34,34 @@ t.test('selects packages with a specific malware kind', async t => {
       walk: async i => i,
       securityArchive: asSecurityArchiveLike(
         new Map([
+          [
+            joinDepIDTuple(['registry', '', 'a@1.0.0']),
+            {
+              id: joinDepIDTuple(['registry', '', 'a@1.0.0']),
+              alerts: [{ type: 'malware' }],
+            },
+          ],
+          [
+            joinDepIDTuple(['registry', '', 'b@1.0.0']),
+            {
+              id: joinDepIDTuple(['registry', '', 'b@1.0.0']),
+              alerts: [{ type: 'gptMalware' }],
+            },
+          ],
+          [
+            joinDepIDTuple(['registry', '', 'c@1.0.0']),
+            {
+              id: joinDepIDTuple(['registry', '', 'c@1.0.0']),
+              alerts: [{ type: 'gptSecurity' }],
+            },
+          ],
+          [
+            joinDepIDTuple(['registry', '', 'd@1.0.0']),
+            {
+              id: joinDepIDTuple(['registry', '', 'd@1.0.0']),
+              alerts: [{ type: 'gptAnomaly' }],
+            },
+          ],
           [
             joinDepIDTuple(['registry', '', 'e@1.0.0']),
             {
@@ -60,7 +90,7 @@ t.test('selects packages with a specific malware kind', async t => {
       const res = await malware(getState(':malware("critical")'))
       t.strictSame(
         [...res.partial.nodes].map(n => n.name),
-        ['e'],
+        ['a', 'e'],
         'should select only packages with the specified malware alert',
       )
       t.matchSnapshot({
@@ -74,7 +104,7 @@ t.test('selects packages with a specific malware kind', async t => {
     const res = await malware(getState(':malware(0)'))
     t.strictSame(
       [...res.partial.nodes].map(n => n.name),
-      ['e'],
+      ['a', 'e'],
       'should select only packages with the specified malware alert',
     )
     t.matchSnapshot({
@@ -87,7 +117,7 @@ t.test('selects packages with a specific malware kind', async t => {
     const res = await malware(getState(':malware(high)'))
     t.strictSame(
       [...res.partial.nodes].map(n => n.name),
-      ['f'],
+      ['b', 'f'],
       'should select only packages with the specified malware alert',
     )
     t.matchSnapshot({
@@ -96,11 +126,155 @@ t.test('selects packages with a specific malware kind', async t => {
     })
   })
 
+  await t.test(
+    'greater than comparator with number (unquoted)',
+    async t => {
+      const res = await malware(getState(':malware(>1)'))
+      t.strictSame(
+        [...res.partial.nodes].map(n => n.name).sort(),
+        ['c', 'd'],
+        'should select packages with malware kind greater than 1',
+      )
+      t.matchSnapshot({
+        nodes: [...res.partial.nodes].map(n => n.name).sort(),
+        edges: [...res.partial.edges].map(e => e.name).sort(),
+      })
+    },
+  )
+
+  await t.test(
+    'greater than comparator with string kind (quoted)',
+    async t => {
+      const res = await malware(getState(':malware(">high")'))
+      t.strictSame(
+        [...res.partial.nodes].map(n => n.name).sort(),
+        ['c', 'd'],
+        'should select packages with malware kind greater than high',
+      )
+      t.matchSnapshot({
+        nodes: [...res.partial.nodes].map(n => n.name).sort(),
+        edges: [...res.partial.edges].map(e => e.name).sort(),
+      })
+    },
+  )
+
+  await t.test(
+    'less than comparator with number (unquoted)',
+    async t => {
+      const res = await malware(getState(':malware(<2)'))
+      t.strictSame(
+        [...res.partial.nodes].map(n => n.name).sort(),
+        ['a', 'b', 'e', 'f'],
+        'should select packages with malware kind less than 2',
+      )
+      t.matchSnapshot({
+        nodes: [...res.partial.nodes].map(n => n.name).sort(),
+        edges: [...res.partial.edges].map(e => e.name).sort(),
+      })
+    },
+  )
+
+  await t.test(
+    'less than comparator with string kind (quoted)',
+    async t => {
+      const res = await malware(getState(':malware("<medium")'))
+      t.strictSame(
+        [...res.partial.nodes].map(n => n.name).sort(),
+        ['a', 'b', 'e', 'f'],
+        'should select packages with malware kind less than medium',
+      )
+      t.matchSnapshot({
+        nodes: [...res.partial.nodes].map(n => n.name).sort(),
+        edges: [...res.partial.edges].map(e => e.name).sort(),
+      })
+    },
+  )
+
+  await t.test(
+    'greater than or equal to comparator with number (unquoted)',
+    async t => {
+      const res = await malware(getState(':malware(>=2)'))
+      t.strictSame(
+        [...res.partial.nodes].map(n => n.name).sort(),
+        ['c', 'd'],
+        'should select packages with malware kind greater than or equal to 2',
+      )
+      t.matchSnapshot({
+        nodes: [...res.partial.nodes].map(n => n.name).sort(),
+        edges: [...res.partial.edges].map(e => e.name).sort(),
+      })
+    },
+  )
+
+  await t.test(
+    'greater than or equal to comparator with string kind (quoted)',
+    async t => {
+      const res = await malware(getState(':malware(">=medium")'))
+      t.strictSame(
+        [...res.partial.nodes].map(n => n.name).sort(),
+        ['c', 'd'],
+        'should select packages with malware kind greater than or equal to medium',
+      )
+      t.matchSnapshot({
+        nodes: [...res.partial.nodes].map(n => n.name).sort(),
+        edges: [...res.partial.edges].map(e => e.name).sort(),
+      })
+    },
+  )
+
+  await t.test(
+    'less than or equal to comparator with number (unquoted)',
+    async t => {
+      const res = await malware(getState(':malware(<=1)'))
+      t.strictSame(
+        [...res.partial.nodes].map(n => n.name).sort(),
+        ['a', 'b', 'e', 'f'],
+        'should select packages with malware kind less than or equal to 1',
+      )
+      t.matchSnapshot({
+        nodes: [...res.partial.nodes].map(n => n.name).sort(),
+        edges: [...res.partial.edges].map(e => e.name).sort(),
+      })
+    },
+  )
+
+  await t.test(
+    'less than or equal to comparator with string kind (quoted)',
+    async t => {
+      const res = await malware(getState(':malware("<=high")'))
+      t.strictSame(
+        [...res.partial.nodes].map(n => n.name).sort(),
+        ['a', 'b', 'e', 'f'],
+        'should select packages with malware kind less than or equal to high',
+      )
+      t.matchSnapshot({
+        nodes: [...res.partial.nodes].map(n => n.name).sort(),
+        edges: [...res.partial.edges].map(e => e.name).sort(),
+      })
+    },
+  )
+
   await t.test('wrong parameter', async t => {
     await t.rejects(
       malware(getState(':malware')),
       { message: /Failed to parse :malware selector/ },
       'should throw an error',
+    )
+  })
+
+  await t.test('invalid comparison value', async t => {
+    await t.rejects(
+      malware(getState(':malware(>invalid)')),
+      { message: /Failed to parse :malware selector/ },
+      'should throw an error for invalid comparison value',
+    )
+  })
+
+  await t.test('out of range number', async t => {
+    await t.rejects(
+      malware(getState(':malware(>5)')),
+      { message: /Failed to parse :malware selector/ },
+      'should throw an error for out of range number',
     )
   })
 })
@@ -160,5 +334,59 @@ t.test('asMalwareKind', async t => {
     () => asMalwareKind('invalid'),
     { message: /Expected a valid malware kind/ },
     'should throw an error for invalid malware kinds',
+  )
+})
+
+t.test('parseInternals', async t => {
+  const testParseInternals = (query: string) => {
+    const ast = parse(query)
+    const nodes = asPostcssNodeWithChildren(ast.first.first).nodes
+    return parseInternals(nodes)
+  }
+
+  t.strictSame(
+    testParseInternals(':malware(critical)'),
+    { kind: 'critical', comparator: undefined },
+    'should parse simple kind without comparator',
+  )
+
+  t.strictSame(
+    testParseInternals(':malware(">1")'),
+    { kind: '1', comparator: '>' },
+    'should parse kind with greater than comparator',
+  )
+
+  t.strictSame(
+    testParseInternals(':malware(<low)'),
+    { kind: 'low', comparator: '<' },
+    'should parse kind with less than comparator',
+  )
+
+  t.strictSame(
+    testParseInternals(':malware(">=medium")'),
+    { kind: 'medium', comparator: '>=' },
+    'should parse kind with greater than or equal comparator',
+  )
+
+  t.strictSame(
+    testParseInternals(':malware(<=2)'),
+    { kind: '2', comparator: '<=' },
+    'should parse kind with less than or equal comparator',
+  )
+
+  t.throws(
+    () => testParseInternals(':malware(>invalid)'),
+    {
+      message: /Expected a valid malware kind or number between 0-3/,
+    },
+    'should throw for invalid kind with comparator',
+  )
+
+  t.throws(
+    () => testParseInternals(':malware(>4)'),
+    {
+      message: /Expected a valid malware kind or number between 0-3/,
+    },
+    'should throw for out of range number with comparator',
   )
 })

--- a/src/query/test/pseudo/score.ts
+++ b/src/query/test/pseudo/score.ts
@@ -166,12 +166,38 @@ t.test('selects packages based on their security score', async t => {
     })
   })
 
+  await t.test('greater than comparator (unquoted)', async t => {
+    const res = await score(getState(':score(>0.8)'))
+    t.strictSame(
+      [...res.partial.nodes].map(n => n.name),
+      ['a', 'd'],
+      'should select packages with overall score greater than 0.8 using unquoted parameter',
+    )
+    t.matchSnapshot({
+      nodes: [...res.partial.nodes].map(n => n.name),
+      edges: [...res.partial.edges].map(e => e.name),
+    })
+  })
+
   await t.test('less than comparator', async t => {
     const res = await score(getState(':score("<0.5")'))
     t.strictSame(
       [...res.partial.nodes].map(n => n.name),
       ['c', 'e'],
       'should select packages with overall score less than 0.5',
+    )
+    t.matchSnapshot({
+      nodes: [...res.partial.nodes].map(n => n.name),
+      edges: [...res.partial.edges].map(e => e.name),
+    })
+  })
+
+  await t.test('less than comparator (unquoted)', async t => {
+    const res = await score(getState(':score(<0.5)'))
+    t.strictSame(
+      [...res.partial.nodes].map(n => n.name),
+      ['c', 'e'],
+      'should select packages with overall score less than 0.5 using unquoted parameter',
     )
     t.matchSnapshot({
       nodes: [...res.partial.nodes].map(n => n.name),
@@ -192,6 +218,22 @@ t.test('selects packages based on their security score', async t => {
     })
   })
 
+  await t.test(
+    'greater than or equal comparator (unquoted)',
+    async t => {
+      const res = await score(getState(':score(>=0.75)'))
+      t.strictSame(
+        [...res.partial.nodes].map(n => n.name),
+        ['a', 'd'],
+        'should select packages with overall score greater than or equal to 0.75 using unquoted parameter',
+      )
+      t.matchSnapshot({
+        nodes: [...res.partial.nodes].map(n => n.name),
+        edges: [...res.partial.edges].map(e => e.name),
+      })
+    },
+  )
+
   await t.test('less than or equal comparator', async t => {
     const res = await score(getState(':score(<=40)'))
     t.strictSame(
@@ -204,6 +246,22 @@ t.test('selects packages based on their security score', async t => {
       edges: [...res.partial.edges].map(e => e.name),
     })
   })
+
+  await t.test(
+    'less than or equal comparator (unquoted)',
+    async t => {
+      const res = await score(getState(':score(<=40)'))
+      t.strictSame(
+        [...res.partial.nodes].map(n => n.name),
+        ['c', 'e'],
+        'should select packages with overall score less than or equal to 0.4 (40%) using unquoted parameter',
+      )
+      t.matchSnapshot({
+        nodes: [...res.partial.nodes].map(n => n.name),
+        edges: [...res.partial.edges].map(e => e.name),
+      })
+    },
+  )
 
   await t.test('with specific kind parameter', async t => {
     const res = await score(getState(':score("0.95", license)'))

--- a/src/query/test/pseudo/severity.ts
+++ b/src/query/test/pseudo/severity.ts
@@ -7,8 +7,10 @@ import {
   severity,
   isSeverityKind,
   asSeverityKind,
+  parseInternals,
 } from '../../src/pseudo/severity.ts'
 import { parse } from '../../src/parser.ts'
+import { asPostcssNodeWithChildren } from '../../src/types.ts'
 
 t.test('selects packages with a specific severity kind', async t => {
   const getState = (query: string, graph = getSimpleGraph()) => {
@@ -44,6 +46,20 @@ t.test('selects packages with a specific severity kind', async t => {
             {
               id: joinDepIDTuple(['registry', '', 'f@1.0.0']),
               alerts: [{ type: 'cve' }],
+            },
+          ],
+          [
+            joinDepIDTuple(['registry', '', 'a@1.0.0']),
+            {
+              id: joinDepIDTuple(['registry', '', 'a@1.0.0']),
+              alerts: [{ type: 'potentialVulnerability' }],
+            },
+          ],
+          [
+            joinDepIDTuple(['registry', '', 'b@1.0.0']),
+            {
+              id: joinDepIDTuple(['registry', '', 'b@1.0.0']),
+              alerts: [{ type: 'mildCVE' }],
             },
           ],
         ]),
@@ -95,6 +111,70 @@ t.test('selects packages with a specific severity kind', async t => {
       edges: [...res.partial.edges].map(e => e.name),
     })
   })
+
+  await t.test(
+    'greater than comparator with number (unquoted)',
+    async t => {
+      const res = await severity(getState(':severity(>1)'))
+      t.strictSame(
+        [...res.partial.nodes].map(n => n.name).sort(),
+        ['a', 'b'],
+        'should select packages with severity greater than high/1',
+      )
+      t.matchSnapshot({
+        nodes: [...res.partial.nodes].map(n => n.name).sort(),
+        edges: [...res.partial.edges].map(e => e.name).sort(),
+      })
+    },
+  )
+
+  await t.test(
+    'less than comparator with number (quoted)',
+    async t => {
+      const res = await severity(getState(':severity("<2")'))
+      t.strictSame(
+        [...res.partial.nodes].map(n => n.name).sort(),
+        ['e', 'f'],
+        'should select packages with severity less than medium/2',
+      )
+      t.matchSnapshot({
+        nodes: [...res.partial.nodes].map(n => n.name).sort(),
+        edges: [...res.partial.edges].map(e => e.name).sort(),
+      })
+    },
+  )
+
+  await t.test(
+    'greater than or equal to comparator with number (quoted)',
+    async t => {
+      const res = await severity(getState(':severity(">=2")'))
+      t.strictSame(
+        [...res.partial.nodes].map(n => n.name).sort(),
+        ['a', 'b'],
+        'should select packages with severity greater than or equal to medium/2',
+      )
+      t.matchSnapshot({
+        nodes: [...res.partial.nodes].map(n => n.name).sort(),
+        edges: [...res.partial.edges].map(e => e.name).sort(),
+      })
+    },
+  )
+
+  await t.test(
+    'less than or equal to comparator with number (unquoted)',
+    async t => {
+      const res = await severity(getState(':severity(<=1)'))
+      t.strictSame(
+        [...res.partial.nodes].map(n => n.name).sort(),
+        ['e', 'f'],
+        'should select packages with severity less than or equal to high/1',
+      )
+      t.matchSnapshot({
+        nodes: [...res.partial.nodes].map(n => n.name).sort(),
+        edges: [...res.partial.edges].map(e => e.name).sort(),
+      })
+    },
+  )
 
   await t.test('wrong parameter', async t => {
     await t.rejects(
@@ -160,5 +240,66 @@ t.test('asSeverityKind', async t => {
     () => asSeverityKind('invalid'),
     { message: /Expected a valid severity kind/ },
     'should throw an error for invalid severity kinds',
+  )
+})
+
+t.test('parseInternals', async t => {
+  const testParseInternals = (query: string) => {
+    const ast = parse(query)
+    return parseInternals(
+      asPostcssNodeWithChildren(ast.first.first).nodes,
+    )
+  }
+
+  t.strictSame(
+    testParseInternals(':severity(critical)'),
+    { kind: 'critical', comparator: undefined },
+    'should parse exact severity kind',
+  )
+
+  t.strictSame(
+    testParseInternals(':severity(>medium)'),
+    { kind: 'medium', comparator: '>' },
+    'should parse severity kind with > comparator',
+  )
+
+  t.strictSame(
+    testParseInternals(':severity(<high)'),
+    { kind: 'high', comparator: '<' },
+    'should parse severity kind with < comparator',
+  )
+
+  t.strictSame(
+    testParseInternals(':severity(>=2)'),
+    { kind: '2', comparator: '>=' },
+    'should parse severity kind with >= comparator',
+  )
+
+  t.strictSame(
+    testParseInternals(':severity(<=low)'),
+    { kind: 'low', comparator: '<=' },
+    'should parse severity kind with <= comparator',
+  )
+
+  t.throws(
+    () => testParseInternals(':severity'),
+    { message: /Missing severity kind parameter/ },
+    'should throw for missing parameter',
+  )
+
+  t.throws(
+    () => testParseInternals(':severity(>invalid)'),
+    {
+      message: /Expected a valid severity kind or number between 0-3/,
+    },
+    'should throw for invalid kind with comparator',
+  )
+
+  t.throws(
+    () => testParseInternals(':severity(>4)'),
+    {
+      message: /Expected a valid severity kind or number between 0-3/,
+    },
+    'should throw for out of range number with comparator',
   )
 })

--- a/src/query/test/pseudo/squat.ts
+++ b/src/query/test/pseudo/squat.ts
@@ -7,8 +7,10 @@ import {
   squat,
   isSquatKind,
   asSquatKind,
+  parseInternals,
 } from '../../src/pseudo/squat.ts'
 import { parse } from '../../src/parser.ts'
+import { asPostcssNodeWithChildren } from '../../src/types.ts'
 
 t.test('selects packages with a specific squat kind', async t => {
   const getState = (query: string, graph = getSimpleGraph()) => {
@@ -96,6 +98,227 @@ t.test('selects packages with a specific squat kind', async t => {
     })
   })
 
+  await t.test(
+    'greater than comparator with number (unquoted)',
+    async t => {
+      const res = await squat(getState(':squat(>0)'))
+      t.strictSame(
+        [...res.partial.nodes].map(n => n.name).sort(),
+        ['f'],
+        'should select packages with squat greater than critical/0',
+      )
+      t.matchSnapshot({
+        nodes: [...res.partial.nodes].map(n => n.name).sort(),
+        edges: [...res.partial.edges].map(e => e.name).sort(),
+      })
+    },
+  )
+
+  await t.test(
+    'less than comparator with number (quoted)',
+    async t => {
+      const res = await squat(getState(':squat("<2")'))
+      t.strictSame(
+        [...res.partial.nodes].map(n => n.name).sort(),
+        ['e'],
+        'should select packages with squat less than medium/2',
+      )
+      t.matchSnapshot({
+        nodes: [...res.partial.nodes].map(n => n.name).sort(),
+        edges: [...res.partial.edges].map(e => e.name).sort(),
+      })
+    },
+  )
+
+  await t.test(
+    'greater than or equal to comparator with number (quoted)',
+    async t => {
+      const res = await squat(getState(':squat(">=2")'))
+      t.strictSame(
+        [...res.partial.nodes].map(n => n.name).sort(),
+        ['f'],
+        'should select packages with squat greater than or equal to medium/2',
+      )
+      t.matchSnapshot({
+        nodes: [...res.partial.nodes].map(n => n.name).sort(),
+        edges: [...res.partial.edges].map(e => e.name).sort(),
+      })
+    },
+  )
+
+  await t.test(
+    'greater than or equal to comparator - exact match (unquoted)',
+    async t => {
+      const res = await squat(getState(':squat(>=0)'))
+      t.strictSame(
+        [...res.partial.nodes].map(n => n.name).sort(),
+        ['e', 'f'],
+        'should select packages with squat greater than or equal to critical/0 (including exact matches)',
+      )
+      t.matchSnapshot({
+        nodes: [...res.partial.nodes].map(n => n.name).sort(),
+        edges: [...res.partial.edges].map(e => e.name).sort(),
+      })
+    },
+  )
+
+  await t.test(
+    'less than or equal to comparator with number (unquoted)',
+    async t => {
+      const res = await squat(getState(':squat(<=0)'))
+      t.strictSame(
+        [...res.partial.nodes].map(n => n.name).sort(),
+        ['e'],
+        'should select packages with squat less than or equal to critical/0',
+      )
+      t.matchSnapshot({
+        nodes: [...res.partial.nodes].map(n => n.name).sort(),
+        edges: [...res.partial.edges].map(e => e.name).sort(),
+      })
+    },
+  )
+
+  await t.test(
+    'less than or equal to comparator - exact match (quoted)',
+    async t => {
+      const res = await squat(getState(':squat("<=2")'))
+      t.strictSame(
+        [...res.partial.nodes].map(n => n.name).sort(),
+        ['e', 'f'],
+        'should select packages with squat less than or equal to medium/2 (including exact matches)',
+      )
+      t.matchSnapshot({
+        nodes: [...res.partial.nodes].map(n => n.name).sort(),
+        edges: [...res.partial.edges].map(e => e.name).sort(),
+      })
+    },
+  )
+
+  await t.test('empty alerts array', async t => {
+    const getCustomState = (
+      query: string,
+      graph = getSimpleGraph(),
+    ) => {
+      const ast = parse(query)
+      const current = ast.first.first
+      const state: ParserState = {
+        current,
+        initial: {
+          edges: new Set(graph.edges.values()),
+          nodes: new Set(graph.nodes.values()),
+        },
+        partial: {
+          edges: new Set(graph.edges.values()),
+          nodes: new Set(graph.nodes.values()),
+        },
+        collect: {
+          edges: new Set(),
+          nodes: new Set(),
+        },
+        cancellable: async () => {},
+        walk: async i => i,
+        securityArchive: asSecurityArchiveLike(
+          new Map([
+            [
+              joinDepIDTuple(['registry', '', 'e@1.0.0']),
+              {
+                id: joinDepIDTuple(['registry', '', 'e@1.0.0']),
+                alerts: [{ type: 'didYouMean' }],
+              },
+            ],
+            [
+              joinDepIDTuple(['registry', '', 'f@1.0.0']),
+              {
+                id: joinDepIDTuple(['registry', '', 'f@1.0.0']),
+                alerts: [{ type: 'gptDidYouMean' }],
+              },
+            ],
+            [
+              joinDepIDTuple(['registry', '', 'c@1.0.0']),
+              {
+                id: joinDepIDTuple(['registry', '', 'c@1.0.0']),
+                alerts: [], // Empty alerts array
+              },
+            ],
+          ]),
+        ),
+        specOptions: {},
+        retries: 0,
+      }
+      return state
+    }
+
+    const res = await squat(getCustomState(':squat(>0)'))
+    t.strictSame(
+      [...res.partial.nodes].map(n => n.name).sort(),
+      ['f'],
+      'should exclude nodes with empty alerts array',
+    )
+  })
+
+  await t.test('node with unknown alert type', async t => {
+    const getCustomState = (
+      query: string,
+      graph = getSimpleGraph(),
+    ) => {
+      const ast = parse(query)
+      const current = ast.first.first
+      const state: ParserState = {
+        current,
+        initial: {
+          edges: new Set(graph.edges.values()),
+          nodes: new Set(graph.nodes.values()),
+        },
+        partial: {
+          edges: new Set(graph.edges.values()),
+          nodes: new Set(graph.nodes.values()),
+        },
+        collect: {
+          edges: new Set(),
+          nodes: new Set(),
+        },
+        cancellable: async () => {},
+        walk: async i => i,
+        securityArchive: asSecurityArchiveLike(
+          new Map([
+            [
+              joinDepIDTuple(['registry', '', 'e@1.0.0']),
+              {
+                id: joinDepIDTuple(['registry', '', 'e@1.0.0']),
+                alerts: [{ type: 'didYouMean' }],
+              },
+            ],
+            [
+              joinDepIDTuple(['registry', '', 'f@1.0.0']),
+              {
+                id: joinDepIDTuple(['registry', '', 'f@1.0.0']),
+                alerts: [{ type: 'gptDidYouMean' }],
+              },
+            ],
+            [
+              joinDepIDTuple(['registry', '', 'c@1.0.0']),
+              {
+                id: joinDepIDTuple(['registry', '', 'c@1.0.0']),
+                // Use an unknown alert type that won't have a matching level
+                alerts: [{ type: 'unknownAlertType' }],
+              },
+            ],
+          ]),
+        ),
+        specOptions: {},
+        retries: 0,
+      }
+      return state
+    }
+
+    const res = await squat(getCustomState(':squat(>0)'))
+    t.strictSame(
+      [...res.partial.nodes].map(n => n.name).sort(),
+      ['f'],
+      'should exclude nodes with unknown alert types',
+    )
+  })
+
   await t.test('wrong parameter', async t => {
     await t.rejects(
       squat(getState(':squat')),
@@ -160,5 +383,66 @@ t.test('asSquatKind', async t => {
     () => asSquatKind('invalid'),
     { message: /Expected a valid squat kind/ },
     'should throw an error for invalid squat kinds',
+  )
+})
+
+t.test('parseInternals', async t => {
+  const testParseInternals = (query: string) => {
+    const ast = parse(query)
+    return parseInternals(
+      asPostcssNodeWithChildren(ast.first.first).nodes,
+    )
+  }
+
+  t.strictSame(
+    testParseInternals(':squat(critical)'),
+    { kind: 'critical', comparator: undefined },
+    'should parse exact squat kind',
+  )
+
+  t.strictSame(
+    testParseInternals(':squat(>medium)'),
+    { kind: 'medium', comparator: '>' },
+    'should parse squat kind with > comparator',
+  )
+
+  t.strictSame(
+    testParseInternals(':squat(<critical)'),
+    { kind: 'critical', comparator: '<' },
+    'should parse squat kind with < comparator',
+  )
+
+  t.strictSame(
+    testParseInternals(':squat(>=2)'),
+    { kind: '2', comparator: '>=' },
+    'should parse squat kind with >= comparator',
+  )
+
+  t.strictSame(
+    testParseInternals(':squat(<=0)'),
+    { kind: '0', comparator: '<=' },
+    'should parse squat kind with <= comparator',
+  )
+
+  t.throws(
+    () => testParseInternals(':squat'),
+    /Expected a query node/,
+    'should throw for missing parameter',
+  )
+
+  t.throws(
+    () => testParseInternals(':squat(>invalid)'),
+    {
+      message: /Expected a valid squat kind for comparison/,
+    },
+    'should throw for invalid kind with comparator',
+  )
+
+  t.throws(
+    () => testParseInternals(':squat(>3)'),
+    {
+      message: /Expected a valid squat kind for comparison/,
+    },
+    'should throw for out of range number with comparator',
   )
 })


### PR DESCRIPTION
- Added a new step to the query `parse` method that cleans up any usage of combinators within the pseudo selectors that accept comparator characters, 
- support unquoted params in semver selector, e.g: `:semver(>2.0.0)`
- support unquoted params in published selector, e.g: `:published(>2024)`
- support unquoted params in score selector, e.g: `:score(>=50)`
- support comparison params in malware selector, e.g: `:malware(<1)`
- support comparison params in severity selector, e.g: `:severity(>=0)`
- support comparison params in squat selector, e.g: `:squat(<=2)`

Replaces: https://github.com/vltpkg/vltpkg/pull/642