### PR TITLE
ci: exclude node 24 for now [ci full-matrix]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -195,7 +195,7 @@ jobs:
             os: windows-latest
             shell: powershell
         exclude:
-          - node-version: ${{ needs.pre-check.outputs.full-matrix == 'false' && '24.x' }}
+          - node-version: '24.x'
           - platform: ${{ fromJSON(needs.pre-check.outputs.full-matrix == 'false' && '{"name":"macOS","os":"macos-latest","shell":"bash"}') }}
           - platform: ${{ fromJSON(needs.pre-check.outputs.full-matrix == 'false' && '{"name":"macOS Intel","os":"macos-13","shell":"bash"}') }}
           - platform: ${{ fromJSON(needs.pre-check.outputs.full-matrix == 'false' && '{"name":"Windows Powershell","os":"windows-latest","shell":"powershell"}') }}

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -82,7 +82,7 @@ jobs:
             os: windows-latest
             shell: powershell
         exclude:
-          - node-version: ${{ needs.pre-check.outputs.full-matrix == 'false' && '24.x' }}
+          - node-version: '24.x'
           - platform: ${{ fromJSON(needs.pre-check.outputs.full-matrix == 'false' && '{"name":"macOS","os":"macos-latest","shell":"bash"}') }}
           - platform: ${{ fromJSON(needs.pre-check.outputs.full-matrix == 'false' && '{"name":"macOS Intel","os":"macos-13","shell":"bash"}') }}
           - platform: ${{ fromJSON(needs.pre-check.outputs.full-matrix == 'false' && '{"name":"Windows Powershell","os":"windows-latest","shell":"powershell"}') }}


### PR DESCRIPTION
GUI tests fail on Node 24. This is not an issue for the actual GUI
but with the tooling required to run the tests in Node (vitest, etc).
Found a similar report here: https://github.com/reduxjs/redux-toolkit/issues/4966
For now just exclude it from the matrix always, we'll add it back later once
tooling catches up.
