### PR TITLE
release: notify slack from workflow for important alerts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,7 @@ jobs:
     name: Pre-Check
     runs-on: ubuntu-latest
     outputs:
+      release-pr: ${{ steps.release-pr.outputs.value }}
       changed: ${{ steps.filters.outputs.changed }}
       dependent: ${{ steps.filters.outputs.dependent }}
       related: ${{ steps.filters.outputs.related }}
@@ -221,3 +222,29 @@ jobs:
 
       - name: Run Tests
         run: pnpm ${{ needs.pre-check.outputs.dependent }} --filter="!smoke-test" --no-bail --aggregate-output test
+
+  on-failure:
+    name: Notify on Failure
+    runs-on: ubuntu-latest
+    if: ${{ always() && needs.pre-check.outputs.release-pr == 'true' && (needs.lint.result == 'failure' || needs.test.result == 'failure') }}
+    needs:
+      - pre-check
+      - lint
+      - test
+    steps:
+      - name: Slack Notify
+        uses: rtCamp/action-slack-notify@v2.3.3
+        env:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_GITHUB_ALERTS_WEBHOOK_URL }}
+          SLACK_USERNAME: vltops
+          SLACK_CHANNEL: github-alerts
+          SLACK_ICON: https://github.com/vltpkg.png
+          SLACK_COLOR: failure
+          SLACK_FOOTER: ''
+          SLACKIFY_MARKDOWN: true
+          MSG_MINIMAL: 'actions url,commit'
+          SLACK_TITLE: ${{ github.event.pull_request.title }} Lint/Test Failed
+          SLACK_MESSAGE: |
+            [PR ${{ github.event.number }}](https://github.com/${{ github.repository }}/pull/${{ github.event.number }})
+            Lint: ${{ needs.lint.result == 'failure' && ':x:' || ':white_check_mark:' }}
+            Test: ${{ needs.test.result == 'failure' && ':x:' || ':white_check_mark:' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,6 +49,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: pre-check
     if: needs.pre-check.outputs.action == 'pr'
+    outputs:
+      version: ${{ steps.version.outputs.value }}
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
@@ -254,3 +256,64 @@ jobs:
           git config --global user.name "vltops"
           git tag -a "v$VERSION" -m "Release v$VERSION"
           git push origin "v$VERSION"
+
+  on-pr:
+    name: Notify PR
+    runs-on: ubuntu-latest
+    if: ${{ always() && needs.pr.result == 'failure' }}
+    needs: pr
+    steps:
+      - name: Slack Notify
+        uses: rtCamp/action-slack-notify@v2.3.3
+        env:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_GITHUB_ALERTS_WEBHOOK_URL }}
+          SLACK_USERNAME: vltops
+          SLACK_CHANNEL: github-alerts
+          SLACK_ICON: https://github.com/vltpkg.png
+          SLACK_COLOR: 'failure'
+          SLACK_FOOTER: ''
+          SLACKIFY_MARKDOWN: true
+          SLACK_TITLE: Release ${{ needs.pr.outputs.version }} PR Failed
+          SLACK_MESSAGE: |
+            :x: The release PR failed to be created or updated. This most likely requires manual intervention.
+
+  on-publish:
+    name: Notify Publish
+    runs-on: ubuntu-latest
+    if: ${{ always() && needs.publish.result != 'skipped' && needs.pre-check.outputs.dry-run != 'true' }}
+    needs:
+      - pre-check
+      - publish
+    steps:
+      - name: Message
+        id: message
+        run: |
+          MESSAGE=""
+          if [[ "${{ needs.publish.result }}" == "success" ]]; then
+            MESSAGE=":white_check_mark: ${{ github.event.head_commit.message }} was published successfully! :tada:"
+          else
+            delimiter="$(openssl rand -hex 8)"
+            {
+              echo "value<<${delimiter}"
+              echo ":rotating_light: The merged release PR failed to be published."
+              echo "This requires manual intervention to publish the missing packages."
+              echo "Manually rerun the workflow if the errors were transient:"
+              echo "gh workflow run release.yml --ref=main -f action=publish"
+              echo "${delimiter}"
+            } >> "${GITHUB_OUTPUT}"
+            exit 0
+          fi
+          echo "value=$MESSAGE" >> $GITHUB_OUTPUT
+
+      - name: Slack Notify
+        uses: rtCamp/action-slack-notify@v2.3.3
+        env:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_GITHUB_ALERTS_WEBHOOK_URL }}
+          SLACK_USERNAME: vltops
+          SLACK_CHANNEL: github-alerts
+          SLACK_ICON: https://github.com/vltpkg.png
+          SLACK_COLOR: ${{ needs.publish.result == 'success' && 'success' || 'failure' }}
+          SLACK_FOOTER: ''
+          SLACKIFY_MARKDOWN: true
+          SLACK_TITLE: ${{ github.event.head_commit.message }} Publish ${{ needs.publish.result == 'success' && 'Success' || 'Failed' }}
+          SLACK_MESSAGE: ${{ steps.message.outputs.value }}

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -20,6 +20,7 @@ jobs:
     name: Pre-Check
     runs-on: ubuntu-latest
     outputs:
