### PR TITLE
query: refactor type pseudo selector

### DIFF
--- a/src/query/src/pseudo.ts
+++ b/src/query/src/pseudo.ts
@@ -1,4 +1,3 @@
-import { splitDepID } from '@vltpkg/dep-id/browser'
 import { error } from '@vltpkg/error-cause'
 import type { EdgeLike, NodeLike } from '@vltpkg/graph'
 
@@ -6,7 +5,6 @@ import { removeDanglingEdges, removeNode } from './pseudo/helpers.ts'
 import {
   asPostcssNodeWithChildren,
   asPseudoNode,
-  asTagNode,
   isSelectorNode,
 } from './types.ts'
 import type { ParserFn, ParserState } from './types.ts'
@@ -51,6 +49,7 @@ import { squat } from './pseudo/squat.ts'
 import { suspicious } from './pseudo/suspicious.ts'
 import { tracker } from './pseudo/tracker.ts'
 import { trivial } from './pseudo/trivial.ts'
+import { type } from './pseudo/type.ts'
 import { undesirable } from './pseudo/undesirable.ts'
 import { unknown } from './pseudo/unknown.ts'
 import { unmaintained } from './pseudo/unmaintained.ts'
@@ -293,23 +292,6 @@ const scope = async (state: ParserState) => {
   return state
 }
 
