### PR TITLE
cli-sdk: update list & query cmd help

### DIFF
--- a/src/cli-sdk/src/commands/list.ts
+++ b/src/cli-sdk/src/commands/list.ts
@@ -20,10 +20,18 @@ import type { Views } from '../view.ts'
 export const usage: CommandUsage = () =>
   commandUsage({
     command: 'ls',
-    usage: ['', '<query> --view=[human | json | mermaid | gui]'],
-    description: `List installed dependencies matching the provided query.
-                  Defaults to listing direct dependencies of a project and
-                  any configured workspace.`,
+    usage: ['', '[query | specs] [--view=human | json | mermaid | gui]'],
+    description:
+      `List installed dependencies matching given package names or resulting
+      packages from matching a given Dependency Selector Syntax query if one
+      is provided.
+
+      The vlt Dependency Selector Syntax is a CSS-like query language that
+      allows you to filter installed dependencies using a variety of metadata
+      in the form of CSS-like attributes, pseudo selectors & combinators.
+
+      Defaults to listing direct dependencies of a project and any configured
+      workspace.`,
     examples: {
       '': {
         description:
@@ -40,7 +48,7 @@ export const usage: CommandUsage = () =>
         description:
           'Lists direct dependencies of a specific package',
       },
-      [`'*.workspace > *.peer'`]: {
+      [`'*:workspace > *:peer'`]: {
         description: 'List all peer dependencies of all workspaces',
       },
     },

--- a/src/cli-sdk/src/commands/list.ts
+++ b/src/cli-sdk/src/commands/list.ts
@@ -20,9 +20,11 @@ import type { Views } from '../view.ts'
 export const usage: CommandUsage = () =>
   commandUsage({
     command: 'ls',
-    usage: ['', '[query | specs] [--view=human | json | mermaid | gui]'],
-    description:
-      `List installed dependencies matching given package names or resulting
+    usage: [
+      '',
+      '[query | specs] [--view=human | json | mermaid | gui]',
+    ],
+    description: `List installed dependencies matching given package names or resulting
       packages from matching a given Dependency Selector Syntax query if one
       is provided.
 

--- a/src/cli-sdk/src/commands/query.ts
+++ b/src/cli-sdk/src/commands/query.ts
@@ -29,12 +29,16 @@ export const usage: CommandUsage = () =>
       '<query> --expect-results=<comparison string>',
     ],
     description:
-      'List installed dependencies matching the provided query.',
+      `List installed dependencies matching the provided query.
+
+       The vlt Dependency Selector Syntax is a CSS-like query language that
+       allows you to filter installed dependencies using a variety of metadata
+       in the form of CSS-like attributes, pseudo selectors & combinators.`,
     examples: {
       [`'#foo'`]: {
-        description: 'Query packages with the name "foo"',
+        description: 'Query dependencies declared as "foo"',
       },
-      [`'*.workspace > *.peer'`]: {
+      [`'*:workspace > *:peer'`]: {
         description: 'Query all peer dependencies of workspaces',
       },
       [`':project > *:attr(scripts, [build])'`]: {

--- a/src/cli-sdk/src/commands/query.ts
+++ b/src/cli-sdk/src/commands/query.ts
@@ -28,8 +28,7 @@ export const usage: CommandUsage = () =>
       '<query> --view=<human | json | mermaid | gui>',
       '<query> --expect-results=<comparison string>',
     ],
-    description:
-      `List installed dependencies matching the provided query.
+    description: `List installed dependencies matching the provided query.
 
        The vlt Dependency Selector Syntax is a CSS-like query language that
        allows you to filter installed dependencies using a variety of metadata

--- a/src/cli-sdk/tap-snapshots/test/commands/list.ts.test.cjs
+++ b/src/cli-sdk/tap-snapshots/test/commands/list.ts.test.cjs
@@ -18,10 +18,17 @@ exports[`test/commands/list.ts > TAP > list > colors > should use colors when se
 exports[`test/commands/list.ts > TAP > list > should have usage 1`] = `
 Usage:
   vlt ls
-  vlt ls <query> --view=[human | json | mermaid | gui]
+  vlt ls [query | specs] [--view=human | json | mermaid | gui]
 
-List installed dependencies matching the provided query. Defaults to listing
-direct dependencies of a project and any configured workspace.
+List installed dependencies matching given package names or resulting packages
+from matching a given Dependency Selector Syntax query if one is provided.
+
+The vlt Dependency Selector Syntax is a CSS-like query language that allows you
+to filter installed dependencies using a variety of metadata in the form of
+CSS-like attributes, pseudo selectors & combinators.
+
+Defaults to listing direct dependencies of a project and any configured
+workspace.
 
   Examples
 
@@ -43,7 +50,7 @@ direct dependencies of a project and any configured workspace.
 
     List all peer dependencies of all workspaces
 
-    ​vlt ls '*.workspace > *.peer'
+    ​vlt ls '*:workspace > *:peer'
 
   Options
 

--- a/src/cli-sdk/tap-snapshots/test/commands/query.ts.test.cjs
+++ b/src/cli-sdk/tap-snapshots/test/commands/query.ts.test.cjs
@@ -33,15 +33,19 @@ Usage:
 
 List installed dependencies matching the provided query.
 
+The vlt Dependency Selector Syntax is a CSS-like query language that allows you
+to filter installed dependencies using a variety of metadata in the form of
+CSS-like attributes, pseudo selectors & combinators.
+
   Examples
 
-    Query packages with the name "foo"
+    Query dependencies declared as "foo"
 
     ​vlt query '#foo'
 
     Query all peer dependencies of workspaces
 
-    ​vlt query '*.workspace > *.peer'
+    ​vlt query '*:workspace > *:peer'
 
     Query all direct project dependencies with a "build" script
 


### PR DESCRIPTION
Fixes up references to no longer supported class selectors and added an intro to the query language making a reference to the Dependency Selector Syntax name.