### PR TITLE
rollback-remove: remove empty entries from rollback

### DIFF
--- a/src/rollback-remove/src/index.ts
+++ b/src/rollback-remove/src/index.ts
@@ -66,7 +66,7 @@ export class RollbackRemove {
       env,
     })
     for (const path of this.#paths.values()) {
-      child.stdin.write(path + '\u0000')
+      child.stdin.write(`${path}\0`)
     }
     child.stdin.end()
     if (detached) {


### PR DESCRIPTION
Fixes #707

The remover in `rollback-remove` had a bug where the child process did not properly handle stdin being empty. So if no data was ever written to the stream, it ended up parsing that as `[""]`. This result was then passed to `rimraf` which then deleted the current working directory (aka the entire project).

This case was already handled in the parent which is why we didn't catch this behavior previously. Before ever spawning the process we check if we have entries to rollback.

**BUT**

When we end up in an error state (like in #707) we explicitly call `process.exit()` because it speeds up the exiting of the CLI process (ref #449). In our published binaries we use Deno which will kill detached child processes if `process.exit()` is called directly. In that case the remover abruptly ends without any data being received on stdin and we end up with the directory deleted.

#449 mentions that we should treat calling `process.exit()` as a temporary fix. I'm going to look for an issue (or open a new one) to discuss that change as well.