### PR TITLE
cli-sdk(config): better error message when setting unknown config

### DIFF
--- a/src/cli-sdk/src/commands/config.ts
+++ b/src/cli-sdk/src/commands/config.ts
@@ -8,6 +8,7 @@ import {
 } from '../config/index.ts'
 import type {
   ConfigDefinitions,
+  ConfigFileData,
   LoadedConfig,
   RecordPairs,
 } from '../config/index.ts'
@@ -186,10 +187,19 @@ const set = async (conf: LoadedConfig) => {
       code: 'EUSAGE',
     })
   }
+  let parsed: ConfigFileData | null = null
+  try {
+    parsed = conf.jack.parseRaw(pairs.map(kv => `--${kv}`)).values
+  } catch {
+    const j = definition.toJSON()
+    throw error('Invalid config keys', {
+      code: 'ECONFIG',
+      found: pairs.map(kv => kv.split('=')[0]),
+      wanted: Object.keys(j).sort((a, b) => a.localeCompare(b, 'en')),
+    })
+  }
   await conf.addConfigToFile(
     conf.get('config'),
-    pairsToRecords(
-      conf.jack.parseRaw(pairs.map(kv => `--${kv}`)).values,
-    ),
+    pairsToRecords(parsed),
   )
 }

--- a/src/cli-sdk/src/print-err.ts
+++ b/src/cli-sdk/src/print-err.ts
@@ -152,5 +152,17 @@ const print = (
 
       return true
     }
+
+    case 'ECONFIG': {
+      const { found, wanted } = err.cause
+      stderr(`Config Error: ${err.message}`)
+      if (found) {
+        stderr(indent(`Found: ${format(found)}`))
+      }
+      if (wanted) {
+        stderr(indent(`Wanted: ${format(wanted)}`))
+      }
+      return true
+    }
   }
 }

--- a/src/cli-sdk/tap-snapshots/test/print-err.ts.test.cjs
+++ b/src/cli-sdk/tap-snapshots/test/print-err.ts.test.cjs
@@ -5,6 +5,20 @@
  * Make sure to inspect the output below.  Do not ignore changes!
  */
 'use strict'
+exports[`test/print-err.ts > TAP > ECONFIG > no cause > must match snapshot 1`] = `
+Array [
+  "Config Error: Invalid config keys",
+]
+`
+
+exports[`test/print-err.ts > TAP > ECONFIG > with cause > must match snapshot 1`] = `
+Array [
+  "Config Error: Invalid config keys",
+  "  Found: [ 'garbage' ]",
+  "  Wanted: [ 'wanted' ]",
+]
+`
+
 exports[`test/print-err.ts > TAP > EREQUEST > no cause > must match snapshot 1`] = `
 Array [
   "Request Error: oh no! my request!",

--- a/src/cli-sdk/test/commands/config.ts
+++ b/src/cli-sdk/test/commands/config.ts
@@ -202,6 +202,17 @@ t.test('set', async t => {
       ])
     })
   }
+  t.test('invalid key', async t => {
+    await t.rejects(run(t, ['set', 'garbage=value'], {}), {
+      message: 'Invalid config keys',
+      cause: {
+        found: ['garbage'],
+        wanted: Object.keys(definition.toJSON()).sort((a, b) =>
+          a.localeCompare(b, 'en'),
+        ),
+      },
+    })
+  })
 })
 
 t.test('garbage', async t => {

--- a/src/cli-sdk/test/print-err.ts
+++ b/src/cli-sdk/test/print-err.ts
@@ -121,6 +121,26 @@ t.test('ERESOLVE', t => {
   t.end()
 })
 
+t.test('ECONFIG', async t => {
+  t.test('with cause', async t => {
+    const er = error('Invalid config keys', {
+      code: 'ECONFIG',
+      found: ['garbage'],
+      wanted: ['wanted'],
+    })
+    printErr(er, usage, stderr, formatter)
+    t.matchSnapshot(printed)
+  })
+
+  t.test('no cause', async t => {
+    const er = error('Invalid config keys', {
+      code: 'ECONFIG',
+    })
+    printErr(er, usage, stderr, formatter)
+    t.matchSnapshot(printed)
+  })
+})
+
 t.test('EREQUEST', async t => {
   t.test('with cause', async t => {
     printErr(

--- a/src/error-cause/src/index.ts
+++ b/src/error-cause/src/index.ts
@@ -246,6 +246,7 @@ export const errorCodes = [
   'EUNKNOWN',
   'EUSAGE',
   'EREQUEST',
+  'ECONFIG',
 ] as const
 
 const errorCodesSet = new Set(errorCodes)


### PR DESCRIPTION
Fixes #391

**Before**

```
╰❯ vlt config set registryyyyyy=https://whoa.com --config=project
Error: Unknown option '--registryyyyyy'. To specify a positional argument starting with a '-', place it at the end of the command after '--', as in '-- --registryyyyyy'
Cause:
  code: JACKSPEAK
  found: --registryyyyyy=https://whoa.com
Stack:
  at Jack.parseRaw (/Users/lukekarrys/.config/packages/node_modules/.pnpm/jackspeak@4.1.0/node_modules/jackspeak/src/index.ts:737:17)
  at set (/Users/lukekarrys/.config/packages/src/cli-sdk/src/commands/config.ts:192:17)
  at command (/Users/lukekarrys/.config/packages/src/cli-sdk/src/commands/config.ts:71:14)
  at outputCommand (/Users/lukekarrys/.config/packages/src/cli-sdk/src/output.ts:157:39)
  at Module.run (/Users/lukekarrys/.config/packages/src/cli-sdk/src/index.ts:68:9)
  at async run (/Users/lukekarrys/.config/packages/npm/build/src/bins.ts:30:5)
  at async <anonymous> (/Users/lukekarrys/.config/packages/npm/build/src/bins/vlt.ts:3:1)
```

**After**

```
Config Error: Invalid config keys
  Found: [ 'registryyyyyy' ]
  Wanted: [
    'arch',
    'bail',
    'before',
    'cache',
    'color',
    'config',
    'dashboard-root',
    'editor',
    'expect-results',
    'fallback-command',
    'fetch-retries',
    'fetch-retry-factor',
    'fetch-retry-maxtimeout',
    'fetch-retry-mintimeout',
    'git-host-archives',
    'git-hosts',
    'git-shallow',
    'help',
    'identity',
    'no-bail',
    'no-color',
    'node-version',
    'os',
    'package',
    'recursive',
    'registries',
    'registry',
    'save-dev',
    'save-optional',
    'save-peer',
    'save-prod',
    'scope-registries',
    'script-shell',
    'stale-while-revalidate-factor',
    'tag',
    'version',
    'view',
    'workspace',
    'workspace-group',
    'yes'
  ]
```
