### PR TITLE
query: refactor project selector

### DIFF
--- a/src/query/src/pseudo.ts
+++ b/src/query/src/pseudo.ts
@@ -252,34 +252,19 @@ const root = async (state: ParserState) => {
 }
 
 /**
- * :project Pseudo-Element, returns all graph importers (e.g: the
+ * :project Pseudo-Class, matches only graph importers (e.g: the
  * root node along with any configured workspace)
  */
 const project = async (state: ParserState) => {
-  const [anyNode] = state.initial.nodes.values()
-  const importers = anyNode?.graph.importers
-  if (!importers?.size) {
-    throw error(':project pseudo-element works on local graphs only')
-  }
-
-  // make a list of all edges that are coming from importers
-  // so that we can filter out any edges that are not direct
-  // dependencies of the importers
-  const importersEdgesIn = new Set<EdgeLike>()
-  for (const importer of importers) {
-    for (const edge of importer.edgesIn) {
-      importersEdgesIn.add(edge)
+  for (const node of state.partial.nodes) {
+    if (!node.importer) {
+      removeNode(state, node)
     }
   }
-
   for (const edge of state.partial.edges) {
-    if (!edge.to || !importersEdgesIn.has(edge)) {
+    if (!edge.to?.importer) {
       state.partial.edges.delete(edge)
     }
-  }
-  state.partial.nodes.clear()
-  for (const importer of importers) {
-    state.partial.nodes.add(importer)
   }
   return state
 }

--- a/src/query/tap-snapshots/test/pseudo.ts.test.cjs
+++ b/src/query/tap-snapshots/test/pseudo.ts.test.cjs
@@ -919,7 +919,7 @@ Object {
 }
 `
 
-exports[`test/pseudo.ts > TAP > pseudo > query > ":project" 1`] = `
+exports[`test/pseudo.ts > TAP > pseudo > query > ":project /*all*/" 1`] = `
 Object {
   "edges": Array [],
   "nodes": Array [
@@ -928,21 +928,17 @@ Object {
 }
 `
 
-exports[`test/pseudo.ts > TAP > pseudo > query > ":project" 2`] = `
+exports[`test/pseudo.ts > TAP > pseudo > query > ":project /*b*/" 1`] = `
 Object {
   "edges": Array [],
-  "nodes": Array [
-    "my-project",
-  ],
+  "nodes": Array [],
 }
 `
 
-exports[`test/pseudo.ts > TAP > pseudo > query > ":project" 3`] = `
+exports[`test/pseudo.ts > TAP > pseudo > query > ":project /*empty*/" 1`] = `
 Object {
   "edges": Array [],
-  "nodes": Array [
-    "my-project",
-  ],
+  "nodes": Array [],
 }
 `
 
@@ -1237,7 +1233,7 @@ Object {
 }
 `
 
-exports[`test/pseudo.ts > TAP > pseudo > workspace > query > ":project" 1`] = `
+exports[`test/pseudo.ts > TAP > pseudo > workspace > query > ":project /*all*/" 1`] = `
 Object {
   "edges": Array [],
   "nodes": Array [
@@ -1247,22 +1243,18 @@ Object {
 }
 `
 
-exports[`test/pseudo.ts > TAP > pseudo > workspace > query > ":project" 2`] = `
+exports[`test/pseudo.ts > TAP > pseudo > workspace > query > ":project /*empty*/" 1`] = `
 Object {
   "edges": Array [],
-  "nodes": Array [
-    "w",
-    "ws",
-  ],
+  "nodes": Array [],
 }
 `
 
-exports[`test/pseudo.ts > TAP > pseudo > workspace > query > ":project" 3`] = `
+exports[`test/pseudo.ts > TAP > pseudo > workspace > query > ":project /*w*/" 1`] = `
 Object {
   "edges": Array [],
   "nodes": Array [
     "w",
-    "ws",
   ],
 }
 `

--- a/src/query/test/index.ts
+++ b/src/query/test/index.ts
@@ -113,6 +113,8 @@ t.test('workspace', async t => {
     [':root', ['ws']], // select :root
     [':root > *', []], // direct deps of :root
     [':root > :root', ['ws']], // :root always places a ref to root
+    [':project#w', ['w']], // select by project + workspace name
+    ['#w:project', ['w']], // should be interchangeable
     ['/* do something */ [name^=w]', ['ws', 'w']], // support comments
   ])
   const query = new Query({


### PR DESCRIPTION
Tweaks the `:project` pseudo selector so that it now behaves similar to other selectors as a filter instead of always returning all importer nodes no matter what.

This will fix problems in which the selector would not work properly if not used as the first element,e.g:

    vlt query '#a:project'

    vs

    vlt query ':project#a'

With this refactor both examples above will always return the same values.