### PR TITLE
query: fix names in attribute selector

### DIFF
--- a/src/query/src/attribute.ts
+++ b/src/query/src/attribute.ts
@@ -3,6 +3,7 @@ import type { NodeLike } from '@vltpkg/graph'
 import type { JSONField, Manifest } from '@vltpkg/types'
 import { asAttributeNode } from './types.ts'
 import type { ParserState } from './types.ts'
+import { removeDanglingEdges } from './pseudo/helpers.ts'
 
 export type ComparatorFn = (attr: string, value?: string) => boolean
 
@@ -129,17 +130,7 @@ export const filterAttributes = (
     }
   }
 
-  for (const edge of state.partial.edges) {
-    // edge.name is a special case in order
-    // to be able to match missing nodes by name
-    if (propertyName === 'name' && check(edge.name)) {
-      continue
-    }
-    // remove any remaining dangling edge
-    if (!edge.to) {
-      state.partial.edges.delete(edge)
-    }
-  }
+  removeDanglingEdges(state)
   return state
 }
 

--- a/src/query/tap-snapshots/test/attribute.ts.test.cjs
+++ b/src/query/tap-snapshots/test/attribute.ts.test.cjs
@@ -7,10 +7,7 @@
 'use strict'
 exports[`test/attribute.ts > TAP > attribute > missing node > query > "[name]" 1`] = `
 Object {
-  "edges": Array [
-    "a",
-    "b",
-  ],
+  "edges": Array [],
   "nodes": Array [
     "node-missing-project",
   ],
@@ -19,9 +16,7 @@ Object {
 
 exports[`test/attribute.ts > TAP > attribute > missing node > query > "[name=a]" 1`] = `
 Object {
-  "edges": Array [
-    "a",
-  ],
+  "edges": Array [],
   "nodes": Array [],
 }
 `


### PR DESCRIPTION
After the previous id selector refactor it has been stablished that in order to provide a more concise and unambiguous experience the id selectors are the only way to select by edge name and the attribute selector should now only match in properties from the node manifest.

Based on that this changeset removes the affordance to match edge names in the attribute selector.

Refs: https://github.com/vltpkg/vltpkg/pull/643