### PR TITLE
bugfix: docs theme switcher

### DIFF
--- a/www/docs/src/components/footer/theme-switcher.tsx
+++ b/www/docs/src/components/footer/theme-switcher.tsx
@@ -53,13 +53,12 @@ const storeTheme = (
 
 const ThemeSwitcher = () => {
   const [theme, setTheme] = useState<Theme>(() => {
-    const theme = document.cookie
+    const themeCookie = document.cookie
       .split('; ')
       .find(row => row.startsWith('theme='))
       ?.split('=')[1]
-      ?.split('+')[0] as Theme
-
-    return theme
+      ?.split('+')[0]
+    return (themeCookie || 'system') as Theme
   })
 
   useEffect(() => {

--- a/www/docs/src/components/theme-provider/theme-provider.astro
+++ b/www/docs/src/components/theme-provider/theme-provider.astro
@@ -24,10 +24,9 @@
   }
 
   const getThemePreference = () => {
-    const cookie =
-      document.cookie ?
-        getCookie('theme', document.cookie) || 'system+dark'
-      : 'system+dark'
+    const themeCookie =
+      document.cookie ? getCookie('theme', document.cookie) : null
+    const cookie = themeCookie || 'system+dark'
     const [userTheme, _] = cookie.split('+')
     return userTheme
   }


### PR DESCRIPTION
Fixes vltpkg/statusboard#131

- fix theme provider to properly handle missing theme cookie by defaulting to 'system+dark'
- fix theme switcher component to default to 'system' when no theme cookie exists
- ensure consistent theme handling to prevent undefined states