+      release-pr: ${{ steps.release-pr.outputs.value }}
       full-matrix: ${{ steps.full-matrix.outputs.value }}
     steps:
       - name: Release PR
@@ -115,3 +116,27 @@ jobs:
           # For now, we will run the smoke tests in a single job to avoid flakes
           # and ensure consistent results.
           TAP_JOBS: 1
+
+  on-failure:
+    name: Notify on Failure
+    runs-on: ubuntu-latest
+    if: ${{ always() && needs.pre-check.outputs.release-pr == 'true' && needs.test.result == 'failure' }}
+    needs:
+      - pre-check
+      - test
+    steps:
+      - name: Slack Notify
+        uses: rtCamp/action-slack-notify@v2.3.3
+        env:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_GITHUB_ALERTS_WEBHOOK_URL }}
+          SLACK_USERNAME: vltops
+          SLACK_CHANNEL: github-alerts
+          SLACK_ICON: https://github.com/vltpkg.png
+          SLACK_COLOR: failure
+          SLACK_FOOTER: ''
+          SLACKIFY_MARKDOWN: true
+          MSG_MINIMAL: 'actions url,commit'
+          SLACK_TITLE: ${{ github.event.pull_request.title }} Smoke Test Failed
+          SLACK_MESSAGE: |
+            [PR ${{ github.event.number }}](https://github.com/${{ github.repository }}/pull/${{ github.event.number }})
+            Smoke Test: ${{ needs.test.result == 'failure' && ':x:' || ':white_check_mark:' }}


### PR DESCRIPTION
The release PR should always be green because we test our PRs before merging which should also be green. And then merging the release PR should always successfully publish the packages.

But these "always" things can fail for some of the following reasons. This adds slack notifications for these cases to a new slack channel `#github-alerts`. A slack app and webhook URL has already been created and added to this repo as a secret.

### Flaky CI
We've mostly squashed these for now but we want to be alerted if they start to happen again. Currently if these do happen they are easy to ignore because the PR will be recreated pretty often.

### Not Rebasing PRs Before Merge
We tried turning on a rule for this on PRs but it slowed us down a lot. I think this is still the right choice but because of the nature of a monorepo with many workspaces, not rebasing can cause failures on main after merging. Here's a recent commit where that happened: c133f87ee96f915d01170db8815a36c3f5e43e92

### Release PR Fails to Create/Update
This error would be mostly invisible until someone went to check the release PR and noticed it was behind main.

### Publish Fails After a Merged Release
A release can also fail to be published after a successful release PR is merged. In that case it is very important to follow up manually to see what went wrong.