### PR TITLE
gui: bugfix header build version

### DIFF
--- a/src/gui/src/app/create-new-project.tsx
+++ b/src/gui/src/app/create-new-project.tsx
@@ -14,6 +14,9 @@ export const CreateNewProject = () => {
   const updateErrorCause = useGraphStore(
     state => state.updateErrorCause,
   )
+  const updateBuildVersion = useGraphStore(
+    state => state.updateBuildVersion,
+  )
   const stamp = useGraphStore(state => state.stamp)
 
   const [inProgress, setInProgress] = useState<boolean>(false)
@@ -23,6 +26,7 @@ export const CreateNewProject = () => {
       navigate,
       updateDashboard,
       updateErrorCause,
+      updateBuildVersion,
       stamp,
     })
   }, [stamp])

--- a/src/gui/src/app/dashboard.tsx
+++ b/src/gui/src/app/dashboard.tsx
@@ -6,12 +6,16 @@ import { startDashboardData } from '@/lib/start-dashboard-data.js'
 
 export const Dashboard = () => {
   const dashboard = useGraphStore(state => state.dashboard)
+  const buildVersion = useGraphStore(state => state.buildVersion)
   const navigate = useNavigate()
   const updateDashboard = useGraphStore(
     state => state.updateDashboard,
   )
   const updateErrorCause = useGraphStore(
     state => state.updateErrorCause,
+  )
+  const updateBuildVersion = useGraphStore(
+    state => state.updateBuildVersion,
   )
   const stamp = useGraphStore(state => state.stamp)
 
@@ -20,6 +24,7 @@ export const Dashboard = () => {
       navigate,
       updateErrorCause,
       updateDashboard,
+      updateBuildVersion,
       stamp,
     })
   }, [stamp])
@@ -33,11 +38,11 @@ export const Dashboard = () => {
               Directory: {dashboard.cwd}
             </p>
           : ''}
-          {dashboard?.buildVersion ?
+          {buildVersion && (
             <p className="hidden text-right font-mono text-xs font-light text-muted-foreground md:inline-flex">
-              build: v{dashboard.buildVersion}
+              build: v{buildVersion}
             </p>
-          : ''}
+          )}
         </div>
       </div>
       <DashboardContent />

--- a/src/gui/src/app/explorer.tsx
+++ b/src/gui/src/app/explorer.tsx
@@ -87,7 +87,7 @@ export const Explorer = () => {
 }
 
 const ExplorerContent = () => {
-  const dashboard = useGraphStore(state => state.dashboard)
+  const buildVersion = useGraphStore(state => state.buildVersion)
   const updateEdges = useGraphStore(state => state.updateEdges)
   const updateNodes = useGraphStore(state => state.updateNodes)
   const graph = useGraphStore(state => state.graph)
@@ -148,11 +148,11 @@ const ExplorerContent = () => {
               :host-context(file:{graph.projectRoot})
             </p>
           : ''}
-          {dashboard?.buildVersion ?
+          {buildVersion && (
             <p className="text-right font-mono text-xs font-light text-muted-foreground">
-              build: v{dashboard.buildVersion}
+              build: v{buildVersion}
             </p>
-          : ''}
+          )}
         </div>
       </div>
       <section className="flex w-full items-center px-8 py-4">

--- a/src/gui/src/app/queries.tsx
+++ b/src/gui/src/app/queries.tsx
@@ -32,6 +32,9 @@ const Queries = () => {
   const savedLabels = useGraphStore(state => state.savedQueryLabels)
   const [isCreating, setIsCreating] = useState<boolean>(false)
   const dashboard = useGraphStore(state => state.dashboard)
+  const updateBuildVersion = useGraphStore(
+    state => state.updateBuildVersion,
+  )
   const updateDashboard = useGraphStore(
     state => state.updateDashboard,
   )
@@ -64,6 +67,7 @@ const Queries = () => {
       navigate,
       updateDashboard,
       updateErrorCause,
+      updateBuildVersion,
       stamp,
     })
   }, [stamp])

--- a/src/gui/src/lib/start-dashboard-data.ts
+++ b/src/gui/src/lib/start-dashboard-data.ts
@@ -8,6 +8,7 @@ export type StartDashboardDataOptions = {
   navigate: (route: string) => void
   updateDashboard: Action['updateDashboard']
   updateErrorCause: Action['updateErrorCause']
+  updateBuildVersion: Action['updateBuildVersion']
   stamp: State['stamp']
 }
 
@@ -22,6 +23,7 @@ export const requestDashboardData = async ({
 export const startDashboardData = ({
   navigate,
   updateDashboard,
+  updateBuildVersion,
   updateErrorCause,
   stamp,
 }: StartDashboardDataOptions) => {
@@ -30,6 +32,7 @@ export const startDashboardData = ({
       stamp,
     })
     updateDashboard(dashboardData)
+    updateBuildVersion(dashboardData?.buildVersion)
   }
 
   void _startDashboard().catch((err: unknown) => {

--- a/src/gui/src/state/index.ts
+++ b/src/gui/src/state/index.ts
@@ -70,6 +70,9 @@ const initialState: State = {
     )
     return defaultLabels
   })(),
+  buildVersion: localStorage.getItem(
+    'build-version',
+  ) as State['buildVersion'],
 }
 
 /**
@@ -245,6 +248,15 @@ export const useGraphStore = create<Action & State>((set, get) => {
         'saved-queries',
         JSON.stringify(updatedQueries),
       )
+    },
+    updateBuildVersion: (newVersion: State['buildVersion']) => {
+      if (!newVersion) return
+
+      const currentVersion = get().buildVersion
+      if (currentVersion === newVersion) return
+
+      localStorage.setItem('build-version', newVersion)
+      set(() => ({ buildVersion: newVersion }))
     },
   }
 

--- a/src/gui/src/state/types.ts
+++ b/src/gui/src/state/types.ts
@@ -29,6 +29,7 @@ export type Action = {
   saveQueryLabel: (queryLabel: QueryLabel) => void
   updateSavedQueryLabel: (queryLabel: QueryLabel) => void
   deleteSavedQueryLabels: (queryLabels: QueryLabel[]) => void
+  updateBuildVersion: (buildVersion: State['buildVersion']) => void
 }
 
 /**
@@ -144,6 +145,10 @@ export type State = {
    * Saved labels used for query tags in localStorage.
    */
   savedQueryLabels?: QueryLabel[]
+  /**
+   * The app version.
+   */
+  buildVersion?: string
 }
 
 export type DashboardTools =

--- a/src/gui/test/lib/start-dashboard-data.ts
+++ b/src/gui/test/lib/start-dashboard-data.ts
@@ -56,6 +56,7 @@ test('standard dashboard response', async () => {
           res()
         },
         updateErrorCause: rej,
+        updateBuildVersion: vi.fn(),
         stamp: 'standard',
       })
     } catch (err) {
@@ -77,6 +78,7 @@ test('missing dashboard response', async () => {
           throw new Error('Should not have dashboard data')
         },
         updateErrorCause: vi.fn(),
+        updateBuildVersion: vi.fn(),
         stamp: 'missing',
       })
     } catch (err) {


### PR DESCRIPTION
Fixes the build version in the `header` component by setting the `buildVersion` in `zustand` and `localStorage`

Closes vltpkg/statusboard#119

- **creates** `buildVersion` type in `zustand` for app version
- **passes** `updateBuildVersion` `zustand` state variable to `start-dashboard-data`
- **updates** `start-dashboard-data` test
