### PR TITLE
cli: improve how invalid options are reported

### DIFF
--- a/src/cli-sdk/src/config/index.ts
+++ b/src/cli-sdk/src/config/index.ts
@@ -436,27 +436,20 @@ export class Config {
     const result = await this.#readConfigFile(file)
 
     if (result) {
-      try {
-        const { command, ...values } = recordsToPairs(result)
-        if (command) {
-          for (const [c, opts] of Object.entries(command)) {
-            const cmd = getCommand(c)
-            if (cmd) {
-              this.commandValues[cmd] = merge<ConfigData>(
-                this.commandValues[cmd] ?? ({} as ConfigData),
-                opts as ConfigData,
-              )
-            }
+      const { command, ...values } = recordsToPairs(result)
+      if (command) {
+        for (const [c, opts] of Object.entries(command)) {
+          const cmd = getCommand(c)
+          if (cmd) {
+            this.commandValues[cmd] = merge<ConfigData>(
+              this.commandValues[cmd] ?? ({} as ConfigData),
+              opts as ConfigData,
+            )
           }
         }
-        this.jack.setConfigValues(values, file)
-        return result
-      } catch (er) {
-        throw error('failed to load config values from file', {
-          path: file,
-          cause: er,
-        })
       }
+      this.jack.setConfigValues(values, file)
+      return result
     }
   }
 

--- a/src/cli-sdk/src/print-err.ts
+++ b/src/cli-sdk/src/print-err.ts
@@ -154,13 +154,16 @@ const print = (
     }
 
     case 'ECONFIG': {
-      const { found, wanted } = err.cause
+      const { found, wanted, validOptions } = err.cause
       stderr(`Config Error: ${err.message}`)
       if (found) {
         stderr(indent(`Found: ${format(found)}`))
       }
       if (wanted) {
         stderr(indent(`Wanted: ${format(wanted)}`))
+      }
+      if (validOptions) {
+        stderr(indent(`Valid Options: ${format(validOptions)}`))
       }
       return true
     }

--- a/src/cli-sdk/tap-snapshots/test/config/definition.ts.test.cjs
+++ b/src/cli-sdk/tap-snapshots/test/config/definition.ts.test.cjs
@@ -395,6 +395,51 @@ Object {
 }
 `
 
+exports[`test/config/definition.ts > TAP > getSortedCliDefinitions > sorted CLI definitions 1`] = `
+Array [
+  "--arch=<arch>",
+  "--bail",
+  "--before=<date>",
+  "--cache=<path>",
+  "--color",
+  "--config=<user | project>",
+  "--dashboard-root=<path>",
+  "--editor=<program>",
+  "--expect-results=<value>",
+  "--fallback-command=<command>",
+  "--fetch-retries=<n>",
+  "--fetch-retry-factor=<n>",
+  "--fetch-retry-maxtimeout=<n>",
+  "--fetch-retry-mintimeout=<n>",
+  "--git-host-archives=<name=template>",
+  "--git-hosts=<name=template>",
+  "--git-shallow",
+  "--help",
+  "--identity=<name>",
+  "--no-bail",
+  "--no-color",
+  "--node-version=<version>",
+  "--os=<os>",
+  "--package=<p>",
+  "--recursive",
+  "--registries=<name=url>",
+  "--registry=<url>",
+  "--save-dev",
+  "--save-optional",
+  "--save-peer",
+  "--save-prod",
+  "--scope-registries=<@scope=url>",
+  "--script-shell=<program>",
+  "--stale-while-revalidate-factor=<n>",
+  "--tag=<tag>",
+  "--version",
+  "--view=<output>",
+  "--workspace=<ws>",
+  "--workspace-group=<workspace-group>",
+  "--yes",
+]
+`
+
 exports[`test/config/definition.ts > TAP > getSortedKeys > sorted keys 1`] = `
 Array [
   "arch",

--- a/src/cli-sdk/tap-snapshots/test/index.ts.test.cjs
+++ b/src/cli-sdk/tap-snapshots/test/index.ts.test.cjs
@@ -5,10 +5,68 @@
  * Make sure to inspect the output below.  Do not ignore changes!
  */
 'use strict'
+exports[`test/index.ts > TAP > invalid config in file > must match snapshot 1`] = `
+Problem in Config File {CWD}/.tap/fixtures/test-index.ts-invalid-config-in-file/vlt.json
+Invalid value string for color, expected boolean
+  Field: color
+  Found: "foo"
+  Wanted: boolean
+  Run 'vlt help' for more information about available options.
+`
+
 exports[`test/index.ts > TAP > unknown config > must match snapshot 1`] = `
-Error: Unknown CLI flags. Run 'vlt help' for more information about available flags.
-  Found: --unknown
-  Wanted:
+Invalid Option Flag
+Unknown option '--unknown'. To specify a positional argument starting with a '-', place it at the end of the command after '--', as in '-- --unknown'
+  Found: "--unknown"
+  Valid Options:
+    --arch=<arch>
+    --bail
+    --before=<date>
+    --cache=<path>
+    --color
+    --config=<user | project>
+    --dashboard-root=<path>
+    --editor=<program>
+    --expect-results=<value>
+    --fallback-command=<command>
+    --fetch-retries=<n>
+    --fetch-retry-factor=<n>
+    --fetch-retry-maxtimeout=<n>
+    --fetch-retry-mintimeout=<n>
+    --git-host-archives=<name=template>
+    --git-hosts=<name=template>
+    --git-shallow
+    --help
+    --identity=<name>
+    --no-bail
+    --no-color
+    --node-version=<version>
+    --os=<os>
+    --package=<p>
+    --recursive
+    --registries=<name=url>
+    --registry=<url>
+    --save-dev
+    --save-optional
+    --save-peer
+    --save-prod
+    --scope-registries=<@scope=url>
+    --script-shell=<program>
+    --stale-while-revalidate-factor=<n>
+    --tag=<tag>
+    --version
+    --view=<output>
+    --workspace=<ws>
+    --workspace-group=<workspace-group>
+    --yes
+  Run 'vlt help' for more information about available options.
+`
+
+exports[`test/index.ts > TAP > unknown config in file > must match snapshot 1`] = `
+Problem in Config File {CWD}/.tap/fixtures/test-index.ts-unknown-config-in-file/vlt.json
+Unknown config option: asdf
+  Found: "asdf"
+  Valid Options:
     arch
     bail
     before
@@ -49,4 +107,5 @@ Error: Unknown CLI flags. Run 'vlt help' for more information about available fl
     workspace
     workspace-group
     yes
+  Run 'vlt help' for more information about available options.
 `

--- a/src/cli-sdk/tap-snapshots/test/print-err.ts.test.cjs
+++ b/src/cli-sdk/tap-snapshots/test/print-err.ts.test.cjs
@@ -15,7 +15,8 @@ exports[`test/print-err.ts > TAP > ECONFIG > with cause > must match snapshot 1`
 Array [
   "Config Error: Invalid config keys",
   "  Found: [ 'garbage' ]",
-  "  Wanted: [ 'wanted' ]",
+  "  Wanted: string[]",
+  "  Valid Options: [ 'wanted' ]",
 ]
 `
 

--- a/src/cli-sdk/test/config/definition.ts
+++ b/src/cli-sdk/test/config/definition.ts
@@ -1,4 +1,5 @@
 import t from 'tap'
+import { setupEnv } from '../fixtures/util.ts'
 const {
   commands,
   definition,
@@ -9,7 +10,6 @@ const {
 } = await t.mockImport<
   typeof import('../../src/config/definition.ts')
 >('../../src/config/definition.ts')
-import { setupEnv } from '../fixtures/util.ts'
 
 t.matchSnapshot(commands, 'commands')
 const defObj = definition.toJSON()
@@ -63,6 +63,7 @@ t.test('default view depends on stdout TTY status', t => {
   t.test('tty true', async t => {
     delete process.env.VLT_VIEW
     t.intercept(process.stdout, 'isTTY', { value: true })
+    t.equal(process.stdout.isTTY, true)
     const { definition } = await t.mockImport<
       typeof import('../../src/config/definition.ts')
     >('../../src/config/definition.ts')
@@ -73,6 +74,7 @@ t.test('default view depends on stdout TTY status', t => {
   t.test('tty false', async t => {
     delete process.env.VLT_VIEW
     t.intercept(process.stdout, 'isTTY', { value: false })
+    t.equal(process.stdout.isTTY, false)
     const { definition } = await t.mockImport<
       typeof import('../../src/config/definition.ts')
     >('../../src/config/definition.ts')
@@ -117,10 +119,11 @@ t.test('infer editor from env/platform', async t => {
         value: { ...cleanEnv, EDITOR, VISUAL },
       })
       t.intercept(process, 'platform', { value: platform })
-      const { definition } = await t.mockImport<
+      const { definition, defaultEditor } = await t.mockImport<
         typeof import('../../src/config/definition.ts')
       >('../../src/config/definition.ts')
       t.match(definition.parse().values.editor, expect)
+      t.match(defaultEditor(), expect)
     })
   }
 })
@@ -133,4 +136,11 @@ t.test('getCommand', async t => {
 
 t.test('getSortedKeys', async t => {
   t.matchSnapshot(getSortedKeys(), 'sorted keys')
+})
+
+t.test('getSortedCliDefinitions', async t => {
+  const { getSortedCliOptions } = await t.mockImport<
+    typeof import('../../src/config/definition.ts')
+  >('../../src/config/definition.ts')
+  t.matchSnapshot(getSortedCliOptions(), 'sorted CLI definitions')
 })

--- a/src/cli-sdk/test/config/index.ts
+++ b/src/cli-sdk/test/config/index.ts
@@ -6,9 +6,9 @@ import {
 } from 'node:fs'
 import * as OS from 'node:os'
 import { resolve } from 'node:path'
+import { format } from 'node:util'
 import t from 'tap'
 import type { ConfigData } from '../../src/config/index.ts'
-import { format } from 'node:util'
 
 const clearEnv = () => {
   for (const k of Object.keys(process.env)) {
@@ -280,16 +280,12 @@ t.test('invalid config', async t => {
       '.git': '',
     })
     await t.rejects(Config.load(dir, undefined, true), {
+      message: 'Invalid value string for color, expected boolean',
       cause: {
         path: resolve(dir, 'vlt.json'),
-        cause: {
-          message: 'Invalid value string for color, expected boolean',
-          cause: {
-            name: 'color',
-            found: 'not a boolean',
-            wanted: 'boolean',
-          },
-        },
+        name: 'color',
+        found: 'not a boolean',
+        wanted: 'boolean',
       },
     })
   })

--- a/src/cli-sdk/test/print-err.ts
+++ b/src/cli-sdk/test/print-err.ts
@@ -126,7 +126,8 @@ t.test('ECONFIG', async t => {
     const er = error('Invalid config keys', {
       code: 'ECONFIG',
       found: ['garbage'],
-      wanted: ['wanted'],
+      wanted: 'string[]',
+      validOptions: ['wanted'],
     })
     printErr(er, usage, stderr, formatter)
     t.matchSnapshot(printed)


### PR DESCRIPTION
This applies the same `code: 'ECONFIG'` behavior for all config options, including invalid values, providing more assistance beyond just listing the available options.

Now it properly detects for example when an option is given a value that shouldn't be (because it's a flag) or vice versa (not given a value to an option that is not a boolean flag), or given an invalid value (eg, `--config=asdfasdf` where only specific values are allowed).

It also properly differentiates between config _file_ errors and cli option errors, presenting the suggestions in a more useful manner.