### PR TITLE
gui: do not use prod labels

### DIFF
--- a/src/gui/src/components/explorer-grid/index.tsx
+++ b/src/gui/src/components/explorer-grid/index.tsx
@@ -66,7 +66,7 @@ const getItemsData = (
       items.push({
         ...edge,
         id: `${edge.from?.id}${title}`,
-        labels: edge.type ? [edge.type] : [],
+        labels: edge.type && edge.type !== 'prod' ? [edge.type] : [],
         title,
         version: 'Missing package',
         sameItems,
@@ -110,7 +110,7 @@ const getItemsData = (
             Boolean,
           ) as string[],
         ),
-      )
+      ).filter(i => i !== 'prod')
       const data: GridItemData = {
         ...edge,
         id: `${edge.from?.id}${edge.to?.id}` || title,
@@ -229,7 +229,7 @@ const getDependencyItems = (
       version: edge.to.version || '',
       stacked: false,
       size: 1,
-      labels: [edge.type],
+      labels: edge.type !== 'prod' ? [edge.type] : [],
     })
   }
   return items
@@ -259,6 +259,7 @@ const getUninstalledDependencyItems = (
     const edge = node.edgesOut.get(name)
     if (edge?.to) continue
     const title = `${name}@${version}`
+    const edgeType = shorten(type, name, manifest)
     items.push({
       spec: Spec.parse(name, version),
       depName: edge?.name,
@@ -269,7 +270,7 @@ const getUninstalledDependencyItems = (
       version,
       stacked: false,
       size: 1,
-      labels: [shorten(type, name, manifest)],
+      labels: edgeType !== 'prod' ? [edgeType] : [],
     })
   }
   return items.sort((a, b) => a.name.localeCompare(b.name, 'en'))


### PR DESCRIPTION
We got user feedback that labelling dependencies as "prod" is confusing since that's not a jargon end-users are used with.

Let's stop printing prod labels and only signal `dev`, `peer`, `optional` and `workspace` as labels / categories.

### Before

<table width="100%" border="0" cellspacing="0" cellpadding="10">
  <tr>
    <td width="50%">
      <img src="https://github.com/user-attachments/assets/08e6cbd3-bfdd-472f-9fb4-31f4341f7491" alt="Screenshot 2025-04-25 at 3 18 31 PM" style="width: 100%;">
    </td>
    <td width="50%">
      <img src="https://github.com/user-attachments/assets/290a9714-2475-40cd-a1b6-011e44f5f99a" alt="Screenshot 2025-04-25 at 3 25 59 PM" style="width: 100%;">
    </td>
  </tr>
</table>



### After

<table width="100%" border="0" cellspacing="0" cellpadding="10">
  <tr>
    <td width="50%">
      <img src="https://github.com/user-attachments/assets/0a12deb2-bf86-4074-8a29-5d9fda6a25ff" alt="Screenshot 2025-04-25 at 3 18 31 PM" style="width: 100%;">
    </td>
    <td width="50%">
      <img src="https://github.com/user-attachments/assets/376d7185-702d-4cf9-a145-59db8c9cb981" alt="Screenshot 2025-04-25 at 3 25 59 PM" style="width: 100%;">
    </td>
  </tr>
</table>
