### PR TITLE
vlx: infer default executable when there is only one

### DIFF
--- a/src/vlx/src/infer-default-executable.ts
+++ b/src/vlx/src/infer-default-executable.ts
@@ -11,11 +11,18 @@ export const inferDefaultExecutable = ({
 }: Manifest): undefined | [string, string] => {
   if (!bin) return undefined
 
-  const binName = name?.startsWith('@') ? name.split('/')[1] : name
+  let binName = name?.startsWith('@') ? name.split('/')[1] : name
   if (!binName) return undefined
 
   if (typeof bin === 'string') {
     return [binName, bin]
+  }
+
+  // if it's exactly one key, that's the one,
+  // even if it doesn't match the name
+  const keys = Object.keys(bin)
+  if (keys.length === 1) {
+    binName = (keys as [string])[0]
   }
 
   bin = bin[binName]

--- a/src/vlx/test/infer-default-executable.ts
+++ b/src/vlx/test/infer-default-executable.ts
@@ -12,6 +12,14 @@ t.strictSame(
 t.strictSame(
   inferDefaultExecutable({
     name: 'xyz',
+    bin: { single: 'blah.js' },
+  }),
+  ['single', 'blah.js'],
+)
+
+t.strictSame(
+  inferDefaultExecutable({
+    name: 'xyz',
     bin: {
       asf: 'foo.bad',
       xyz: 'ok.js',


### PR DESCRIPTION
Just a tiny bugfix.