### PR TITLE
query: add comments to query search responses

### DIFF
--- a/src/query/src/index.ts
+++ b/src/query/src/index.ts
@@ -48,10 +48,10 @@ const selectors = {
   comment: async (state: ParserState) => {
     if (state.current.value && !state.comment) {
       const commentValue = state.current.value
-      const cleanComment = commentValue.replace(
-        /^\/\*\s*|\s*\*\/$/g,
-        '',
-      )
+      const cleanComment = commentValue
+        .replace(/^\/\*/, '')
+        .replace(/\*\/$/, '')
+        .trim()
       state.comment = cleanComment
     }
     return state

--- a/src/query/src/index.ts
+++ b/src/query/src/index.ts
@@ -45,7 +45,17 @@ const selectors = {
   },
   /* c8 ignore end */
   combinator,
-  comment: noopFn,
+  comment: async (state: ParserState) => {
+    if (state.current.value && !state.comment) {
+      const commentValue = state.current.value
+      const cleanComment = commentValue.replace(
+        /^\/\*\s*|\s*\*\/$/g,
+        '',
+      )
+      state.comment = cleanComment
+    }
+    return state
+  },
   id,
   nesting: noopFn,
   pseudo,
@@ -407,7 +417,7 @@ export class Query {
       scopeIDs = [joinDepIDTuple(['file', '.'])],
     }: SearchOptions,
   ): Promise<QueryResponse> {
-    if (!query) return { edges: [], nodes: [] }
+    if (!query) return { edges: [], nodes: [], comment: '' }
 
     const cachedResult = this.#cache.get(query)
     if (cachedResult) {
@@ -429,7 +439,7 @@ export class Query {
     const loose = asPostcssNodeWithChildren(current).nodes.length > 1
     // builds initial state and walks over it,
     // retrieving the collected result
-    const { collect } = await walk({
+    const { collect, comment } = await walk({
       cancellable: async () => {
         await new Promise(resolve => {
           setTimeout(resolve, 0)
@@ -445,6 +455,7 @@ export class Query {
         nodes: new Set<NodeLike>(),
         edges: new Set<EdgeLike>(),
       },
+      comment: '',
       loose,
       partial: { nodes, edges },
       retries: this.#retries,
@@ -458,6 +469,7 @@ export class Query {
     const res: QueryResponse = {
       edges: this.#getQueryResponseEdges(collect.edges),
       nodes: this.#getQueryResponseNodes(collect.nodes),
+      comment,
     }
     this.#cache.set(query, res)
     return res

--- a/src/query/src/pseudo.ts
+++ b/src/query/src/pseudo.ts
@@ -90,6 +90,7 @@ const has = async (state: ParserState) => {
         specOptions: state.specOptions,
         signal: state.signal,
         scopeIDs: state.scopeIDs,
+        comment: state.comment,
       })
       for (const n of nestedState.collect.nodes) {
         collectNodes.add(n)
@@ -175,6 +176,7 @@ const is = async (state: ParserState) => {
         specOptions: state.specOptions,
         signal: state.signal,
         scopeIDs: state.scopeIDs,
+        comment: state.comment,
       })
       for (const n of nestedState.collect.nodes) {
         collect.add(n)
@@ -217,6 +219,7 @@ const not = async (state: ParserState) => {
         specOptions: state.specOptions,
         signal: state.signal,
         scopeIDs: state.scopeIDs,
+        comment: state.comment,
       })
       for (const n of nestedState.collect.nodes) {
         collect.add(n)

--- a/src/query/src/types.ts
+++ b/src/query/src/types.ts
@@ -45,6 +45,7 @@ export type GraphSelectionState = {
 export type ParserState = {
   cancellable: () => Promise<void>
   collect: GraphSelectionState
+  comment: string
   current: PostcssNode
   initial: GraphSelectionState
   loose?: boolean
@@ -63,6 +64,7 @@ export type ParserState = {
 export type QueryResponse = {
   edges: QueryResponseEdge[]
   nodes: QueryResponseNode[]
+  comment: string
 }
 
 export type QueryResponseEdge = Omit<EdgeLike, 'from' | 'to'> & {

--- a/src/query/test/attribute.ts
+++ b/src/query/test/attribute.ts
@@ -234,6 +234,7 @@ t.test('filterAttributes', async t => {
       edges: new Set<EdgeLike>(),
       nodes: new Set<NodeLike>(),
     },
+    comment: '',
     current: { type: 'attribute', value: 'postinstall' } as Attribute,
     initial: copyGraphSelectionState(all),
     partial: all,

--- a/src/query/test/fixtures/selector.ts
+++ b/src/query/test/fixtures/selector.ts
@@ -81,6 +81,7 @@ export const selectorFixture =
         edges: new Set(),
         nodes: new Set(),
       },
+      comment: '',
       current,
       loose,
       initial,

--- a/src/query/test/pseudo/abandoned.ts
+++ b/src/query/test/pseudo/abandoned.ts
@@ -11,6 +11,7 @@ t.test('selects packages with an abandoned alert', async t => {
     const ast = parse(query)
     const current = ast.first.first
     const state: ParserState = {
+      comment: '',
       current,
       initial: {
         edges: new Set(graph.edges.values()),
@@ -63,6 +64,7 @@ t.test('missing security archive', async t => {
     const ast = parse(query)
     const current = ast.first.first
     const state: ParserState = {
+      comment: '',
       current,
       initial: {
         edges: new Set(),

--- a/src/query/test/pseudo/attr.ts
+++ b/src/query/test/pseudo/attr.ts
@@ -9,6 +9,7 @@ t.test('selects packages based on attribute properties', async t => {
     const ast = postcssSelectorParser().astSync(query)
     const current = ast.first.first
     const state: ParserState = {
+      comment: '',
       current,
       initial: {
         edges: new Set(graph.edges.values()),

--- a/src/query/test/pseudo/confused.ts
+++ b/src/query/test/pseudo/confused.ts
@@ -11,6 +11,7 @@ t.test('selects packages with a manifestConfusion alert', async t => {
     const ast = parse(query)
     const current = ast.first.first
     const state: ParserState = {
+      comment: '',
       current,
       initial: {
         edges: new Set(graph.edges.values()),
@@ -63,6 +64,7 @@ t.test('missing security archive', async t => {
     const ast = parse(query)
     const current = ast.first.first
     const state: ParserState = {
+      comment: '',
       current,
       initial: {
         edges: new Set(),
@@ -109,6 +111,7 @@ t.test('nodes with confused=true flag', async t => {
     }
 
     const state: ParserState = {
+      comment: '',
       current,
       initial: {
         edges: new Set(graph.edges.values()),

--- a/src/query/test/pseudo/cve.ts
+++ b/src/query/test/pseudo/cve.ts
@@ -14,6 +14,7 @@ t.test('selects packages with a CVE alert', async t => {
     const ast = parse(query)
     const current = ast.first.first
     const state: ParserState = {
+      comment: '',
       current,
       initial: {
         edges: new Set(graph.edges.values()),
@@ -124,6 +125,7 @@ t.test('missing security archive', async t => {
     const ast = parse(query)
     const current = ast.first.first
     const state: ParserState = {
+      comment: '',
       current,
       initial: {
         edges: new Set(),
@@ -159,6 +161,7 @@ t.test('missing CVE ID', async t => {
     const ast = parse(query)
     const current = ast.first.first
     const state: ParserState = {
+      comment: '',
       current,
       initial: {
         edges: new Set(),

--- a/src/query/test/pseudo/cwe.ts
+++ b/src/query/test/pseudo/cwe.ts
@@ -12,6 +12,7 @@ t.test('selects packages with a CWE alert', async t => {
     const ast = parse(query)
     const current = ast.first.first
     const state: ParserState = {
+      comment: '',
       current,
       initial: {
         edges: new Set(graph.edges.values()),
@@ -126,6 +127,7 @@ t.test('missing security archive', async t => {
     const ast = parse(query)
     const current = ast.first.first
     const state: ParserState = {
+      comment: '',
       current,
       initial: {
         edges: new Set(),
@@ -161,6 +163,7 @@ t.test('missing CWE ID', async t => {
     const ast = parse(query)
     const current = ast.first.first
     const state: ParserState = {
+      comment: '',
       current,
       initial: {
         edges: new Set(),

--- a/src/query/test/pseudo/debug.ts
+++ b/src/query/test/pseudo/debug.ts
@@ -11,6 +11,7 @@ t.test('selects packages with a debugAccess alert', async t => {
     const ast = parse(query)
     const current = ast.first.first
     const state: ParserState = {
+      comment: '',
       current,
       initial: {
         edges: new Set(graph.edges.values()),
@@ -63,6 +64,7 @@ t.test('missing security archive', async t => {
     const ast = parse(query)
     const current = ast.first.first
     const state: ParserState = {
+      comment: '',
       current,
       initial: {
         edges: new Set(),

--- a/src/query/test/pseudo/deprecated.ts
+++ b/src/query/test/pseudo/deprecated.ts
@@ -11,6 +11,7 @@ t.test('selects packages with deprecated alert', async t => {
     const ast = parse(query)
     const current = ast.first.first
     const state: ParserState = {
+      comment: '',
       current,
       initial: {
         edges: new Set(graph.edges.values()),
@@ -63,6 +64,7 @@ t.test('missing security archive', async t => {
     const ast = parse(query)
     const current = ast.first.first
     const state: ParserState = {
+      comment: '',
       current,
       initial: {
         edges: new Set(),

--- a/src/query/test/pseudo/dynamic.ts
+++ b/src/query/test/pseudo/dynamic.ts
@@ -11,6 +11,7 @@ t.test('selects packages with a dynamicRequire alert', async t => {
     const ast = parse(query)
     const current = ast.first.first
     const state: ParserState = {
+      comment: '',
       current,
       initial: {
         edges: new Set(graph.edges.values()),
@@ -63,6 +64,7 @@ t.test('missing security archive', async t => {
     const ast = parse(query)
     const current = ast.first.first
     const state: ParserState = {
+      comment: '',
       current,
       initial: {
         edges: new Set(),

--- a/src/query/test/pseudo/empty.ts
+++ b/src/query/test/pseudo/empty.ts
@@ -13,6 +13,7 @@ t.test('selects packages with no dependencies', async t => {
     const ast = parse(query)
     const current = ast.first.first
     const state: ParserState = {
+      comment: '',
       current,
       initial: {
         edges: new Set(graph.edges.values()),

--- a/src/query/test/pseudo/entropic.ts
+++ b/src/query/test/pseudo/entropic.ts
@@ -13,6 +13,7 @@ t.test(
       const ast = parse(query)
       const current = ast.first.first
       const state: ParserState = {
+        comment: '',
         current,
         initial: {
           edges: new Set(graph.edges.values()),
@@ -66,6 +67,7 @@ t.test('missing security archive', async t => {
     const ast = parse(query)
     const current = ast.first.first
     const state: ParserState = {
+      comment: '',
       current,
       initial: {
         edges: new Set(),

--- a/src/query/test/pseudo/env.ts
+++ b/src/query/test/pseudo/env.ts
@@ -11,6 +11,7 @@ t.test('selects packages with a envVars alert', async t => {
     const ast = parse(query)
     const current = ast.first.first
     const state: ParserState = {
+      comment: '',
       current,
       initial: {
         edges: new Set(graph.edges.values()),
@@ -63,6 +64,7 @@ t.test('missing security archive', async t => {
     const ast = parse(query)
     const current = ast.first.first
     const state: ParserState = {
+      comment: '',
       current,
       initial: {
         edges: new Set(),

--- a/src/query/test/pseudo/eval.ts
+++ b/src/query/test/pseudo/eval.ts
@@ -11,6 +11,7 @@ t.test('selects packages with an eval alert', async t => {
     const ast = parse(query)
     const current = ast.first.first
     const state: ParserState = {
+      comment: '',
       current,
       initial: {
         edges: new Set(graph.edges.values()),
@@ -63,6 +64,7 @@ t.test('missing security archive', async t => {
     const ast = parse(query)
     const current = ast.first.first
     const state: ParserState = {
+      comment: '',
       current,
       initial: {
         edges: new Set(),

--- a/src/query/test/pseudo/fs.ts
+++ b/src/query/test/pseudo/fs.ts
@@ -11,6 +11,7 @@ t.test('selects packages with a filesystemAccess alert', async t => {
     const ast = parse(query)
     const current = ast.first.first
     const state: ParserState = {
+      comment: '',
       current,
       initial: {
         edges: new Set(graph.edges.values()),
@@ -63,6 +64,7 @@ t.test('missing security archive', async t => {
     const ast = parse(query)
     const current = ast.first.first
     const state: ParserState = {
+      comment: '',
       current,
       initial: {
         edges: new Set(),

--- a/src/query/test/pseudo/helpers.ts
+++ b/src/query/test/pseudo/helpers.ts
@@ -215,6 +215,7 @@ t.test('selects packages with an unmaintained alert', async t => {
     const ast = parse(query)
     const current = ast.first.first
     const state: ParserState = {
+      comment: '',
       current,
       initial: {
         edges: new Set(graph.edges.values()),
@@ -271,6 +272,7 @@ t.test('missing security archive', async t => {
     const ast = parse(query)
     const current = ast.first.first
     const state: ParserState = {
+      comment: '',
       current,
       initial: {
         edges: new Set(),

--- a/src/query/test/pseudo/license.ts
+++ b/src/query/test/pseudo/license.ts
@@ -15,6 +15,7 @@ t.test('selects packages with a specific license kind', async t => {
     const ast = parse(query)
     const current = ast.first.first
     const state: ParserState = {
+      comment: '',
       current,
       initial: {
         edges: new Set(graph.edges.values()),
@@ -98,6 +99,7 @@ t.test('missing security archive', async t => {
     const ast = parse(query)
     const current = ast.first.first
     const state: ParserState = {
+      comment: '',
       current,
       initial: {
         edges: new Set(),

--- a/src/query/test/pseudo/link.ts
+++ b/src/query/test/pseudo/link.ts
@@ -9,6 +9,7 @@ t.test('selects file links and tar.gz packages', async t => {
     const ast = postcssSelectorParser().astSync(query)
     const current = ast.first.first
     const state: ParserState = {
+      comment: '',
       current,
       initial: {
         edges: new Set(graph.edges.values()),

--- a/src/query/test/pseudo/malware.ts
+++ b/src/query/test/pseudo/malware.ts
@@ -17,6 +17,7 @@ t.test('selects packages with a specific malware kind', async t => {
     const ast = parse(query)
     const current = ast.first.first
     const state: ParserState = {
+      comment: '',
       current,
       initial: {
         edges: new Set(graph.edges.values()),
@@ -285,6 +286,7 @@ t.test('missing security archive', async t => {
     const ast = parse(query)
     const current = ast.first.first
     const state: ParserState = {
+      comment: '',
       current,
       initial: {
         edges: new Set(),

--- a/src/query/test/pseudo/minified.ts
+++ b/src/query/test/pseudo/minified.ts
@@ -11,6 +11,7 @@ t.test('selects packages with a minifiedFile alert', async t => {
     const ast = parse(query)
     const current = ast.first.first
     const state: ParserState = {
+      comment: '',
       current,
       initial: {
         edges: new Set(graph.edges.values()),
@@ -63,6 +64,7 @@ t.test('missing security archive', async t => {
     const ast = parse(query)
     const current = ast.first.first
     const state: ParserState = {
+      comment: '',
       current,
       initial: {
         edges: new Set(),

--- a/src/query/test/pseudo/missing.ts
+++ b/src/query/test/pseudo/missing.ts
@@ -12,6 +12,7 @@ t.test('selects edges with no linked node', async t => {
     const ast = postcssSelectorParser().astSync(query)
     const current = ast.first.first
     const state: ParserState = {
+      comment: '',
       current,
       initial: {
         edges: new Set(graph.edges.values()),

--- a/src/query/test/pseudo/native.ts
+++ b/src/query/test/pseudo/native.ts
@@ -11,6 +11,7 @@ t.test('selects packages with a hasNativeCode alert', async t => {
     const ast = parse(query)
     const current = ast.first.first
     const state: ParserState = {
+      comment: '',
       current,
       initial: {
         edges: new Set(graph.edges.values()),
@@ -63,6 +64,7 @@ t.test('missing security archive', async t => {
     const ast = parse(query)
     const current = ast.first.first
     const state: ParserState = {
+      comment: '',
       current,
       initial: {
         edges: new Set(),

--- a/src/query/test/pseudo/network.ts
+++ b/src/query/test/pseudo/network.ts
@@ -11,6 +11,7 @@ t.test('selects packages with a networkAccess alert', async t => {
     const ast = parse(query)
     const current = ast.first.first
     const state: ParserState = {
+      comment: '',
       current,
       initial: {
         edges: new Set(graph.edges.values()),
@@ -63,6 +64,7 @@ t.test('missing security archive', async t => {
     const ast = parse(query)
     const current = ast.first.first
     const state: ParserState = {
+      comment: '',
       current,
       initial: {
         edges: new Set(),

--- a/src/query/test/pseudo/obfuscated.ts
+++ b/src/query/test/pseudo/obfuscated.ts
@@ -11,6 +11,7 @@ t.test('selects packages with an obfuscated alert', async t => {
     const ast = parse(query)
     const current = ast.first.first
     const state: ParserState = {
+      comment: '',
       current,
       initial: {
         edges: new Set(graph.edges.values()),
@@ -63,6 +64,7 @@ t.test('missing security archive', async t => {
     const ast = parse(query)
     const current = ast.first.first
     const state: ParserState = {
+      comment: '',
       current,
       initial: {
         edges: new Set(),

--- a/src/query/test/pseudo/outdated.ts
+++ b/src/query/test/pseudo/outdated.ts
@@ -116,6 +116,7 @@ const getState = (query: string, graph = getSemverRichGraph()) => {
   const ast = parse(query)
   const current = asPostcssNodeWithChildren(ast.first.first)
   const state: ParserState = {
+    comment: '',
     current,
     initial: {
       edges: new Set(graph.edges.values()),

--- a/src/query/test/pseudo/private.ts
+++ b/src/query/test/pseudo/private.ts
@@ -13,6 +13,7 @@ t.test('selects packages with private flag', async t => {
     const ast = postcssSelectorParser().astSync(query)
     const current = ast.first.first
     const state: ParserState = {
+      comment: '',
       current,
       initial: {
         edges: new Set(graph.edges.values()),

--- a/src/query/test/pseudo/published.ts
+++ b/src/query/test/pseudo/published.ts
@@ -81,6 +81,7 @@ const getState = (query: string, graph = getSemverRichGraph()) => {
   const ast = parse(query)
   const current = ast.first.first
   const state: ParserState = {
+    comment: '',
     current,
     initial: {
       edges: new Set(graph.edges.values()),

--- a/src/query/test/pseudo/root.ts
+++ b/src/query/test/pseudo/root.ts
@@ -12,6 +12,7 @@ t.test('selects the root node of the graph', async t => {
     const ast = postcssSelectorParser().astSync(query)
     const current = ast.first.first
     const state: ParserState = {
+      comment: '',
       current,
       initial: {
         edges: new Set(graph.edges.values()),

--- a/src/query/test/pseudo/scanned.ts
+++ b/src/query/test/pseudo/scanned.ts
@@ -39,6 +39,7 @@ t.test('scanned selector', async t => {
       ]),
     )
     const state: ParserState = {
+      comment: '',
       current,
       initial: {
         edges: new Set(graph.edges.values()),

--- a/src/query/test/pseudo/score.ts
+++ b/src/query/test/pseudo/score.ts
@@ -92,6 +92,7 @@ t.test('selects packages based on their security score', async t => {
     const ast = parse(query)
     const current = ast.first.first
     const state: ParserState = {
+      comment: '',
       current,
       initial: {
         edges: new Set(graph.edges.values()),
@@ -350,6 +351,7 @@ t.test('error cases', async t => {
       const ast = parse(query)
       const current = ast.first.first
       const state: ParserState = {
+        comment: '',
         current,
         initial: {
           edges: new Set(),
@@ -386,6 +388,7 @@ t.test('error cases', async t => {
       const ast = parse(query)
       const current = ast.first.first
       const state: ParserState = {
+        comment: '',
         current,
         initial: {
           edges: new Set(),
@@ -422,6 +425,7 @@ t.test('error cases', async t => {
       const ast = parse(query)
       const current = ast.first.first
       const state: ParserState = {
+        comment: '',
         current,
         initial: {
           edges: new Set(),
@@ -458,6 +462,7 @@ t.test('error cases', async t => {
       const ast = parse(query)
       const current = ast.first.first
       const state: ParserState = {
+        comment: '',
         current,
         initial: {
           edges: new Set(),

--- a/src/query/test/pseudo/scripts.ts
+++ b/src/query/test/pseudo/scripts.ts
@@ -11,6 +11,7 @@ t.test('selects packages with an installScripts alert', async t => {
     const ast = parse(query)
     const current = ast.first.first
     const state: ParserState = {
+      comment: '',
       current,
       initial: {
         edges: new Set(graph.edges.values()),
@@ -63,6 +64,7 @@ t.test('missing security archive', async t => {
     const ast = parse(query)
     const current = ast.first.first
     const state: ParserState = {
+      comment: '',
       current,
       initial: {
         edges: new Set(),

--- a/src/query/test/pseudo/semver.ts
+++ b/src/query/test/pseudo/semver.ts
@@ -18,6 +18,7 @@ t.test('select from semver definition', async t => {
     const ast = parse(query)
     const current = asPostcssNodeWithChildren(ast.first.first)
     const state: ParserState = {
+      comment: '',
       current,
       initial: {
         edges: new Set(graph.edges.values()),

--- a/src/query/test/pseudo/severity.ts
+++ b/src/query/test/pseudo/severity.ts
@@ -17,6 +17,7 @@ t.test('selects packages with a specific severity kind', async t => {
     const ast = parse(query)
     const current = ast.first.first
     const state: ParserState = {
+      comment: '',
       current,
       initial: {
         edges: new Set(graph.edges.values()),
@@ -191,6 +192,7 @@ t.test('missing security archive', async t => {
     const ast = parse(query)
     const current = ast.first.first
     const state: ParserState = {
+      comment: '',
       current,
       initial: {
         edges: new Set(),

--- a/src/query/test/pseudo/shell.ts
+++ b/src/query/test/pseudo/shell.ts
@@ -11,6 +11,7 @@ t.test('selects packages with a shellAccess alert', async t => {
     const ast = parse(query)
     const current = ast.first.first
     const state: ParserState = {
+      comment: '',
       current,
       initial: {
         edges: new Set(graph.edges.values()),
@@ -63,6 +64,7 @@ t.test('missing security archive', async t => {
     const ast = parse(query)
     const current = ast.first.first
     const state: ParserState = {
+      comment: '',
       current,
       initial: {
         edges: new Set(),

--- a/src/query/test/pseudo/shrinkwrap.ts
+++ b/src/query/test/pseudo/shrinkwrap.ts
@@ -11,6 +11,7 @@ t.test('selects packages with a shrinkwrap alert', async t => {
     const ast = parse(query)
     const current = ast.first.first
     const state: ParserState = {
+      comment: '',
       current,
       initial: {
         edges: new Set(graph.edges.values()),
@@ -63,6 +64,7 @@ t.test('missing security archive', async t => {
     const ast = parse(query)
     const current = ast.first.first
     const state: ParserState = {
+      comment: '',
       current,
       initial: {
         edges: new Set(),

--- a/src/query/test/pseudo/squat.ts
+++ b/src/query/test/pseudo/squat.ts
@@ -17,6 +17,7 @@ t.test('selects packages with a specific squat kind', async t => {
     const ast = parse(query)
     const current = ast.first.first
     const state: ParserState = {
+      comment: '',
       current,
       initial: {
         edges: new Set(graph.edges.values()),
@@ -203,6 +204,7 @@ t.test('selects packages with a specific squat kind', async t => {
       const ast = parse(query)
       const current = ast.first.first
       const state: ParserState = {
+        comment: '',
         current,
         initial: {
           edges: new Set(graph.edges.values()),
@@ -266,6 +268,7 @@ t.test('selects packages with a specific squat kind', async t => {
       const ast = parse(query)
       const current = ast.first.first
       const state: ParserState = {
+        comment: '',
         current,
         initial: {
           edges: new Set(graph.edges.values()),
@@ -336,6 +339,7 @@ t.test('missing security archive', async t => {
     const ast = parse(query)
     const current = ast.first.first
     const state: ParserState = {
+      comment: '',
       current,
       initial: {
         edges: new Set(),

--- a/src/query/test/pseudo/suspicious.ts
+++ b/src/query/test/pseudo/suspicious.ts
@@ -11,6 +11,7 @@ t.test('selects packages with a suspicious alert', async t => {
     const ast = parse(query)
     const current = ast.first.first
     const state: ParserState = {
+      comment: '',
       current,
       initial: {
         edges: new Set(graph.edges.values()),
@@ -63,6 +64,7 @@ t.test('missing security archive', async t => {
     const ast = parse(query)
     const current = ast.first.first
     const state: ParserState = {
+      comment: '',
       current,
       initial: {
         edges: new Set(),

--- a/src/query/test/pseudo/tracker.ts
+++ b/src/query/test/pseudo/tracker.ts
@@ -11,6 +11,7 @@ t.test('selects packages with a tracker alert', async t => {
     const ast = parse(query)
     const current = ast.first.first
     const state: ParserState = {
+      comment: '',
       current,
       initial: {
         edges: new Set(graph.edges.values()),
@@ -63,6 +64,7 @@ t.test('missing security archive', async t => {
     const ast = parse(query)
     const current = ast.first.first
     const state: ParserState = {
+      comment: '',
       current,
       initial: {
         edges: new Set(),

--- a/src/query/test/pseudo/trivial.ts
+++ b/src/query/test/pseudo/trivial.ts
@@ -11,6 +11,7 @@ t.test('selects packages with a trivial alert', async t => {
     const ast = parse(query)
     const current = ast.first.first
     const state: ParserState = {
+      comment: '',
       current,
       initial: {
         edges: new Set(graph.edges.values()),
@@ -63,6 +64,7 @@ t.test('missing security archive', async t => {
     const ast = parse(query)
     const current = ast.first.first
     const state: ParserState = {
+      comment: '',
       current,
       initial: {
         edges: new Set(),

--- a/src/query/test/pseudo/type.ts
+++ b/src/query/test/pseudo/type.ts
@@ -12,6 +12,7 @@ t.test('selects nodes by type', async t => {
     const ast = postcssSelectorParser().astSync(query)
     const current = ast.first.first
     const state: ParserState = {
+      comment: '',
       current,
       initial: {
         edges: new Set(graph.edges.values()),

--- a/src/query/test/pseudo/undesirable.ts
+++ b/src/query/test/pseudo/undesirable.ts
@@ -11,6 +11,7 @@ t.test('selects packages with an undesirable alert', async t => {
     const ast = parse(query)
     const current = ast.first.first
     const state: ParserState = {
+      comment: '',
       current,
       initial: {
         edges: new Set(graph.edges.values()),
@@ -63,6 +64,7 @@ t.test('missing security archive', async t => {
     const ast = parse(query)
     const current = ast.first.first
     const state: ParserState = {
+      comment: '',
       current,
       initial: {
         edges: new Set(),

--- a/src/query/test/pseudo/unknown.ts
+++ b/src/query/test/pseudo/unknown.ts
@@ -11,6 +11,7 @@ t.test('selects packages with an unknown alert', async t => {
     const ast = parse(query)
     const current = ast.first.first
     const state: ParserState = {
+      comment: '',
       current,
       initial: {
         edges: new Set(graph.edges.values()),
@@ -63,6 +64,7 @@ t.test('missing security archive', async t => {
     const ast = parse(query)
     const current = ast.first.first
     const state: ParserState = {
+      comment: '',
       current,
       initial: {
         edges: new Set(),

--- a/src/query/test/pseudo/unmaintained.ts
+++ b/src/query/test/pseudo/unmaintained.ts
@@ -11,6 +11,7 @@ t.test('selects packages with an unmaintained alert', async t => {
     const ast = parse(query)
     const current = ast.first.first
     const state: ParserState = {
+      comment: '',
       current,
       initial: {
         edges: new Set(graph.edges.values()),
@@ -63,6 +64,7 @@ t.test('missing security archive', async t => {
     const ast = parse(query)
     const current = ast.first.first
     const state: ParserState = {
+      comment: '',
       current,
       initial: {
         edges: new Set(),

--- a/src/query/test/pseudo/unpopular.ts
+++ b/src/query/test/pseudo/unpopular.ts
@@ -11,6 +11,7 @@ t.test('selects packages with an unpopular alert', async t => {
     const ast = parse(query)
     const current = ast.first.first
     const state: ParserState = {
+      comment: '',
       current,
       initial: {
         edges: new Set(graph.edges.values()),
@@ -63,6 +64,7 @@ t.test('missing security archive', async t => {
     const ast = parse(query)
     const current = ast.first.first
     const state: ParserState = {
+      comment: '',
       current,
       initial: {
         edges: new Set(),

--- a/src/query/test/pseudo/unstable.ts
+++ b/src/query/test/pseudo/unstable.ts
@@ -11,6 +11,7 @@ t.test('selects packages with an unstable alert', async t => {
     const ast = parse(query)
     const current = ast.first.first
     const state: ParserState = {
+      comment: '',
       current,
       initial: {
         edges: new Set(graph.edges.values()),
@@ -63,6 +64,7 @@ t.test('missing security archive', async t => {
     const ast = parse(query)
     const current = ast.first.first
     const state: ParserState = {
+      comment: '',
       current,
       initial: {
         edges: new Set(),


### PR DESCRIPTION
Adds a `QueryResponse.comments` property that allows for retrieving the first comment found in the query.