### PR TITLE
query: fix scope selector

### DIFF
--- a/src/cli-sdk/src/commands/list.ts
+++ b/src/cli-sdk/src/commands/list.ts
@@ -12,6 +12,7 @@ import {
 } from '@vltpkg/graph'
 import { Query } from '@vltpkg/query'
 import { SecurityArchive } from '@vltpkg/security-archive'
+import type { DepID } from '@vltpkg/dep-id'
 import { commandUsage } from '../config/usage.ts'
 import type { CommandFn, CommandUsage } from '../index.ts'
 import { startGUI } from '../start-gui.ts'
@@ -110,6 +111,8 @@ export const command: CommandFn<ListResult> = async conf => {
   const selectImporters: string[] = []
 
   const importers = new Set<Node>()
+  const scopeIDs: DepID[] = []
+
   if (monorepo) {
     for (const workspace of monorepo.filter(conf.values)) {
       const w: Node | undefined = graph.nodes.get(workspace.id)
@@ -117,6 +120,7 @@ export const command: CommandFn<ListResult> = async conf => {
         importers.add(w)
         selectImporters.push(`[name="${w.name}"]`)
         selectImporters.push(`[name="${w.name}"] > *`)
+        scopeIDs.push(workspace.id)
       }
     }
   }
@@ -137,6 +141,10 @@ export const command: CommandFn<ListResult> = async conf => {
 
   const { edges, nodes } = await query.search(
     queryString || defaultQueryString,
+    {
+      signal: new AbortController().signal,
+      scopeIDs: scopeIDs.length > 0 ? scopeIDs : undefined,
+    },
   )
 
   return {

--- a/src/cli-sdk/tap-snapshots/test/commands/list.ts.test.cjs
+++ b/src/cli-sdk/tap-snapshots/test/commands/list.ts.test.cjs
@@ -415,3 +415,8 @@ exports[`test/commands/list.ts > TAP > list > workspaces > should list workspace
   }
 ]
 `
+
+exports[`test/commands/list.ts > TAP > list > workspaces > should use specified workspace as scope selector 1`] = `
+a
+
+`

--- a/src/cli-sdk/tap-snapshots/test/commands/query.ts.test.cjs
+++ b/src/cli-sdk/tap-snapshots/test/commands/query.ts.test.cjs
@@ -319,3 +319,8 @@ exports[`test/commands/query.ts > TAP > query > workspaces > should list workspa
   }
 ]
 `
+
+exports[`test/commands/query.ts > TAP > query > workspaces > should use specified workspace as scope selector 1`] = `
+a
+
+`

--- a/src/cli-sdk/test/commands/list.ts
+++ b/src/cli-sdk/test/commands/list.ts
@@ -303,6 +303,18 @@ t.test('list', async t => {
       ),
       'should list single workspace',
     )
+
+    t.matchSnapshot(
+      await runCommand(
+        {
+          positionals: [':scope'],
+          values: { view: 'human', workspace: ['a'] },
+          options,
+        },
+        C,
+      ),
+      'should use specified workspace as scope selector',
+    )
   })
 
   t.test('view=gui', async t => {

--- a/src/cli-sdk/test/commands/query.ts
+++ b/src/cli-sdk/test/commands/query.ts
@@ -378,6 +378,21 @@ t.test('query', async t => {
       ),
       'should list single workspace',
     )
+
+    t.matchSnapshot(
+      await runCommand(
+        {
+          positionals: [':scope'],
+          values: {
+            workspace: ['a'],
+            view: 'human',
+          },
+          options,
+        },
+        Command,
+      ),
+      'should use specified workspace as scope selector',
+    )
   })
 
   t.test('view=gui', async t => {

--- a/src/gui/src/app/explorer.tsx
+++ b/src/gui/src/app/explorer.tsx
@@ -104,7 +104,10 @@ const ExplorerContent = () => {
       if (!q) return
       ac.current.abort(new Error('Query changed'))
       ac.current = new AbortController()
-      const queryResponse = await q.search(query, ac.current.signal)
+      const queryResponse = await q.search(query, {
+        signal: ac.current.signal,
+        scopeIDs: graph ? [graph.mainImporter.id] : undefined,
+      })
 
       updateEdges(queryResponse.edges)
       updateNodes(queryResponse.nodes)

--- a/src/gui/test/components/explorer-grid/index.tsx
+++ b/src/gui/test/components/explorer-grid/index.tsx
@@ -223,7 +223,9 @@ test('explorer-grid renders workspace with edges in', async () => {
     specOptions: {},
     securityArchive: undefined,
   })
-  const result = await q.search(':project[name=b]')
+  const result = await q.search(':project[name=b]', {
+    signal: new AbortController().signal,
+  })
 
   const Container = () => {
     const updateEdges = useStore(state => state.updateEdges)

--- a/src/query/src/pseudo.ts
+++ b/src/query/src/pseudo.ts
@@ -88,6 +88,8 @@ const has = async (state: ParserState) => {
         retries: state.retries,
         securityArchive: state.securityArchive,
         specOptions: state.specOptions,
+        signal: state.signal,
+        scopeIDs: state.scopeIDs,
       })
       for (const n of nestedState.collect.nodes) {
         collectNodes.add(n)
@@ -171,6 +173,8 @@ const is = async (state: ParserState) => {
         retries: state.retries,
         securityArchive: state.securityArchive,
         specOptions: state.specOptions,
+        signal: state.signal,
+        scopeIDs: state.scopeIDs,
       })
       for (const n of nestedState.collect.nodes) {
         collect.add(n)
@@ -211,6 +215,8 @@ const not = async (state: ParserState) => {
         retries: state.retries,
         securityArchive: state.securityArchive,
         specOptions: state.specOptions,
+        signal: state.signal,
+        scopeIDs: state.scopeIDs,
       })
       for (const n of nestedState.collect.nodes) {
         collect.add(n)
@@ -270,18 +276,20 @@ const project = async (state: ParserState) => {
 }
 
 /**
- * :scope Pseudo-Element, returns the original scope of items
- * at the start of a given selector.
+ * :scope Pseudo-Element, returns only the nodes that match the provided scopeIDs
+ * from the Query.search method.
  */
 const scope = async (state: ParserState) => {
-  state.partial.edges.clear()
-  state.partial.nodes.clear()
-  for (const edge of state.initial.edges) {
-    state.partial.edges.add(edge)
+  const scopeIDSet = new Set(state.scopeIDs)
+
+  for (const node of state.partial.nodes) {
+    if (!scopeIDSet.has(node.id)) {
+      removeNode(state, node)
+    }
   }
-  for (const node of state.initial.nodes) {
-    state.partial.nodes.add(node)
-  }
+
+  removeDanglingEdges(state)
+
   return state
 }
 

--- a/src/query/src/types.ts
+++ b/src/query/src/types.ts
@@ -5,6 +5,7 @@ import type {
   SecurityArchiveLike,
   PackageScore,
 } from '@vltpkg/security-archive'
+import type { DepID } from '@vltpkg/dep-id'
 import type {
   Tag,
   String,
@@ -50,12 +51,13 @@ export type ParserState = {
   next?: PostcssNode
   prev?: PostcssNode
   result?: NodeLike[]
-  signal?: AbortSignal
+  signal: AbortSignal
   walk: ParserFn
   partial: GraphSelectionState
   retries: number
   securityArchive: SecurityArchiveLike | undefined
   specOptions: SpecOptions
+  scopeIDs?: DepID[]
 }
 
 export type QueryResponse = {

--- a/src/query/tap-snapshots/test/pseudo.ts.test.cjs
+++ b/src/query/tap-snapshots/test/pseudo.ts.test.cjs
@@ -971,24 +971,8 @@ Object {
 
 exports[`test/pseudo.ts > TAP > pseudo > query > ":scope" 1`] = `
 Object {
-  "edges": Array [
-    "@x/y",
-    "a",
-    "b",
-    "c",
-    "d",
-    "e",
-    "e",
-    "f",
-  ],
+  "edges": Array [],
   "nodes": Array [
-    "@x/y",
-    "a",
-    "b",
-    "c",
-    "d",
-    "e",
-    "f",
     "my-project",
   ],
 }
@@ -996,51 +980,15 @@ Object {
 
 exports[`test/pseudo.ts > TAP > pseudo > query > ":scope" 2`] = `
 Object {
-  "edges": Array [
-    "@x/y",
-    "a",
-    "b",
-    "c",
-    "d",
-    "e",
-    "e",
-    "f",
-  ],
-  "nodes": Array [
-    "@x/y",
-    "a",
-    "b",
-    "c",
-    "d",
-    "e",
-    "f",
-    "my-project",
-  ],
+  "edges": Array [],
+  "nodes": Array [],
 }
 `
 
 exports[`test/pseudo.ts > TAP > pseudo > query > ":scope" 3`] = `
 Object {
-  "edges": Array [
-    "@x/y",
-    "a",
-    "b",
-    "c",
-    "d",
-    "e",
-    "e",
-    "f",
-  ],
-  "nodes": Array [
-    "@x/y",
-    "a",
-    "b",
-    "c",
-    "d",
-    "e",
-    "f",
-    "my-project",
-  ],
+  "edges": Array [],
+  "nodes": Array [],
 }
 `
 
@@ -1285,6 +1233,15 @@ Object {
 `
 
 exports[`test/pseudo.ts > TAP > pseudo > workspace > query > ":type(workspace)" 1`] = `
+Object {
+  "edges": Array [],
+  "nodes": Array [
+    "w",
+  ],
+}
+`
+
+exports[`test/pseudo.ts > TAP > pseudo > workspace > query > customScopedID 1`] = `
 Object {
   "edges": Array [],
   "nodes": Array [

--- a/src/query/test/attribute.ts
+++ b/src/query/test/attribute.ts
@@ -242,6 +242,7 @@ t.test('filterAttributes', async t => {
     retries: 0,
     securityArchive: undefined,
     specOptions: {},
+    signal: new AbortController().signal,
   }
   filterAttributes(
     state,

--- a/src/query/test/fixtures/selector.ts
+++ b/src/query/test/fixtures/selector.ts
@@ -1,6 +1,7 @@
 import { parse } from '../../src/parser.ts'
 import type { EdgeLike, GraphLike, NodeLike } from '@vltpkg/graph'
 import { joinDepIDTuple } from '@vltpkg/dep-id'
+import type { DepID } from '@vltpkg/dep-id'
 import type {
   GraphSelectionState,
   ParserState,
@@ -51,6 +52,7 @@ export const selectorFixture =
     initial?: GraphSelectionState,
     partial?: GraphSelectionState,
     loose?: boolean,
+    scopeIDs?: DepID[],
   ): Promise<FixtureResult> => {
     initial ??= {
       edges: new Set(),
@@ -60,6 +62,7 @@ export const selectorFixture =
       edges: new Set(),
       nodes: new Set(),
     }
+    scopeIDs ??= [joinDepIDTuple(['file', '.'])]
     let current: PostcssNode
     if (typeof query === 'string') {
       const ast = parse(query)
@@ -84,7 +87,9 @@ export const selectorFixture =
       partial,
       walk,
       retries: 0,
+      scopeIDs,
       securityArchive: undefined,
+      signal: new AbortController().signal,
       specOptions: {},
     }
     const res = await testFn(state)

--- a/src/query/test/pseudo.ts
+++ b/src/query/test/pseudo.ts
@@ -39,21 +39,9 @@ t.test('pseudo', async t => {
     [':project /*all*/', all, ['my-project']], // no workspaces in graph
     [':project /*empty*/', empty, []], // from empty nodes
     [':project /*b*/', b, []], // from diff node
-    [
-      ':scope',
-      all,
-      ['my-project', 'a', 'b', 'c', 'd', 'e', 'f', '@x/y'],
-    ], // :scope refers to the initial values from initial
-    [
-      ':scope',
-      b,
-      ['my-project', 'a', 'b', 'c', 'd', 'e', 'f', '@x/y'],
-    ], // :scope resets the initial values from a partial
-    [
-      ':scope',
-      empty,
-      ['my-project', 'a', 'b', 'c', 'd', 'e', 'f', '@x/y'],
-    ], // :scope resets the initial values from empty partial
+    [':scope', all, ['my-project']], // :scope refers to the initial values from initial
+    [':scope', b, []], // :scope resets the initial values from a partial
+    [':scope', empty, []], // :scope resets the initial values from empty partial
     // :attr selector
     [':attr([scripts])', all, ['b']], // prop lookup only
     [':attr([scripts])', b, ['b']], // start with a single node
@@ -234,6 +222,27 @@ t.test('pseudo', async t => {
         `query > "${query}"`,
       )
     }
+
+    // test custom scopedID
+    const result = await testPseudo(
+      ':scope',
+      initial,
+      copyGraphSelectionState(all),
+      false,
+      [joinDepIDTuple(['workspace', 'w'])],
+    )
+    t.strictSame(
+      result.nodes.map(i => i.name),
+      ['w'],
+      'query > customScopedID',
+    )
+    t.matchSnapshot(
+      {
+        edges: result.edges.map(i => i.name).sort(),
+        nodes: result.nodes.map(i => i.name).sort(),
+      },
+      'query > customScopedID',
+    )
   })
 
   await t.test('complex workspace', async t => {

--- a/src/query/test/pseudo/abandoned.ts
+++ b/src/query/test/pseudo/abandoned.ts
@@ -26,7 +26,6 @@ t.test('selects packages with an abandoned alert', async t => {
       },
       cancellable: async () => {},
       walk: async i => i,
-      retries: 0,
       securityArchive: asSecurityArchiveLike(
         new Map([
           [
@@ -36,6 +35,8 @@ t.test('selects packages with an abandoned alert', async t => {
         ]),
       ),
       specOptions: {},
+      retries: 0,
+      signal: new AbortController().signal,
     }
     return state
   }
@@ -77,9 +78,10 @@ t.test('missing security archive', async t => {
       },
       cancellable: async () => {},
       walk: async i => i,
-      retries: 0,
       securityArchive: undefined,
       specOptions: {},
+      retries: 0,
+      signal: new AbortController().signal,
     }
     return state
   }

--- a/src/query/test/pseudo/attr.ts
+++ b/src/query/test/pseudo/attr.ts
@@ -24,9 +24,10 @@ t.test('selects packages based on attribute properties', async t => {
       },
       cancellable: async () => {},
       walk: async i => i,
-      retries: 0,
       securityArchive: undefined,
       specOptions: {},
+      retries: 0,
+      signal: new AbortController().signal,
     }
     return state
   }

--- a/src/query/test/pseudo/confused.ts
+++ b/src/query/test/pseudo/confused.ts
@@ -36,6 +36,7 @@ t.test('selects packages with a manifestConfusion alert', async t => {
         ]),
       ),
       specOptions: {},
+      signal: new AbortController().signal,
     }
     return state
   }
@@ -80,6 +81,7 @@ t.test('missing security archive', async t => {
       retries: 0,
       securityArchive: undefined,
       specOptions: {},
+      signal: new AbortController().signal,
     }
     return state
   }
@@ -132,6 +134,7 @@ t.test('nodes with confused=true flag', async t => {
         ]),
       ),
       specOptions: {},
+      signal: new AbortController().signal,
     }
     return state
   }

--- a/src/query/test/pseudo/cve.ts
+++ b/src/query/test/pseudo/cve.ts
@@ -49,6 +49,7 @@ t.test('selects packages with a CVE alert', async t => {
                 quality: 0,
                 supplyChain: 0,
                 vulnerability: 0,
+                signal: new AbortController().signal,
               },
               alerts: [
                 {
@@ -67,6 +68,7 @@ t.test('selects packages with a CVE alert', async t => {
         ]),
       ),
       specOptions: {},
+      signal: new AbortController().signal,
     }
     return state
   }
@@ -140,6 +142,7 @@ t.test('missing security archive', async t => {
       retries: 0,
       securityArchive: undefined,
       specOptions: {},
+      signal: new AbortController().signal,
     }
     return state
   }
@@ -174,6 +177,7 @@ t.test('missing CVE ID', async t => {
       retries: 0,
       securityArchive: asSecurityArchiveLike(new Map()),
       specOptions: {},
+      signal: new AbortController().signal,
     }
     return state
   }

--- a/src/query/test/pseudo/cwe.ts
+++ b/src/query/test/pseudo/cwe.ts
@@ -47,6 +47,7 @@ t.test('selects packages with a CWE alert', async t => {
                 quality: 0,
                 supplyChain: 0,
                 vulnerability: 0,
+                signal: new AbortController().signal,
               },
               alerts: [
                 {
@@ -69,6 +70,7 @@ t.test('selects packages with a CWE alert', async t => {
         ]),
       ),
       specOptions: {},
+      signal: new AbortController().signal,
     }
     return state
   }
@@ -142,6 +144,7 @@ t.test('missing security archive', async t => {
       retries: 0,
       securityArchive: undefined,
       specOptions: {},
+      signal: new AbortController().signal,
     }
     return state
   }
@@ -176,6 +179,7 @@ t.test('missing CWE ID', async t => {
       retries: 0,
       securityArchive: asSecurityArchiveLike(new Map()),
       specOptions: {},
+      signal: new AbortController().signal,
     }
     return state
   }

--- a/src/query/test/pseudo/debug.ts
+++ b/src/query/test/pseudo/debug.ts
@@ -36,6 +36,7 @@ t.test('selects packages with a debugAccess alert', async t => {
         ]),
       ),
       specOptions: {},
+      signal: new AbortController().signal,
     }
     return state
   }
@@ -80,6 +81,7 @@ t.test('missing security archive', async t => {
       retries: 0,
       securityArchive: undefined,
       specOptions: {},
+      signal: new AbortController().signal,
     }
     return state
   }

--- a/src/query/test/pseudo/deprecated.ts
+++ b/src/query/test/pseudo/deprecated.ts
@@ -26,7 +26,6 @@ t.test('selects packages with deprecated alert', async t => {
       },
       cancellable: async () => {},
       walk: async i => i,
-      retries: 0,
       securityArchive: asSecurityArchiveLike(
         new Map([
           [
@@ -36,6 +35,8 @@ t.test('selects packages with deprecated alert', async t => {
         ]),
       ),
       specOptions: {},
+      retries: 0,
+      signal: new AbortController().signal,
     }
     return state
   }
@@ -77,9 +78,10 @@ t.test('missing security archive', async t => {
       },
       cancellable: async () => {},
       walk: async i => i,
-      retries: 0,
       securityArchive: undefined,
       specOptions: {},
+      retries: 0,
+      signal: new AbortController().signal,
     }
     return state
   }

--- a/src/query/test/pseudo/dynamic.ts
+++ b/src/query/test/pseudo/dynamic.ts
@@ -26,7 +26,6 @@ t.test('selects packages with a dynamicRequire alert', async t => {
       },
       cancellable: async () => {},
       walk: async i => i,
-      retries: 0,
       securityArchive: asSecurityArchiveLike(
         new Map([
           [
@@ -36,6 +35,8 @@ t.test('selects packages with a dynamicRequire alert', async t => {
         ]),
       ),
       specOptions: {},
+      retries: 0,
+      signal: new AbortController().signal,
     }
     return state
   }
@@ -77,9 +78,10 @@ t.test('missing security archive', async t => {
       },
       cancellable: async () => {},
       walk: async i => i,
-      retries: 0,
       securityArchive: undefined,
       specOptions: {},
+      retries: 0,
+      signal: new AbortController().signal,
     }
     return state
   }

--- a/src/query/test/pseudo/empty.ts
+++ b/src/query/test/pseudo/empty.ts
@@ -31,6 +31,7 @@ t.test('selects packages with no dependencies', async t => {
       retries: 0,
       securityArchive: undefined,
       specOptions: {},
+      signal: new AbortController().signal,
     }
     return state
   }

--- a/src/query/test/pseudo/entropic.ts
+++ b/src/query/test/pseudo/entropic.ts
@@ -28,7 +28,6 @@ t.test(
         },
         cancellable: async () => {},
         walk: async i => i,
-        retries: 0,
         securityArchive: asSecurityArchiveLike(
           new Map([
             [
@@ -38,6 +37,8 @@ t.test(
           ]),
         ),
         specOptions: {},
+        retries: 0,
+        signal: new AbortController().signal,
       }
       return state
     }
@@ -80,9 +81,10 @@ t.test('missing security archive', async t => {
       },
       cancellable: async () => {},
       walk: async i => i,
-      retries: 0,
       securityArchive: undefined,
       specOptions: {},
+      retries: 0,
+      signal: new AbortController().signal,
     }
     return state
   }

--- a/src/query/test/pseudo/env.ts
+++ b/src/query/test/pseudo/env.ts
@@ -36,6 +36,7 @@ t.test('selects packages with a envVars alert', async t => {
         ]),
       ),
       specOptions: {},
+      signal: new AbortController().signal,
     }
     return state
   }
@@ -80,6 +81,7 @@ t.test('missing security archive', async t => {
       retries: 0,
       securityArchive: undefined,
       specOptions: {},
+      signal: new AbortController().signal,
     }
     return state
   }

--- a/src/query/test/pseudo/eval.ts
+++ b/src/query/test/pseudo/eval.ts
@@ -36,6 +36,7 @@ t.test('selects packages with an eval alert', async t => {
         ]),
       ),
       specOptions: {},
+      signal: new AbortController().signal,
     }
     return state
   }
@@ -80,6 +81,7 @@ t.test('missing security archive', async t => {
       retries: 0,
       securityArchive: undefined,
       specOptions: {},
+      signal: new AbortController().signal,
     }
     return state
   }

--- a/src/query/test/pseudo/fs.ts
+++ b/src/query/test/pseudo/fs.ts
@@ -36,6 +36,7 @@ t.test('selects packages with a filesystemAccess alert', async t => {
         ]),
       ),
       specOptions: {},
+      signal: new AbortController().signal,
     }
     return state
   }
@@ -80,6 +81,7 @@ t.test('missing security archive', async t => {
       retries: 0,
       securityArchive: undefined,
       specOptions: {},
+      signal: new AbortController().signal,
     }
     return state
   }

--- a/src/query/test/pseudo/helpers.ts
+++ b/src/query/test/pseudo/helpers.ts
@@ -240,6 +240,7 @@ t.test('selects packages with an unmaintained alert', async t => {
       ),
       specOptions: {},
       retries: 0,
+      signal: new AbortController().signal,
     }
     return state
   }
@@ -288,6 +289,7 @@ t.test('missing security archive', async t => {
       securityArchive: undefined,
       specOptions: {},
       retries: 0,
+      signal: new AbortController().signal,
     }
     return state
   }

--- a/src/query/test/pseudo/license.ts
+++ b/src/query/test/pseudo/license.ts
@@ -50,6 +50,7 @@ t.test('selects packages with a specific license kind', async t => {
         ]),
       ),
       specOptions: {},
+      signal: new AbortController().signal,
     }
     return state
   }
@@ -115,6 +116,7 @@ t.test('missing security archive', async t => {
       retries: 0,
       securityArchive: undefined,
       specOptions: {},
+      signal: new AbortController().signal,
     }
     return state
   }

--- a/src/query/test/pseudo/link.ts
+++ b/src/query/test/pseudo/link.ts
@@ -27,6 +27,7 @@ t.test('selects file links and tar.gz packages', async t => {
       retries: 0,
       securityArchive: undefined,
       specOptions: {},
+      signal: new AbortController().signal,
     }
     return state
   }

--- a/src/query/test/pseudo/malware.ts
+++ b/src/query/test/pseudo/malware.ts
@@ -80,6 +80,7 @@ t.test('selects packages with a specific malware kind', async t => {
       ),
       specOptions: {},
       retries: 0,
+      signal: new AbortController().signal,
     }
     return state
   }
@@ -302,6 +303,7 @@ t.test('missing security archive', async t => {
       securityArchive: undefined,
       specOptions: {},
       retries: 0,
+      signal: new AbortController().signal,
     }
     return state
   }

--- a/src/query/test/pseudo/minified.ts
+++ b/src/query/test/pseudo/minified.ts
@@ -36,6 +36,7 @@ t.test('selects packages with a minifiedFile alert', async t => {
       ),
       specOptions: {},
       retries: 0,
+      signal: new AbortController().signal,
     }
     return state
   }
@@ -80,6 +81,7 @@ t.test('missing security archive', async t => {
       securityArchive: undefined,
       specOptions: {},
       retries: 0,
+      signal: new AbortController().signal,
     }
     return state
   }

--- a/src/query/test/pseudo/missing.ts
+++ b/src/query/test/pseudo/missing.ts
@@ -30,6 +30,7 @@ t.test('selects edges with no linked node', async t => {
       retries: 0,
       securityArchive: undefined,
       specOptions: {},
+      signal: new AbortController().signal,
     }
     return state
   }

--- a/src/query/test/pseudo/native.ts
+++ b/src/query/test/pseudo/native.ts
@@ -36,6 +36,7 @@ t.test('selects packages with a hasNativeCode alert', async t => {
       ),
       specOptions: {},
       retries: 0,
+      signal: new AbortController().signal,
     }
     return state
   }
@@ -80,6 +81,7 @@ t.test('missing security archive', async t => {
       securityArchive: undefined,
       specOptions: {},
       retries: 0,
+      signal: new AbortController().signal,
     }
     return state
   }

--- a/src/query/test/pseudo/network.ts
+++ b/src/query/test/pseudo/network.ts
@@ -36,6 +36,7 @@ t.test('selects packages with a networkAccess alert', async t => {
       ),
       specOptions: {},
       retries: 0,
+      signal: new AbortController().signal,
     }
     return state
   }
@@ -80,6 +81,7 @@ t.test('missing security archive', async t => {
       securityArchive: undefined,
       specOptions: {},
       retries: 0,
+      signal: new AbortController().signal,
     }
     return state
   }

--- a/src/query/test/pseudo/obfuscated.ts
+++ b/src/query/test/pseudo/obfuscated.ts
@@ -36,6 +36,7 @@ t.test('selects packages with an obfuscated alert', async t => {
       ),
       specOptions: {},
       retries: 0,
+      signal: new AbortController().signal,
     }
     return state
   }
@@ -80,6 +81,7 @@ t.test('missing security archive', async t => {
       securityArchive: undefined,
       specOptions: {},
       retries: 0,
+      signal: new AbortController().signal,
     }
     return state
   }

--- a/src/query/test/pseudo/outdated.ts
+++ b/src/query/test/pseudo/outdated.ts
@@ -134,6 +134,7 @@ const getState = (query: string, graph = getSemverRichGraph()) => {
     retries: 0,
     securityArchive: undefined,
     specOptions,
+    signal: new AbortController().signal,
   }
   return state
 }

--- a/src/query/test/pseudo/private.ts
+++ b/src/query/test/pseudo/private.ts
@@ -31,6 +31,7 @@ t.test('selects packages with private flag', async t => {
       retries: 0,
       securityArchive: undefined,
       specOptions: {},
+      signal: new AbortController().signal,
     }
     return state
   }

--- a/src/query/test/pseudo/published.ts
+++ b/src/query/test/pseudo/published.ts
@@ -99,6 +99,7 @@ const getState = (query: string, graph = getSemverRichGraph()) => {
     retries: 0,
     securityArchive: undefined,
     specOptions,
+    signal: new AbortController().signal,
   }
   return state
 }

--- a/src/query/test/pseudo/scanned.ts
+++ b/src/query/test/pseudo/scanned.ts
@@ -57,6 +57,7 @@ t.test('scanned selector', async t => {
       securityArchive,
       specOptions: {},
       retries: 0,
+      signal: new AbortController().signal,
     }
     return state
   }

--- a/src/query/test/pseudo/score.ts
+++ b/src/query/test/pseudo/score.ts
@@ -110,6 +110,7 @@ t.test('selects packages based on their security score', async t => {
       securityArchive: createTestSecurityArchive(),
       specOptions: {},
       retries: 0,
+      signal: new AbortController().signal,
     }
     return state
   }
@@ -367,6 +368,7 @@ t.test('error cases', async t => {
         securityArchive: undefined,
         specOptions: {},
         retries: 0,
+        signal: new AbortController().signal,
       }
       return state
     }
@@ -402,6 +404,7 @@ t.test('error cases', async t => {
         securityArchive: createTestSecurityArchive(),
         specOptions: {},
         retries: 0,
+        signal: new AbortController().signal,
       }
       return state
     }
@@ -437,6 +440,7 @@ t.test('error cases', async t => {
         securityArchive: createTestSecurityArchive(),
         specOptions: {},
         retries: 0,
+        signal: new AbortController().signal,
       }
       return state
     }
@@ -472,6 +476,7 @@ t.test('error cases', async t => {
         securityArchive: createTestSecurityArchive(),
         specOptions: {},
         retries: 0,
+        signal: new AbortController().signal,
       }
       return state
     }

--- a/src/query/test/pseudo/scripts.ts
+++ b/src/query/test/pseudo/scripts.ts
@@ -36,6 +36,7 @@ t.test('selects packages with an installScripts alert', async t => {
       ),
       specOptions: {},
       retries: 0,
+      signal: new AbortController().signal,
     }
     return state
   }
@@ -80,6 +81,7 @@ t.test('missing security archive', async t => {
       securityArchive: undefined,
       specOptions: {},
       retries: 0,
+      signal: new AbortController().signal,
     }
     return state
   }

--- a/src/query/test/pseudo/semver.ts
+++ b/src/query/test/pseudo/semver.ts
@@ -36,6 +36,7 @@ t.test('select from semver definition', async t => {
       walk: async i => i,
       securityArchive: undefined,
       specOptions: {},
+      signal: new AbortController().signal,
     }
     return state
   }

--- a/src/query/test/pseudo/severity.ts
+++ b/src/query/test/pseudo/severity.ts
@@ -66,6 +66,7 @@ t.test('selects packages with a specific severity kind', async t => {
       ),
       specOptions: {},
       retries: 0,
+      signal: new AbortController().signal,
     }
     return state
   }
@@ -208,6 +209,7 @@ t.test('missing security archive', async t => {
       securityArchive: undefined,
       specOptions: {},
       retries: 0,
+      signal: new AbortController().signal,
     }
     return state
   }

--- a/src/query/test/pseudo/shell.ts
+++ b/src/query/test/pseudo/shell.ts
@@ -36,6 +36,7 @@ t.test('selects packages with a shellAccess alert', async t => {
       ),
       specOptions: {},
       retries: 0,
+      signal: new AbortController().signal,
     }
     return state
   }
@@ -80,6 +81,7 @@ t.test('missing security archive', async t => {
       securityArchive: undefined,
       specOptions: {},
       retries: 0,
+      signal: new AbortController().signal,
     }
     return state
   }

--- a/src/query/test/pseudo/shrinkwrap.ts
+++ b/src/query/test/pseudo/shrinkwrap.ts
@@ -36,6 +36,7 @@ t.test('selects packages with a shrinkwrap alert', async t => {
       ),
       specOptions: {},
       retries: 0,
+      signal: new AbortController().signal,
     }
     return state
   }
@@ -80,6 +81,7 @@ t.test('missing security archive', async t => {
       securityArchive: undefined,
       specOptions: {},
       retries: 0,
+      signal: new AbortController().signal,
     }
     return state
   }

--- a/src/query/test/pseudo/squat.ts
+++ b/src/query/test/pseudo/squat.ts
@@ -52,6 +52,7 @@ t.test('selects packages with a specific squat kind', async t => {
       ),
       specOptions: {},
       retries: 0,
+      signal: new AbortController().signal,
     }
     return state
   }
@@ -244,6 +245,7 @@ t.test('selects packages with a specific squat kind', async t => {
         ),
         specOptions: {},
         retries: 0,
+        signal: new AbortController().signal,
       }
       return state
     }
@@ -307,6 +309,7 @@ t.test('selects packages with a specific squat kind', async t => {
         ),
         specOptions: {},
         retries: 0,
+        signal: new AbortController().signal,
       }
       return state
     }
@@ -351,6 +354,7 @@ t.test('missing security archive', async t => {
       securityArchive: undefined,
       specOptions: {},
       retries: 0,
+      signal: new AbortController().signal,
     }
     return state
   }

--- a/src/query/test/pseudo/suspicious.ts
+++ b/src/query/test/pseudo/suspicious.ts
@@ -36,6 +36,7 @@ t.test('selects packages with a suspicious alert', async t => {
       ),
       specOptions: {},
       retries: 0,
+      signal: new AbortController().signal,
     }
     return state
   }
@@ -80,6 +81,7 @@ t.test('missing security archive', async t => {
       securityArchive: undefined,
       specOptions: {},
       retries: 0,
+      signal: new AbortController().signal,
     }
     return state
   }

--- a/src/query/test/pseudo/tracker.ts
+++ b/src/query/test/pseudo/tracker.ts
@@ -36,6 +36,7 @@ t.test('selects packages with a tracker alert', async t => {
       ),
       specOptions: {},
       retries: 0,
+      signal: new AbortController().signal,
     }
     return state
   }
@@ -80,6 +81,7 @@ t.test('missing security archive', async t => {
       securityArchive: undefined,
       specOptions: {},
       retries: 0,
+      signal: new AbortController().signal,
     }
     return state
   }

--- a/src/query/test/pseudo/trivial.ts
+++ b/src/query/test/pseudo/trivial.ts
@@ -36,6 +36,7 @@ t.test('selects packages with a trivial alert', async t => {
       ),
       specOptions: {},
       retries: 0,
+      signal: new AbortController().signal,
     }
     return state
   }
@@ -80,6 +81,7 @@ t.test('missing security archive', async t => {
       securityArchive: undefined,
       specOptions: {},
       retries: 0,
+      signal: new AbortController().signal,
     }
     return state
   }

--- a/src/query/test/pseudo/undesirable.ts
+++ b/src/query/test/pseudo/undesirable.ts
@@ -36,6 +36,7 @@ t.test('selects packages with an undesirable alert', async t => {
       ),
       specOptions: {},
       retries: 0,
+      signal: new AbortController().signal,
     }
     return state
   }
@@ -80,6 +81,7 @@ t.test('missing security archive', async t => {
       securityArchive: undefined,
       specOptions: {},
       retries: 0,
+      signal: new AbortController().signal,
     }
     return state
   }

--- a/src/query/test/pseudo/unknown.ts
+++ b/src/query/test/pseudo/unknown.ts
@@ -36,6 +36,7 @@ t.test('selects packages with an unknown alert', async t => {
       ),
       specOptions: {},
       retries: 0,
+      signal: new AbortController().signal,
     }
     return state
   }
@@ -80,6 +81,7 @@ t.test('missing security archive', async t => {
       securityArchive: undefined,
       specOptions: {},
       retries: 0,
+      signal: new AbortController().signal,
     }
     return state
   }

--- a/src/query/test/pseudo/unmaintained.ts
+++ b/src/query/test/pseudo/unmaintained.ts
@@ -36,6 +36,7 @@ t.test('selects packages with an unmaintained alert', async t => {
       ),
       specOptions: {},
       retries: 0,
+      signal: new AbortController().signal,
     }
     return state
   }
@@ -80,6 +81,7 @@ t.test('missing security archive', async t => {
       securityArchive: undefined,
       specOptions: {},
       retries: 0,
+      signal: new AbortController().signal,
     }
     return state
   }

--- a/src/query/test/pseudo/unpopular.ts
+++ b/src/query/test/pseudo/unpopular.ts
@@ -36,6 +36,7 @@ t.test('selects packages with an unpopular alert', async t => {
       ),
       specOptions: {},
       retries: 0,
+      signal: new AbortController().signal,
     }
     return state
   }
@@ -80,6 +81,7 @@ t.test('missing security archive', async t => {
       securityArchive: undefined,
       specOptions: {},
       retries: 0,
+      signal: new AbortController().signal,
     }
     return state
   }

--- a/src/query/test/pseudo/unstable.ts
+++ b/src/query/test/pseudo/unstable.ts
@@ -36,6 +36,7 @@ t.test('selects packages with an unstable alert', async t => {
       ),
       specOptions: {},
       retries: 0,
+      signal: new AbortController().signal,
     }
     return state
   }
@@ -80,6 +81,7 @@ t.test('missing security archive', async t => {
       securityArchive: undefined,
       specOptions: {},
       retries: 0,
+      signal: new AbortController().signal,
     }
     return state
   }


### PR DESCRIPTION
The `:scope` selector should default to `:root` but its value should be parameterized, so that we can potentially set it to a given workspace when running from a workspace folder.

Also, `vlt query` and `vlt ls` should set their default scope to either the root folder or a workspace folder dependending on the context.

Fixes: https://github.com/vltpkg/vltpkg/issues/718