### PR TITLE
security-archive: fix missing cache folder

### DIFF
--- a/src/security-archive/src/index.ts
+++ b/src/security-archive/src/index.ts
@@ -1,4 +1,6 @@
 import { DatabaseSync } from 'node:sqlite'
+import { mkdirSync } from 'node:fs'
+import { dirname } from 'node:path'
 import { LRUCache } from 'lru-cache'
 import pRetry, { AbortError } from 'p-retry'
 import { loadPackageJson } from 'package-json-from-dist'
@@ -150,6 +152,7 @@ export class SecurityArchive
    * Opens a connection to the database at the given path.
    */
   #openDatabase(): DatabaseSync {
+    mkdirSync(dirname(this.#path), { recursive: true })
     const db = new DatabaseSync(this.#path)
     db.exec(
       'CREATE TABLE IF NOT EXISTS cache ' +

--- a/src/security-archive/test/index.ts
+++ b/src/security-archive/test/index.ts
@@ -242,6 +242,15 @@ ${JSON.stringify({
     )
   })
 
+  await t.test('missing cache folder', async t => {
+    const dir = t.testdir()
+    const path = resolve(dir, 'missing-folder/new.db')
+
+    const archive = new SecurityArchive({ path })
+    await archive.refresh({ graph, specOptions })
+    t.ok('cache folder created')
+  })
+
   await t.test('bad api response', async t => {
     const dir = t.testdir()
     const path = resolve(dir, 'missing.db')


### PR DESCRIPTION
In case the xdg cache folder is missing, it should be created prior to trying to open the database.

Fixes: https://github.com/vltpkg/vltpkg/issues/670