### PR TITLE
query: fix outdated selector

### DIFF
--- a/src/query/src/pseudo/outdated.ts
+++ b/src/query/src/pseudo/outdated.ts
@@ -1,6 +1,6 @@
 import pRetry, { AbortError } from 'p-retry'
 import { hydrate, splitDepID } from '@vltpkg/dep-id/browser'
-import { error } from '@vltpkg/error-cause'
+import { asError, error } from '@vltpkg/error-cause'
 import type { NodeLike } from '@vltpkg/graph'
 import type { SpecOptions } from '@vltpkg/spec/browser'
 import {
@@ -273,9 +273,13 @@ export const outdated = async (state: ParserState) => {
       asPostcssNodeWithChildren(state.current).nodes,
     )
   } catch (err) {
-    throw error('Failed to parse :outdated selector', {
-      cause: err,
-    })
+    if (asError(err).message === 'Expected a query node') {
+      internals = { kind: 'any' } satisfies OutdatedInternals
+    } else {
+      throw error('Failed to parse :outdated selector', {
+        cause: err,
+      })
+    }
   }
 
   const { kind } = internals

--- a/src/query/tap-snapshots/test/pseudo/outdated.ts.test.cjs
+++ b/src/query/tap-snapshots/test/pseudo/outdated.ts.test.cjs
@@ -21,6 +21,27 @@ Array [
 ]
 `
 
+exports[`test/pseudo/outdated.ts > TAP > select from outdated definition > outdated as an element > must match snapshot 1`] = `
+Object {
+  "edges": Array [
+    "a",
+    "c",
+    "d",
+    "e",
+    "g",
+    "e",
+  ],
+  "nodes": Array [
+    "a",
+    "c",
+    "d",
+    "e",
+    "g",
+    "e",
+  ],
+}
+`
+
 exports[`test/pseudo/outdated.ts > TAP > select from outdated definition > outdated kind any > must match snapshot 1`] = `
 Object {
   "edges": Array [

--- a/src/query/test/pseudo/outdated.ts
+++ b/src/query/test/pseudo/outdated.ts
@@ -139,6 +139,19 @@ const getState = (query: string, graph = getSemverRichGraph()) => {
 }
 
 t.test('select from outdated definition', async t => {
+  await t.test('outdated as an element', async t => {
+    const res = await outdated(getState(':outdated'))
+    t.strictSame(
+      [...res.partial.nodes].map(n => n.name),
+      ['a', 'c', 'd', 'e', 'g', 'e'],
+      'should have expected result using outdated defaulting to "any"',
+    )
+    t.matchSnapshot({
+      nodes: [...res.partial.nodes].map(n => n.name),
+      edges: [...res.partial.edges].map(e => e.name),
+    })
+  })
+
   await t.test('outdated kind any', async t => {
     const res = await outdated(getState(':outdated(any)'))
     t.strictSame(
@@ -219,7 +232,7 @@ t.test('select from outdated definition', async t => {
 
   await t.test('invalid pseudo selector usage', async t => {
     await t.rejects(
-      outdated(getState(':semver')),
+      outdated(getState(':outdated(foo)')),
       /Failed to parse :outdated selector/,
       'should throw an error for invalid pseudo selector usage',
     )


### PR DESCRIPTION
Fixes using the `:outdated` as a pseudo element with no params. e.g:

    vlt query ':root > *:outdated'

Fixes: https://github.com/vltpkg/statusboard/issues/124