### PR TITLE
query: refactor root pseudo selector

### DIFF
--- a/src/query/src/pseudo.ts
+++ b/src/query/src/pseudo.ts
@@ -40,6 +40,7 @@ import { peer } from './pseudo/peer.ts'
 import { published } from './pseudo/published.ts'
 import { privateParser } from './pseudo/private.ts'
 import { prod } from './pseudo/prod.ts'
+import { root } from './pseudo/root.ts'
 import { scanned } from './pseudo/scanned.ts'
 import { score } from './pseudo/score.ts'
 import { scripts } from './pseudo/scripts.ts'
@@ -235,25 +236,6 @@ const not = async (state: ParserState) => {
       removeNode(state, node)
     }
   }
-  return state
-}
-
-/**
- * :root Pseudo-Element will return the project root node for the graph.
- */
-const root = async (state: ParserState) => {
-  const [anyNode] = state.initial.nodes.values()
-  const mainImporter = anyNode?.graph.mainImporter
-  if (!mainImporter) {
-    throw error(':root pseudo-element works on local graphs only')
-  }
-  for (const edge of state.partial.edges) {
-    if (edge.to !== mainImporter) {
-      state.partial.edges.delete(edge)
-    }
-  }
-  state.partial.nodes.clear()
-  state.partial.nodes.add(mainImporter)
   return state
 }
 

--- a/src/query/src/pseudo/root.ts
+++ b/src/query/src/pseudo/root.ts
@@ -1,0 +1,23 @@
+import { error } from '@vltpkg/error-cause'
+import type { ParserState } from '../types.ts'
+
+/**
+ * :root Pseudo-Element will return the project root node for the graph.
+ * It matches only the main importer node of the graph, which represents
+ * the root of the project.
+ */
+export const root = async (state: ParserState) => {
+  const [anyNode] = state.initial.nodes.values()
+  const mainImporter = anyNode?.graph.mainImporter
+  if (!mainImporter) {
+    throw error(':root pseudo-element works on local graphs only')
+  }
+  for (const edge of state.partial.edges) {
+    if (edge.to !== mainImporter) {
+      state.partial.edges.delete(edge)
+    }
+  }
+  state.partial.nodes.clear()
+  state.partial.nodes.add(mainImporter)
+  return state
+}

--- a/src/query/tap-snapshots/test/pseudo/root.ts.test.cjs
+++ b/src/query/tap-snapshots/test/pseudo/root.ts.test.cjs
@@ -1,0 +1,24 @@
+/* IMPORTANT
+ * This snapshot file is auto-generated, but designed for humans.
+ * It should be checked into source control and tracked carefully.
+ * Re-generate by setting TAP_SNAPSHOT=1 and running tests.
+ * Make sure to inspect the output below.  Do not ignore changes!
+ */
+'use strict'
+exports[`test/pseudo/root.ts > TAP > selects the root node of the graph > selects root node in simple graph > must match snapshot 1`] = `
+Object {
+  "edges": Array [],
+  "nodes": Array [
+    "my-project",
+  ],
+}
+`
+
+exports[`test/pseudo/root.ts > TAP > selects the root node of the graph > selects root node in workspace graph > must match snapshot 1`] = `
+Object {
+  "edges": Array [],
+  "nodes": Array [
+    "ws",
+  ],
+}
+`

--- a/src/query/test/pseudo/root.ts
+++ b/src/query/test/pseudo/root.ts
@@ -1,0 +1,80 @@
+import t from 'tap'
+import postcssSelectorParser from 'postcss-selector-parser'
+import type { ParserState } from '../../src/types.ts'
+import { root } from '../../src/pseudo/root.ts'
+import {
+  getSimpleGraph,
+  getSingleWorkspaceGraph,
+} from '../fixtures/graph.ts'
+
+t.test('selects the root node of the graph', async t => {
+  const getState = (query: string, graph = getSimpleGraph()) => {
+    const ast = postcssSelectorParser().astSync(query)
+    const current = ast.first.first
+    const state: ParserState = {
+      current,
+      initial: {
+        edges: new Set(graph.edges.values()),
+        nodes: new Set(graph.nodes.values()),
+      },
+      partial: {
+        edges: new Set(graph.edges.values()),
+        nodes: new Set(graph.nodes.values()),
+      },
+      collect: {
+        edges: new Set(),
+        nodes: new Set(),
+      },
+      cancellable: async () => {},
+      walk: async i => i,
+      retries: 0,
+      securityArchive: undefined,
+      specOptions: {},
+      signal: new AbortController().signal,
+    }
+    return state
+  }
+
+  await t.test('selects root node in simple graph', async t => {
+    const res = await root(getState(':root'))
+    t.strictSame(
+      [...res.partial.nodes].map(n => n.name),
+      ['my-project'],
+      'should select only the root node',
+    )
+    t.matchSnapshot({
+      nodes: [...res.partial.nodes].map(n => n.name),
+      edges: [...res.partial.edges].map(e => e.name),
+    })
+  })
+
+  await t.test('selects root node in workspace graph', async t => {
+    const wsGraph = getSingleWorkspaceGraph()
+    const res = await root(getState(':root', wsGraph))
+    t.strictSame(
+      [...res.partial.nodes].map(n => n.name),
+      ['ws'],
+      'should select only the workspace root node',
+    )
+    t.matchSnapshot({
+      nodes: [...res.partial.nodes].map(n => n.name),
+      edges: [...res.partial.edges].map(e => e.name),
+    })
+  })
+
+  await t.test(
+    'throws error when no main importer exists',
+    async t => {
+      // Create a state with empty nodes set
+      const state = getState(':root')
+      state.initial.nodes.clear()
+      await t.rejects(
+        root(state),
+        {
+          message: ':root pseudo-element works on local graphs only',
+        },
+        'should throw error when no main importer exists',
+      )
+    },
+  )
+})


### PR DESCRIPTION
Refactor `:root` into its own file and add unit tests for it.