### PR TITLE
query: fix workspace selector

### DIFF
--- a/src/query/src/pseudo/workspace.ts
+++ b/src/query/src/pseudo/workspace.ts
@@ -1,5 +1,5 @@
 import type { ParserState } from '../types.ts'
-import { removeDanglingEdges, removeNode } from './helpers.ts'
+import { removeNode } from './helpers.ts'
 
 /**
  * :workspace Pseudo-Selector will only match workspace dependencies.
@@ -12,7 +12,10 @@ export const workspace = async (state: ParserState) => {
     }
   }
 
-  removeDanglingEdges(state)
+  // Clears up all edges so that the :workspace pseudo-selector never matches
+  // edges that are possibly coming from other packages, this way we can only
+  // have a single workspace result per workspace name.
+  state.partial.edges.clear()
 
   return state
 }

--- a/src/query/tap-snapshots/test/pseudo/workspace.ts.test.cjs
+++ b/src/query/tap-snapshots/test/pseudo/workspace.ts.test.cjs
@@ -1,0 +1,17 @@
+/* IMPORTANT
+ * This snapshot file is auto-generated, but designed for humans.
+ * It should be checked into source control and tracked carefully.
+ * Re-generate by setting TAP_SNAPSHOT=1 and running tests.
+ * Make sure to inspect the output below.  Do not ignore changes!
+ */
+'use strict'
+exports[`test/pseudo/workspace.ts > TAP > :workspace pseudo-selector > with multiple workspaces > should match snapshot for multi-workspace graph 1`] = `
+Object {
+  "edges": Array [],
+  "nodes": Array [
+    "a",
+    "b",
+    "c",
+  ],
+}
+`

--- a/src/query/test/pseudo/workspace.ts
+++ b/src/query/test/pseudo/workspace.ts
@@ -91,6 +91,14 @@ t.test(':workspace pseudo-selector', async t => {
       'should return all workspace nodes in multi-workspace graph',
     )
 
+    t.matchSnapshot(
+      {
+        nodes: [...result.nodes].map(n => n.name).sort(),
+        edges: [...result.edges].map(e => e.name).sort(),
+      },
+      'should match snapshot for multi-workspace graph',
+    )
+
     // Verify all nodes are workspace nodes
     for (const node of result.nodes) {
       t.equal(


### PR DESCRIPTION
The `:workspace` selector should filter out all edges, so that it really only selects the workspace nodes and not any of its edges.

Refs: https://github.com/vltpkg/statusboard/issues/133