### PR TITLE
query: fix unmatching pseudo selectors

### DIFF
--- a/src/query/src/pseudo.ts
+++ b/src/query/src/pseudo.ts
@@ -389,6 +389,8 @@ export const pseudo = async (state: ParserState) => {
 
   if (!parserFn) {
     if (state.loose) {
+      state.partial.edges.clear()
+      state.partial.nodes.clear()
       return state
     }
 

--- a/src/query/tap-snapshots/test/pseudo.ts.test.cjs
+++ b/src/query/tap-snapshots/test/pseudo.ts.test.cjs
@@ -749,6 +749,13 @@ Object {
 }
 `
 
+exports[`test/pseudo.ts > TAP > pseudo > query > ":is(:foo)" 1`] = `
+Object {
+  "edges": Array [],
+  "nodes": Array [],
+}
+`
+
 exports[`test/pseudo.ts > TAP > pseudo > query > ":is(:root)" 1`] = `
 Object {
   "edges": Array [],

--- a/src/query/test/index.ts
+++ b/src/query/test/index.ts
@@ -88,6 +88,7 @@ t.test('simple graph', async t => {
     ['#a', ['a']], // identifier
     ['#a:v(1)', ['a']], // matches identifier + semver
     ['#a:v(2)', []], // fails to match identifier + semver
+    [':root, #a, :foo', ['my-project', 'a']], // should be loose on multiple selectors
   ])
 
   const query = new Query({

--- a/src/query/test/pseudo.ts
+++ b/src/query/test/pseudo.ts
@@ -125,7 +125,7 @@ t.test('pseudo', async t => {
       all,
       ['my-project', 'a', 'b', 'c', 'd', 'e', 'f', '@x/y'],
     ], // ignore any invalid selectors on loose mode
-    //[':is(.asdf)', all, ['my-project', 'a', 'b', 'c', 'd', 'e', 'f', '@x/y']], // ignore broken selectors on loose mode
+    [':is(:foo)', all, []], // broken selectors fail to match items when in loose mode
     [':is([name=a], [name=b], [name=f])', empty, []], // can match multiple nodes if no partial
     [':missing', all, []], // no dangling edges in this graph
     [':not(:root)', all, ['a', 'b', 'c', 'd', 'e', 'f', '@x/y']], // can negate single node


### PR DESCRIPTION
When in loose mode, unknown pseudo selectors names will now fail to match any item. Using multiple selectors in the root query, e.g: `#a, #b, #c` will now switch loose mode on by default to the remainder of the query parser.

This makes it so that if the user has an unidentified pseudo selector in a multiple-selector query, e.g: `#a, :foo` they will still get a result with items matching `#a` while `:foo` is ignored.