### PR TITLE
graph: add node first edge in getter

### DIFF
--- a/src/graph/tap-snapshots/test/node.ts.test.cjs
+++ b/src/graph/tap-snapshots/test/node.ts.test.cjs
@@ -8,7 +8,7 @@
 exports[`test/node.ts > TAP > Node > should print with special tag name 1`] = `
 Node [@vltpkg/graph.Node] {
   confused: false,
-  edgesIn: Set(0) {},
+  edgesIn: [Set],
   edgesOut: Map(0) {},
   id: 'file·.',
   importer: true,


### PR DESCRIPTION
Adds a new `node.firstEdgeIn` getter that retrieves a single item that represents a link to a deterministic "parent" node, which will make it possible to have transitive nodes and edges trace a unique path to the graph importer.

Refs: https://github.com/vltpkg/statusboard/issues/133