### PR TITLE
cli-sdk(pkg): strip symbol keys from human output

### DIFF
--- a/src/cli-sdk/src/commands/pkg.ts
+++ b/src/cli-sdk/src/commands/pkg.ts
@@ -22,7 +22,13 @@ export const views = {
         config,
       )
     }
-    return results
+    return results && typeof results === 'object' ?
+        Object.fromEntries(
+          Object.entries(results).filter(
+            ([k]) => typeof k !== 'symbol',
+          ),
+        )
+      : results
   },
 } as const satisfies Views
 

--- a/src/cli-sdk/src/output.ts
+++ b/src/cli-sdk/src/output.ts
@@ -28,10 +28,12 @@ export const getView = <T>(
     : views && typeof views === 'object' ? views[viewName]
     : identity
 
-  // if the user specified a view that doesn't exist,
-  // then set it back to the default, and try again.
-  // This will fall back to identity if it's also missing.
-  if (!viewFn && conf.values.view !== defaultView) {
+  // if the user specified a view that doesn't exist, then set it back to the
+  // default, and try again. This will fall back to identity if it's also
+  // missing. We also always treat 'json' as a valid view that falls back to
+  // identity. This allows the explicit use of `--view=json` to work even
+  // when the default view is `human`.
+  if (!viewFn && viewName !== 'json' && viewName !== defaultView) {
     conf.values.view = defaultView
     process.env.VLT_VIEW = defaultView
     return getView(conf, views)

--- a/src/cli-sdk/tap-snapshots/test/commands/pkg.ts.test.cjs
+++ b/src/cli-sdk/tap-snapshots/test/commands/pkg.ts.test.cjs
@@ -5,7 +5,7 @@
  * Make sure to inspect the output below.  Do not ignore changes!
  */
 'use strict'
-exports[`test/commands/pkg.ts > TAP > human output for init subcommand > must match snapshot 1`] = `
+exports[`test/commands/pkg.ts > TAP > human output > init > must match snapshot 1`] = `
 Wrote manifest to /some/path:
 
 {

--- a/src/cli-sdk/test/commands/pkg.ts
+++ b/src/cli-sdk/test/commands/pkg.ts
@@ -282,31 +282,42 @@ t.test('delete', async t => {
   )
 })
 
-t.test('human output for init subcommand', t => {
-  t.matchSnapshot(
-    Command.views.human(
-      {
-        manifest: {
-          path: '/some/path',
-          data: { name: 'myproject' },
-        },
-      },
-      {} as ViewOptions,
-      {
-        positionals: ['init'],
-      } as LoadedConfig,
-    ),
-  )
-  const res = {}
-  t.equal(
+t.test('human output', async t => {
+  const human = (
+    res: unknown,
+    { positionals }: { positionals: string[] },
+  ) =>
     Command.views.human(
       res,
       {} as ViewOptions,
       {
-        positionals: ['not', 'init'],
+        positionals,
       } as LoadedConfig,
-    ),
-    res,
-  )
-  t.end()
+    )
+
+  t.test('init', async t => {
+    t.matchSnapshot(
+      human(
+        {
+          manifest: {
+            path: '/some/path',
+            data: { name: 'myproject' },
+          },
+        },
+        { positionals: ['init'] },
+      ),
+    )
+    t.strictSame(human({}, { positionals: ['not', 'init'] }), {})
+  })
+
+  t.test('get', async t => {
+    t.strictSame(
+      human(
+        { [Symbol.for('some symbol')]: 1, a: 2 },
+        { positionals: ['get'] },
+      ),
+      { a: 2 },
+    )
+    t.strictSame(human(1, { positionals: ['get'] }), 1)
+  })
 })


### PR DESCRIPTION
Closes #490

This also makes `pkg` with the explicit flag `--view=json` work as expected. Previously only `vlt pkg get | some-other-command` would output JSON because it would detect that the output stream is not a TTY.
