### PR TITLE
smoke-test: skip gui test

### DIFF
--- a/infra/smoke-test/test/gui.ts
+++ b/infra/smoke-test/test/gui.ts
@@ -1,7 +1,7 @@
 import t from 'tap'
 import { runMultiple } from './fixtures/run.ts'
 
-t.test('can run gui', async t => {
+t.skip('can run gui', async t => {
   const urlMessage = /Please open http:\/\/localhost:[^\s]+ manually/
   const { status, signal, output } = await runMultiple(t, ['gui'], {
     // Don't check stdout/stderr since different print warnings about sqlite


### PR DESCRIPTION
This reverts the test added in ca7432b1242f70de60f1217c70efca34236bcd5c to a `t.skip` for now.
