### PR TITLE
workspaces: fix duplicated names

### DIFF
--- a/src/workspaces/src/index.ts
+++ b/src/workspaces/src/index.ts
@@ -299,6 +299,18 @@ export class Monorepo {
       fromCache?.manifest ?? this.packageJson.read(fullpath)
     const ws = fromCache ?? new Workspace(path, manifest, fullpath)
     if (group) ws.groups.push(group)
+
+    // Check for duplicate workspace names
+    const existingWS = this.#workspaces.get(ws.name)
+    if (existingWS && existingWS.fullpath !== ws.fullpath) {
+      throw error('Duplicate workspace name found', {
+        name: ws.name,
+        path: this.projectRoot,
+        wanted: ws.fullpath,
+        found: existingWS.fullpath,
+      })
+    }
+
     this.#workspaces.set(ws.fullpath, ws)
     this.#workspaces.set(ws.path, ws)
     this.#workspaces.set(ws.name, ws)

--- a/src/workspaces/test/index.ts
+++ b/src/workspaces/test/index.ts
@@ -462,3 +462,36 @@ t.test('force a full load, but still not found', t => {
   t.strictSame(m.getDeps(m.get('src/ws')!, true), [])
   t.end()
 })
+
+t.test('duplicate workspace names are not allowed', t => {
+  const dir = t.testdir({
+    'vlt-workspaces.json': JSON.stringify({
+      packages: ['./src/*'],
+    }),
+    src: {
+      foo: {
+        'package.json': JSON.stringify({
+          name: 'foo',
+          version: '1.2.3',
+        }),
+      },
+      foo1: {
+        'package.json': JSON.stringify({
+          name: 'foo', // Same name as foo
+          version: '1.2.3',
+        }),
+      },
+    },
+  })
+
+  t.throws(() => Monorepo.load(dir), {
+    message: 'Duplicate workspace name found',
+    cause: {
+      name: 'foo',
+      wanted: resolve(dir, 'src/foo'),
+      found: resolve(dir, 'src/foo1'),
+    },
+  })
+
+  t.end()
+})


### PR DESCRIPTION
Different workspaces should not share the same name.

Fixes: https://github.com/vltpkg/vltpkg/issues/358