### PR TITLE
ci: run tshy during lint to make sure it wont fail during release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,34 +110,35 @@ jobs:
         run: pnpm install
 
       - name: Formatting
-        run: pnpm run format:check
         id: format
         continue-on-error: true
+        run: pnpm run format:check
 
       - name: Linting
-        run: pnpm run lint:check
         id: lint
         continue-on-error: true
+        run: pnpm run lint:check
 
       - name: Dependencies
-        run: pnpm run deps:check
         id: deps
         continue-on-error: true
+        run: pnpm run deps:check
 
       - name: Docs
-        run: pnpm --filter docs typedoc:check
         id: docs
         continue-on-error: true
+        run: pnpm --filter docs typedoc:check
 
       - name: Consistent Workspaces
+        id: workspaces
+        continue-on-error: true
         run: |
           pnpm run fix:pkg
+          pnpm -r tshy
           if [ -n "$(git status --porcelain)" ]; then
             git diff
             exit 1
           fi
-        id: workspaces
-        continue-on-error: true
 
       - name: Check Results
         run: |

--- a/scripts/consistent-package-json.ts
+++ b/scripts/consistent-package-json.ts
@@ -143,6 +143,7 @@ const fixScripts = async (ws: Workspace) => {
     ...(ws.pj.devDependencies?.tshy ?
       {
         prepack: 'tshy',
+        tshy: 'tshy',
       }
     : {}),
     ...(ws.pj.dependencies?.astro ?

--- a/src/cache-unzip/package.json
+++ b/src/cache-unzip/package.json
@@ -47,6 +47,7 @@
     "snap": "tap",
     "test": "tap",
     "posttest": "tsc --noEmit",
+    "tshy": "tshy",
     "typecheck": "tsc --noEmit"
   },
   "tap": {

--- a/src/cache/package.json
+++ b/src/cache/package.json
@@ -49,6 +49,7 @@
     "snap": "tap",
     "test": "tap",
     "posttest": "tsc --noEmit",
+    "tshy": "tshy",
     "typecheck": "tsc --noEmit"
   },
   "tap": {

--- a/src/cli-sdk/package.json
+++ b/src/cli-sdk/package.json
@@ -80,6 +80,7 @@
     "snap": "tap",
     "test": "tap",
     "posttest": "tsc --noEmit",
+    "tshy": "tshy",
     "typecheck": "tsc --noEmit"
   },
   "tap": {

--- a/src/cmd-shim/package.json
+++ b/src/cmd-shim/package.json
@@ -46,6 +46,7 @@
     "snap": "tap",
     "test": "tap",
     "posttest": "tsc --noEmit",
+    "tshy": "tshy",
     "typecheck": "tsc --noEmit"
   },
   "tap": {

--- a/src/dep-id/package.json
+++ b/src/dep-id/package.json
@@ -48,6 +48,7 @@
     "snap": "tap",
     "test": "tap",
     "posttest": "tsc --noEmit",
+    "tshy": "tshy",
     "typecheck": "tsc --noEmit"
   },
   "tap": {

--- a/src/dot-prop/package.json
+++ b/src/dot-prop/package.json
@@ -42,6 +42,7 @@
     "snap": "tap",
     "test": "tap",
     "posttest": "tsc --noEmit",
+    "tshy": "tshy",
     "typecheck": "tsc --noEmit"
   },
   "tap": {

--- a/src/error-cause/package.json
+++ b/src/error-cause/package.json
@@ -42,6 +42,7 @@
     "snap": "tap",
     "test": "tap",
     "posttest": "tsc --noEmit",
+    "tshy": "tshy",
     "typecheck": "tsc --noEmit"
   },
   "tap": {

--- a/src/fast-split/package.json
+++ b/src/fast-split/package.json
@@ -43,6 +43,7 @@
     "snap": "tap",
     "test": "tap",
     "posttest": "tsc --noEmit",
+    "tshy": "tshy",
     "typecheck": "tsc --noEmit"
   },
   "tap": {

--- a/src/git-scp-url/package.json
+++ b/src/git-scp-url/package.json
@@ -42,6 +42,7 @@
     "snap": "tap",
     "test": "tap",
     "posttest": "tsc --noEmit",
+    "tshy": "tshy",
     "typecheck": "tsc --noEmit"
   },
   "tap": {

--- a/src/git/package.json
+++ b/src/git/package.json
@@ -57,6 +57,7 @@
     "snap": "tap",
     "test": "tap",
     "posttest": "tsc --noEmit",
+    "tshy": "tshy",
     "typecheck": "tsc --noEmit"
   },
   "tap": {

--- a/src/graph/package.json
+++ b/src/graph/package.json
@@ -63,6 +63,7 @@
     "snap": "tap",
     "test": "tap",
     "posttest": "tsc --noEmit",
+    "tshy": "tshy",
     "typecheck": "tsc --noEmit"
   },
   "tap": {

--- a/src/init/package.json
+++ b/src/init/package.json
@@ -49,6 +49,7 @@
     "snap": "tap",
     "test": "tap",
     "posttest": "tsc --noEmit",
+    "tshy": "tshy",
     "typecheck": "tsc --noEmit"
   },
   "tap": {

--- a/src/keychain/package.json
+++ b/src/keychain/package.json
@@ -45,6 +45,7 @@
     "snap": "tap",
     "test": "tap",
     "posttest": "tsc --noEmit",
+    "tshy": "tshy",
     "typecheck": "tsc --noEmit"
   },
   "tap": {

--- a/src/output/package.json
+++ b/src/output/package.json
@@ -42,6 +42,7 @@
     "snap": "tap",
     "test": "tap",
     "posttest": "tsc --noEmit",
+    "tshy": "tshy",
     "typecheck": "tsc --noEmit"
   },
   "tap": {

--- a/src/package-info/package.json
+++ b/src/package-info/package.json
@@ -59,6 +59,7 @@
     "snap": "tap",
     "test": "tap",
     "posttest": "tsc --noEmit",
+    "tshy": "tshy",
     "typecheck": "tsc --noEmit"
   },
   "tap": {

--- a/src/package-json/package.json
+++ b/src/package-json/package.json
@@ -47,6 +47,7 @@
     "snap": "tap",
     "test": "tap",
     "posttest": "tsc --noEmit",
+    "tshy": "tshy",
     "typecheck": "tsc --noEmit"
   },
   "tap": {

--- a/src/pick-manifest/package.json
+++ b/src/pick-manifest/package.json
@@ -52,6 +52,7 @@
     "snap": "tap",
     "test": "tap",
     "posttest": "tsc --noEmit",
+    "tshy": "tshy",
     "typecheck": "tsc --noEmit"
   },
   "tap": {

--- a/src/promise-spawn/package.json
+++ b/src/promise-spawn/package.json
@@ -46,6 +46,7 @@
     "snap": "tap",
     "test": "tap",
     "posttest": "tsc --noEmit",
+    "tshy": "tshy",
     "typecheck": "tsc --noEmit"
   },
   "tap": {

--- a/src/query/package.json
+++ b/src/query/package.json
@@ -53,6 +53,7 @@
     "snap": "tap",
     "test": "tap",
     "posttest": "tsc --noEmit",
+    "tshy": "tshy",
     "typecheck": "tsc --noEmit"
   },
   "tap": {

--- a/src/registry-client/package.json
+++ b/src/registry-client/package.json
@@ -56,6 +56,7 @@
     "snap": "tap",
     "test": "tap",
     "posttest": "tsc --noEmit",
+    "tshy": "tshy",
     "typecheck": "tsc --noEmit"
   },
   "tap": {

--- a/src/rollback-remove/package.json
+++ b/src/rollback-remove/package.json
@@ -45,6 +45,7 @@
     "snap": "tap",
     "test": "tap",
     "posttest": "tsc --noEmit",
+    "tshy": "tshy",
     "typecheck": "tsc --noEmit"
   },
   "tap": {

--- a/src/run/package.json
+++ b/src/run/package.json
@@ -50,6 +50,7 @@
     "snap": "tap",
     "test": "tap",
     "posttest": "tsc --noEmit",
+    "tshy": "tshy",
     "typecheck": "tsc --noEmit"
   },
   "tap": {

--- a/src/satisfies/package.json
+++ b/src/satisfies/package.json
@@ -49,6 +49,7 @@
     "snap": "tap",
     "test": "tap",
     "posttest": "tsc --noEmit",
+    "tshy": "tshy",
     "typecheck": "tsc --noEmit"
   },
   "tap": {

--- a/src/security-archive/package.json
+++ b/src/security-archive/package.json
@@ -54,6 +54,7 @@
     "snap": "tap",
     "test": "tap",
     "posttest": "tsc --noEmit",
+    "tshy": "tshy",
     "typecheck": "tsc --noEmit"
   },
   "tap": {

--- a/src/semver/package.json
+++ b/src/semver/package.json
@@ -53,6 +53,7 @@
     "snap": "tap",
     "test": "tap",
     "posttest": "tsc --noEmit",
+    "tshy": "tshy",
     "typecheck": "tsc --noEmit"
   },
   "tap": {

--- a/src/server/package.json
+++ b/src/server/package.json
@@ -63,6 +63,7 @@
     "snap": "tap",
     "test": "tap",
     "posttest": "tsc --noEmit",
+    "tshy": "tshy",
     "typecheck": "tsc --noEmit"
   },
   "tap": {

--- a/src/spec/package.json
+++ b/src/spec/package.json
@@ -50,6 +50,7 @@
     "snap": "tap",
     "test": "tap",
     "posttest": "tsc --noEmit",
+    "tshy": "tshy",
     "typecheck": "tsc --noEmit"
   },
   "tap": {

--- a/src/tar/package.json
+++ b/src/tar/package.json
@@ -54,6 +54,7 @@
     "snap": "tap",
     "test": "tap",
     "posttest": "tsc --noEmit",
+    "tshy": "tshy",
     "typecheck": "tsc --noEmit"
   },
   "tap": {

--- a/src/types/package.json
+++ b/src/types/package.json
@@ -45,6 +45,7 @@
     "snap": "tap",
     "test": "tap",
     "posttest": "tsc --noEmit",
+    "tshy": "tshy",
     "typecheck": "tsc --noEmit"
   },
   "tap": {

--- a/src/url-open/package.json
+++ b/src/url-open/package.json
@@ -46,6 +46,7 @@
     "snap": "tap",
     "test": "tap",
     "posttest": "tsc --noEmit",
+    "tshy": "tshy",
     "typecheck": "tsc --noEmit"
   },
   "tap": {

--- a/src/vlx/package.json
+++ b/src/vlx/package.json
@@ -55,6 +55,7 @@
     "snap": "tap",
     "test": "tap",
     "posttest": "tsc --noEmit",
+    "tshy": "tshy",
     "typecheck": "tsc --noEmit"
   },
   "tap": {

--- a/src/which/package.json
+++ b/src/which/package.json
@@ -45,6 +45,7 @@
     "snap": "tap",
     "test": "tap",
     "posttest": "tsc --noEmit",
+    "tshy": "tshy",
     "typecheck": "tsc --noEmit"
   },
   "tap": {

--- a/src/workspaces/package.json
+++ b/src/workspaces/package.json
@@ -53,6 +53,7 @@
     "snap": "tap",
     "test": "tap",
     "posttest": "tsc --noEmit",
+    "tshy": "tshy",
     "typecheck": "tsc --noEmit"
   },
   "tap": {

--- a/src/xdg/package.json
+++ b/src/xdg/package.json
@@ -42,6 +42,7 @@
     "snap": "tap",
     "test": "tap",
     "posttest": "tsc --noEmit",
+    "tshy": "tshy",
     "typecheck": "tsc --noEmit"
   },
   "tap": {


### PR DESCRIPTION
We run `tshy` still as part of our release process but not during development which can create git churn during the release process a workspace is created or has its `exports` updated (ref f09ca4d8f43e85a7640b0561c60b1bb0ee4fe40c, d49c9c900dc4eaed6c9721b9762eadc7be6d1958).

This changes adds `pnpm -r tshy` as a lint check during the consistent workspaces check. The result will be if tshy is going to make changes then the PR will fail.