-/**
- * :type(str) Pseudo-Element will match only nodes that are of
- * the same type as the value used
- */
-const typeFn = async (state: ParserState) => {
-  const type = asPostcssNodeWithChildren(state.current)
-  const selector = asPostcssNodeWithChildren(type.nodes[0])
-  const name = asTagNode(selector.nodes[0]).value
-  for (const node of state.partial.nodes) {
-    const nodeType = splitDepID(node.id)[0]
-    if (nodeType !== name) {
-      removeNode(state, node)
-    }
-  }
-  return state
-}
-
 const pseudoSelectors = new Map<string, ParserFn>(
   Object.entries({
     abandoned,
@@ -359,7 +341,7 @@ const pseudoSelectors = new Map<string, ParserFn>(
     suspicious,
     tracker,
     trivial,
-    type: typeFn,
+    type,
     undesirable,
     unknown,
     unmaintained,

--- a/src/query/src/pseudo/type.ts
+++ b/src/query/src/pseudo/type.ts
@@ -1,0 +1,23 @@
+import { splitDepID } from '@vltpkg/dep-id/browser'
+import type { ParserState } from '../types.ts'
+import { asPostcssNodeWithChildren, asTagNode } from '../types.ts'
+import { removeDanglingEdges, removeNode } from './helpers.ts'
+
+/**
+ * :type(str) Pseudo-Element will match only nodes that are of
+ * the same type as the value used. The type is determined by the
+ * first part of the dependency ID.
+ */
+export const type = async (state: ParserState) => {
+  const type = asPostcssNodeWithChildren(state.current)
+  const selector = asPostcssNodeWithChildren(type.nodes[0])
+  const name = asTagNode(selector.nodes[0]).value
+  for (const node of state.partial.nodes) {
+    const nodeType = splitDepID(node.id)[0]
+    if (nodeType !== name) {
+      removeNode(state, node)
+    }
+  }
+  removeDanglingEdges(state)
+  return state
+}

--- a/src/query/tap-snapshots/test/pseudo/type.ts.test.cjs
+++ b/src/query/tap-snapshots/test/pseudo/type.ts.test.cjs
@@ -1,0 +1,51 @@
+/* IMPORTANT
+ * This snapshot file is auto-generated, but designed for humans.
+ * It should be checked into source control and tracked carefully.
+ * Re-generate by setting TAP_SNAPSHOT=1 and running tests.
+ * Make sure to inspect the output below.  Do not ignore changes!
+ */
+'use strict'
+exports[`test/pseudo/type.ts > TAP > selects nodes by type > handles an empty partial state > must match snapshot 1`] = `
+Object {
+  "edges": Array [],
+  "nodes": Array [],
+}
+`
+
+exports[`test/pseudo/type.ts > TAP > selects nodes by type > returns no nodes when type does not match > must match snapshot 1`] = `
+Object {
+  "edges": Array [],
+  "nodes": Array [],
+}
+`
+
+exports[`test/pseudo/type.ts > TAP > selects nodes by type > selects nodes of specified type in simple graph > must match snapshot 1`] = `
+Object {
+  "edges": Array [
+    "a",
+    "b",
+    "c",
+    "d",
+    "e",
+    "e",
+    "f",
+  ],
+  "nodes": Array [
+    "a",
+    "b",
+    "c",
+    "d",
+    "e",
+    "f",
+  ],
+}
+`
+
+exports[`test/pseudo/type.ts > TAP > selects nodes by type > selects nodes of specified type in workspace graph > must match snapshot 1`] = `
+Object {
+  "edges": Array [],
+  "nodes": Array [
+    "w",
+  ],
+}
+`

--- a/src/query/test/pseudo/type.ts
+++ b/src/query/test/pseudo/type.ts
@@ -1,0 +1,103 @@
+import t from 'tap'
+import postcssSelectorParser from 'postcss-selector-parser'
+import type { ParserState } from '../../src/types.ts'
+import { type } from '../../src/pseudo/type.ts'
+import {
+  getSimpleGraph,
+  getSingleWorkspaceGraph,
+} from '../fixtures/graph.ts'
+
+t.test('selects nodes by type', async t => {
+  const getState = (query: string, graph = getSimpleGraph()) => {
+    const ast = postcssSelectorParser().astSync(query)
+    const current = ast.first.first
+    const state: ParserState = {
+      current,
+      initial: {
+        edges: new Set(graph.edges.values()),
+        nodes: new Set(graph.nodes.values()),
+      },
+      partial: {
+        edges: new Set(graph.edges.values()),
+        nodes: new Set(graph.nodes.values()),
+      },
+      collect: {
+        edges: new Set(),
+        nodes: new Set(),
+      },
+      cancellable: async () => {},
+      walk: async i => i,
+      retries: 0,
+      securityArchive: undefined,
+      specOptions: {},
+      signal: new AbortController().signal,
+    }
+    return state
+  }
+
+  await t.test(
+    'selects nodes of specified type in simple graph',
+    async t => {
+      const res = await type(getState(':type(registry)'))
+      t.strictSame(
+        [...res.partial.nodes].map(n => n.name).sort(),
+        ['a', 'b', 'c', 'd', 'e', 'f'].sort(),
+        'should select only npm packages',
+      )
+      t.matchSnapshot({
+        nodes: [...res.partial.nodes].map(n => n.name).sort(),
+        edges: [...res.partial.edges].map(e => e.name).sort(),
+      })
+    },
+  )
+
+  await t.test(
+    'selects nodes of specified type in workspace graph',
+    async t => {
+      const wsGraph = getSingleWorkspaceGraph()
+      const res = await type(getState(':type(workspace)', wsGraph))
+      t.strictSame(
+        [...res.partial.nodes].map(n => n.name).sort(),
+        ['w'],
+        'should select only workspace packages',
+      )
+      t.matchSnapshot({
+        nodes: [...res.partial.nodes].map(n => n.name).sort(),
+        edges: [...res.partial.edges].map(e => e.name).sort(),
+      })
+    },
+  )
+
+  await t.test(
+    'returns no nodes when type does not match',
+    async t => {
+      const res = await type(getState(':type(nonexistent)'))
+      t.strictSame(
+        [...res.partial.nodes].map(n => n.name),
+        [],
+        'should not select any packages when type does not match',
+      )
+      t.matchSnapshot({
+        nodes: [...res.partial.nodes].map(n => n.name),
+        edges: [...res.partial.edges].map(e => e.name),
+      })
+    },
+  )
+
+  await t.test('handles an empty partial state', async t => {
+    const state = getState(':type(npm)')
+    state.partial.nodes.clear()
+    state.partial.edges.clear()
+
+    const res = await type(state)
+    t.strictSame(
+      [...res.partial.nodes].map(n => n.name),
+      [],
+      'should return empty array when starting with empty partial state',
+    )
+    t.matchSnapshot({
+      nodes: [...res.partial.nodes].map(n => n.name),
+      edges: [...res.partial.edges].map(e => e.name),
+    })
+  })
+})


### PR DESCRIPTION
Refactor `:type(<type>)` into its own file and add unit tests for it.