### PR TITLE
cli-sdk: better error info for failed requests

### DIFF
--- a/src/cli-sdk/src/print-err.ts
+++ b/src/cli-sdk/src/print-err.ts
@@ -29,6 +29,11 @@ const indent = (lines: string, num = 2) =>
     .map(l => ' '.repeat(num) + l)
     .join('\n')
 
+const isErrorWithProps = (
+  value: unknown,
+): value is Error & Record<string, unknown> =>
+  value instanceof Error && Object.keys(value).length > 0
+
 export const printErr = (
   err: unknown,
   usage: CommandUsage,
@@ -122,6 +127,29 @@ const print = (
       if (response) {
         stderr(indent(`Response: ${format(response)}`))
       }
+      return true
+    }
+
+    case 'EREQUEST': {
+      const { url, method } = err.cause
+      const { code, syscall } =
+        isErrorWithProps(err.cause.cause) ?
+          err.cause.cause
+        : ({} as Record<string, unknown>)
+      stderr(`Request Error: ${err.message}`)
+      if (code) {
+        stderr(indent(`Code: ${format(code)}`))
+      }
+      if (syscall) {
+        stderr(indent(`Syscall: ${format(syscall)}`))
+      }
+      if (url) {
+        stderr(indent(`URL: ${url}`))
+      }
+      if (method) {
+        stderr(indent(`Method: ${format(method)}`))
+      }
+
       return true
     }
   }

--- a/src/cli-sdk/tap-snapshots/test/print-err.ts.test.cjs
+++ b/src/cli-sdk/tap-snapshots/test/print-err.ts.test.cjs
@@ -1,0 +1,24 @@
+/* IMPORTANT
+ * This snapshot file is auto-generated, but designed for humans.
+ * It should be checked into source control and tracked carefully.
+ * Re-generate by setting TAP_SNAPSHOT=1 and running tests.
+ * Make sure to inspect the output below.  Do not ignore changes!
+ */
+'use strict'
+exports[`test/print-err.ts > TAP > EREQUEST > no cause > must match snapshot 1`] = `
+Array [
+  "Request Error: oh no! my request!",
+  "  URL: https://x.y/",
+  "  Method: GET",
+]
+`
+
+exports[`test/print-err.ts > TAP > EREQUEST > with cause > must match snapshot 1`] = `
+Array [
+  "Request Error: oh no! my request!",
+  "  Code: ECONNRESET",
+  "  Syscall: read",
+  "  URL: https://x.y/",
+  "  Method: GET",
+]
+`

--- a/src/cli-sdk/test/print-err.ts
+++ b/src/cli-sdk/test/print-err.ts
@@ -121,6 +121,40 @@ t.test('ERESOLVE', t => {
   t.end()
 })
 
+t.test('EREQUEST', async t => {
+  t.test('with cause', async t => {
+    printErr(
+      error('oh no! my request!', {
+        code: 'EREQUEST',
+        url: new URL('https://x.y/'),
+        method: 'GET',
+        cause: Object.assign(new Error('some internal thing'), {
+          code: 'ECONNRESET',
+          syscall: 'read',
+        }),
+      }),
+      usage,
+      stderr,
+      formatter,
+    )
+    t.matchSnapshot(printed)
+  })
+
+  t.test('no cause', async t => {
+    printErr(
+      error('oh no! my request!', {
+        code: 'EREQUEST',
+        url: new URL('https://x.y/'),
+        method: 'GET',
+      }),
+      usage,
+      stderr,
+      formatter,
+    )
+    t.matchSnapshot(printed)
+  })
+})
+
 t.test('error with an unknown code', t => {
   const er = error('this is an error', {
     code: 'ENOTACODEWEKNOWABOUT' as Codes,

--- a/src/error-cause/src/index.ts
+++ b/src/error-cause/src/index.ts
@@ -116,6 +116,9 @@ export type ErrorCauseOptions = {
   /** string or URL object */
   url?: URL | string
 
+  /** HTTP method */
+  method?: string
+
   /** git repository remote or path */
   repository?: string
 
@@ -242,6 +245,7 @@ export const errorCodes = [
   'ERESOLVE',
   'EUNKNOWN',
   'EUSAGE',
+  'EREQUEST',
 ] as const
 
 const errorCodesSet = new Set(errorCodes)

--- a/src/registry-client/src/index.ts
+++ b/src/registry-client/src/index.ts
@@ -472,10 +472,27 @@ export class RegistryClient {
       await getToken(origin, this.identity),
     )
 
+    let response: Dispatcher.ResponseData | null = null
+    try {
+      response = await this.agent.request(
+        options as Dispatcher.RequestOptions,
+      )
+      /* c8 ignore start */
+    } catch (er) {
+      // Rethrow so we get a better stack trace
+      throw error('Request failed', {
+        code: 'EREQUEST',
+        cause: er,
+        url,
+        method,
+      })
+    }
+    /* c8 ignore stop */
+
     const result = await this.#handleResponse(
       u,
       options,
-      await this.agent.request(options as Dispatcher.RequestOptions),
+      response,
       entry,
     )
 


### PR DESCRIPTION
**Before**
```sh
╰❯ vlt i react --registry=https://thisdoesnotexistttttttttttttttttttttt.com
build⠋ > actual > reify
1 requests
Error: getaddrinfo ENOTFOUND thisdoesnotexistttttttttttttttttttttt.com
Stack:
  at __node_internal_captureLargerStackTrace (ext:deno_node/internal/errors.ts:93:9)
  at __node_internal_ (ext:deno_node/internal/errors.ts:246:10)
  at GetAddrInfoReqWrap.onlookupall [as oncomplete] (node:dns:43:26)
  at ext:deno_node/internal_binding/cares_wrap.ts:82:9
  at eventLoopTick (ext:core/01_core.js:178:7)
```

**After**
```sh
╰❯ ~/projects/vltpkg/vltpkg/scripts/bins/compile/vlt i react --registry=https://thisdoesnotexistttttttttttttttttttttt.com
build⠋ > actual > reify
1 requests
Request Error: Request failed
  Code: ENOTFOUND
  Syscall: getaddrinfo
  URL: https://thisdoesnotexistttttttttttttttttttttt.com/react
  Method: GET
```

---

These requests are retried by undici so it would be nice if we could surface the retry attempt too for debugging. My example above forces the ENOTFOUND error by using a bad registry host. But in the real world, this error happens transiently so it would be helpful to print anything else about the request.