### PR TITLE
gui: clear results when search fails

### DIFF
--- a/src/gui/src/app/explorer.tsx
+++ b/src/gui/src/app/explorer.tsx
@@ -126,7 +126,10 @@ const ExplorerContent = () => {
         window.scrollTo(0, 0)
       }
     }
-    void updateQueryData().catch(() => {})
+    void updateQueryData().catch(() => {
+      updateEdges([])
+      updateNodes([])
+    })
   }, [query, q])
 
   // avoids flash of content

--- a/src/gui/test/app/__snapshots__/explorer.tsx.snap
+++ b/src/gui/test/app/__snapshots__/explorer.tsx.snap
@@ -46,3 +46,34 @@ exports[`render default 1`] = `
 </div>
 
 `;
+
+exports[`render no results if search throws 1`] = `
+
+<div>
+  <section class="flex h-full max-h-[calc(100svh-65px-16px)] w-full grow flex-col justify-between overflow-y-auto rounded-b-lg border-[1px]">
+    <div class="flex h-[50px] w-full border-b-[1px] px-8 py-4">
+      <div class="flex w-full max-w-8xl items-center justify-between">
+        <p class="font-mono text-xs font-light text-muted-foreground">
+          :host-context(file:/path/to/project)
+        </p>
+      </div>
+    </div>
+    <section class="flex w-full items-center px-8 py-4">
+      <div class="flex w-full max-w-8xl flex-row items-center gap-2">
+        <gui-root-button>
+        </gui-root-button>
+        <gui-query-bar
+          tabindex="0"
+          classname="relative w-full"
+          startcontent="[object Object]"
+          endcontent="[object Object]"
+        >
+        </gui-query-bar>
+      </div>
+    </section>
+    <gui-explorer-grid>
+    </gui-explorer-grid>
+  </section>
+</div>
+
+`;


### PR DESCRIPTION
When a `Query.search` has an error the GUI should show no results.

This changes the current behavior of showing previous results that can be misleading to the user and make sure the results are always directly related to the current query.

### Screencast / Example

https://github.com/user-attachments/assets/3f2ec63f-52f2-47b7-bc99-9baff2935276

Refs: https://github.com/vltpkg/vltpkg/issues/539
Refs: https://github.com/vltpkg/vltpkg/pull/689


