### PR TITLE
gui: remove state refs to selected node

### DIFF
--- a/src/gui/src/state/index.ts
+++ b/src/gui/src/state/index.ts
@@ -48,7 +48,6 @@ const initialState: State = {
       window.location.href || 'http://localhost',
     ).searchParams.get('query') ?? DEFAULT_QUERY,
   q: undefined,
-  selectedNode: undefined,
   specOptions: undefined,
   stamp: newStamp(),
   theme: localStorage.getItem('vite-ui-theme') as State['theme'],
@@ -95,8 +94,6 @@ export const useGraphStore = create<Action & State>((set, get) => {
     updateNodes: (nodes: State['nodes']) => set(() => ({ nodes })),
     updateProjectInfo: (projectInfo: State['projectInfo']) =>
       set(() => ({ projectInfo })),
-    updateSelectedNode: (selectedNode: State['selectedNode']) =>
-      set(() => ({ selectedNode })),
     updateSpecOptions: (specOptions: State['specOptions']) =>
       set(() => ({ specOptions })),
     updateStamp: () => set(() => ({ stamp: newStamp() })),

--- a/src/gui/src/state/types.ts
+++ b/src/gui/src/state/types.ts
@@ -18,7 +18,6 @@ export type Action = {
   updateLinePositionReference: (position: number) => void
   updateNodes: (nodes: State['nodes']) => void
   updateProjectInfo: (projectInfo: State['projectInfo']) => void
-  updateSelectedNode: (node: State['selectedNode']) => void
   updateSpecOptions: (specOptions: State['specOptions']) => void
   updateStamp: () => void
   updateTheme: (theme: State['theme']) => void
@@ -119,11 +118,6 @@ export type State = {
    * The query string typed by the user in the interface.
    */
   query: string
-  // TODO: remove selectedNode as it's unused
-  /**
-   * Reference to a currently selected node.
-   */
-  selectedNode?: QueryResponseNode
   /**
    * Spec options used for the current graph.
    */


### PR DESCRIPTION
This is an unused property that dates back to the initial proof of concept implementation.