### PR TITLE
gui: version count in `tabs-versions`

### DIFF
--- a/src/gui/src/components/explorer-grid/selected-item/tabs-versions.tsx
+++ b/src/gui/src/components/explorer-grid/selected-item/tabs-versions.tsx
@@ -1,4 +1,11 @@
-import { useEffect, useState, useCallback, useRef } from 'react'
+import {
+  useEffect,
+  useState,
+  useCallback,
+  useRef,
+  useMemo,
+  memo,
+} from 'react'
 import { AnimatePresence, motion } from 'framer-motion'
 import { TabsTrigger, TabsContent } from '@/components/ui/tabs.jsx'
 import {
@@ -12,7 +19,6 @@ import {
 import { useSelectedItemStore } from '@/components/explorer-grid/selected-item/context.jsx'
 import { DataBadge } from '@/components/ui/data-badge.jsx'
 import { format, formatDistanceStrict } from 'date-fns'
-import type { Version } from '@/lib/external-info.js'
 import { cn } from '@/lib/utils.js'
 import {
   Avatar,
@@ -35,13 +41,16 @@ import {
   DropdownMenuContent,
   DropdownMenuCheckboxItem,
 } from '@/components/ui/dropdown-menu.jsx'
-import type { ChartConfig } from '@/components/ui/chart.jsx'
 import {
   ChartContainer,
   ChartTooltip,
   ChartTooltipContent,
 } from '@/components/ui/chart.jsx'
 import { Bar, BarChart, XAxis, CartesianGrid } from 'recharts'
+import { NumberFlow } from '@/components/number-flow.jsx'
+
+import type { ChartConfig } from '@/components/ui/chart.jsx'
+import type { Version } from '@/lib/external-info.js'
 
 export const VersionsTabButton = () => {
   const versions = useSelectedItemStore(state => state.versions)
@@ -70,278 +79,302 @@ export const VersionsTabButton = () => {
   )
 }
 
-const VersionHeader = ({
-  items,
-  setItems,
+const VersionHeaderButton = ({
+  onClick,
+  children,
 }: {
-  items: VersionItem[]
-  setItems: (items: VersionItem[]) => void
+  onClick: () => void
+  children: React.ReactNode
 }) => {
-  const [order, setOrder] = useState<{
-    version: 'asc' | 'desc'
-    unpackedSize: 'asc' | 'desc'
-    publishedDate: 'asc' | 'desc'
-    publisher: 'asc' | 'desc'
-    downloadsPerVersion: 'asc' | 'desc'
-  }>({
-    version: 'asc',
-    unpackedSize: 'asc',
-    publishedDate: 'asc',
-    publisher: 'asc',
-    downloadsPerVersion: 'asc',
-  })
-
-  const sortItems = (
-    key: keyof VersionItem,
-    order: 'asc' | 'desc',
-  ) => {
-    setItems(
-      [...items].sort((a, b) => {
-        // Handle undefined values first
-        if (a[key] === undefined && b[key] === undefined) return 0
-        if (a[key] === undefined) return 1 // undefined values go to the end
-        if (b[key] === undefined) return -1 // undefined values go to the end
-
-        if (key === 'unpackedSize') {
-          const aSize = a[key] ?? 0
-          const bSize = b[key] ?? 0
-          return order === 'asc' ? aSize - bSize : bSize - aSize
-        }
-        if (key === 'publishedDate') {
-          const aDate = new Date(a[key]).getTime()
-          const bDate = new Date(b[key]).getTime()
-          return order === 'asc' ? aDate - bDate : bDate - aDate
-        }
-        if (key === 'publishedAuthor') {
-          const aName = a.publishedAuthor?.name
-          const bName = b.publishedAuthor?.name
-
-          if (!aName || !bName) return 0
-
-          const comparison = aName
-            .toLowerCase()
-            .localeCompare(bName.toLowerCase())
-          return order === 'asc' ? comparison : -comparison
-        }
-        if (key === 'downloadsPerVersion') {
-          const aDownloads = a.downloadsPerVersion ?? 0
-          const bDownloads = b.downloadsPerVersion ?? 0
-          return order === 'asc' ?
-              aDownloads - bDownloads
-            : bDownloads - aDownloads
-        }
-        return order === 'asc' ?
-            a.version.localeCompare(b.version)
-          : b.version.localeCompare(a.version)
-      }),
-    )
-  }
-
-  const onVersionClick = () => {
-    const newOrder = order.version === 'asc' ? 'desc' : 'asc'
-    setOrder(prev => ({ ...prev, version: newOrder }))
-    sortItems('version', newOrder)
-  }
-
-  const onUnpackedSizeClick = () => {
-    const newOrder = order.unpackedSize === 'asc' ? 'desc' : 'asc'
-    setOrder(prev => ({ ...prev, unpackedSize: newOrder }))
-    sortItems('unpackedSize', newOrder)
-  }
-
-  const onPublishedDateClick = () => {
-    const newOrder = order.publishedDate === 'asc' ? 'desc' : 'asc'
-    setOrder(prev => ({ ...prev, publishedDate: newOrder }))
-    sortItems('publishedDate', newOrder)
-  }
-
-  const onDownloadsClick = () => {
-    const newOrder =
-      order.downloadsPerVersion === 'asc' ? 'desc' : 'asc'
-    setOrder(prev => ({ ...prev, downloadsPerVersion: newOrder }))
-    sortItems('downloadsPerVersion', newOrder)
-  }
-
-  const onPublisherClick = () => {
-    const newOrder = order.publisher === 'asc' ? 'desc' : 'asc'
-    setOrder(prev => ({ ...prev, publisher: newOrder }))
-    sortItems('publishedAuthor', newOrder)
-  }
-
   return (
-    <div className="hidden cursor-default grid-cols-12 gap-3 pb-2 xl:grid">
-      <div className="col-span-2 flex w-full items-center justify-center">
-        <button
-          onClick={onVersionClick}
-          className="relative z-[1] inline-flex w-fit cursor-default items-center justify-center gap-2 text-nowrap text-sm text-muted-foreground transition-all duration-300 after:absolute after:left-[-0.75rem] after:z-[-1] after:h-[calc(100%+0.5rem)] after:w-[calc(100%+1.5rem)] after:rounded-sm after:bg-transparent after:content-[''] hover:text-foreground hover:after:bg-muted">
-          <span>Version</span>
-          <ArrowUpDown size={16} />
-        </button>
-      </div>
-      <div className="col-span-2 ml-1 w-full text-center">
-        <button
-          onClick={onUnpackedSizeClick}
-          className="relative z-[1] inline-flex w-fit cursor-default items-center justify-center gap-2 text-nowrap text-sm text-muted-foreground transition-all duration-300 after:absolute after:left-[-0.75rem] after:z-[-1] after:h-[calc(100%+0.5rem)] after:w-[calc(100%+1.5rem)] after:rounded-sm after:bg-transparent after:content-[''] hover:text-foreground hover:after:bg-muted">
-          <span>Size</span>
-          <ArrowUpDown size={16} />
-        </button>
-      </div>
-      <div className="col-span-3 w-full text-center">
-        <button
-          onClick={onPublishedDateClick}
-          className="relative z-[1] inline-flex w-fit cursor-default items-center justify-center gap-2 text-nowrap text-sm text-muted-foreground transition-all duration-300 after:absolute after:left-[-0.75rem] after:z-[-1] after:h-[calc(100%+0.5rem)] after:w-[calc(100%+1.5rem)] after:rounded-sm after:bg-transparent after:content-[''] hover:text-foreground hover:after:bg-muted">
-          <span>Published Date</span>
-          <ArrowUpDown size={16} />
-        </button>
-      </div>
-      <div className="col-span-2 w-full text-center">
-        <button
-          onClick={onDownloadsClick}
-          className="relative z-[1] inline-flex w-fit cursor-default items-center justify-center gap-2 text-nowrap text-sm text-muted-foreground transition-all duration-300 after:absolute after:left-[-0.75rem] after:z-[-1] after:h-[calc(100%+0.5rem)] after:w-[calc(100%+1.5rem)] after:rounded-sm after:bg-transparent after:content-[''] hover:text-foreground hover:after:bg-muted">
-          <span>Downloads</span>
-          <ArrowUpDown size={16} />
-        </button>
-      </div>
-      <div className="col-span-3 flex w-full items-center justify-center text-center">
-        <button
-          onClick={onPublisherClick}
-          className="relative z-[1] inline-flex w-fit cursor-default items-center justify-center gap-2 text-nowrap text-sm text-muted-foreground transition-all duration-300 after:absolute after:left-[-0.75rem] after:z-[-1] after:h-[calc(100%+0.5rem)] after:w-[calc(100%+1.5rem)] after:rounded-sm after:bg-transparent after:content-[''] hover:text-foreground hover:after:bg-muted">
-          <span>Publisher</span>
-          <ArrowUpDown size={16} />
-        </button>
-      </div>
-    </div>
+    <button
+      className="duration-250 inline-flex cursor-default items-center justify-center gap-2 text-nowrap rounded-sm px-2 py-1 text-sm text-muted-foreground transition-all hover:bg-secondary hover:text-foreground [&>svg]:size-4"
+      onClick={onClick}>
+      {children}
+    </button>
   )
 }
+
+const VersionHeader = memo(
+  ({
+    items,
+    setItems,
+    totalItems,
+  }: {
+    items: VersionItem[]
+    setItems: (items: VersionItem[]) => void
+    totalItems: number
+  }) => {
+    const [order, setOrder] = useState<{
+      version: 'asc' | 'desc'
+      unpackedSize: 'asc' | 'desc'
+      publishedDate: 'asc' | 'desc'
+      publisher: 'asc' | 'desc'
+      downloadsPerVersion: 'asc' | 'desc'
+    }>({
+      version: 'asc',
+      unpackedSize: 'asc',
+      publishedDate: 'asc',
+      publisher: 'asc',
+      downloadsPerVersion: 'asc',
+    })
+
+    const sortItems = (
+      key: keyof VersionItem,
+      order: 'asc' | 'desc',
+    ) => {
+      setItems(
+        [...items].sort((a, b) => {
+          // Handle undefined values first
+          if (a[key] === undefined && b[key] === undefined) return 0
+          if (a[key] === undefined) return 1 // undefined values go to the end
+          if (b[key] === undefined) return -1 // undefined values go to the end
+
+          if (key === 'unpackedSize') {
+            const aSize = a[key] ?? 0
+            const bSize = b[key] ?? 0
+            return order === 'asc' ? aSize - bSize : bSize - aSize
+          }
+          if (key === 'publishedDate') {
+            const aDate = new Date(a[key]).getTime()
+            const bDate = new Date(b[key]).getTime()
+            return order === 'asc' ? aDate - bDate : bDate - aDate
+          }
+          if (key === 'publishedAuthor') {
+            const aName = a.publishedAuthor?.name
+            const bName = b.publishedAuthor?.name
+
+            if (!aName || !bName) return 0
+
+            const comparison = aName
+              .toLowerCase()
+              .localeCompare(bName.toLowerCase())
+            return order === 'asc' ? comparison : -comparison
+          }
+          if (key === 'downloadsPerVersion') {
+            const aDownloads = a.downloadsPerVersion ?? 0
+            const bDownloads = b.downloadsPerVersion ?? 0
+            return order === 'asc' ?
+                aDownloads - bDownloads
+              : bDownloads - aDownloads
+          }
+          return order === 'asc' ?
+              a.version.localeCompare(b.version)
+            : b.version.localeCompare(a.version)
+        }),
+      )
+    }
+
+    const onVersionClick = () => {
+      const newOrder = order.version === 'asc' ? 'desc' : 'asc'
+      setOrder(prev => ({ ...prev, version: newOrder }))
+      sortItems('version', newOrder)
+    }
+
+    const onUnpackedSizeClick = () => {
+      const newOrder = order.unpackedSize === 'asc' ? 'desc' : 'asc'
+      setOrder(prev => ({ ...prev, unpackedSize: newOrder }))
+      sortItems('unpackedSize', newOrder)
+    }
+
+    const onPublishedDateClick = () => {
+      const newOrder = order.publishedDate === 'asc' ? 'desc' : 'asc'
+      setOrder(prev => ({ ...prev, publishedDate: newOrder }))
+      sortItems('publishedDate', newOrder)
+    }
+
+    const onDownloadsClick = () => {
+      const newOrder =
+        order.downloadsPerVersion === 'asc' ? 'desc' : 'asc'
+      setOrder(prev => ({ ...prev, downloadsPerVersion: newOrder }))
+      sortItems('downloadsPerVersion', newOrder)
+    }
+
+    const onPublisherClick = () => {
+      const newOrder = order.publisher === 'asc' ? 'desc' : 'asc'
+      setOrder(prev => ({ ...prev, publisher: newOrder }))
+      sortItems('publishedAuthor', newOrder)
+    }
+
+    return (
+      <div className="hidden cursor-default grid-cols-12 gap-3 xl:grid">
+        <div className="col-span-2 flex w-full items-center justify-start">
+          <VersionHeaderButton onClick={onVersionClick}>
+            <ArrowUpDown />
+            <span>Versions</span>
+            <NumberFlow
+              start={totalItems}
+              end={items.length}
+              motionConfig={{
+                duration: 0.2,
+              }}
+            />
+          </VersionHeaderButton>
+        </div>
+        <div className="col-span-2 ml-1 flex w-full items-center justify-end text-center">
+          <VersionHeaderButton onClick={onUnpackedSizeClick}>
+            <ArrowUpDown />
+            <span>Size</span>
+          </VersionHeaderButton>
+        </div>
+        <div className="col-span-3 w-full text-center">
+          <VersionHeaderButton onClick={onPublishedDateClick}>
+            <ArrowUpDown />
+            <span>Published Date</span>
+          </VersionHeaderButton>
+        </div>
+        <div className="col-span-2 w-full text-center">
+          <VersionHeaderButton onClick={onDownloadsClick}>
+            <ArrowUpDown />
+            <span>Downloads</span>
+          </VersionHeaderButton>
+        </div>
+        <div className="col-span-3 flex w-full items-center justify-center text-center">
+          <VersionHeaderButton onClick={onPublisherClick}>
+            <ArrowUpDown />
+            <span>Publisher</span>
+          </VersionHeaderButton>
+        </div>
+      </div>
+    )
+  },
+)
+
+VersionHeader.displayName = 'VersionHeader'
 
 interface VersionItem extends Version {
   downloadsPerVersion?: number
 }
 
-const VersionItem = ({
-  versionInfo,
-}: {
-  versionInfo: VersionItem
-}) => {
-  const {
-    version,
-    unpackedSize,
-    publishedAuthor,
-    publishedDate,
-    downloadsPerVersion,
-  } = versionInfo
+const VersionItem = memo(
+  ({ versionInfo }: { versionInfo: VersionItem }) => {
+    const {
+      version,
+      unpackedSize,
+      publishedAuthor,
+      publishedDate,
+      downloadsPerVersion,
+    } = versionInfo
 
-  return (
-    <div className="group/item flex cursor-default grid-cols-12 flex-col gap-3 rounded-sm py-4 text-foreground transition-colors first:border-t-[0px] xl:grid xl:gap-3 xl:px-2 xl:py-1.5 xl:hover:bg-muted">
-      <div className="order-1 col-span-2 flex w-full flex-col justify-center gap-1 xl:justify-center xl:gap-0">
-        <p className="text-sm font-medium text-muted-foreground xl:hidden">
-          Version
-        </p>
-        <DataBadge
-          variant="mono"
-          tooltip={{ content: version }}
-          classNames={{
-            wrapperClassName:
-              'w-fit max-w-none break-all xl:w-fit xl:max-w-[5.5rem]',
-            contentClassName: 'truncate pt-0.5',
-          }}
-          content={version}
-        />
-      </div>
-      <div className="order-2 col-span-2 flex w-full flex-col gap-2 xl:items-center xl:justify-center xl:gap-0 xl:text-center">
-        {unpackedSize && (
-          <>
-            <p className="text-sm font-medium text-muted-foreground xl:hidden">
-              Size
-            </p>
-            <p className="font-mono text-sm">
-              {formatDownloadSize(unpackedSize)}
-            </p>
-          </>
-        )}
-      </div>
-      <div className="order-4 col-span-3 flex w-full flex-col gap-2 xl:order-3 xl:items-center xl:justify-center xl:gap-0 xl:text-center">
-        {publishedDate && (
-          <>
-            <p className="text-sm font-medium text-muted-foreground xl:hidden">
-              Published Date
-            </p>
-            <div className="flex gap-2 xl:hidden">
-              <Avatar className="size-5">
-                <AvatarImage
-                  className="rounded-sm outline outline-[1px] outline-border"
-                  src={publishedAuthor?.avatar}
-                />
-                {publishedAuthor?.avatar && (
-                  <AvatarFallback className="h-5 h-full w-5 w-full rounded-sm bg-secondary bg-gradient-to-t from-neutral-100 to-neutral-400 px-[10px] outline outline-[1px] outline-border dark:from-neutral-500 dark:to-neutral-800" />
-                )}
-              </Avatar>
-              <p className="col-span-4 font-mono text-sm">
-                {publishedAuthor?.name}
+    return (
+      <div className="group/item flex cursor-default grid-cols-12 flex-col gap-3 rounded-sm py-4 text-foreground first:border-t-[0px] xl:grid xl:gap-3 xl:py-1.5">
+        <div className="order-1 col-span-2 flex w-full flex-col justify-center gap-1 xl:justify-center xl:gap-0">
+          <p className="text-sm font-medium text-muted-foreground xl:hidden">
+            Version
+          </p>
+          <DataBadge
+            variant="mono"
+            tooltip={{ content: version }}
+            classNames={{
+              wrapperClassName:
+                'w-fit max-w-none break-all xl:w-fit xl:max-w-[5.5rem]',
+              contentClassName: 'truncate pt-0.5',
+            }}
+            content={version}
+          />
+        </div>
+        <div className="order-2 col-span-2 flex w-full flex-col gap-2 xl:items-end xl:justify-center xl:gap-0 xl:text-center">
+          {unpackedSize && (
+            <>
+              <p className="text-sm font-medium text-muted-foreground xl:hidden">
+                Size
               </p>
-              <p className="ml-2 inline-flex font-mono text-sm text-muted-foreground xl:hidden">
-                {formatDistanceStrict(publishedDate, new Date(), {
-                  addSuffix: true,
-                })}
+              <p className="font-mono text-sm">
+                {formatDownloadSize(unpackedSize)}
               </p>
-            </div>
-            <TooltipProvider>
-              <Tooltip>
-                <TooltipTrigger className="hidden cursor-default font-mono text-sm xl:inline-flex">
+            </>
+          )}
+        </div>
+        <div className="order-4 col-span-3 flex w-full flex-col gap-2 xl:order-3 xl:items-center xl:justify-center xl:gap-0 xl:text-center">
+          {publishedDate && (
+            <>
+              <p className="text-sm font-medium text-muted-foreground xl:hidden">
+                Published Date
+              </p>
+              <div className="flex gap-2 xl:hidden">
+                <Avatar className="size-5">
+                  <AvatarImage
+                    className="rounded-sm outline outline-[1px] outline-border"
+                    src={publishedAuthor?.avatar}
+                  />
+                  {publishedAuthor?.avatar && (
+                    <AvatarFallback className="h-5 h-full w-5 w-full rounded-sm bg-secondary bg-gradient-to-t from-neutral-100 to-neutral-400 px-[10px] outline outline-[1px] outline-border dark:from-neutral-500 dark:to-neutral-800" />
+                  )}
+                </Avatar>
+                <p className="col-span-4 font-mono text-sm">
+                  {publishedAuthor?.name}
+                </p>
+                <p className="ml-2 inline-flex font-mono text-sm text-muted-foreground xl:hidden">
                   {formatDistanceStrict(publishedDate, new Date(), {
                     addSuffix: true,
                   })}
+                </p>
+              </div>
+              <TooltipProvider>
+                <Tooltip>
+                  <TooltipTrigger className="hidden cursor-default font-mono text-sm xl:inline-flex">
+                    {formatDistanceStrict(publishedDate, new Date(), {
+                      addSuffix: true,
+                    })}
+                  </TooltipTrigger>
+                  <TooltipContent>
+                    {format(
+                      publishedDate,
+                      'MMMM do, yyyy | HH:mm:ss',
+                    )}
+                  </TooltipContent>
+                </Tooltip>
+              </TooltipProvider>
+            </>
+          )}
+        </div>
+        <div
+          className={cn(
+            'order-3 col-span-2 w-full flex-col justify-start gap-2 xl:items-center xl:justify-center xl:gap-0 xl:text-center',
+            !downloadsPerVersion ? 'hidden xl:flex' : 'flex',
+          )}>
+          {downloadsPerVersion && (
+            <>
+              <p className="text-sm font-medium text-muted-foreground xl:hidden">
+                Downloads
+              </p>
+              <p className="font-mono text-sm">
+                {downloadsPerVersion.toLocaleString()}
+              </p>
+            </>
+          )}
+        </div>
+        <div className="order-3 col-span-3 flex hidden w-full items-center justify-center xl:order-4 xl:flex">
+          <div className="flex w-full items-center justify-center gap-2">
+            <Avatar className="flex size-5 items-center justify-center">
+              <AvatarImage
+                className="rounded-sm outline outline-[1px] outline-border"
+                src={publishedAuthor?.avatar}
+              />
+              {publishedAuthor?.avatar && (
+                <AvatarFallback className="h-full w-full rounded-sm bg-secondary bg-gradient-to-t from-neutral-100 to-neutral-400 px-[10px] outline outline-[1px] outline-border dark:from-neutral-500 dark:to-neutral-800" />
+              )}
+            </Avatar>
+            <TooltipProvider>
+              <Tooltip delayDuration={150}>
+                <TooltipTrigger className="cursor-default">
+                  <p className="truncate font-mono text-sm">
+                    {publishedAuthor?.name}
+                  </p>
                 </TooltipTrigger>
                 <TooltipContent>
-                  {format(publishedDate, 'MMMM do, yyyy | HH:mm:ss')}
+                  {publishedAuthor?.name}
                 </TooltipContent>
               </Tooltip>
             </TooltipProvider>
-          </>
-        )}
-      </div>
-      <div
-        className={cn(
-          'order-3 col-span-2 w-full flex-col justify-start gap-2 xl:items-center xl:justify-center xl:gap-0 xl:text-center',
-          !downloadsPerVersion ? 'hidden xl:flex' : 'flex',
-        )}>
-        {downloadsPerVersion && (
-          <>
-            <p className="text-sm font-medium text-muted-foreground xl:hidden">
-              Downloads
-            </p>
-            <p className="font-mono text-sm">
-              {downloadsPerVersion.toLocaleString()}
-            </p>
-          </>
-        )}
-      </div>
-      <div className="order-3 col-span-3 flex hidden w-full items-center justify-center xl:order-4 xl:flex">
-        <div className="flex w-full items-center justify-center gap-2">
-          <Avatar className="flex size-5 items-center justify-center">
-            <AvatarImage
-              className="rounded-sm outline outline-[1px] outline-border"
-              src={publishedAuthor?.avatar}
-            />
-            {publishedAuthor?.avatar && (
-              <AvatarFallback className="h-full w-full rounded-sm bg-secondary bg-gradient-to-t from-neutral-100 to-neutral-400 px-[10px] outline outline-[1px] outline-border dark:from-neutral-500 dark:to-neutral-800" />
-            )}
-          </Avatar>
-          <TooltipProvider>
-            <Tooltip delayDuration={150}>
-              <TooltipTrigger className="cursor-default">
-                <p className="truncate font-mono text-sm">
-                  {publishedAuthor?.name}
-                </p>
-              </TooltipTrigger>
-              <TooltipContent>{publishedAuthor?.name}</TooltipContent>
-            </Tooltip>
-          </TooltipProvider>
+          </div>
         </div>
       </div>
-    </div>
-  )
-}
+    )
+  },
+)
+
+VersionItem.displayName = 'VersionItem'
 
 const createIntersectionObserver = (
   callback: () => void,
@@ -502,46 +535,18 @@ export const VersionsTabContent = () => {
     state => state.downloadsPerVersion,
   )
 
-  const [filteredVersions, setFilteredVersions] = useState<
-    VersionItem[]
-  >([])
   const [page, setPage] = useState(1)
-  const [greaterPage, setGreaterPage] = useState(1)
   const [hasMore, setHasMore] = useState(true)
   const [showPreReleases, setShowPreReleases] = useState(true)
   const [showNewerVersions, setShowNewerVersions] = useState(true)
   const [searchTerm, setSearchTerm] = useState('')
+  const [filteredVersions, setFilteredVersions] = useState<
+    VersionItem[]
+  >([])
   const ITEMS_PER_PAGE = 20
 
-  const activeFilters = [
-    {
-      id: 'pre-releases',
-      label: 'Hide pre-releases',
-      isActive: !showPreReleases,
-      onToggle: (checked: boolean) => setShowPreReleases(!checked),
-    },
-    {
-      id: 'newer-versions',
-      label: 'Hide older versions',
-      isActive: !showNewerVersions,
-      onToggle: (checked: boolean) => setShowNewerVersions(!checked),
-    },
-  ]
-
-  const lastVersionElementRef = createIntersectionObserver(
-    () => setPage(prev => prev + 1),
-    hasMore,
-  )
-
-  useEffect(() => {
-    setPage(1)
-    setGreaterPage(1)
-  }, [showPreReleases, showNewerVersions, searchTerm])
-
-  useEffect(() => {
-    const allVersions = versions ?? []
-
-    const filters = [
+  const filterFunctions = useMemo(
+    () => [
       // Filter pre-releases
       (versions: Version[]) =>
         showPreReleases ? versions : (
@@ -591,46 +596,75 @@ export const VersionsTabContent = () => {
           )
         })
       },
-    ]
+    ],
+    [
+      showPreReleases,
+      showNewerVersions,
+      searchTerm,
+      manifest?.version,
+    ],
+  )
+
+  const processedVersions = useMemo(() => {
+    if (!versions) return []
 
     // Apply all filters in sequence
-    const filteredAllVersions = filters.reduce(
+    const filteredAllVersions = filterFunctions.reduce(
       (versions, filter) => filter(versions),
-      allVersions,
+      versions,
     )
 
     // Add downloads data to each version
-    const versionsWithDownloads = filteredAllVersions.map(
-      version => ({
-        ...version,
-        downloadsPerVersion: downloadsPerVersion?.[version.version],
-      }),
-    )
+    return filteredAllVersions.map(version => ({
+      ...version,
+      downloadsPerVersion: downloadsPerVersion?.[version.version],
+    }))
+  }, [versions, filterFunctions, downloadsPerVersion])
 
-    setFilteredVersions(versionsWithDownloads)
-    setHasMore(versionsWithDownloads.length > page * ITEMS_PER_PAGE)
-  }, [
-    downloadsPerVersion,
-    versions,
-    page,
-    greaterPage,
-    showPreReleases,
-    showNewerVersions,
-    searchTerm,
-  ])
+  // Update filtered versions when processed versions change
+  useEffect(() => {
+    setFilteredVersions(processedVersions)
+    setHasMore(processedVersions.length > page * ITEMS_PER_PAGE)
+  }, [processedVersions, page])
+
+  // Reset page when filters change
+  useEffect(() => {
+    setPage(1)
+  }, [showPreReleases, showNewerVersions, searchTerm])
 
   const isEmpty = !versions?.length
   const hasSearchResults = filteredVersions.length > 0
-  const paginatedVersions = filteredVersions.slice(
-    0,
-    page * ITEMS_PER_PAGE,
+
+  const paginatedVersions = useMemo(
+    () => filteredVersions.slice(0, page * ITEMS_PER_PAGE),
+    [filteredVersions, page, ITEMS_PER_PAGE],
+  )
+
+  const activeFilters = [
+    {
+      id: 'pre-releases',
+      label: 'Hide pre-releases',
+      isActive: !showPreReleases,
+      onToggle: (checked: boolean) => setShowPreReleases(!checked),
+    },
+    {
+      id: 'newer-versions',
+      label: 'Hide older versions',
+      isActive: !showNewerVersions,
+      onToggle: (checked: boolean) => setShowNewerVersions(!checked),
+    },
+  ]
+
+  const lastVersionElementRef = createIntersectionObserver(
+    () => setPage(prev => prev + 1),
+    hasMore,
   )
 
   return (
     <TabsContent value="versions">
       {isEmpty ?
         <EmptyState message="There is no versioning information about this package yet" />
-      : <section className="flex flex-col gap-2 px-6 py-4">
+      : <section className="flex flex-col px-6 py-4">
           <DownloadGraph />
 
           <div className="mb-3 flex items-center gap-2">
@@ -674,34 +708,54 @@ export const VersionsTabContent = () => {
             </DropdownMenu>
           </div>
 
-          <AnimatePresence initial={false} mode="popLayout">
+          <AnimatePresence initial={false} mode="sync">
             {(!showNewerVersions || !showPreReleases) && (
               <motion.div
-                layout
-                initial={{ opacity: 0, top: -40 }}
-                animate={{ opacity: 1, top: 0 }}
-                exit={{ opacity: 0, top: -40 }}
+                initial={{
+                  opacity: 0,
+                  height: 0,
+                }}
+                animate={{
+                  opacity: 1,
+                  height: 'auto',
+                }}
+                exit={{ opacity: 0, height: 0 }}
                 className="flex gap-2 overflow-hidden"
                 transition={{
                   type: 'spring',
                   duration: 0.28,
                   bounce: 0.02,
                 }}>
-                <AnimatePresence initial={false} mode="sync">
+                <AnimatePresence initial={false} mode="popLayout">
                   {activeFilters.map(
                     (filter, idx) =>
                       filter.isActive && (
                         <motion.div
                           layout
-                          initial={{ opacity: 0, scale: 0.8 }}
-                          animate={{ opacity: 1, scale: 1 }}
-                          exit={{ opacity: 0, scale: 0.8 }}
+                          initial={{
+                            opacity: 0,
+                            filter: 'blur(2px)',
+                            scale: 0.9,
+                          }}
+                          animate={{
+                            opacity: 1,
+                            filter: 'blur(0px)',
+                            scale: 1,
+                          }}
+                          exit={{
+                            opacity: 0,
+                            filter: 'blur(2px)',
+                            scale: 0.9,
+                          }}
                           transition={{
                             type: 'spring',
-                            duration: 0.28,
-                            bounce: 0.02,
+                            duration: 0.2,
+                            bounce: 0.01,
                           }}
-                          className="relative inline-flex cursor-default items-center rounded-full border-[1px] border-muted-foreground/20 bg-white py-1 text-xs font-medium text-foreground dark:bg-muted-foreground/5"
+                          style={{
+                            originY: '0px',
+                          }}
+                          className="relative inline-flex h-fit cursor-default items-center overflow-hidden whitespace-nowrap rounded-full border-[1px] border-muted-foreground/20 bg-white py-1 text-xs font-medium text-foreground dark:bg-muted-foreground/5"
                           key={`filter-${filter.id}-${idx}`}>
                           <span className="px-3">{filter.label}</span>
                         </motion.div>
@@ -716,14 +770,13 @@ export const VersionsTabContent = () => {
             <EmptyState
               message={`No versions found matching "${searchTerm}"`}
             />
-          : <>
+          : <div>
               {paginatedVersions.length > 0 && (
-                <motion.div
-                  layout="preserve-aspect"
-                  className="relative mt-2 flex flex-col gap-2">
+                <div className="mt-2 flex flex-col gap-2 overflow-hidden">
                   <VersionHeader
                     items={filteredVersions}
                     setItems={setFilteredVersions}
+                    totalItems={versions.length}
                   />
                   <div className="flex flex-col divide-y-[1px] divide-muted overflow-hidden">
                     {paginatedVersions.map((version, idx) => {
@@ -747,9 +800,9 @@ export const VersionsTabContent = () => {
                       )
                     })}
                   </div>
-                </motion.div>
+                </div>
               )}
-            </>
+            </div>
           }
         </section>
       }

--- a/src/gui/src/components/number-flow.tsx
+++ b/src/gui/src/components/number-flow.tsx
@@ -1,0 +1,155 @@
+import {
+  motion,
+  useMotionValue,
+  animate,
+  AnimatePresence,
+} from 'framer-motion'
+import { useEffect, useState, forwardRef } from 'react'
+import { cn } from '@/lib/utils.js'
+import { tv } from 'tailwind-variants'
+
+import type { Variants, Transition } from 'framer-motion'
+import type { VariantProps } from 'tailwind-variants'
+
+const numberFlowVariants = tv({
+  slots: {
+    wrapper: '',
+    p: '',
+    span: '',
+  },
+  variants: {
+    variant: {
+      default: {
+        wrapper: 'inline-flex',
+        p: 'overflow-hidden',
+        span: 'inline-block text-sm text-current tabular-nums font-mono',
+      },
+    },
+  },
+  defaultVariants: {
+    variant: 'default',
+  },
+})
+
+type NumberFlowProps = React.HTMLAttributes<HTMLDivElement> &
+  VariantProps<typeof numberFlowVariants> & {
+    start: number
+    end: number
+    format?: {
+      pad?: number
+    }
+    motionConfig?: {
+      duration?: number
+      yValue?: number
+      blurValue?: number
+    }
+    classNames?: {
+      wrapper?: string
+      p?: string
+      span?: string
+    }
+  }
+
+const NumberFlow = forwardRef<HTMLDivElement, NumberFlowProps>(
+  (
+    {
+      className,
+      variant,
+      start,
+      end,
+      motionConfig,
+      format,
+      classNames,
+      ...props
+    },
+    ref,
+  ) => {
+    const motionValue = useMotionValue<number>(start)
+    const [dir, setDir] = useState<'up' | 'down'>('up')
+    const [displayNumber, setDisplayNumber] = useState<number>(start)
+
+    const { wrapper, p, span } = numberFlowVariants({ variant })
+
+    const { pad = 2 } = format ?? {}
+    const {
+      duration = 2,
+      yValue = 2,
+      blurValue = 1,
+    } = motionConfig ?? {}
+
+    const digitVariants: Variants & Transition = {
+      initial: (dir: 'up' | 'down') => ({
+        y: dir === 'up' ? yValue : -yValue,
+        filter: `blur(${blurValue}px)`,
+        opacity: 0,
+      }),
+      animate: {
+        y: '0px',
+        filter: 'blur(0px)',
+        opacity: 1,
+      },
+      exit: (dir: 'up' | 'down') => ({
+        y: dir === 'up' ? -yValue : yValue,
+        filter: `blur(${blurValue}px)`,
+        opacity: 0,
+      }),
+      transition: {
+        type: 'spring',
+        bounce: 0.35,
+        duration: 0.3,
+      },
+    }
+
+    useEffect(() => {
+      setDir(end > start ? 'up' : 'down')
+
+      const controls = animate(motionValue, end, {
+        duration,
+        ease: 'easeInOut',
+        onUpdate: latest => {
+          setDisplayNumber(Math.round(latest))
+        },
+      })
+
+      return controls.stop
+    }, [start, end])
+
+    const paddedDigits = displayNumber
+      .toString()
+      .padStart(pad, '0')
+      .split('')
+
+    return (
+      <div
+        ref={ref}
+        className={cn(wrapper(), classNames?.wrapper, className)}
+        data-id="number-flow-wrapper"
+        {...props}>
+        <p data-id="number-flow-p" className={cn(p(), classNames?.p)}>
+          <AnimatePresence mode="popLayout" initial={false}>
+            {paddedDigits.map((n, i) => (
+              <motion.span
+                data-key={`number-flow-span-${n}-${i}`}
+                key={`${i}-${n}`}
+                custom={dir}
+                initial="initial"
+                animate="animate"
+                exit="exit"
+                variants={digitVariants}
+                className={cn(span(), classNames?.span)}
+                style={{
+                  originY: '0px',
+                }}>
+                {n}
+              </motion.span>
+            ))}
+          </AnimatePresence>
+        </p>
+      </div>
+    )
+  },
+)
+
+NumberFlow.displayName = 'NumberFlow'
+
+export { NumberFlow }

--- a/src/gui/src/main.css
+++ b/src/gui/src/main.css
@@ -172,6 +172,7 @@ html {
   -moz-osx-font-smoothing: grayscale;
   font-smooth: auto;
   background-color: hsl(var(--sidebar-background));
+  scroll-behavior: smooth;
 }
 
 @supports (-webkit-font-smoothing: subpixel-antialiased) {

--- a/src/gui/test/components/__snapshots__/number-flow.tsx.snap
+++ b/src/gui/test/components/__snapshots__/number-flow.tsx.snap
@@ -1,0 +1,81 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`number-flow renders default 1`] = `
+
+<div
+  class="inline-flex"
+  data-id="number-flow-wrapper"
+>
+  <p
+    data-id="number-flow-p"
+    class="overflow-hidden"
+  >
+    <span
+      data-key="number-flow-span-0-0"
+      class="inline-block text-sm text-current tabular-nums font-mono"
+      style="filter: blur(0px); opacity: 1; transform: none; transform-origin: 50% 0px 0;"
+    >
+      0
+    </span>
+    <span
+      data-key="number-flow-span-1-1"
+      class="inline-block text-sm text-current tabular-nums font-mono"
+      style="filter: blur(0px); opacity: 1; transform: none; transform-origin: 50% 0px 0;"
+    >
+      1
+    </span>
+  </p>
+</div>
+
+`;
+
+exports[`number-flow renders with custom classes 1`] = `
+
+<div
+  class="inline-flex custom-wrapper"
+  data-id="number-flow-wrapper"
+>
+  <p
+    data-id="number-flow-p"
+    class="overflow-hidden custom-p"
+  >
+    <span
+      data-key="number-flow-span-0-0"
+      class="inline-block text-sm text-current tabular-nums font-mono custom-span"
+      style="filter: blur(0px); opacity: 1; transform: none; transform-origin: 50% 0px 0;"
+    >
+      0
+    </span>
+    <span
+      data-key="number-flow-span-1-1"
+      class="inline-block text-sm text-current tabular-nums font-mono custom-span"
+      style="filter: blur(0px); opacity: 1; transform: none; transform-origin: 50% 0px 0;"
+    >
+      1
+    </span>
+  </p>
+</div>
+
+`;
+
+exports[`number-flow renders with custom padding 1`] = `
+
+<div
+  class="inline-flex"
+  data-id="number-flow-wrapper"
+>
+  <p
+    data-id="number-flow-p"
+    class="overflow-hidden"
+  >
+    <span
+      data-key="number-flow-span-1-0"
+      class="inline-block text-sm text-current tabular-nums font-mono"
+      style="filter: blur(0px); opacity: 1; transform: none; transform-origin: 50% 0px 0;"
+    >
+      1
+    </span>
+  </p>
+</div>
+
+`;

--- a/src/gui/test/components/explorer-grid/selected-item/__snapshots__/tabs-versions.tsx.snap
+++ b/src/gui/test/components/explorer-grid/selected-item/__snapshots__/tabs-versions.tsx.snap
@@ -21,7 +21,7 @@ exports[`VersionsTabButton renders default 1`] = `
 exports[`VersionsTabContent filters newer versions 1`] = `
 
 <gui-tabs-content value="versions">
-  <section class="flex flex-col gap-2 px-6 py-4">
+  <section class="flex flex-col px-6 py-4">
     <div class="mb-3 border-b-[1px] border-muted pb-1">
       <div class="flex cursor-default justify-between">
         <div class="flex flex-col gap-0.5">
@@ -124,223 +124,231 @@ exports[`VersionsTabContent filters newer versions 1`] = `
         </gui-dropdown-menu-content>
       </gui-dropdown-menu>
     </div>
-    <div class="relative mt-2 flex flex-col gap-2">
-      <div class="hidden cursor-default grid-cols-12 gap-3 pb-2 xl:grid">
-        <div class="col-span-2 flex w-full items-center justify-center">
-          <button class="relative z-[1] inline-flex w-fit cursor-default items-center justify-center gap-2 text-nowrap text-sm text-muted-foreground transition-all duration-300 after:absolute after:left-[-0.75rem] after:z-[-1] after:h-[calc(100%+0.5rem)] after:w-[calc(100%+1.5rem)] after:rounded-sm after:bg-transparent after:content-[''] hover:text-foreground hover:after:bg-muted">
-            <span>
-              Version
-            </span>
-            <gui-arrow-up-down-icon size="16">
-            </gui-arrow-up-down-icon>
-          </button>
-        </div>
-        <div class="col-span-2 ml-1 w-full text-center">
-          <button class="relative z-[1] inline-flex w-fit cursor-default items-center justify-center gap-2 text-nowrap text-sm text-muted-foreground transition-all duration-300 after:absolute after:left-[-0.75rem] after:z-[-1] after:h-[calc(100%+0.5rem)] after:w-[calc(100%+1.5rem)] after:rounded-sm after:bg-transparent after:content-[''] hover:text-foreground hover:after:bg-muted">
-            <span>
-              Size
-            </span>
-            <gui-arrow-up-down-icon size="16">
-            </gui-arrow-up-down-icon>
-          </button>
-        </div>
-        <div class="col-span-3 w-full text-center">
-          <button class="relative z-[1] inline-flex w-fit cursor-default items-center justify-center gap-2 text-nowrap text-sm text-muted-foreground transition-all duration-300 after:absolute after:left-[-0.75rem] after:z-[-1] after:h-[calc(100%+0.5rem)] after:w-[calc(100%+1.5rem)] after:rounded-sm after:bg-transparent after:content-[''] hover:text-foreground hover:after:bg-muted">
-            <span>
-              Published Date
-            </span>
-            <gui-arrow-up-down-icon size="16">
-            </gui-arrow-up-down-icon>
-          </button>
-        </div>
-        <div class="col-span-2 w-full text-center">
-          <button class="relative z-[1] inline-flex w-fit cursor-default items-center justify-center gap-2 text-nowrap text-sm text-muted-foreground transition-all duration-300 after:absolute after:left-[-0.75rem] after:z-[-1] after:h-[calc(100%+0.5rem)] after:w-[calc(100%+1.5rem)] after:rounded-sm after:bg-transparent after:content-[''] hover:text-foreground hover:after:bg-muted">
-            <span>
-              Downloads
-            </span>
-            <gui-arrow-up-down-icon size="16">
-            </gui-arrow-up-down-icon>
-          </button>
-        </div>
-        <div class="col-span-3 flex w-full items-center justify-center text-center">
-          <button class="relative z-[1] inline-flex w-fit cursor-default items-center justify-center gap-2 text-nowrap text-sm text-muted-foreground transition-all duration-300 after:absolute after:left-[-0.75rem] after:z-[-1] after:h-[calc(100%+0.5rem)] after:w-[calc(100%+1.5rem)] after:rounded-sm after:bg-transparent after:content-[''] hover:text-foreground hover:after:bg-muted">
-            <span>
-              Publisher
-            </span>
-            <gui-arrow-up-down-icon size="16">
-            </gui-arrow-up-down-icon>
-          </button>
-        </div>
-      </div>
-      <div class="flex flex-col divide-y-[1px] divide-muted overflow-hidden">
-        <div>
-          <div class="group/item flex cursor-default grid-cols-12 flex-col gap-3 rounded-sm py-4 text-foreground transition-colors first:border-t-[0px] xl:grid xl:gap-3 xl:px-2 xl:py-1.5 xl:hover:bg-muted">
-            <div class="order-1 col-span-2 flex w-full flex-col justify-center gap-1 xl:justify-center xl:gap-0">
-              <p class="text-sm font-medium text-muted-foreground xl:hidden">
-                Version
-              </p>
-              <gui-data-badge
-                variant="mono"
-                tooltip="[object Object]"
-                classnames="[object Object]"
-                content="2.0.0"
+    <div>
+      <div class="mt-2 flex flex-col gap-2 overflow-hidden">
+        <div class="hidden cursor-default grid-cols-12 gap-3 xl:grid">
+          <div class="col-span-2 flex w-full items-center justify-start">
+            <button class="duration-250 inline-flex cursor-default items-center justify-center gap-2 text-nowrap rounded-sm px-2 py-1 text-sm text-muted-foreground transition-all hover:bg-secondary hover:text-foreground [&amp;>svg]:size-4">
+              <gui-arrow-up-down-icon>
+              </gui-arrow-up-down-icon>
+              <span>
+                Versions
+              </span>
+              <gui-number-flow
+                start="2"
+                end="2"
+                motionconfig="[object Object]"
               >
-              </gui-data-badge>
-            </div>
-            <div class="order-2 col-span-2 flex w-full flex-col gap-2 xl:items-center xl:justify-center xl:gap-0 xl:text-center">
-              <p class="text-sm font-medium text-muted-foreground xl:hidden">
+              </gui-number-flow>
+            </button>
+          </div>
+          <div class="col-span-2 ml-1 flex w-full items-center justify-end text-center">
+            <button class="duration-250 inline-flex cursor-default items-center justify-center gap-2 text-nowrap rounded-sm px-2 py-1 text-sm text-muted-foreground transition-all hover:bg-secondary hover:text-foreground [&amp;>svg]:size-4">
+              <gui-arrow-up-down-icon>
+              </gui-arrow-up-down-icon>
+              <span>
                 Size
-              </p>
-              <p class="font-mono text-sm">
-                121 KB
-              </p>
-            </div>
-            <div class="order-4 col-span-3 flex w-full flex-col gap-2 xl:order-3 xl:items-center xl:justify-center xl:gap-0 xl:text-center">
-              <p class="text-sm font-medium text-muted-foreground xl:hidden">
+              </span>
+            </button>
+          </div>
+          <div class="col-span-3 w-full text-center">
+            <button class="duration-250 inline-flex cursor-default items-center justify-center gap-2 text-nowrap rounded-sm px-2 py-1 text-sm text-muted-foreground transition-all hover:bg-secondary hover:text-foreground [&amp;>svg]:size-4">
+              <gui-arrow-up-down-icon>
+              </gui-arrow-up-down-icon>
+              <span>
                 Published Date
-              </p>
-              <div class="flex gap-2 xl:hidden">
-                <gui-avatar classname="size-5">
-                  <gui-avatar-image
-                    classname="rounded-sm outline outline-[1px] outline-border"
-                    src="https://example.com/avatar.jpg"
-                  >
-                  </gui-avatar-image>
-                  <gui-avatar-fallback classname="h-5 h-full w-5 w-full rounded-sm bg-secondary bg-gradient-to-t from-neutral-100 to-neutral-400 px-[10px] outline outline-[1px] outline-border dark:from-neutral-500 dark:to-neutral-800">
-                  </gui-avatar-fallback>
-                </gui-avatar>
-                <p class="col-span-4 font-mono text-sm">
-                  John Doe
+              </span>
+            </button>
+          </div>
+          <div class="col-span-2 w-full text-center">
+            <button class="duration-250 inline-flex cursor-default items-center justify-center gap-2 text-nowrap rounded-sm px-2 py-1 text-sm text-muted-foreground transition-all hover:bg-secondary hover:text-foreground [&amp;>svg]:size-4">
+              <gui-arrow-up-down-icon>
+              </gui-arrow-up-down-icon>
+              <span>
+                Downloads
+              </span>
+            </button>
+          </div>
+          <div class="col-span-3 flex w-full items-center justify-center text-center">
+            <button class="duration-250 inline-flex cursor-default items-center justify-center gap-2 text-nowrap rounded-sm px-2 py-1 text-sm text-muted-foreground transition-all hover:bg-secondary hover:text-foreground [&amp;>svg]:size-4">
+              <gui-arrow-up-down-icon>
+              </gui-arrow-up-down-icon>
+              <span>
+                Publisher
+              </span>
+            </button>
+          </div>
+        </div>
+        <div class="flex flex-col divide-y-[1px] divide-muted overflow-hidden">
+          <div>
+            <div class="group/item flex cursor-default grid-cols-12 flex-col gap-3 rounded-sm py-4 text-foreground first:border-t-[0px] xl:grid xl:gap-3 xl:py-1.5">
+              <div class="order-1 col-span-2 flex w-full flex-col justify-center gap-1 xl:justify-center xl:gap-0">
+                <p class="text-sm font-medium text-muted-foreground xl:hidden">
+                  Version
                 </p>
-                <p class="ml-2 inline-flex font-mono text-sm text-muted-foreground xl:hidden">
-                  1 day ago
+                <gui-data-badge
+                  variant="mono"
+                  tooltip="[object Object]"
+                  classnames="[object Object]"
+                  content="2.0.0"
+                >
+                </gui-data-badge>
+              </div>
+              <div class="order-2 col-span-2 flex w-full flex-col gap-2 xl:items-end xl:justify-center xl:gap-0 xl:text-center">
+                <p class="text-sm font-medium text-muted-foreground xl:hidden">
+                  Size
+                </p>
+                <p class="font-mono text-sm">
+                  121 KB
                 </p>
               </div>
-              <gui-tooltip-provider>
-                <gui-tooltip>
-                  <gui-tooltip-trigger classname="hidden cursor-default font-mono text-sm xl:inline-flex">
+              <div class="order-4 col-span-3 flex w-full flex-col gap-2 xl:order-3 xl:items-center xl:justify-center xl:gap-0 xl:text-center">
+                <p class="text-sm font-medium text-muted-foreground xl:hidden">
+                  Published Date
+                </p>
+                <div class="flex gap-2 xl:hidden">
+                  <gui-avatar classname="size-5">
+                    <gui-avatar-image
+                      classname="rounded-sm outline outline-[1px] outline-border"
+                      src="https://example.com/avatar.jpg"
+                    >
+                    </gui-avatar-image>
+                    <gui-avatar-fallback classname="h-5 h-full w-5 w-full rounded-sm bg-secondary bg-gradient-to-t from-neutral-100 to-neutral-400 px-[10px] outline outline-[1px] outline-border dark:from-neutral-500 dark:to-neutral-800">
+                    </gui-avatar-fallback>
+                  </gui-avatar>
+                  <p class="col-span-4 font-mono text-sm">
+                    John Doe
+                  </p>
+                  <p class="ml-2 inline-flex font-mono text-sm text-muted-foreground xl:hidden">
                     1 day ago
-                  </gui-tooltip-trigger>
-                  <gui-tooltip-content>
-                    2025-04-15
-                  </gui-tooltip-content>
-                </gui-tooltip>
-              </gui-tooltip-provider>
-            </div>
-            <div class="order-3 col-span-2 w-full flex-col justify-start gap-2 xl:items-center xl:justify-center xl:gap-0 xl:text-center hidden xl:flex">
-            </div>
-            <div class="order-3 col-span-3 flex hidden w-full items-center justify-center xl:order-4 xl:flex">
-              <div class="flex w-full items-center justify-center gap-2">
-                <gui-avatar classname="flex size-5 items-center justify-center">
-                  <gui-avatar-image
-                    classname="rounded-sm outline outline-[1px] outline-border"
-                    src="https://example.com/avatar.jpg"
-                  >
-                  </gui-avatar-image>
-                  <gui-avatar-fallback classname="h-full w-full rounded-sm bg-secondary bg-gradient-to-t from-neutral-100 to-neutral-400 px-[10px] outline outline-[1px] outline-border dark:from-neutral-500 dark:to-neutral-800">
-                  </gui-avatar-fallback>
-                </gui-avatar>
+                  </p>
+                </div>
                 <gui-tooltip-provider>
-                  <gui-tooltip delayduration="150">
-                    <gui-tooltip-trigger classname="cursor-default">
-                      <p class="truncate font-mono text-sm">
-                        John Doe
-                      </p>
+                  <gui-tooltip>
+                    <gui-tooltip-trigger classname="hidden cursor-default font-mono text-sm xl:inline-flex">
+                      1 day ago
                     </gui-tooltip-trigger>
                     <gui-tooltip-content>
-                      John Doe
+                      2025-04-15
                     </gui-tooltip-content>
                   </gui-tooltip>
                 </gui-tooltip-provider>
+              </div>
+              <div class="order-3 col-span-2 w-full flex-col justify-start gap-2 xl:items-center xl:justify-center xl:gap-0 xl:text-center hidden xl:flex">
+              </div>
+              <div class="order-3 col-span-3 flex hidden w-full items-center justify-center xl:order-4 xl:flex">
+                <div class="flex w-full items-center justify-center gap-2">
+                  <gui-avatar classname="flex size-5 items-center justify-center">
+                    <gui-avatar-image
+                      classname="rounded-sm outline outline-[1px] outline-border"
+                      src="https://example.com/avatar.jpg"
+                    >
+                    </gui-avatar-image>
+                    <gui-avatar-fallback classname="h-full w-full rounded-sm bg-secondary bg-gradient-to-t from-neutral-100 to-neutral-400 px-[10px] outline outline-[1px] outline-border dark:from-neutral-500 dark:to-neutral-800">
+                    </gui-avatar-fallback>
+                  </gui-avatar>
+                  <gui-tooltip-provider>
+                    <gui-tooltip delayduration="150">
+                      <gui-tooltip-trigger classname="cursor-default">
+                        <p class="truncate font-mono text-sm">
+                          John Doe
+                        </p>
+                      </gui-tooltip-trigger>
+                      <gui-tooltip-content>
+                        John Doe
+                      </gui-tooltip-content>
+                    </gui-tooltip>
+                  </gui-tooltip-provider>
+                </div>
               </div>
             </div>
           </div>
-        </div>
-        <div>
-          <div class="group/item flex cursor-default grid-cols-12 flex-col gap-3 rounded-sm py-4 text-foreground transition-colors first:border-t-[0px] xl:grid xl:gap-3 xl:px-2 xl:py-1.5 xl:hover:bg-muted">
-            <div class="order-1 col-span-2 flex w-full flex-col justify-center gap-1 xl:justify-center xl:gap-0">
-              <p class="text-sm font-medium text-muted-foreground xl:hidden">
-                Version
-              </p>
-              <gui-data-badge
-                variant="mono"
-                tooltip="[object Object]"
-                classnames="[object Object]"
-                content="1.0.0"
-              >
-              </gui-data-badge>
-            </div>
-            <div class="order-2 col-span-2 flex w-full flex-col gap-2 xl:items-center xl:justify-center xl:gap-0 xl:text-center">
-              <p class="text-sm font-medium text-muted-foreground xl:hidden">
-                Size
-              </p>
-              <p class="font-mono text-sm">
-                121 KB
-              </p>
-            </div>
-            <div class="order-4 col-span-3 flex w-full flex-col gap-2 xl:order-3 xl:items-center xl:justify-center xl:gap-0 xl:text-center">
-              <p class="text-sm font-medium text-muted-foreground xl:hidden">
-                Published Date
-              </p>
-              <div class="flex gap-2 xl:hidden">
-                <gui-avatar classname="size-5">
-                  <gui-avatar-image
-                    classname="rounded-sm outline outline-[1px] outline-border"
-                    src="https://example.com/avatar.jpg"
-                  >
-                  </gui-avatar-image>
-                  <gui-avatar-fallback classname="h-5 h-full w-5 w-full rounded-sm bg-secondary bg-gradient-to-t from-neutral-100 to-neutral-400 px-[10px] outline outline-[1px] outline-border dark:from-neutral-500 dark:to-neutral-800">
-                  </gui-avatar-fallback>
-                </gui-avatar>
-                <p class="col-span-4 font-mono text-sm">
-                  John Doe
+          <div>
+            <div class="group/item flex cursor-default grid-cols-12 flex-col gap-3 rounded-sm py-4 text-foreground first:border-t-[0px] xl:grid xl:gap-3 xl:py-1.5">
+              <div class="order-1 col-span-2 flex w-full flex-col justify-center gap-1 xl:justify-center xl:gap-0">
+                <p class="text-sm font-medium text-muted-foreground xl:hidden">
+                  Version
                 </p>
-                <p class="ml-2 inline-flex font-mono text-sm text-muted-foreground xl:hidden">
-                  1 day ago
+                <gui-data-badge
+                  variant="mono"
+                  tooltip="[object Object]"
+                  classnames="[object Object]"
+                  content="1.0.0"
+                >
+                </gui-data-badge>
+              </div>
+              <div class="order-2 col-span-2 flex w-full flex-col gap-2 xl:items-end xl:justify-center xl:gap-0 xl:text-center">
+                <p class="text-sm font-medium text-muted-foreground xl:hidden">
+                  Size
+                </p>
+                <p class="font-mono text-sm">
+                  121 KB
                 </p>
               </div>
-              <gui-tooltip-provider>
-                <gui-tooltip>
-                  <gui-tooltip-trigger classname="hidden cursor-default font-mono text-sm xl:inline-flex">
+              <div class="order-4 col-span-3 flex w-full flex-col gap-2 xl:order-3 xl:items-center xl:justify-center xl:gap-0 xl:text-center">
+                <p class="text-sm font-medium text-muted-foreground xl:hidden">
+                  Published Date
+                </p>
+                <div class="flex gap-2 xl:hidden">
+                  <gui-avatar classname="size-5">
+                    <gui-avatar-image
+                      classname="rounded-sm outline outline-[1px] outline-border"
+                      src="https://example.com/avatar.jpg"
+                    >
+                    </gui-avatar-image>
+                    <gui-avatar-fallback classname="h-5 h-full w-5 w-full rounded-sm bg-secondary bg-gradient-to-t from-neutral-100 to-neutral-400 px-[10px] outline outline-[1px] outline-border dark:from-neutral-500 dark:to-neutral-800">
+                    </gui-avatar-fallback>
+                  </gui-avatar>
+                  <p class="col-span-4 font-mono text-sm">
+                    John Doe
+                  </p>
+                  <p class="ml-2 inline-flex font-mono text-sm text-muted-foreground xl:hidden">
                     1 day ago
-                  </gui-tooltip-trigger>
-                  <gui-tooltip-content>
-                    2025-04-15
-                  </gui-tooltip-content>
-                </gui-tooltip>
-              </gui-tooltip-provider>
-            </div>
-            <div class="order-3 col-span-2 w-full flex-col justify-start gap-2 xl:items-center xl:justify-center xl:gap-0 xl:text-center flex">
-              <p class="text-sm font-medium text-muted-foreground xl:hidden">
-                Downloads
-              </p>
-              <p class="font-mono text-sm">
-                123,456
-              </p>
-            </div>
-            <div class="order-3 col-span-3 flex hidden w-full items-center justify-center xl:order-4 xl:flex">
-              <div class="flex w-full items-center justify-center gap-2">
-                <gui-avatar classname="flex size-5 items-center justify-center">
-                  <gui-avatar-image
-                    classname="rounded-sm outline outline-[1px] outline-border"
-                    src="https://example.com/avatar.jpg"
-                  >
-                  </gui-avatar-image>
-                  <gui-avatar-fallback classname="h-full w-full rounded-sm bg-secondary bg-gradient-to-t from-neutral-100 to-neutral-400 px-[10px] outline outline-[1px] outline-border dark:from-neutral-500 dark:to-neutral-800">
-                  </gui-avatar-fallback>
-                </gui-avatar>
+                  </p>
+                </div>
                 <gui-tooltip-provider>
-                  <gui-tooltip delayduration="150">
-                    <gui-tooltip-trigger classname="cursor-default">
-                      <p class="truncate font-mono text-sm">
-                        John Doe
-                      </p>
+                  <gui-tooltip>
+                    <gui-tooltip-trigger classname="hidden cursor-default font-mono text-sm xl:inline-flex">
+                      1 day ago
                     </gui-tooltip-trigger>
                     <gui-tooltip-content>
-                      John Doe
+                      2025-04-15
                     </gui-tooltip-content>
                   </gui-tooltip>
                 </gui-tooltip-provider>
+              </div>
+              <div class="order-3 col-span-2 w-full flex-col justify-start gap-2 xl:items-center xl:justify-center xl:gap-0 xl:text-center flex">
+                <p class="text-sm font-medium text-muted-foreground xl:hidden">
+                  Downloads
+                </p>
+                <p class="font-mono text-sm">
+                  123,456
+                </p>
+              </div>
+              <div class="order-3 col-span-3 flex hidden w-full items-center justify-center xl:order-4 xl:flex">
+                <div class="flex w-full items-center justify-center gap-2">
+                  <gui-avatar classname="flex size-5 items-center justify-center">
+                    <gui-avatar-image
+                      classname="rounded-sm outline outline-[1px] outline-border"
+                      src="https://example.com/avatar.jpg"
+                    >
+                    </gui-avatar-image>
+                    <gui-avatar-fallback classname="h-full w-full rounded-sm bg-secondary bg-gradient-to-t from-neutral-100 to-neutral-400 px-[10px] outline outline-[1px] outline-border dark:from-neutral-500 dark:to-neutral-800">
+                    </gui-avatar-fallback>
+                  </gui-avatar>
+                  <gui-tooltip-provider>
+                    <gui-tooltip delayduration="150">
+                      <gui-tooltip-trigger classname="cursor-default">
+                        <p class="truncate font-mono text-sm">
+                          John Doe
+                        </p>
+                      </gui-tooltip-trigger>
+                      <gui-tooltip-content>
+                        John Doe
+                      </gui-tooltip-content>
+                    </gui-tooltip>
+                  </gui-tooltip-provider>
+                </div>
               </div>
             </div>
           </div>
@@ -355,7 +363,7 @@ exports[`VersionsTabContent filters newer versions 1`] = `
 exports[`VersionsTabContent filters pre-releases 1`] = `
 
 <gui-tabs-content value="versions">
-  <section class="flex flex-col gap-2 px-6 py-4">
+  <section class="flex flex-col px-6 py-4">
     <div class="mb-3 border-b-[1px] border-muted pb-1">
       <div class="flex cursor-default justify-between">
         <div class="flex flex-col gap-0.5">
@@ -458,223 +466,231 @@ exports[`VersionsTabContent filters pre-releases 1`] = `
         </gui-dropdown-menu-content>
       </gui-dropdown-menu>
     </div>
-    <div class="relative mt-2 flex flex-col gap-2">
-      <div class="hidden cursor-default grid-cols-12 gap-3 pb-2 xl:grid">
-        <div class="col-span-2 flex w-full items-center justify-center">
-          <button class="relative z-[1] inline-flex w-fit cursor-default items-center justify-center gap-2 text-nowrap text-sm text-muted-foreground transition-all duration-300 after:absolute after:left-[-0.75rem] after:z-[-1] after:h-[calc(100%+0.5rem)] after:w-[calc(100%+1.5rem)] after:rounded-sm after:bg-transparent after:content-[''] hover:text-foreground hover:after:bg-muted">
-            <span>
-              Version
-            </span>
-            <gui-arrow-up-down-icon size="16">
-            </gui-arrow-up-down-icon>
-          </button>
-        </div>
-        <div class="col-span-2 ml-1 w-full text-center">
-          <button class="relative z-[1] inline-flex w-fit cursor-default items-center justify-center gap-2 text-nowrap text-sm text-muted-foreground transition-all duration-300 after:absolute after:left-[-0.75rem] after:z-[-1] after:h-[calc(100%+0.5rem)] after:w-[calc(100%+1.5rem)] after:rounded-sm after:bg-transparent after:content-[''] hover:text-foreground hover:after:bg-muted">
-            <span>
-              Size
-            </span>
-            <gui-arrow-up-down-icon size="16">
-            </gui-arrow-up-down-icon>
-          </button>
-        </div>
-        <div class="col-span-3 w-full text-center">
-          <button class="relative z-[1] inline-flex w-fit cursor-default items-center justify-center gap-2 text-nowrap text-sm text-muted-foreground transition-all duration-300 after:absolute after:left-[-0.75rem] after:z-[-1] after:h-[calc(100%+0.5rem)] after:w-[calc(100%+1.5rem)] after:rounded-sm after:bg-transparent after:content-[''] hover:text-foreground hover:after:bg-muted">
-            <span>
-              Published Date
-            </span>
-            <gui-arrow-up-down-icon size="16">
-            </gui-arrow-up-down-icon>
-          </button>
-        </div>
-        <div class="col-span-2 w-full text-center">
-          <button class="relative z-[1] inline-flex w-fit cursor-default items-center justify-center gap-2 text-nowrap text-sm text-muted-foreground transition-all duration-300 after:absolute after:left-[-0.75rem] after:z-[-1] after:h-[calc(100%+0.5rem)] after:w-[calc(100%+1.5rem)] after:rounded-sm after:bg-transparent after:content-[''] hover:text-foreground hover:after:bg-muted">
-            <span>
-              Downloads
-            </span>
-            <gui-arrow-up-down-icon size="16">
-            </gui-arrow-up-down-icon>
-          </button>
-        </div>
-        <div class="col-span-3 flex w-full items-center justify-center text-center">
-          <button class="relative z-[1] inline-flex w-fit cursor-default items-center justify-center gap-2 text-nowrap text-sm text-muted-foreground transition-all duration-300 after:absolute after:left-[-0.75rem] after:z-[-1] after:h-[calc(100%+0.5rem)] after:w-[calc(100%+1.5rem)] after:rounded-sm after:bg-transparent after:content-[''] hover:text-foreground hover:after:bg-muted">
-            <span>
-              Publisher
-            </span>
-            <gui-arrow-up-down-icon size="16">
-            </gui-arrow-up-down-icon>
-          </button>
-        </div>
-      </div>
-      <div class="flex flex-col divide-y-[1px] divide-muted overflow-hidden">
-        <div>
-          <div class="group/item flex cursor-default grid-cols-12 flex-col gap-3 rounded-sm py-4 text-foreground transition-colors first:border-t-[0px] xl:grid xl:gap-3 xl:px-2 xl:py-1.5 xl:hover:bg-muted">
-            <div class="order-1 col-span-2 flex w-full flex-col justify-center gap-1 xl:justify-center xl:gap-0">
-              <p class="text-sm font-medium text-muted-foreground xl:hidden">
-                Version
-              </p>
-              <gui-data-badge
-                variant="mono"
-                tooltip="[object Object]"
-                classnames="[object Object]"
-                content="2.0.0-beta.1"
+    <div>
+      <div class="mt-2 flex flex-col gap-2 overflow-hidden">
+        <div class="hidden cursor-default grid-cols-12 gap-3 xl:grid">
+          <div class="col-span-2 flex w-full items-center justify-start">
+            <button class="duration-250 inline-flex cursor-default items-center justify-center gap-2 text-nowrap rounded-sm px-2 py-1 text-sm text-muted-foreground transition-all hover:bg-secondary hover:text-foreground [&amp;>svg]:size-4">
+              <gui-arrow-up-down-icon>
+              </gui-arrow-up-down-icon>
+              <span>
+                Versions
+              </span>
+              <gui-number-flow
+                start="2"
+                end="2"
+                motionconfig="[object Object]"
               >
-              </gui-data-badge>
-            </div>
-            <div class="order-2 col-span-2 flex w-full flex-col gap-2 xl:items-center xl:justify-center xl:gap-0 xl:text-center">
-              <p class="text-sm font-medium text-muted-foreground xl:hidden">
+              </gui-number-flow>
+            </button>
+          </div>
+          <div class="col-span-2 ml-1 flex w-full items-center justify-end text-center">
+            <button class="duration-250 inline-flex cursor-default items-center justify-center gap-2 text-nowrap rounded-sm px-2 py-1 text-sm text-muted-foreground transition-all hover:bg-secondary hover:text-foreground [&amp;>svg]:size-4">
+              <gui-arrow-up-down-icon>
+              </gui-arrow-up-down-icon>
+              <span>
                 Size
-              </p>
-              <p class="font-mono text-sm">
-                121 KB
-              </p>
-            </div>
-            <div class="order-4 col-span-3 flex w-full flex-col gap-2 xl:order-3 xl:items-center xl:justify-center xl:gap-0 xl:text-center">
-              <p class="text-sm font-medium text-muted-foreground xl:hidden">
+              </span>
+            </button>
+          </div>
+          <div class="col-span-3 w-full text-center">
+            <button class="duration-250 inline-flex cursor-default items-center justify-center gap-2 text-nowrap rounded-sm px-2 py-1 text-sm text-muted-foreground transition-all hover:bg-secondary hover:text-foreground [&amp;>svg]:size-4">
+              <gui-arrow-up-down-icon>
+              </gui-arrow-up-down-icon>
+              <span>
                 Published Date
-              </p>
-              <div class="flex gap-2 xl:hidden">
-                <gui-avatar classname="size-5">
-                  <gui-avatar-image
-                    classname="rounded-sm outline outline-[1px] outline-border"
-                    src="https://example.com/avatar.jpg"
-                  >
-                  </gui-avatar-image>
-                  <gui-avatar-fallback classname="h-5 h-full w-5 w-full rounded-sm bg-secondary bg-gradient-to-t from-neutral-100 to-neutral-400 px-[10px] outline outline-[1px] outline-border dark:from-neutral-500 dark:to-neutral-800">
-                  </gui-avatar-fallback>
-                </gui-avatar>
-                <p class="col-span-4 font-mono text-sm">
-                  John Doe
+              </span>
+            </button>
+          </div>
+          <div class="col-span-2 w-full text-center">
+            <button class="duration-250 inline-flex cursor-default items-center justify-center gap-2 text-nowrap rounded-sm px-2 py-1 text-sm text-muted-foreground transition-all hover:bg-secondary hover:text-foreground [&amp;>svg]:size-4">
+              <gui-arrow-up-down-icon>
+              </gui-arrow-up-down-icon>
+              <span>
+                Downloads
+              </span>
+            </button>
+          </div>
+          <div class="col-span-3 flex w-full items-center justify-center text-center">
+            <button class="duration-250 inline-flex cursor-default items-center justify-center gap-2 text-nowrap rounded-sm px-2 py-1 text-sm text-muted-foreground transition-all hover:bg-secondary hover:text-foreground [&amp;>svg]:size-4">
+              <gui-arrow-up-down-icon>
+              </gui-arrow-up-down-icon>
+              <span>
+                Publisher
+              </span>
+            </button>
+          </div>
+        </div>
+        <div class="flex flex-col divide-y-[1px] divide-muted overflow-hidden">
+          <div>
+            <div class="group/item flex cursor-default grid-cols-12 flex-col gap-3 rounded-sm py-4 text-foreground first:border-t-[0px] xl:grid xl:gap-3 xl:py-1.5">
+              <div class="order-1 col-span-2 flex w-full flex-col justify-center gap-1 xl:justify-center xl:gap-0">
+                <p class="text-sm font-medium text-muted-foreground xl:hidden">
+                  Version
                 </p>
-                <p class="ml-2 inline-flex font-mono text-sm text-muted-foreground xl:hidden">
-                  1 day ago
+                <gui-data-badge
+                  variant="mono"
+                  tooltip="[object Object]"
+                  classnames="[object Object]"
+                  content="2.0.0-beta.1"
+                >
+                </gui-data-badge>
+              </div>
+              <div class="order-2 col-span-2 flex w-full flex-col gap-2 xl:items-end xl:justify-center xl:gap-0 xl:text-center">
+                <p class="text-sm font-medium text-muted-foreground xl:hidden">
+                  Size
+                </p>
+                <p class="font-mono text-sm">
+                  121 KB
                 </p>
               </div>
-              <gui-tooltip-provider>
-                <gui-tooltip>
-                  <gui-tooltip-trigger classname="hidden cursor-default font-mono text-sm xl:inline-flex">
+              <div class="order-4 col-span-3 flex w-full flex-col gap-2 xl:order-3 xl:items-center xl:justify-center xl:gap-0 xl:text-center">
+                <p class="text-sm font-medium text-muted-foreground xl:hidden">
+                  Published Date
+                </p>
+                <div class="flex gap-2 xl:hidden">
+                  <gui-avatar classname="size-5">
+                    <gui-avatar-image
+                      classname="rounded-sm outline outline-[1px] outline-border"
+                      src="https://example.com/avatar.jpg"
+                    >
+                    </gui-avatar-image>
+                    <gui-avatar-fallback classname="h-5 h-full w-5 w-full rounded-sm bg-secondary bg-gradient-to-t from-neutral-100 to-neutral-400 px-[10px] outline outline-[1px] outline-border dark:from-neutral-500 dark:to-neutral-800">
+                    </gui-avatar-fallback>
+                  </gui-avatar>
+                  <p class="col-span-4 font-mono text-sm">
+                    John Doe
+                  </p>
+                  <p class="ml-2 inline-flex font-mono text-sm text-muted-foreground xl:hidden">
                     1 day ago
-                  </gui-tooltip-trigger>
-                  <gui-tooltip-content>
-                    2025-04-15
-                  </gui-tooltip-content>
-                </gui-tooltip>
-              </gui-tooltip-provider>
-            </div>
-            <div class="order-3 col-span-2 w-full flex-col justify-start gap-2 xl:items-center xl:justify-center xl:gap-0 xl:text-center hidden xl:flex">
-            </div>
-            <div class="order-3 col-span-3 flex hidden w-full items-center justify-center xl:order-4 xl:flex">
-              <div class="flex w-full items-center justify-center gap-2">
-                <gui-avatar classname="flex size-5 items-center justify-center">
-                  <gui-avatar-image
-                    classname="rounded-sm outline outline-[1px] outline-border"
-                    src="https://example.com/avatar.jpg"
-                  >
-                  </gui-avatar-image>
-                  <gui-avatar-fallback classname="h-full w-full rounded-sm bg-secondary bg-gradient-to-t from-neutral-100 to-neutral-400 px-[10px] outline outline-[1px] outline-border dark:from-neutral-500 dark:to-neutral-800">
-                  </gui-avatar-fallback>
-                </gui-avatar>
+                  </p>
+                </div>
                 <gui-tooltip-provider>
-                  <gui-tooltip delayduration="150">
-                    <gui-tooltip-trigger classname="cursor-default">
-                      <p class="truncate font-mono text-sm">
-                        John Doe
-                      </p>
+                  <gui-tooltip>
+                    <gui-tooltip-trigger classname="hidden cursor-default font-mono text-sm xl:inline-flex">
+                      1 day ago
                     </gui-tooltip-trigger>
                     <gui-tooltip-content>
-                      John Doe
+                      2025-04-15
                     </gui-tooltip-content>
                   </gui-tooltip>
                 </gui-tooltip-provider>
+              </div>
+              <div class="order-3 col-span-2 w-full flex-col justify-start gap-2 xl:items-center xl:justify-center xl:gap-0 xl:text-center hidden xl:flex">
+              </div>
+              <div class="order-3 col-span-3 flex hidden w-full items-center justify-center xl:order-4 xl:flex">
+                <div class="flex w-full items-center justify-center gap-2">
+                  <gui-avatar classname="flex size-5 items-center justify-center">
+                    <gui-avatar-image
+                      classname="rounded-sm outline outline-[1px] outline-border"
+                      src="https://example.com/avatar.jpg"
+                    >
+                    </gui-avatar-image>
+                    <gui-avatar-fallback classname="h-full w-full rounded-sm bg-secondary bg-gradient-to-t from-neutral-100 to-neutral-400 px-[10px] outline outline-[1px] outline-border dark:from-neutral-500 dark:to-neutral-800">
+                    </gui-avatar-fallback>
+                  </gui-avatar>
+                  <gui-tooltip-provider>
+                    <gui-tooltip delayduration="150">
+                      <gui-tooltip-trigger classname="cursor-default">
+                        <p class="truncate font-mono text-sm">
+                          John Doe
+                        </p>
+                      </gui-tooltip-trigger>
+                      <gui-tooltip-content>
+                        John Doe
+                      </gui-tooltip-content>
+                    </gui-tooltip>
+                  </gui-tooltip-provider>
+                </div>
               </div>
             </div>
           </div>
-        </div>
-        <div>
-          <div class="group/item flex cursor-default grid-cols-12 flex-col gap-3 rounded-sm py-4 text-foreground transition-colors first:border-t-[0px] xl:grid xl:gap-3 xl:px-2 xl:py-1.5 xl:hover:bg-muted">
-            <div class="order-1 col-span-2 flex w-full flex-col justify-center gap-1 xl:justify-center xl:gap-0">
-              <p class="text-sm font-medium text-muted-foreground xl:hidden">
-                Version
-              </p>
-              <gui-data-badge
-                variant="mono"
-                tooltip="[object Object]"
-                classnames="[object Object]"
-                content="1.0.0"
-              >
-              </gui-data-badge>
-            </div>
-            <div class="order-2 col-span-2 flex w-full flex-col gap-2 xl:items-center xl:justify-center xl:gap-0 xl:text-center">
-              <p class="text-sm font-medium text-muted-foreground xl:hidden">
-                Size
-              </p>
-              <p class="font-mono text-sm">
-                121 KB
-              </p>
-            </div>
-            <div class="order-4 col-span-3 flex w-full flex-col gap-2 xl:order-3 xl:items-center xl:justify-center xl:gap-0 xl:text-center">
-              <p class="text-sm font-medium text-muted-foreground xl:hidden">
-                Published Date
-              </p>
-              <div class="flex gap-2 xl:hidden">
-                <gui-avatar classname="size-5">
-                  <gui-avatar-image
-                    classname="rounded-sm outline outline-[1px] outline-border"
-                    src="https://example.com/avatar.jpg"
-                  >
-                  </gui-avatar-image>
-                  <gui-avatar-fallback classname="h-5 h-full w-5 w-full rounded-sm bg-secondary bg-gradient-to-t from-neutral-100 to-neutral-400 px-[10px] outline outline-[1px] outline-border dark:from-neutral-500 dark:to-neutral-800">
-                  </gui-avatar-fallback>
-                </gui-avatar>
-                <p class="col-span-4 font-mono text-sm">
-                  John Doe
+          <div>
+            <div class="group/item flex cursor-default grid-cols-12 flex-col gap-3 rounded-sm py-4 text-foreground first:border-t-[0px] xl:grid xl:gap-3 xl:py-1.5">
+              <div class="order-1 col-span-2 flex w-full flex-col justify-center gap-1 xl:justify-center xl:gap-0">
+                <p class="text-sm font-medium text-muted-foreground xl:hidden">
+                  Version
                 </p>
-                <p class="ml-2 inline-flex font-mono text-sm text-muted-foreground xl:hidden">
-                  1 day ago
+                <gui-data-badge
+                  variant="mono"
+                  tooltip="[object Object]"
+                  classnames="[object Object]"
+                  content="1.0.0"
+                >
+                </gui-data-badge>
+              </div>
+              <div class="order-2 col-span-2 flex w-full flex-col gap-2 xl:items-end xl:justify-center xl:gap-0 xl:text-center">
+                <p class="text-sm font-medium text-muted-foreground xl:hidden">
+                  Size
+                </p>
+                <p class="font-mono text-sm">
+                  121 KB
                 </p>
               </div>
-              <gui-tooltip-provider>
-                <gui-tooltip>
-                  <gui-tooltip-trigger classname="hidden cursor-default font-mono text-sm xl:inline-flex">
+              <div class="order-4 col-span-3 flex w-full flex-col gap-2 xl:order-3 xl:items-center xl:justify-center xl:gap-0 xl:text-center">
+                <p class="text-sm font-medium text-muted-foreground xl:hidden">
+                  Published Date
+                </p>
+                <div class="flex gap-2 xl:hidden">
+                  <gui-avatar classname="size-5">
+                    <gui-avatar-image
+                      classname="rounded-sm outline outline-[1px] outline-border"
+                      src="https://example.com/avatar.jpg"
+                    >
+                    </gui-avatar-image>
+                    <gui-avatar-fallback classname="h-5 h-full w-5 w-full rounded-sm bg-secondary bg-gradient-to-t from-neutral-100 to-neutral-400 px-[10px] outline outline-[1px] outline-border dark:from-neutral-500 dark:to-neutral-800">
+                    </gui-avatar-fallback>
+                  </gui-avatar>
+                  <p class="col-span-4 font-mono text-sm">
+                    John Doe
+                  </p>
+                  <p class="ml-2 inline-flex font-mono text-sm text-muted-foreground xl:hidden">
                     1 day ago
-                  </gui-tooltip-trigger>
-                  <gui-tooltip-content>
-                    2025-04-15
-                  </gui-tooltip-content>
-                </gui-tooltip>
-              </gui-tooltip-provider>
-            </div>
-            <div class="order-3 col-span-2 w-full flex-col justify-start gap-2 xl:items-center xl:justify-center xl:gap-0 xl:text-center flex">
-              <p class="text-sm font-medium text-muted-foreground xl:hidden">
-                Downloads
-              </p>
-              <p class="font-mono text-sm">
-                123,456
-              </p>
-            </div>
-            <div class="order-3 col-span-3 flex hidden w-full items-center justify-center xl:order-4 xl:flex">
-              <div class="flex w-full items-center justify-center gap-2">
-                <gui-avatar classname="flex size-5 items-center justify-center">
-                  <gui-avatar-image
-                    classname="rounded-sm outline outline-[1px] outline-border"
-                    src="https://example.com/avatar.jpg"
-                  >
-                  </gui-avatar-image>
-                  <gui-avatar-fallback classname="h-full w-full rounded-sm bg-secondary bg-gradient-to-t from-neutral-100 to-neutral-400 px-[10px] outline outline-[1px] outline-border dark:from-neutral-500 dark:to-neutral-800">
-                  </gui-avatar-fallback>
-                </gui-avatar>
+                  </p>
+                </div>
                 <gui-tooltip-provider>
-                  <gui-tooltip delayduration="150">
-                    <gui-tooltip-trigger classname="cursor-default">
-                      <p class="truncate font-mono text-sm">
-                        John Doe
-                      </p>
+                  <gui-tooltip>
+                    <gui-tooltip-trigger classname="hidden cursor-default font-mono text-sm xl:inline-flex">
+                      1 day ago
                     </gui-tooltip-trigger>
                     <gui-tooltip-content>
-                      John Doe
+                      2025-04-15
                     </gui-tooltip-content>
                   </gui-tooltip>
                 </gui-tooltip-provider>
+              </div>
+              <div class="order-3 col-span-2 w-full flex-col justify-start gap-2 xl:items-center xl:justify-center xl:gap-0 xl:text-center flex">
+                <p class="text-sm font-medium text-muted-foreground xl:hidden">
+                  Downloads
+                </p>
+                <p class="font-mono text-sm">
+                  123,456
+                </p>
+              </div>
+              <div class="order-3 col-span-3 flex hidden w-full items-center justify-center xl:order-4 xl:flex">
+                <div class="flex w-full items-center justify-center gap-2">
+                  <gui-avatar classname="flex size-5 items-center justify-center">
+                    <gui-avatar-image
+                      classname="rounded-sm outline outline-[1px] outline-border"
+                      src="https://example.com/avatar.jpg"
+                    >
+                    </gui-avatar-image>
+                    <gui-avatar-fallback classname="h-full w-full rounded-sm bg-secondary bg-gradient-to-t from-neutral-100 to-neutral-400 px-[10px] outline outline-[1px] outline-border dark:from-neutral-500 dark:to-neutral-800">
+                    </gui-avatar-fallback>
+                  </gui-avatar>
+                  <gui-tooltip-provider>
+                    <gui-tooltip delayduration="150">
+                      <gui-tooltip-trigger classname="cursor-default">
+                        <p class="truncate font-mono text-sm">
+                          John Doe
+                        </p>
+                      </gui-tooltip-trigger>
+                      <gui-tooltip-content>
+                        John Doe
+                      </gui-tooltip-content>
+                    </gui-tooltip>
+                  </gui-tooltip-provider>
+                </div>
               </div>
             </div>
           </div>
@@ -689,7 +705,7 @@ exports[`VersionsTabContent filters pre-releases 1`] = `
 exports[`VersionsTabContent filters versions 1`] = `
 
 <gui-tabs-content value="versions">
-  <section class="flex flex-col gap-2 px-6 py-4">
+  <section class="flex flex-col px-6 py-4">
     <div class="mb-3 flex items-center gap-2">
       <div class="relative flex w-full items-center justify-start">
         <gui-search-icon
@@ -733,223 +749,231 @@ exports[`VersionsTabContent filters versions 1`] = `
         </gui-dropdown-menu-content>
       </gui-dropdown-menu>
     </div>
-    <div class="relative mt-2 flex flex-col gap-2">
-      <div class="hidden cursor-default grid-cols-12 gap-3 pb-2 xl:grid">
-        <div class="col-span-2 flex w-full items-center justify-center">
-          <button class="relative z-[1] inline-flex w-fit cursor-default items-center justify-center gap-2 text-nowrap text-sm text-muted-foreground transition-all duration-300 after:absolute after:left-[-0.75rem] after:z-[-1] after:h-[calc(100%+0.5rem)] after:w-[calc(100%+1.5rem)] after:rounded-sm after:bg-transparent after:content-[''] hover:text-foreground hover:after:bg-muted">
-            <span>
-              Version
-            </span>
-            <gui-arrow-up-down-icon size="16">
-            </gui-arrow-up-down-icon>
-          </button>
-        </div>
-        <div class="col-span-2 ml-1 w-full text-center">
-          <button class="relative z-[1] inline-flex w-fit cursor-default items-center justify-center gap-2 text-nowrap text-sm text-muted-foreground transition-all duration-300 after:absolute after:left-[-0.75rem] after:z-[-1] after:h-[calc(100%+0.5rem)] after:w-[calc(100%+1.5rem)] after:rounded-sm after:bg-transparent after:content-[''] hover:text-foreground hover:after:bg-muted">
-            <span>
-              Size
-            </span>
-            <gui-arrow-up-down-icon size="16">
-            </gui-arrow-up-down-icon>
-          </button>
-        </div>
-        <div class="col-span-3 w-full text-center">
-          <button class="relative z-[1] inline-flex w-fit cursor-default items-center justify-center gap-2 text-nowrap text-sm text-muted-foreground transition-all duration-300 after:absolute after:left-[-0.75rem] after:z-[-1] after:h-[calc(100%+0.5rem)] after:w-[calc(100%+1.5rem)] after:rounded-sm after:bg-transparent after:content-[''] hover:text-foreground hover:after:bg-muted">
-            <span>
-              Published Date
-            </span>
-            <gui-arrow-up-down-icon size="16">
-            </gui-arrow-up-down-icon>
-          </button>
-        </div>
-        <div class="col-span-2 w-full text-center">
-          <button class="relative z-[1] inline-flex w-fit cursor-default items-center justify-center gap-2 text-nowrap text-sm text-muted-foreground transition-all duration-300 after:absolute after:left-[-0.75rem] after:z-[-1] after:h-[calc(100%+0.5rem)] after:w-[calc(100%+1.5rem)] after:rounded-sm after:bg-transparent after:content-[''] hover:text-foreground hover:after:bg-muted">
-            <span>
-              Downloads
-            </span>
-            <gui-arrow-up-down-icon size="16">
-            </gui-arrow-up-down-icon>
-          </button>
-        </div>
-        <div class="col-span-3 flex w-full items-center justify-center text-center">
-          <button class="relative z-[1] inline-flex w-fit cursor-default items-center justify-center gap-2 text-nowrap text-sm text-muted-foreground transition-all duration-300 after:absolute after:left-[-0.75rem] after:z-[-1] after:h-[calc(100%+0.5rem)] after:w-[calc(100%+1.5rem)] after:rounded-sm after:bg-transparent after:content-[''] hover:text-foreground hover:after:bg-muted">
-            <span>
-              Publisher
-            </span>
-            <gui-arrow-up-down-icon size="16">
-            </gui-arrow-up-down-icon>
-          </button>
-        </div>
-      </div>
-      <div class="flex flex-col divide-y-[1px] divide-muted overflow-hidden">
-        <div>
-          <div class="group/item flex cursor-default grid-cols-12 flex-col gap-3 rounded-sm py-4 text-foreground transition-colors first:border-t-[0px] xl:grid xl:gap-3 xl:px-2 xl:py-1.5 xl:hover:bg-muted">
-            <div class="order-1 col-span-2 flex w-full flex-col justify-center gap-1 xl:justify-center xl:gap-0">
-              <p class="text-sm font-medium text-muted-foreground xl:hidden">
-                Version
-              </p>
-              <gui-data-badge
-                variant="mono"
-                tooltip="[object Object]"
-                classnames="[object Object]"
-                content="1.0.0"
+    <div>
+      <div class="mt-2 flex flex-col gap-2 overflow-hidden">
+        <div class="hidden cursor-default grid-cols-12 gap-3 xl:grid">
+          <div class="col-span-2 flex w-full items-center justify-start">
+            <button class="duration-250 inline-flex cursor-default items-center justify-center gap-2 text-nowrap rounded-sm px-2 py-1 text-sm text-muted-foreground transition-all hover:bg-secondary hover:text-foreground [&amp;>svg]:size-4">
+              <gui-arrow-up-down-icon>
+              </gui-arrow-up-down-icon>
+              <span>
+                Versions
+              </span>
+              <gui-number-flow
+                start="2"
+                end="2"
+                motionconfig="[object Object]"
               >
-              </gui-data-badge>
-            </div>
-            <div class="order-2 col-span-2 flex w-full flex-col gap-2 xl:items-center xl:justify-center xl:gap-0 xl:text-center">
-              <p class="text-sm font-medium text-muted-foreground xl:hidden">
+              </gui-number-flow>
+            </button>
+          </div>
+          <div class="col-span-2 ml-1 flex w-full items-center justify-end text-center">
+            <button class="duration-250 inline-flex cursor-default items-center justify-center gap-2 text-nowrap rounded-sm px-2 py-1 text-sm text-muted-foreground transition-all hover:bg-secondary hover:text-foreground [&amp;>svg]:size-4">
+              <gui-arrow-up-down-icon>
+              </gui-arrow-up-down-icon>
+              <span>
                 Size
-              </p>
-              <p class="font-mono text-sm">
-                121 KB
-              </p>
-            </div>
-            <div class="order-4 col-span-3 flex w-full flex-col gap-2 xl:order-3 xl:items-center xl:justify-center xl:gap-0 xl:text-center">
-              <p class="text-sm font-medium text-muted-foreground xl:hidden">
+              </span>
+            </button>
+          </div>
+          <div class="col-span-3 w-full text-center">
+            <button class="duration-250 inline-flex cursor-default items-center justify-center gap-2 text-nowrap rounded-sm px-2 py-1 text-sm text-muted-foreground transition-all hover:bg-secondary hover:text-foreground [&amp;>svg]:size-4">
+              <gui-arrow-up-down-icon>
+              </gui-arrow-up-down-icon>
+              <span>
                 Published Date
-              </p>
-              <div class="flex gap-2 xl:hidden">
-                <gui-avatar classname="size-5">
-                  <gui-avatar-image
-                    classname="rounded-sm outline outline-[1px] outline-border"
-                    src="https://example.com/avatar.jpg"
-                  >
-                  </gui-avatar-image>
-                  <gui-avatar-fallback classname="h-5 h-full w-5 w-full rounded-sm bg-secondary bg-gradient-to-t from-neutral-100 to-neutral-400 px-[10px] outline outline-[1px] outline-border dark:from-neutral-500 dark:to-neutral-800">
-                  </gui-avatar-fallback>
-                </gui-avatar>
-                <p class="col-span-4 font-mono text-sm">
-                  John Doe
+              </span>
+            </button>
+          </div>
+          <div class="col-span-2 w-full text-center">
+            <button class="duration-250 inline-flex cursor-default items-center justify-center gap-2 text-nowrap rounded-sm px-2 py-1 text-sm text-muted-foreground transition-all hover:bg-secondary hover:text-foreground [&amp;>svg]:size-4">
+              <gui-arrow-up-down-icon>
+              </gui-arrow-up-down-icon>
+              <span>
+                Downloads
+              </span>
+            </button>
+          </div>
+          <div class="col-span-3 flex w-full items-center justify-center text-center">
+            <button class="duration-250 inline-flex cursor-default items-center justify-center gap-2 text-nowrap rounded-sm px-2 py-1 text-sm text-muted-foreground transition-all hover:bg-secondary hover:text-foreground [&amp;>svg]:size-4">
+              <gui-arrow-up-down-icon>
+              </gui-arrow-up-down-icon>
+              <span>
+                Publisher
+              </span>
+            </button>
+          </div>
+        </div>
+        <div class="flex flex-col divide-y-[1px] divide-muted overflow-hidden">
+          <div>
+            <div class="group/item flex cursor-default grid-cols-12 flex-col gap-3 rounded-sm py-4 text-foreground first:border-t-[0px] xl:grid xl:gap-3 xl:py-1.5">
+              <div class="order-1 col-span-2 flex w-full flex-col justify-center gap-1 xl:justify-center xl:gap-0">
+                <p class="text-sm font-medium text-muted-foreground xl:hidden">
+                  Version
                 </p>
-                <p class="ml-2 inline-flex font-mono text-sm text-muted-foreground xl:hidden">
-                  1 day ago
+                <gui-data-badge
+                  variant="mono"
+                  tooltip="[object Object]"
+                  classnames="[object Object]"
+                  content="1.0.0"
+                >
+                </gui-data-badge>
+              </div>
+              <div class="order-2 col-span-2 flex w-full flex-col gap-2 xl:items-end xl:justify-center xl:gap-0 xl:text-center">
+                <p class="text-sm font-medium text-muted-foreground xl:hidden">
+                  Size
+                </p>
+                <p class="font-mono text-sm">
+                  121 KB
                 </p>
               </div>
-              <gui-tooltip-provider>
-                <gui-tooltip>
-                  <gui-tooltip-trigger classname="hidden cursor-default font-mono text-sm xl:inline-flex">
+              <div class="order-4 col-span-3 flex w-full flex-col gap-2 xl:order-3 xl:items-center xl:justify-center xl:gap-0 xl:text-center">
+                <p class="text-sm font-medium text-muted-foreground xl:hidden">
+                  Published Date
+                </p>
+                <div class="flex gap-2 xl:hidden">
+                  <gui-avatar classname="size-5">
+                    <gui-avatar-image
+                      classname="rounded-sm outline outline-[1px] outline-border"
+                      src="https://example.com/avatar.jpg"
+                    >
+                    </gui-avatar-image>
+                    <gui-avatar-fallback classname="h-5 h-full w-5 w-full rounded-sm bg-secondary bg-gradient-to-t from-neutral-100 to-neutral-400 px-[10px] outline outline-[1px] outline-border dark:from-neutral-500 dark:to-neutral-800">
+                    </gui-avatar-fallback>
+                  </gui-avatar>
+                  <p class="col-span-4 font-mono text-sm">
+                    John Doe
+                  </p>
+                  <p class="ml-2 inline-flex font-mono text-sm text-muted-foreground xl:hidden">
                     1 day ago
-                  </gui-tooltip-trigger>
-                  <gui-tooltip-content>
-                    2025-04-15
-                  </gui-tooltip-content>
-                </gui-tooltip>
-              </gui-tooltip-provider>
-            </div>
-            <div class="order-3 col-span-2 w-full flex-col justify-start gap-2 xl:items-center xl:justify-center xl:gap-0 xl:text-center flex">
-              <p class="text-sm font-medium text-muted-foreground xl:hidden">
-                Downloads
-              </p>
-              <p class="font-mono text-sm">
-                123,456
-              </p>
-            </div>
-            <div class="order-3 col-span-3 flex hidden w-full items-center justify-center xl:order-4 xl:flex">
-              <div class="flex w-full items-center justify-center gap-2">
-                <gui-avatar classname="flex size-5 items-center justify-center">
-                  <gui-avatar-image
-                    classname="rounded-sm outline outline-[1px] outline-border"
-                    src="https://example.com/avatar.jpg"
-                  >
-                  </gui-avatar-image>
-                  <gui-avatar-fallback classname="h-full w-full rounded-sm bg-secondary bg-gradient-to-t from-neutral-100 to-neutral-400 px-[10px] outline outline-[1px] outline-border dark:from-neutral-500 dark:to-neutral-800">
-                  </gui-avatar-fallback>
-                </gui-avatar>
+                  </p>
+                </div>
                 <gui-tooltip-provider>
-                  <gui-tooltip delayduration="150">
-                    <gui-tooltip-trigger classname="cursor-default">
-                      <p class="truncate font-mono text-sm">
-                        John Doe
-                      </p>
+                  <gui-tooltip>
+                    <gui-tooltip-trigger classname="hidden cursor-default font-mono text-sm xl:inline-flex">
+                      1 day ago
                     </gui-tooltip-trigger>
                     <gui-tooltip-content>
-                      John Doe
+                      2025-04-15
                     </gui-tooltip-content>
                   </gui-tooltip>
                 </gui-tooltip-provider>
+              </div>
+              <div class="order-3 col-span-2 w-full flex-col justify-start gap-2 xl:items-center xl:justify-center xl:gap-0 xl:text-center flex">
+                <p class="text-sm font-medium text-muted-foreground xl:hidden">
+                  Downloads
+                </p>
+                <p class="font-mono text-sm">
+                  123,456
+                </p>
+              </div>
+              <div class="order-3 col-span-3 flex hidden w-full items-center justify-center xl:order-4 xl:flex">
+                <div class="flex w-full items-center justify-center gap-2">
+                  <gui-avatar classname="flex size-5 items-center justify-center">
+                    <gui-avatar-image
+                      classname="rounded-sm outline outline-[1px] outline-border"
+                      src="https://example.com/avatar.jpg"
+                    >
+                    </gui-avatar-image>
+                    <gui-avatar-fallback classname="h-full w-full rounded-sm bg-secondary bg-gradient-to-t from-neutral-100 to-neutral-400 px-[10px] outline outline-[1px] outline-border dark:from-neutral-500 dark:to-neutral-800">
+                    </gui-avatar-fallback>
+                  </gui-avatar>
+                  <gui-tooltip-provider>
+                    <gui-tooltip delayduration="150">
+                      <gui-tooltip-trigger classname="cursor-default">
+                        <p class="truncate font-mono text-sm">
+                          John Doe
+                        </p>
+                      </gui-tooltip-trigger>
+                      <gui-tooltip-content>
+                        John Doe
+                      </gui-tooltip-content>
+                    </gui-tooltip>
+                  </gui-tooltip-provider>
+                </div>
               </div>
             </div>
           </div>
-        </div>
-        <div>
-          <div class="group/item flex cursor-default grid-cols-12 flex-col gap-3 rounded-sm py-4 text-foreground transition-colors first:border-t-[0px] xl:grid xl:gap-3 xl:px-2 xl:py-1.5 xl:hover:bg-muted">
-            <div class="order-1 col-span-2 flex w-full flex-col justify-center gap-1 xl:justify-center xl:gap-0">
-              <p class="text-sm font-medium text-muted-foreground xl:hidden">
-                Version
-              </p>
-              <gui-data-badge
-                variant="mono"
-                tooltip="[object Object]"
-                classnames="[object Object]"
-                content="2.0.0-beta.1"
-              >
-              </gui-data-badge>
-            </div>
-            <div class="order-2 col-span-2 flex w-full flex-col gap-2 xl:items-center xl:justify-center xl:gap-0 xl:text-center">
-              <p class="text-sm font-medium text-muted-foreground xl:hidden">
-                Size
-              </p>
-              <p class="font-mono text-sm">
-                121 KB
-              </p>
-            </div>
-            <div class="order-4 col-span-3 flex w-full flex-col gap-2 xl:order-3 xl:items-center xl:justify-center xl:gap-0 xl:text-center">
-              <p class="text-sm font-medium text-muted-foreground xl:hidden">
-                Published Date
-              </p>
-              <div class="flex gap-2 xl:hidden">
-                <gui-avatar classname="size-5">
-                  <gui-avatar-image
-                    classname="rounded-sm outline outline-[1px] outline-border"
-                    src="https://example.com/avatar.jpg"
-                  >
-                  </gui-avatar-image>
-                  <gui-avatar-fallback classname="h-5 h-full w-5 w-full rounded-sm bg-secondary bg-gradient-to-t from-neutral-100 to-neutral-400 px-[10px] outline outline-[1px] outline-border dark:from-neutral-500 dark:to-neutral-800">
-                  </gui-avatar-fallback>
-                </gui-avatar>
-                <p class="col-span-4 font-mono text-sm">
-                  John Doe
+          <div>
+            <div class="group/item flex cursor-default grid-cols-12 flex-col gap-3 rounded-sm py-4 text-foreground first:border-t-[0px] xl:grid xl:gap-3 xl:py-1.5">
+              <div class="order-1 col-span-2 flex w-full flex-col justify-center gap-1 xl:justify-center xl:gap-0">
+                <p class="text-sm font-medium text-muted-foreground xl:hidden">
+                  Version
                 </p>
-                <p class="ml-2 inline-flex font-mono text-sm text-muted-foreground xl:hidden">
-                  1 day ago
+                <gui-data-badge
+                  variant="mono"
+                  tooltip="[object Object]"
+                  classnames="[object Object]"
+                  content="2.0.0-beta.1"
+                >
+                </gui-data-badge>
+              </div>
+              <div class="order-2 col-span-2 flex w-full flex-col gap-2 xl:items-end xl:justify-center xl:gap-0 xl:text-center">
+                <p class="text-sm font-medium text-muted-foreground xl:hidden">
+                  Size
+                </p>
+                <p class="font-mono text-sm">
+                  121 KB
                 </p>
               </div>
-              <gui-tooltip-provider>
-                <gui-tooltip>
-                  <gui-tooltip-trigger classname="hidden cursor-default font-mono text-sm xl:inline-flex">
+              <div class="order-4 col-span-3 flex w-full flex-col gap-2 xl:order-3 xl:items-center xl:justify-center xl:gap-0 xl:text-center">
+                <p class="text-sm font-medium text-muted-foreground xl:hidden">
+                  Published Date
+                </p>
+                <div class="flex gap-2 xl:hidden">
+                  <gui-avatar classname="size-5">
+                    <gui-avatar-image
+                      classname="rounded-sm outline outline-[1px] outline-border"
+                      src="https://example.com/avatar.jpg"
+                    >
+                    </gui-avatar-image>
+                    <gui-avatar-fallback classname="h-5 h-full w-5 w-full rounded-sm bg-secondary bg-gradient-to-t from-neutral-100 to-neutral-400 px-[10px] outline outline-[1px] outline-border dark:from-neutral-500 dark:to-neutral-800">
+                    </gui-avatar-fallback>
+                  </gui-avatar>
+                  <p class="col-span-4 font-mono text-sm">
+                    John Doe
+                  </p>
+                  <p class="ml-2 inline-flex font-mono text-sm text-muted-foreground xl:hidden">
                     1 day ago
-                  </gui-tooltip-trigger>
-                  <gui-tooltip-content>
-                    2025-04-15
-                  </gui-tooltip-content>
-                </gui-tooltip>
-              </gui-tooltip-provider>
-            </div>
-            <div class="order-3 col-span-2 w-full flex-col justify-start gap-2 xl:items-center xl:justify-center xl:gap-0 xl:text-center hidden xl:flex">
-            </div>
-            <div class="order-3 col-span-3 flex hidden w-full items-center justify-center xl:order-4 xl:flex">
-              <div class="flex w-full items-center justify-center gap-2">
-                <gui-avatar classname="flex size-5 items-center justify-center">
-                  <gui-avatar-image
-                    classname="rounded-sm outline outline-[1px] outline-border"
-                    src="https://example.com/avatar.jpg"
-                  >
-                  </gui-avatar-image>
-                  <gui-avatar-fallback classname="h-full w-full rounded-sm bg-secondary bg-gradient-to-t from-neutral-100 to-neutral-400 px-[10px] outline outline-[1px] outline-border dark:from-neutral-500 dark:to-neutral-800">
-                  </gui-avatar-fallback>
-                </gui-avatar>
+                  </p>
+                </div>
                 <gui-tooltip-provider>
-                  <gui-tooltip delayduration="150">
-                    <gui-tooltip-trigger classname="cursor-default">
-                      <p class="truncate font-mono text-sm">
-                        John Doe
-                      </p>
+                  <gui-tooltip>
+                    <gui-tooltip-trigger classname="hidden cursor-default font-mono text-sm xl:inline-flex">
+                      1 day ago
                     </gui-tooltip-trigger>
                     <gui-tooltip-content>
-                      John Doe
+                      2025-04-15
                     </gui-tooltip-content>
                   </gui-tooltip>
                 </gui-tooltip-provider>
+              </div>
+              <div class="order-3 col-span-2 w-full flex-col justify-start gap-2 xl:items-center xl:justify-center xl:gap-0 xl:text-center hidden xl:flex">
+              </div>
+              <div class="order-3 col-span-3 flex hidden w-full items-center justify-center xl:order-4 xl:flex">
+                <div class="flex w-full items-center justify-center gap-2">
+                  <gui-avatar classname="flex size-5 items-center justify-center">
+                    <gui-avatar-image
+                      classname="rounded-sm outline outline-[1px] outline-border"
+                      src="https://example.com/avatar.jpg"
+                    >
+                    </gui-avatar-image>
+                    <gui-avatar-fallback classname="h-full w-full rounded-sm bg-secondary bg-gradient-to-t from-neutral-100 to-neutral-400 px-[10px] outline outline-[1px] outline-border dark:from-neutral-500 dark:to-neutral-800">
+                    </gui-avatar-fallback>
+                  </gui-avatar>
+                  <gui-tooltip-provider>
+                    <gui-tooltip delayduration="150">
+                      <gui-tooltip-trigger classname="cursor-default">
+                        <p class="truncate font-mono text-sm">
+                          John Doe
+                        </p>
+                      </gui-tooltip-trigger>
+                      <gui-tooltip-content>
+                        John Doe
+                      </gui-tooltip-content>
+                    </gui-tooltip>
+                  </gui-tooltip-provider>
+                </div>
               </div>
             </div>
           </div>
@@ -964,7 +988,7 @@ exports[`VersionsTabContent filters versions 1`] = `
 exports[`VersionsTabContent handles missing manifest version 1`] = `
 
 <gui-tabs-content value="versions">
-  <section class="flex flex-col gap-2 px-6 py-4">
+  <section class="flex flex-col px-6 py-4">
     <div class="mb-3 flex items-center gap-2">
       <div class="relative flex w-full items-center justify-start">
         <gui-search-icon
@@ -1008,223 +1032,231 @@ exports[`VersionsTabContent handles missing manifest version 1`] = `
         </gui-dropdown-menu-content>
       </gui-dropdown-menu>
     </div>
-    <div class="relative mt-2 flex flex-col gap-2">
-      <div class="hidden cursor-default grid-cols-12 gap-3 pb-2 xl:grid">
-        <div class="col-span-2 flex w-full items-center justify-center">
-          <button class="relative z-[1] inline-flex w-fit cursor-default items-center justify-center gap-2 text-nowrap text-sm text-muted-foreground transition-all duration-300 after:absolute after:left-[-0.75rem] after:z-[-1] after:h-[calc(100%+0.5rem)] after:w-[calc(100%+1.5rem)] after:rounded-sm after:bg-transparent after:content-[''] hover:text-foreground hover:after:bg-muted">
-            <span>
-              Version
-            </span>
-            <gui-arrow-up-down-icon size="16">
-            </gui-arrow-up-down-icon>
-          </button>
-        </div>
-        <div class="col-span-2 ml-1 w-full text-center">
-          <button class="relative z-[1] inline-flex w-fit cursor-default items-center justify-center gap-2 text-nowrap text-sm text-muted-foreground transition-all duration-300 after:absolute after:left-[-0.75rem] after:z-[-1] after:h-[calc(100%+0.5rem)] after:w-[calc(100%+1.5rem)] after:rounded-sm after:bg-transparent after:content-[''] hover:text-foreground hover:after:bg-muted">
-            <span>
-              Size
-            </span>
-            <gui-arrow-up-down-icon size="16">
-            </gui-arrow-up-down-icon>
-          </button>
-        </div>
-        <div class="col-span-3 w-full text-center">
-          <button class="relative z-[1] inline-flex w-fit cursor-default items-center justify-center gap-2 text-nowrap text-sm text-muted-foreground transition-all duration-300 after:absolute after:left-[-0.75rem] after:z-[-1] after:h-[calc(100%+0.5rem)] after:w-[calc(100%+1.5rem)] after:rounded-sm after:bg-transparent after:content-[''] hover:text-foreground hover:after:bg-muted">
-            <span>
-              Published Date
-            </span>
-            <gui-arrow-up-down-icon size="16">
-            </gui-arrow-up-down-icon>
-          </button>
-        </div>
-        <div class="col-span-2 w-full text-center">
-          <button class="relative z-[1] inline-flex w-fit cursor-default items-center justify-center gap-2 text-nowrap text-sm text-muted-foreground transition-all duration-300 after:absolute after:left-[-0.75rem] after:z-[-1] after:h-[calc(100%+0.5rem)] after:w-[calc(100%+1.5rem)] after:rounded-sm after:bg-transparent after:content-[''] hover:text-foreground hover:after:bg-muted">
-            <span>
-              Downloads
-            </span>
-            <gui-arrow-up-down-icon size="16">
-            </gui-arrow-up-down-icon>
-          </button>
-        </div>
-        <div class="col-span-3 flex w-full items-center justify-center text-center">
-          <button class="relative z-[1] inline-flex w-fit cursor-default items-center justify-center gap-2 text-nowrap text-sm text-muted-foreground transition-all duration-300 after:absolute after:left-[-0.75rem] after:z-[-1] after:h-[calc(100%+0.5rem)] after:w-[calc(100%+1.5rem)] after:rounded-sm after:bg-transparent after:content-[''] hover:text-foreground hover:after:bg-muted">
-            <span>
-              Publisher
-            </span>
-            <gui-arrow-up-down-icon size="16">
-            </gui-arrow-up-down-icon>
-          </button>
-        </div>
-      </div>
-      <div class="flex flex-col divide-y-[1px] divide-muted overflow-hidden">
-        <div>
-          <div class="group/item flex cursor-default grid-cols-12 flex-col gap-3 rounded-sm py-4 text-foreground transition-colors first:border-t-[0px] xl:grid xl:gap-3 xl:px-2 xl:py-1.5 xl:hover:bg-muted">
-            <div class="order-1 col-span-2 flex w-full flex-col justify-center gap-1 xl:justify-center xl:gap-0">
-              <p class="text-sm font-medium text-muted-foreground xl:hidden">
-                Version
-              </p>
-              <gui-data-badge
-                variant="mono"
-                tooltip="[object Object]"
-                classnames="[object Object]"
-                content="2.0.0"
+    <div>
+      <div class="mt-2 flex flex-col gap-2 overflow-hidden">
+        <div class="hidden cursor-default grid-cols-12 gap-3 xl:grid">
+          <div class="col-span-2 flex w-full items-center justify-start">
+            <button class="duration-250 inline-flex cursor-default items-center justify-center gap-2 text-nowrap rounded-sm px-2 py-1 text-sm text-muted-foreground transition-all hover:bg-secondary hover:text-foreground [&amp;>svg]:size-4">
+              <gui-arrow-up-down-icon>
+              </gui-arrow-up-down-icon>
+              <span>
+                Versions
+              </span>
+              <gui-number-flow
+                start="2"
+                end="2"
+                motionconfig="[object Object]"
               >
-              </gui-data-badge>
-            </div>
-            <div class="order-2 col-span-2 flex w-full flex-col gap-2 xl:items-center xl:justify-center xl:gap-0 xl:text-center">
-              <p class="text-sm font-medium text-muted-foreground xl:hidden">
+              </gui-number-flow>
+            </button>
+          </div>
+          <div class="col-span-2 ml-1 flex w-full items-center justify-end text-center">
+            <button class="duration-250 inline-flex cursor-default items-center justify-center gap-2 text-nowrap rounded-sm px-2 py-1 text-sm text-muted-foreground transition-all hover:bg-secondary hover:text-foreground [&amp;>svg]:size-4">
+              <gui-arrow-up-down-icon>
+              </gui-arrow-up-down-icon>
+              <span>
                 Size
-              </p>
-              <p class="font-mono text-sm">
-                121 KB
-              </p>
-            </div>
-            <div class="order-4 col-span-3 flex w-full flex-col gap-2 xl:order-3 xl:items-center xl:justify-center xl:gap-0 xl:text-center">
-              <p class="text-sm font-medium text-muted-foreground xl:hidden">
+              </span>
+            </button>
+          </div>
+          <div class="col-span-3 w-full text-center">
+            <button class="duration-250 inline-flex cursor-default items-center justify-center gap-2 text-nowrap rounded-sm px-2 py-1 text-sm text-muted-foreground transition-all hover:bg-secondary hover:text-foreground [&amp;>svg]:size-4">
+              <gui-arrow-up-down-icon>
+              </gui-arrow-up-down-icon>
+              <span>
                 Published Date
-              </p>
-              <div class="flex gap-2 xl:hidden">
-                <gui-avatar classname="size-5">
-                  <gui-avatar-image
-                    classname="rounded-sm outline outline-[1px] outline-border"
-                    src="https://example.com/avatar.jpg"
-                  >
-                  </gui-avatar-image>
-                  <gui-avatar-fallback classname="h-5 h-full w-5 w-full rounded-sm bg-secondary bg-gradient-to-t from-neutral-100 to-neutral-400 px-[10px] outline outline-[1px] outline-border dark:from-neutral-500 dark:to-neutral-800">
-                  </gui-avatar-fallback>
-                </gui-avatar>
-                <p class="col-span-4 font-mono text-sm">
-                  John Doe
+              </span>
+            </button>
+          </div>
+          <div class="col-span-2 w-full text-center">
+            <button class="duration-250 inline-flex cursor-default items-center justify-center gap-2 text-nowrap rounded-sm px-2 py-1 text-sm text-muted-foreground transition-all hover:bg-secondary hover:text-foreground [&amp;>svg]:size-4">
+              <gui-arrow-up-down-icon>
+              </gui-arrow-up-down-icon>
+              <span>
+                Downloads
+              </span>
+            </button>
+          </div>
+          <div class="col-span-3 flex w-full items-center justify-center text-center">
+            <button class="duration-250 inline-flex cursor-default items-center justify-center gap-2 text-nowrap rounded-sm px-2 py-1 text-sm text-muted-foreground transition-all hover:bg-secondary hover:text-foreground [&amp;>svg]:size-4">
+              <gui-arrow-up-down-icon>
+              </gui-arrow-up-down-icon>
+              <span>
+                Publisher
+              </span>
+            </button>
+          </div>
+        </div>
+        <div class="flex flex-col divide-y-[1px] divide-muted overflow-hidden">
+          <div>
+            <div class="group/item flex cursor-default grid-cols-12 flex-col gap-3 rounded-sm py-4 text-foreground first:border-t-[0px] xl:grid xl:gap-3 xl:py-1.5">
+              <div class="order-1 col-span-2 flex w-full flex-col justify-center gap-1 xl:justify-center xl:gap-0">
+                <p class="text-sm font-medium text-muted-foreground xl:hidden">
+                  Version
                 </p>
-                <p class="ml-2 inline-flex font-mono text-sm text-muted-foreground xl:hidden">
-                  1 day ago
+                <gui-data-badge
+                  variant="mono"
+                  tooltip="[object Object]"
+                  classnames="[object Object]"
+                  content="2.0.0"
+                >
+                </gui-data-badge>
+              </div>
+              <div class="order-2 col-span-2 flex w-full flex-col gap-2 xl:items-end xl:justify-center xl:gap-0 xl:text-center">
+                <p class="text-sm font-medium text-muted-foreground xl:hidden">
+                  Size
+                </p>
+                <p class="font-mono text-sm">
+                  121 KB
                 </p>
               </div>
-              <gui-tooltip-provider>
-                <gui-tooltip>
-                  <gui-tooltip-trigger classname="hidden cursor-default font-mono text-sm xl:inline-flex">
+              <div class="order-4 col-span-3 flex w-full flex-col gap-2 xl:order-3 xl:items-center xl:justify-center xl:gap-0 xl:text-center">
+                <p class="text-sm font-medium text-muted-foreground xl:hidden">
+                  Published Date
+                </p>
+                <div class="flex gap-2 xl:hidden">
+                  <gui-avatar classname="size-5">
+                    <gui-avatar-image
+                      classname="rounded-sm outline outline-[1px] outline-border"
+                      src="https://example.com/avatar.jpg"
+                    >
+                    </gui-avatar-image>
+                    <gui-avatar-fallback classname="h-5 h-full w-5 w-full rounded-sm bg-secondary bg-gradient-to-t from-neutral-100 to-neutral-400 px-[10px] outline outline-[1px] outline-border dark:from-neutral-500 dark:to-neutral-800">
+                    </gui-avatar-fallback>
+                  </gui-avatar>
+                  <p class="col-span-4 font-mono text-sm">
+                    John Doe
+                  </p>
+                  <p class="ml-2 inline-flex font-mono text-sm text-muted-foreground xl:hidden">
                     1 day ago
-                  </gui-tooltip-trigger>
-                  <gui-tooltip-content>
-                    2025-04-15
-                  </gui-tooltip-content>
-                </gui-tooltip>
-              </gui-tooltip-provider>
-            </div>
-            <div class="order-3 col-span-2 w-full flex-col justify-start gap-2 xl:items-center xl:justify-center xl:gap-0 xl:text-center hidden xl:flex">
-            </div>
-            <div class="order-3 col-span-3 flex hidden w-full items-center justify-center xl:order-4 xl:flex">
-              <div class="flex w-full items-center justify-center gap-2">
-                <gui-avatar classname="flex size-5 items-center justify-center">
-                  <gui-avatar-image
-                    classname="rounded-sm outline outline-[1px] outline-border"
-                    src="https://example.com/avatar.jpg"
-                  >
-                  </gui-avatar-image>
-                  <gui-avatar-fallback classname="h-full w-full rounded-sm bg-secondary bg-gradient-to-t from-neutral-100 to-neutral-400 px-[10px] outline outline-[1px] outline-border dark:from-neutral-500 dark:to-neutral-800">
-                  </gui-avatar-fallback>
-                </gui-avatar>
+                  </p>
+                </div>
                 <gui-tooltip-provider>
-                  <gui-tooltip delayduration="150">
-                    <gui-tooltip-trigger classname="cursor-default">
-                      <p class="truncate font-mono text-sm">
-                        John Doe
-                      </p>
+                  <gui-tooltip>
+                    <gui-tooltip-trigger classname="hidden cursor-default font-mono text-sm xl:inline-flex">
+                      1 day ago
                     </gui-tooltip-trigger>
                     <gui-tooltip-content>
-                      John Doe
+                      2025-04-15
                     </gui-tooltip-content>
                   </gui-tooltip>
                 </gui-tooltip-provider>
+              </div>
+              <div class="order-3 col-span-2 w-full flex-col justify-start gap-2 xl:items-center xl:justify-center xl:gap-0 xl:text-center hidden xl:flex">
+              </div>
+              <div class="order-3 col-span-3 flex hidden w-full items-center justify-center xl:order-4 xl:flex">
+                <div class="flex w-full items-center justify-center gap-2">
+                  <gui-avatar classname="flex size-5 items-center justify-center">
+                    <gui-avatar-image
+                      classname="rounded-sm outline outline-[1px] outline-border"
+                      src="https://example.com/avatar.jpg"
+                    >
+                    </gui-avatar-image>
+                    <gui-avatar-fallback classname="h-full w-full rounded-sm bg-secondary bg-gradient-to-t from-neutral-100 to-neutral-400 px-[10px] outline outline-[1px] outline-border dark:from-neutral-500 dark:to-neutral-800">
+                    </gui-avatar-fallback>
+                  </gui-avatar>
+                  <gui-tooltip-provider>
+                    <gui-tooltip delayduration="150">
+                      <gui-tooltip-trigger classname="cursor-default">
+                        <p class="truncate font-mono text-sm">
+                          John Doe
+                        </p>
+                      </gui-tooltip-trigger>
+                      <gui-tooltip-content>
+                        John Doe
+                      </gui-tooltip-content>
+                    </gui-tooltip>
+                  </gui-tooltip-provider>
+                </div>
               </div>
             </div>
           </div>
-        </div>
-        <div>
-          <div class="group/item flex cursor-default grid-cols-12 flex-col gap-3 rounded-sm py-4 text-foreground transition-colors first:border-t-[0px] xl:grid xl:gap-3 xl:px-2 xl:py-1.5 xl:hover:bg-muted">
-            <div class="order-1 col-span-2 flex w-full flex-col justify-center gap-1 xl:justify-center xl:gap-0">
-              <p class="text-sm font-medium text-muted-foreground xl:hidden">
-                Version
-              </p>
-              <gui-data-badge
-                variant="mono"
-                tooltip="[object Object]"
-                classnames="[object Object]"
-                content="1.0.0"
-              >
-              </gui-data-badge>
-            </div>
-            <div class="order-2 col-span-2 flex w-full flex-col gap-2 xl:items-center xl:justify-center xl:gap-0 xl:text-center">
-              <p class="text-sm font-medium text-muted-foreground xl:hidden">
-                Size
-              </p>
-              <p class="font-mono text-sm">
-                121 KB
-              </p>
-            </div>
-            <div class="order-4 col-span-3 flex w-full flex-col gap-2 xl:order-3 xl:items-center xl:justify-center xl:gap-0 xl:text-center">
-              <p class="text-sm font-medium text-muted-foreground xl:hidden">
-                Published Date
-              </p>
-              <div class="flex gap-2 xl:hidden">
-                <gui-avatar classname="size-5">
-                  <gui-avatar-image
-                    classname="rounded-sm outline outline-[1px] outline-border"
-                    src="https://example.com/avatar.jpg"
-                  >
-                  </gui-avatar-image>
-                  <gui-avatar-fallback classname="h-5 h-full w-5 w-full rounded-sm bg-secondary bg-gradient-to-t from-neutral-100 to-neutral-400 px-[10px] outline outline-[1px] outline-border dark:from-neutral-500 dark:to-neutral-800">
-                  </gui-avatar-fallback>
-                </gui-avatar>
-                <p class="col-span-4 font-mono text-sm">
-                  John Doe
+          <div>
+            <div class="group/item flex cursor-default grid-cols-12 flex-col gap-3 rounded-sm py-4 text-foreground first:border-t-[0px] xl:grid xl:gap-3 xl:py-1.5">
+              <div class="order-1 col-span-2 flex w-full flex-col justify-center gap-1 xl:justify-center xl:gap-0">
+                <p class="text-sm font-medium text-muted-foreground xl:hidden">
+                  Version
                 </p>
-                <p class="ml-2 inline-flex font-mono text-sm text-muted-foreground xl:hidden">
-                  1 day ago
+                <gui-data-badge
+                  variant="mono"
+                  tooltip="[object Object]"
+                  classnames="[object Object]"
+                  content="1.0.0"
+                >
+                </gui-data-badge>
+              </div>
+              <div class="order-2 col-span-2 flex w-full flex-col gap-2 xl:items-end xl:justify-center xl:gap-0 xl:text-center">
+                <p class="text-sm font-medium text-muted-foreground xl:hidden">
+                  Size
+                </p>
+                <p class="font-mono text-sm">
+                  121 KB
                 </p>
               </div>
-              <gui-tooltip-provider>
-                <gui-tooltip>
-                  <gui-tooltip-trigger classname="hidden cursor-default font-mono text-sm xl:inline-flex">
+              <div class="order-4 col-span-3 flex w-full flex-col gap-2 xl:order-3 xl:items-center xl:justify-center xl:gap-0 xl:text-center">
+                <p class="text-sm font-medium text-muted-foreground xl:hidden">
+                  Published Date
+                </p>
+                <div class="flex gap-2 xl:hidden">
+                  <gui-avatar classname="size-5">
+                    <gui-avatar-image
+                      classname="rounded-sm outline outline-[1px] outline-border"
+                      src="https://example.com/avatar.jpg"
+                    >
+                    </gui-avatar-image>
+                    <gui-avatar-fallback classname="h-5 h-full w-5 w-full rounded-sm bg-secondary bg-gradient-to-t from-neutral-100 to-neutral-400 px-[10px] outline outline-[1px] outline-border dark:from-neutral-500 dark:to-neutral-800">
+                    </gui-avatar-fallback>
+                  </gui-avatar>
+                  <p class="col-span-4 font-mono text-sm">
+                    John Doe
+                  </p>
+                  <p class="ml-2 inline-flex font-mono text-sm text-muted-foreground xl:hidden">
                     1 day ago
-                  </gui-tooltip-trigger>
-                  <gui-tooltip-content>
-                    2025-04-15
-                  </gui-tooltip-content>
-                </gui-tooltip>
-              </gui-tooltip-provider>
-            </div>
-            <div class="order-3 col-span-2 w-full flex-col justify-start gap-2 xl:items-center xl:justify-center xl:gap-0 xl:text-center flex">
-              <p class="text-sm font-medium text-muted-foreground xl:hidden">
-                Downloads
-              </p>
-              <p class="font-mono text-sm">
-                123,456
-              </p>
-            </div>
-            <div class="order-3 col-span-3 flex hidden w-full items-center justify-center xl:order-4 xl:flex">
-              <div class="flex w-full items-center justify-center gap-2">
-                <gui-avatar classname="flex size-5 items-center justify-center">
-                  <gui-avatar-image
-                    classname="rounded-sm outline outline-[1px] outline-border"
-                    src="https://example.com/avatar.jpg"
-                  >
-                  </gui-avatar-image>
-                  <gui-avatar-fallback classname="h-full w-full rounded-sm bg-secondary bg-gradient-to-t from-neutral-100 to-neutral-400 px-[10px] outline outline-[1px] outline-border dark:from-neutral-500 dark:to-neutral-800">
-                  </gui-avatar-fallback>
-                </gui-avatar>
+                  </p>
+                </div>
                 <gui-tooltip-provider>
-                  <gui-tooltip delayduration="150">
-                    <gui-tooltip-trigger classname="cursor-default">
-                      <p class="truncate font-mono text-sm">
-                        John Doe
-                      </p>
+                  <gui-tooltip>
+                    <gui-tooltip-trigger classname="hidden cursor-default font-mono text-sm xl:inline-flex">
+                      1 day ago
                     </gui-tooltip-trigger>
                     <gui-tooltip-content>
-                      John Doe
+                      2025-04-15
                     </gui-tooltip-content>
                   </gui-tooltip>
                 </gui-tooltip-provider>
+              </div>
+              <div class="order-3 col-span-2 w-full flex-col justify-start gap-2 xl:items-center xl:justify-center xl:gap-0 xl:text-center flex">
+                <p class="text-sm font-medium text-muted-foreground xl:hidden">
+                  Downloads
+                </p>
+                <p class="font-mono text-sm">
+                  123,456
+                </p>
+              </div>
+              <div class="order-3 col-span-3 flex hidden w-full items-center justify-center xl:order-4 xl:flex">
+                <div class="flex w-full items-center justify-center gap-2">
+                  <gui-avatar classname="flex size-5 items-center justify-center">
+                    <gui-avatar-image
+                      classname="rounded-sm outline outline-[1px] outline-border"
+                      src="https://example.com/avatar.jpg"
+                    >
+                    </gui-avatar-image>
+                    <gui-avatar-fallback classname="h-full w-full rounded-sm bg-secondary bg-gradient-to-t from-neutral-100 to-neutral-400 px-[10px] outline outline-[1px] outline-border dark:from-neutral-500 dark:to-neutral-800">
+                    </gui-avatar-fallback>
+                  </gui-avatar>
+                  <gui-tooltip-provider>
+                    <gui-tooltip delayduration="150">
+                      <gui-tooltip-trigger classname="cursor-default">
+                        <p class="truncate font-mono text-sm">
+                          John Doe
+                        </p>
+                      </gui-tooltip-trigger>
+                      <gui-tooltip-content>
+                        John Doe
+                      </gui-tooltip-content>
+                    </gui-tooltip>
+                  </gui-tooltip-provider>
+                </div>
               </div>
             </div>
           </div>
@@ -1262,7 +1294,7 @@ exports[`VersionsTabContent renders an empty state 1`] = `
 exports[`VersionsTabContent renders with versions 1`] = `
 
 <gui-tabs-content value="versions">
-  <section class="flex flex-col gap-2 px-6 py-4">
+  <section class="flex flex-col px-6 py-4">
     <div class="mb-3 flex items-center gap-2">
       <div class="relative flex w-full items-center justify-start">
         <gui-search-icon
@@ -1306,223 +1338,231 @@ exports[`VersionsTabContent renders with versions 1`] = `
         </gui-dropdown-menu-content>
       </gui-dropdown-menu>
     </div>
-    <div class="relative mt-2 flex flex-col gap-2">
-      <div class="hidden cursor-default grid-cols-12 gap-3 pb-2 xl:grid">
-        <div class="col-span-2 flex w-full items-center justify-center">
-          <button class="relative z-[1] inline-flex w-fit cursor-default items-center justify-center gap-2 text-nowrap text-sm text-muted-foreground transition-all duration-300 after:absolute after:left-[-0.75rem] after:z-[-1] after:h-[calc(100%+0.5rem)] after:w-[calc(100%+1.5rem)] after:rounded-sm after:bg-transparent after:content-[''] hover:text-foreground hover:after:bg-muted">
-            <span>
-              Version
-            </span>
-            <gui-arrow-up-down-icon size="16">
-            </gui-arrow-up-down-icon>
-          </button>
-        </div>
-        <div class="col-span-2 ml-1 w-full text-center">
-          <button class="relative z-[1] inline-flex w-fit cursor-default items-center justify-center gap-2 text-nowrap text-sm text-muted-foreground transition-all duration-300 after:absolute after:left-[-0.75rem] after:z-[-1] after:h-[calc(100%+0.5rem)] after:w-[calc(100%+1.5rem)] after:rounded-sm after:bg-transparent after:content-[''] hover:text-foreground hover:after:bg-muted">
-            <span>
-              Size
-            </span>
-            <gui-arrow-up-down-icon size="16">
-            </gui-arrow-up-down-icon>
-          </button>
-        </div>
-        <div class="col-span-3 w-full text-center">
-          <button class="relative z-[1] inline-flex w-fit cursor-default items-center justify-center gap-2 text-nowrap text-sm text-muted-foreground transition-all duration-300 after:absolute after:left-[-0.75rem] after:z-[-1] after:h-[calc(100%+0.5rem)] after:w-[calc(100%+1.5rem)] after:rounded-sm after:bg-transparent after:content-[''] hover:text-foreground hover:after:bg-muted">
-            <span>
-              Published Date
-            </span>
-            <gui-arrow-up-down-icon size="16">
-            </gui-arrow-up-down-icon>
-          </button>
-        </div>
-        <div class="col-span-2 w-full text-center">
-          <button class="relative z-[1] inline-flex w-fit cursor-default items-center justify-center gap-2 text-nowrap text-sm text-muted-foreground transition-all duration-300 after:absolute after:left-[-0.75rem] after:z-[-1] after:h-[calc(100%+0.5rem)] after:w-[calc(100%+1.5rem)] after:rounded-sm after:bg-transparent after:content-[''] hover:text-foreground hover:after:bg-muted">
-            <span>
-              Downloads
-            </span>
-            <gui-arrow-up-down-icon size="16">
-            </gui-arrow-up-down-icon>
-          </button>
-        </div>
-        <div class="col-span-3 flex w-full items-center justify-center text-center">
-          <button class="relative z-[1] inline-flex w-fit cursor-default items-center justify-center gap-2 text-nowrap text-sm text-muted-foreground transition-all duration-300 after:absolute after:left-[-0.75rem] after:z-[-1] after:h-[calc(100%+0.5rem)] after:w-[calc(100%+1.5rem)] after:rounded-sm after:bg-transparent after:content-[''] hover:text-foreground hover:after:bg-muted">
-            <span>
-              Publisher
-            </span>
-            <gui-arrow-up-down-icon size="16">
-            </gui-arrow-up-down-icon>
-          </button>
-        </div>
-      </div>
-      <div class="flex flex-col divide-y-[1px] divide-muted overflow-hidden">
-        <div>
-          <div class="group/item flex cursor-default grid-cols-12 flex-col gap-3 rounded-sm py-4 text-foreground transition-colors first:border-t-[0px] xl:grid xl:gap-3 xl:px-2 xl:py-1.5 xl:hover:bg-muted">
-            <div class="order-1 col-span-2 flex w-full flex-col justify-center gap-1 xl:justify-center xl:gap-0">
-              <p class="text-sm font-medium text-muted-foreground xl:hidden">
-                Version
-              </p>
-              <gui-data-badge
-                variant="mono"
-                tooltip="[object Object]"
-                classnames="[object Object]"
-                content="1.0.0"
+    <div>
+      <div class="mt-2 flex flex-col gap-2 overflow-hidden">
+        <div class="hidden cursor-default grid-cols-12 gap-3 xl:grid">
+          <div class="col-span-2 flex w-full items-center justify-start">
+            <button class="duration-250 inline-flex cursor-default items-center justify-center gap-2 text-nowrap rounded-sm px-2 py-1 text-sm text-muted-foreground transition-all hover:bg-secondary hover:text-foreground [&amp;>svg]:size-4">
+              <gui-arrow-up-down-icon>
+              </gui-arrow-up-down-icon>
+              <span>
+                Versions
+              </span>
+              <gui-number-flow
+                start="2"
+                end="2"
+                motionconfig="[object Object]"
               >
-              </gui-data-badge>
-            </div>
-            <div class="order-2 col-span-2 flex w-full flex-col gap-2 xl:items-center xl:justify-center xl:gap-0 xl:text-center">
-              <p class="text-sm font-medium text-muted-foreground xl:hidden">
+              </gui-number-flow>
+            </button>
+          </div>
+          <div class="col-span-2 ml-1 flex w-full items-center justify-end text-center">
+            <button class="duration-250 inline-flex cursor-default items-center justify-center gap-2 text-nowrap rounded-sm px-2 py-1 text-sm text-muted-foreground transition-all hover:bg-secondary hover:text-foreground [&amp;>svg]:size-4">
+              <gui-arrow-up-down-icon>
+              </gui-arrow-up-down-icon>
+              <span>
                 Size
-              </p>
-              <p class="font-mono text-sm">
-                121 KB
-              </p>
-            </div>
-            <div class="order-4 col-span-3 flex w-full flex-col gap-2 xl:order-3 xl:items-center xl:justify-center xl:gap-0 xl:text-center">
-              <p class="text-sm font-medium text-muted-foreground xl:hidden">
+              </span>
+            </button>
+          </div>
+          <div class="col-span-3 w-full text-center">
+            <button class="duration-250 inline-flex cursor-default items-center justify-center gap-2 text-nowrap rounded-sm px-2 py-1 text-sm text-muted-foreground transition-all hover:bg-secondary hover:text-foreground [&amp;>svg]:size-4">
+              <gui-arrow-up-down-icon>
+              </gui-arrow-up-down-icon>
+              <span>
                 Published Date
-              </p>
-              <div class="flex gap-2 xl:hidden">
-                <gui-avatar classname="size-5">
-                  <gui-avatar-image
-                    classname="rounded-sm outline outline-[1px] outline-border"
-                    src="https://example.com/avatar.jpg"
-                  >
-                  </gui-avatar-image>
-                  <gui-avatar-fallback classname="h-5 h-full w-5 w-full rounded-sm bg-secondary bg-gradient-to-t from-neutral-100 to-neutral-400 px-[10px] outline outline-[1px] outline-border dark:from-neutral-500 dark:to-neutral-800">
-                  </gui-avatar-fallback>
-                </gui-avatar>
-                <p class="col-span-4 font-mono text-sm">
-                  John Doe
+              </span>
+            </button>
+          </div>
+          <div class="col-span-2 w-full text-center">
+            <button class="duration-250 inline-flex cursor-default items-center justify-center gap-2 text-nowrap rounded-sm px-2 py-1 text-sm text-muted-foreground transition-all hover:bg-secondary hover:text-foreground [&amp;>svg]:size-4">
+              <gui-arrow-up-down-icon>
+              </gui-arrow-up-down-icon>
+              <span>
+                Downloads
+              </span>
+            </button>
+          </div>
+          <div class="col-span-3 flex w-full items-center justify-center text-center">
+            <button class="duration-250 inline-flex cursor-default items-center justify-center gap-2 text-nowrap rounded-sm px-2 py-1 text-sm text-muted-foreground transition-all hover:bg-secondary hover:text-foreground [&amp;>svg]:size-4">
+              <gui-arrow-up-down-icon>
+              </gui-arrow-up-down-icon>
+              <span>
+                Publisher
+              </span>
+            </button>
+          </div>
+        </div>
+        <div class="flex flex-col divide-y-[1px] divide-muted overflow-hidden">
+          <div>
+            <div class="group/item flex cursor-default grid-cols-12 flex-col gap-3 rounded-sm py-4 text-foreground first:border-t-[0px] xl:grid xl:gap-3 xl:py-1.5">
+              <div class="order-1 col-span-2 flex w-full flex-col justify-center gap-1 xl:justify-center xl:gap-0">
+                <p class="text-sm font-medium text-muted-foreground xl:hidden">
+                  Version
                 </p>
-                <p class="ml-2 inline-flex font-mono text-sm text-muted-foreground xl:hidden">
-                  1 day ago
+                <gui-data-badge
+                  variant="mono"
+                  tooltip="[object Object]"
+                  classnames="[object Object]"
+                  content="1.0.0"
+                >
+                </gui-data-badge>
+              </div>
+              <div class="order-2 col-span-2 flex w-full flex-col gap-2 xl:items-end xl:justify-center xl:gap-0 xl:text-center">
+                <p class="text-sm font-medium text-muted-foreground xl:hidden">
+                  Size
+                </p>
+                <p class="font-mono text-sm">
+                  121 KB
                 </p>
               </div>
-              <gui-tooltip-provider>
-                <gui-tooltip>
-                  <gui-tooltip-trigger classname="hidden cursor-default font-mono text-sm xl:inline-flex">
+              <div class="order-4 col-span-3 flex w-full flex-col gap-2 xl:order-3 xl:items-center xl:justify-center xl:gap-0 xl:text-center">
+                <p class="text-sm font-medium text-muted-foreground xl:hidden">
+                  Published Date
+                </p>
+                <div class="flex gap-2 xl:hidden">
+                  <gui-avatar classname="size-5">
+                    <gui-avatar-image
+                      classname="rounded-sm outline outline-[1px] outline-border"
+                      src="https://example.com/avatar.jpg"
+                    >
+                    </gui-avatar-image>
+                    <gui-avatar-fallback classname="h-5 h-full w-5 w-full rounded-sm bg-secondary bg-gradient-to-t from-neutral-100 to-neutral-400 px-[10px] outline outline-[1px] outline-border dark:from-neutral-500 dark:to-neutral-800">
+                    </gui-avatar-fallback>
+                  </gui-avatar>
+                  <p class="col-span-4 font-mono text-sm">
+                    John Doe
+                  </p>
+                  <p class="ml-2 inline-flex font-mono text-sm text-muted-foreground xl:hidden">
                     1 day ago
-                  </gui-tooltip-trigger>
-                  <gui-tooltip-content>
-                    2025-04-15
-                  </gui-tooltip-content>
-                </gui-tooltip>
-              </gui-tooltip-provider>
-            </div>
-            <div class="order-3 col-span-2 w-full flex-col justify-start gap-2 xl:items-center xl:justify-center xl:gap-0 xl:text-center flex">
-              <p class="text-sm font-medium text-muted-foreground xl:hidden">
-                Downloads
-              </p>
-              <p class="font-mono text-sm">
-                123,456
-              </p>
-            </div>
-            <div class="order-3 col-span-3 flex hidden w-full items-center justify-center xl:order-4 xl:flex">
-              <div class="flex w-full items-center justify-center gap-2">
-                <gui-avatar classname="flex size-5 items-center justify-center">
-                  <gui-avatar-image
-                    classname="rounded-sm outline outline-[1px] outline-border"
-                    src="https://example.com/avatar.jpg"
-                  >
-                  </gui-avatar-image>
-                  <gui-avatar-fallback classname="h-full w-full rounded-sm bg-secondary bg-gradient-to-t from-neutral-100 to-neutral-400 px-[10px] outline outline-[1px] outline-border dark:from-neutral-500 dark:to-neutral-800">
-                  </gui-avatar-fallback>
-                </gui-avatar>
+                  </p>
+                </div>
                 <gui-tooltip-provider>
-                  <gui-tooltip delayduration="150">
-                    <gui-tooltip-trigger classname="cursor-default">
-                      <p class="truncate font-mono text-sm">
-                        John Doe
-                      </p>
+                  <gui-tooltip>
+                    <gui-tooltip-trigger classname="hidden cursor-default font-mono text-sm xl:inline-flex">
+                      1 day ago
                     </gui-tooltip-trigger>
                     <gui-tooltip-content>
-                      John Doe
+                      2025-04-15
                     </gui-tooltip-content>
                   </gui-tooltip>
                 </gui-tooltip-provider>
+              </div>
+              <div class="order-3 col-span-2 w-full flex-col justify-start gap-2 xl:items-center xl:justify-center xl:gap-0 xl:text-center flex">
+                <p class="text-sm font-medium text-muted-foreground xl:hidden">
+                  Downloads
+                </p>
+                <p class="font-mono text-sm">
+                  123,456
+                </p>
+              </div>
+              <div class="order-3 col-span-3 flex hidden w-full items-center justify-center xl:order-4 xl:flex">
+                <div class="flex w-full items-center justify-center gap-2">
+                  <gui-avatar classname="flex size-5 items-center justify-center">
+                    <gui-avatar-image
+                      classname="rounded-sm outline outline-[1px] outline-border"
+                      src="https://example.com/avatar.jpg"
+                    >
+                    </gui-avatar-image>
+                    <gui-avatar-fallback classname="h-full w-full rounded-sm bg-secondary bg-gradient-to-t from-neutral-100 to-neutral-400 px-[10px] outline outline-[1px] outline-border dark:from-neutral-500 dark:to-neutral-800">
+                    </gui-avatar-fallback>
+                  </gui-avatar>
+                  <gui-tooltip-provider>
+                    <gui-tooltip delayduration="150">
+                      <gui-tooltip-trigger classname="cursor-default">
+                        <p class="truncate font-mono text-sm">
+                          John Doe
+                        </p>
+                      </gui-tooltip-trigger>
+                      <gui-tooltip-content>
+                        John Doe
+                      </gui-tooltip-content>
+                    </gui-tooltip>
+                  </gui-tooltip-provider>
+                </div>
               </div>
             </div>
           </div>
-        </div>
-        <div>
-          <div class="group/item flex cursor-default grid-cols-12 flex-col gap-3 rounded-sm py-4 text-foreground transition-colors first:border-t-[0px] xl:grid xl:gap-3 xl:px-2 xl:py-1.5 xl:hover:bg-muted">
-            <div class="order-1 col-span-2 flex w-full flex-col justify-center gap-1 xl:justify-center xl:gap-0">
-              <p class="text-sm font-medium text-muted-foreground xl:hidden">
-                Version
-              </p>
-              <gui-data-badge
-                variant="mono"
-                tooltip="[object Object]"
-                classnames="[object Object]"
-                content="2.0.0-beta.1"
-              >
-              </gui-data-badge>
-            </div>
-            <div class="order-2 col-span-2 flex w-full flex-col gap-2 xl:items-center xl:justify-center xl:gap-0 xl:text-center">
-              <p class="text-sm font-medium text-muted-foreground xl:hidden">
-                Size
-              </p>
-              <p class="font-mono text-sm">
-                121 KB
-              </p>
-            </div>
-            <div class="order-4 col-span-3 flex w-full flex-col gap-2 xl:order-3 xl:items-center xl:justify-center xl:gap-0 xl:text-center">
-              <p class="text-sm font-medium text-muted-foreground xl:hidden">
-                Published Date
-              </p>
-              <div class="flex gap-2 xl:hidden">
-                <gui-avatar classname="size-5">
-                  <gui-avatar-image
-                    classname="rounded-sm outline outline-[1px] outline-border"
-                    src="https://example.com/avatar.jpg"
-                  >
-                  </gui-avatar-image>
-                  <gui-avatar-fallback classname="h-5 h-full w-5 w-full rounded-sm bg-secondary bg-gradient-to-t from-neutral-100 to-neutral-400 px-[10px] outline outline-[1px] outline-border dark:from-neutral-500 dark:to-neutral-800">
-                  </gui-avatar-fallback>
-                </gui-avatar>
-                <p class="col-span-4 font-mono text-sm">
-                  John Doe
+          <div>
+            <div class="group/item flex cursor-default grid-cols-12 flex-col gap-3 rounded-sm py-4 text-foreground first:border-t-[0px] xl:grid xl:gap-3 xl:py-1.5">
+              <div class="order-1 col-span-2 flex w-full flex-col justify-center gap-1 xl:justify-center xl:gap-0">
+                <p class="text-sm font-medium text-muted-foreground xl:hidden">
+                  Version
                 </p>
-                <p class="ml-2 inline-flex font-mono text-sm text-muted-foreground xl:hidden">
-                  1 day ago
+                <gui-data-badge
+                  variant="mono"
+                  tooltip="[object Object]"
+                  classnames="[object Object]"
+                  content="2.0.0-beta.1"
+                >
+                </gui-data-badge>
+              </div>
+              <div class="order-2 col-span-2 flex w-full flex-col gap-2 xl:items-end xl:justify-center xl:gap-0 xl:text-center">
+                <p class="text-sm font-medium text-muted-foreground xl:hidden">
+                  Size
+                </p>
+                <p class="font-mono text-sm">
+                  121 KB
                 </p>
               </div>
-              <gui-tooltip-provider>
-                <gui-tooltip>
-                  <gui-tooltip-trigger classname="hidden cursor-default font-mono text-sm xl:inline-flex">
+              <div class="order-4 col-span-3 flex w-full flex-col gap-2 xl:order-3 xl:items-center xl:justify-center xl:gap-0 xl:text-center">
+                <p class="text-sm font-medium text-muted-foreground xl:hidden">
+                  Published Date
+                </p>
+                <div class="flex gap-2 xl:hidden">
+                  <gui-avatar classname="size-5">
+                    <gui-avatar-image
+                      classname="rounded-sm outline outline-[1px] outline-border"
+                      src="https://example.com/avatar.jpg"
+                    >
+                    </gui-avatar-image>
+                    <gui-avatar-fallback classname="h-5 h-full w-5 w-full rounded-sm bg-secondary bg-gradient-to-t from-neutral-100 to-neutral-400 px-[10px] outline outline-[1px] outline-border dark:from-neutral-500 dark:to-neutral-800">
+                    </gui-avatar-fallback>
+                  </gui-avatar>
+                  <p class="col-span-4 font-mono text-sm">
+                    John Doe
+                  </p>
+                  <p class="ml-2 inline-flex font-mono text-sm text-muted-foreground xl:hidden">
                     1 day ago
-                  </gui-tooltip-trigger>
-                  <gui-tooltip-content>
-                    2025-04-15
-                  </gui-tooltip-content>
-                </gui-tooltip>
-              </gui-tooltip-provider>
-            </div>
-            <div class="order-3 col-span-2 w-full flex-col justify-start gap-2 xl:items-center xl:justify-center xl:gap-0 xl:text-center hidden xl:flex">
-            </div>
-            <div class="order-3 col-span-3 flex hidden w-full items-center justify-center xl:order-4 xl:flex">
-              <div class="flex w-full items-center justify-center gap-2">
-                <gui-avatar classname="flex size-5 items-center justify-center">
-                  <gui-avatar-image
-                    classname="rounded-sm outline outline-[1px] outline-border"
-                    src="https://example.com/avatar.jpg"
-                  >
-                  </gui-avatar-image>
-                  <gui-avatar-fallback classname="h-full w-full rounded-sm bg-secondary bg-gradient-to-t from-neutral-100 to-neutral-400 px-[10px] outline outline-[1px] outline-border dark:from-neutral-500 dark:to-neutral-800">
-                  </gui-avatar-fallback>
-                </gui-avatar>
+                  </p>
+                </div>
                 <gui-tooltip-provider>
-                  <gui-tooltip delayduration="150">
-                    <gui-tooltip-trigger classname="cursor-default">
-                      <p class="truncate font-mono text-sm">
-                        John Doe
-                      </p>
+                  <gui-tooltip>
+                    <gui-tooltip-trigger classname="hidden cursor-default font-mono text-sm xl:inline-flex">
+                      1 day ago
                     </gui-tooltip-trigger>
                     <gui-tooltip-content>
-                      John Doe
+                      2025-04-15
                     </gui-tooltip-content>
                   </gui-tooltip>
                 </gui-tooltip-provider>
+              </div>
+              <div class="order-3 col-span-2 w-full flex-col justify-start gap-2 xl:items-center xl:justify-center xl:gap-0 xl:text-center hidden xl:flex">
+              </div>
+              <div class="order-3 col-span-3 flex hidden w-full items-center justify-center xl:order-4 xl:flex">
+                <div class="flex w-full items-center justify-center gap-2">
+                  <gui-avatar classname="flex size-5 items-center justify-center">
+                    <gui-avatar-image
+                      classname="rounded-sm outline outline-[1px] outline-border"
+                      src="https://example.com/avatar.jpg"
+                    >
+                    </gui-avatar-image>
+                    <gui-avatar-fallback classname="h-full w-full rounded-sm bg-secondary bg-gradient-to-t from-neutral-100 to-neutral-400 px-[10px] outline outline-[1px] outline-border dark:from-neutral-500 dark:to-neutral-800">
+                    </gui-avatar-fallback>
+                  </gui-avatar>
+                  <gui-tooltip-provider>
+                    <gui-tooltip delayduration="150">
+                      <gui-tooltip-trigger classname="cursor-default">
+                        <p class="truncate font-mono text-sm">
+                          John Doe
+                        </p>
+                      </gui-tooltip-trigger>
+                      <gui-tooltip-content>
+                        John Doe
+                      </gui-tooltip-content>
+                    </gui-tooltip>
+                  </gui-tooltip-provider>
+                </div>
               </div>
             </div>
           </div>
@@ -1537,7 +1577,7 @@ exports[`VersionsTabContent renders with versions 1`] = `
 exports[`VersionsTabContent toggles pre-releases 1`] = `
 
 <gui-tabs-content value="versions">
-  <section class="flex flex-col gap-2 px-6 py-4">
+  <section class="flex flex-col px-6 py-4">
     <div class="mb-3 flex items-center gap-2">
       <div class="relative flex w-full items-center justify-start">
         <gui-search-icon
@@ -1581,223 +1621,231 @@ exports[`VersionsTabContent toggles pre-releases 1`] = `
         </gui-dropdown-menu-content>
       </gui-dropdown-menu>
     </div>
-    <div class="relative mt-2 flex flex-col gap-2">
-      <div class="hidden cursor-default grid-cols-12 gap-3 pb-2 xl:grid">
-        <div class="col-span-2 flex w-full items-center justify-center">
-          <button class="relative z-[1] inline-flex w-fit cursor-default items-center justify-center gap-2 text-nowrap text-sm text-muted-foreground transition-all duration-300 after:absolute after:left-[-0.75rem] after:z-[-1] after:h-[calc(100%+0.5rem)] after:w-[calc(100%+1.5rem)] after:rounded-sm after:bg-transparent after:content-[''] hover:text-foreground hover:after:bg-muted">
-            <span>
-              Version
-            </span>
-            <gui-arrow-up-down-icon size="16">
-            </gui-arrow-up-down-icon>
-          </button>
-        </div>
-        <div class="col-span-2 ml-1 w-full text-center">
-          <button class="relative z-[1] inline-flex w-fit cursor-default items-center justify-center gap-2 text-nowrap text-sm text-muted-foreground transition-all duration-300 after:absolute after:left-[-0.75rem] after:z-[-1] after:h-[calc(100%+0.5rem)] after:w-[calc(100%+1.5rem)] after:rounded-sm after:bg-transparent after:content-[''] hover:text-foreground hover:after:bg-muted">
-            <span>
-              Size
-            </span>
-            <gui-arrow-up-down-icon size="16">
-            </gui-arrow-up-down-icon>
-          </button>
-        </div>
-        <div class="col-span-3 w-full text-center">
-          <button class="relative z-[1] inline-flex w-fit cursor-default items-center justify-center gap-2 text-nowrap text-sm text-muted-foreground transition-all duration-300 after:absolute after:left-[-0.75rem] after:z-[-1] after:h-[calc(100%+0.5rem)] after:w-[calc(100%+1.5rem)] after:rounded-sm after:bg-transparent after:content-[''] hover:text-foreground hover:after:bg-muted">
-            <span>
-              Published Date
-            </span>
-            <gui-arrow-up-down-icon size="16">
-            </gui-arrow-up-down-icon>
-          </button>
-        </div>
-        <div class="col-span-2 w-full text-center">
-          <button class="relative z-[1] inline-flex w-fit cursor-default items-center justify-center gap-2 text-nowrap text-sm text-muted-foreground transition-all duration-300 after:absolute after:left-[-0.75rem] after:z-[-1] after:h-[calc(100%+0.5rem)] after:w-[calc(100%+1.5rem)] after:rounded-sm after:bg-transparent after:content-[''] hover:text-foreground hover:after:bg-muted">
-            <span>
-              Downloads
-            </span>
-            <gui-arrow-up-down-icon size="16">
-            </gui-arrow-up-down-icon>
-          </button>
-        </div>
-        <div class="col-span-3 flex w-full items-center justify-center text-center">
-          <button class="relative z-[1] inline-flex w-fit cursor-default items-center justify-center gap-2 text-nowrap text-sm text-muted-foreground transition-all duration-300 after:absolute after:left-[-0.75rem] after:z-[-1] after:h-[calc(100%+0.5rem)] after:w-[calc(100%+1.5rem)] after:rounded-sm after:bg-transparent after:content-[''] hover:text-foreground hover:after:bg-muted">
-            <span>
-              Publisher
-            </span>
-            <gui-arrow-up-down-icon size="16">
-            </gui-arrow-up-down-icon>
-          </button>
-        </div>
-      </div>
-      <div class="flex flex-col divide-y-[1px] divide-muted overflow-hidden">
-        <div>
-          <div class="group/item flex cursor-default grid-cols-12 flex-col gap-3 rounded-sm py-4 text-foreground transition-colors first:border-t-[0px] xl:grid xl:gap-3 xl:px-2 xl:py-1.5 xl:hover:bg-muted">
-            <div class="order-1 col-span-2 flex w-full flex-col justify-center gap-1 xl:justify-center xl:gap-0">
-              <p class="text-sm font-medium text-muted-foreground xl:hidden">
-                Version
-              </p>
-              <gui-data-badge
-                variant="mono"
-                tooltip="[object Object]"
-                classnames="[object Object]"
-                content="2.0.0-beta.1"
+    <div>
+      <div class="mt-2 flex flex-col gap-2 overflow-hidden">
+        <div class="hidden cursor-default grid-cols-12 gap-3 xl:grid">
+          <div class="col-span-2 flex w-full items-center justify-start">
+            <button class="duration-250 inline-flex cursor-default items-center justify-center gap-2 text-nowrap rounded-sm px-2 py-1 text-sm text-muted-foreground transition-all hover:bg-secondary hover:text-foreground [&amp;>svg]:size-4">
+              <gui-arrow-up-down-icon>
+              </gui-arrow-up-down-icon>
+              <span>
+                Versions
+              </span>
+              <gui-number-flow
+                start="2"
+                end="2"
+                motionconfig="[object Object]"
               >
-              </gui-data-badge>
-            </div>
-            <div class="order-2 col-span-2 flex w-full flex-col gap-2 xl:items-center xl:justify-center xl:gap-0 xl:text-center">
-              <p class="text-sm font-medium text-muted-foreground xl:hidden">
+              </gui-number-flow>
+            </button>
+          </div>
+          <div class="col-span-2 ml-1 flex w-full items-center justify-end text-center">
+            <button class="duration-250 inline-flex cursor-default items-center justify-center gap-2 text-nowrap rounded-sm px-2 py-1 text-sm text-muted-foreground transition-all hover:bg-secondary hover:text-foreground [&amp;>svg]:size-4">
+              <gui-arrow-up-down-icon>
+              </gui-arrow-up-down-icon>
+              <span>
                 Size
-              </p>
-              <p class="font-mono text-sm">
-                121 KB
-              </p>
-            </div>
-            <div class="order-4 col-span-3 flex w-full flex-col gap-2 xl:order-3 xl:items-center xl:justify-center xl:gap-0 xl:text-center">
-              <p class="text-sm font-medium text-muted-foreground xl:hidden">
+              </span>
+            </button>
+          </div>
+          <div class="col-span-3 w-full text-center">
+            <button class="duration-250 inline-flex cursor-default items-center justify-center gap-2 text-nowrap rounded-sm px-2 py-1 text-sm text-muted-foreground transition-all hover:bg-secondary hover:text-foreground [&amp;>svg]:size-4">
+              <gui-arrow-up-down-icon>
+              </gui-arrow-up-down-icon>
+              <span>
                 Published Date
-              </p>
-              <div class="flex gap-2 xl:hidden">
-                <gui-avatar classname="size-5">
-                  <gui-avatar-image
-                    classname="rounded-sm outline outline-[1px] outline-border"
-                    src="https://example.com/avatar.jpg"
-                  >
-                  </gui-avatar-image>
-                  <gui-avatar-fallback classname="h-5 h-full w-5 w-full rounded-sm bg-secondary bg-gradient-to-t from-neutral-100 to-neutral-400 px-[10px] outline outline-[1px] outline-border dark:from-neutral-500 dark:to-neutral-800">
-                  </gui-avatar-fallback>
-                </gui-avatar>
-                <p class="col-span-4 font-mono text-sm">
-                  John Doe
+              </span>
+            </button>
+          </div>
+          <div class="col-span-2 w-full text-center">
+            <button class="duration-250 inline-flex cursor-default items-center justify-center gap-2 text-nowrap rounded-sm px-2 py-1 text-sm text-muted-foreground transition-all hover:bg-secondary hover:text-foreground [&amp;>svg]:size-4">
+              <gui-arrow-up-down-icon>
+              </gui-arrow-up-down-icon>
+              <span>
+                Downloads
+              </span>
+            </button>
+          </div>
+          <div class="col-span-3 flex w-full items-center justify-center text-center">
+            <button class="duration-250 inline-flex cursor-default items-center justify-center gap-2 text-nowrap rounded-sm px-2 py-1 text-sm text-muted-foreground transition-all hover:bg-secondary hover:text-foreground [&amp;>svg]:size-4">
+              <gui-arrow-up-down-icon>
+              </gui-arrow-up-down-icon>
+              <span>
+                Publisher
+              </span>
+            </button>
+          </div>
+        </div>
+        <div class="flex flex-col divide-y-[1px] divide-muted overflow-hidden">
+          <div>
+            <div class="group/item flex cursor-default grid-cols-12 flex-col gap-3 rounded-sm py-4 text-foreground first:border-t-[0px] xl:grid xl:gap-3 xl:py-1.5">
+              <div class="order-1 col-span-2 flex w-full flex-col justify-center gap-1 xl:justify-center xl:gap-0">
+                <p class="text-sm font-medium text-muted-foreground xl:hidden">
+                  Version
                 </p>
-                <p class="ml-2 inline-flex font-mono text-sm text-muted-foreground xl:hidden">
-                  1 day ago
+                <gui-data-badge
+                  variant="mono"
+                  tooltip="[object Object]"
+                  classnames="[object Object]"
+                  content="2.0.0-beta.1"
+                >
+                </gui-data-badge>
+              </div>
+              <div class="order-2 col-span-2 flex w-full flex-col gap-2 xl:items-end xl:justify-center xl:gap-0 xl:text-center">
+                <p class="text-sm font-medium text-muted-foreground xl:hidden">
+                  Size
+                </p>
+                <p class="font-mono text-sm">
+                  121 KB
                 </p>
               </div>
-              <gui-tooltip-provider>
-                <gui-tooltip>
-                  <gui-tooltip-trigger classname="hidden cursor-default font-mono text-sm xl:inline-flex">
+              <div class="order-4 col-span-3 flex w-full flex-col gap-2 xl:order-3 xl:items-center xl:justify-center xl:gap-0 xl:text-center">
+                <p class="text-sm font-medium text-muted-foreground xl:hidden">
+                  Published Date
+                </p>
+                <div class="flex gap-2 xl:hidden">
+                  <gui-avatar classname="size-5">
+                    <gui-avatar-image
+                      classname="rounded-sm outline outline-[1px] outline-border"
+                      src="https://example.com/avatar.jpg"
+                    >
+                    </gui-avatar-image>
+                    <gui-avatar-fallback classname="h-5 h-full w-5 w-full rounded-sm bg-secondary bg-gradient-to-t from-neutral-100 to-neutral-400 px-[10px] outline outline-[1px] outline-border dark:from-neutral-500 dark:to-neutral-800">
+                    </gui-avatar-fallback>
+                  </gui-avatar>
+                  <p class="col-span-4 font-mono text-sm">
+                    John Doe
+                  </p>
+                  <p class="ml-2 inline-flex font-mono text-sm text-muted-foreground xl:hidden">
                     1 day ago
-                  </gui-tooltip-trigger>
-                  <gui-tooltip-content>
-                    2025-04-15
-                  </gui-tooltip-content>
-                </gui-tooltip>
-              </gui-tooltip-provider>
-            </div>
-            <div class="order-3 col-span-2 w-full flex-col justify-start gap-2 xl:items-center xl:justify-center xl:gap-0 xl:text-center hidden xl:flex">
-            </div>
-            <div class="order-3 col-span-3 flex hidden w-full items-center justify-center xl:order-4 xl:flex">
-              <div class="flex w-full items-center justify-center gap-2">
-                <gui-avatar classname="flex size-5 items-center justify-center">
-                  <gui-avatar-image
-                    classname="rounded-sm outline outline-[1px] outline-border"
-                    src="https://example.com/avatar.jpg"
-                  >
-                  </gui-avatar-image>
-                  <gui-avatar-fallback classname="h-full w-full rounded-sm bg-secondary bg-gradient-to-t from-neutral-100 to-neutral-400 px-[10px] outline outline-[1px] outline-border dark:from-neutral-500 dark:to-neutral-800">
-                  </gui-avatar-fallback>
-                </gui-avatar>
+                  </p>
+                </div>
                 <gui-tooltip-provider>
-                  <gui-tooltip delayduration="150">
-                    <gui-tooltip-trigger classname="cursor-default">
-                      <p class="truncate font-mono text-sm">
-                        John Doe
-                      </p>
+                  <gui-tooltip>
+                    <gui-tooltip-trigger classname="hidden cursor-default font-mono text-sm xl:inline-flex">
+                      1 day ago
                     </gui-tooltip-trigger>
                     <gui-tooltip-content>
-                      John Doe
+                      2025-04-15
                     </gui-tooltip-content>
                   </gui-tooltip>
                 </gui-tooltip-provider>
+              </div>
+              <div class="order-3 col-span-2 w-full flex-col justify-start gap-2 xl:items-center xl:justify-center xl:gap-0 xl:text-center hidden xl:flex">
+              </div>
+              <div class="order-3 col-span-3 flex hidden w-full items-center justify-center xl:order-4 xl:flex">
+                <div class="flex w-full items-center justify-center gap-2">
+                  <gui-avatar classname="flex size-5 items-center justify-center">
+                    <gui-avatar-image
+                      classname="rounded-sm outline outline-[1px] outline-border"
+                      src="https://example.com/avatar.jpg"
+                    >
+                    </gui-avatar-image>
+                    <gui-avatar-fallback classname="h-full w-full rounded-sm bg-secondary bg-gradient-to-t from-neutral-100 to-neutral-400 px-[10px] outline outline-[1px] outline-border dark:from-neutral-500 dark:to-neutral-800">
+                    </gui-avatar-fallback>
+                  </gui-avatar>
+                  <gui-tooltip-provider>
+                    <gui-tooltip delayduration="150">
+                      <gui-tooltip-trigger classname="cursor-default">
+                        <p class="truncate font-mono text-sm">
+                          John Doe
+                        </p>
+                      </gui-tooltip-trigger>
+                      <gui-tooltip-content>
+                        John Doe
+                      </gui-tooltip-content>
+                    </gui-tooltip>
+                  </gui-tooltip-provider>
+                </div>
               </div>
             </div>
           </div>
-        </div>
-        <div>
-          <div class="group/item flex cursor-default grid-cols-12 flex-col gap-3 rounded-sm py-4 text-foreground transition-colors first:border-t-[0px] xl:grid xl:gap-3 xl:px-2 xl:py-1.5 xl:hover:bg-muted">
-            <div class="order-1 col-span-2 flex w-full flex-col justify-center gap-1 xl:justify-center xl:gap-0">
-              <p class="text-sm font-medium text-muted-foreground xl:hidden">
-                Version
-              </p>
-              <gui-data-badge
-                variant="mono"
-                tooltip="[object Object]"
-                classnames="[object Object]"
-                content="1.0.0"
-              >
-              </gui-data-badge>
-            </div>
-            <div class="order-2 col-span-2 flex w-full flex-col gap-2 xl:items-center xl:justify-center xl:gap-0 xl:text-center">
-              <p class="text-sm font-medium text-muted-foreground xl:hidden">
-                Size
-              </p>
-              <p class="font-mono text-sm">
-                121 KB
-              </p>
-            </div>
-            <div class="order-4 col-span-3 flex w-full flex-col gap-2 xl:order-3 xl:items-center xl:justify-center xl:gap-0 xl:text-center">
-              <p class="text-sm font-medium text-muted-foreground xl:hidden">
-                Published Date
-              </p>
-              <div class="flex gap-2 xl:hidden">
-                <gui-avatar classname="size-5">
-                  <gui-avatar-image
-                    classname="rounded-sm outline outline-[1px] outline-border"
-                    src="https://example.com/avatar.jpg"
-                  >
-                  </gui-avatar-image>
-                  <gui-avatar-fallback classname="h-5 h-full w-5 w-full rounded-sm bg-secondary bg-gradient-to-t from-neutral-100 to-neutral-400 px-[10px] outline outline-[1px] outline-border dark:from-neutral-500 dark:to-neutral-800">
-                  </gui-avatar-fallback>
-                </gui-avatar>
-                <p class="col-span-4 font-mono text-sm">
-                  John Doe
+          <div>
+            <div class="group/item flex cursor-default grid-cols-12 flex-col gap-3 rounded-sm py-4 text-foreground first:border-t-[0px] xl:grid xl:gap-3 xl:py-1.5">
+              <div class="order-1 col-span-2 flex w-full flex-col justify-center gap-1 xl:justify-center xl:gap-0">
+                <p class="text-sm font-medium text-muted-foreground xl:hidden">
+                  Version
                 </p>
-                <p class="ml-2 inline-flex font-mono text-sm text-muted-foreground xl:hidden">
-                  1 day ago
+                <gui-data-badge
+                  variant="mono"
+                  tooltip="[object Object]"
+                  classnames="[object Object]"
+                  content="1.0.0"
+                >
+                </gui-data-badge>
+              </div>
+              <div class="order-2 col-span-2 flex w-full flex-col gap-2 xl:items-end xl:justify-center xl:gap-0 xl:text-center">
+                <p class="text-sm font-medium text-muted-foreground xl:hidden">
+                  Size
+                </p>
+                <p class="font-mono text-sm">
+                  121 KB
                 </p>
               </div>
-              <gui-tooltip-provider>
-                <gui-tooltip>
-                  <gui-tooltip-trigger classname="hidden cursor-default font-mono text-sm xl:inline-flex">
+              <div class="order-4 col-span-3 flex w-full flex-col gap-2 xl:order-3 xl:items-center xl:justify-center xl:gap-0 xl:text-center">
+                <p class="text-sm font-medium text-muted-foreground xl:hidden">
+                  Published Date
+                </p>
+                <div class="flex gap-2 xl:hidden">
+                  <gui-avatar classname="size-5">
+                    <gui-avatar-image
+                      classname="rounded-sm outline outline-[1px] outline-border"
+                      src="https://example.com/avatar.jpg"
+                    >
+                    </gui-avatar-image>
+                    <gui-avatar-fallback classname="h-5 h-full w-5 w-full rounded-sm bg-secondary bg-gradient-to-t from-neutral-100 to-neutral-400 px-[10px] outline outline-[1px] outline-border dark:from-neutral-500 dark:to-neutral-800">
+                    </gui-avatar-fallback>
+                  </gui-avatar>
+                  <p class="col-span-4 font-mono text-sm">
+                    John Doe
+                  </p>
+                  <p class="ml-2 inline-flex font-mono text-sm text-muted-foreground xl:hidden">
                     1 day ago
-                  </gui-tooltip-trigger>
-                  <gui-tooltip-content>
-                    2025-04-15
-                  </gui-tooltip-content>
-                </gui-tooltip>
-              </gui-tooltip-provider>
-            </div>
-            <div class="order-3 col-span-2 w-full flex-col justify-start gap-2 xl:items-center xl:justify-center xl:gap-0 xl:text-center flex">
-              <p class="text-sm font-medium text-muted-foreground xl:hidden">
-                Downloads
-              </p>
-              <p class="font-mono text-sm">
-                123,456
-              </p>
-            </div>
-            <div class="order-3 col-span-3 flex hidden w-full items-center justify-center xl:order-4 xl:flex">
-              <div class="flex w-full items-center justify-center gap-2">
-                <gui-avatar classname="flex size-5 items-center justify-center">
-                  <gui-avatar-image
-                    classname="rounded-sm outline outline-[1px] outline-border"
-                    src="https://example.com/avatar.jpg"
-                  >
-                  </gui-avatar-image>
-                  <gui-avatar-fallback classname="h-full w-full rounded-sm bg-secondary bg-gradient-to-t from-neutral-100 to-neutral-400 px-[10px] outline outline-[1px] outline-border dark:from-neutral-500 dark:to-neutral-800">
-                  </gui-avatar-fallback>
-                </gui-avatar>
+                  </p>
+                </div>
                 <gui-tooltip-provider>
-                  <gui-tooltip delayduration="150">
-                    <gui-tooltip-trigger classname="cursor-default">
-                      <p class="truncate font-mono text-sm">
-                        John Doe
-                      </p>
+                  <gui-tooltip>
+                    <gui-tooltip-trigger classname="hidden cursor-default font-mono text-sm xl:inline-flex">
+                      1 day ago
                     </gui-tooltip-trigger>
                     <gui-tooltip-content>
-                      John Doe
+                      2025-04-15
                     </gui-tooltip-content>
                   </gui-tooltip>
                 </gui-tooltip-provider>
+              </div>
+              <div class="order-3 col-span-2 w-full flex-col justify-start gap-2 xl:items-center xl:justify-center xl:gap-0 xl:text-center flex">
+                <p class="text-sm font-medium text-muted-foreground xl:hidden">
+                  Downloads
+                </p>
+                <p class="font-mono text-sm">
+                  123,456
+                </p>
+              </div>
+              <div class="order-3 col-span-3 flex hidden w-full items-center justify-center xl:order-4 xl:flex">
+                <div class="flex w-full items-center justify-center gap-2">
+                  <gui-avatar classname="flex size-5 items-center justify-center">
+                    <gui-avatar-image
+                      classname="rounded-sm outline outline-[1px] outline-border"
+                      src="https://example.com/avatar.jpg"
+                    >
+                    </gui-avatar-image>
+                    <gui-avatar-fallback classname="h-full w-full rounded-sm bg-secondary bg-gradient-to-t from-neutral-100 to-neutral-400 px-[10px] outline outline-[1px] outline-border dark:from-neutral-500 dark:to-neutral-800">
+                    </gui-avatar-fallback>
+                  </gui-avatar>
+                  <gui-tooltip-provider>
+                    <gui-tooltip delayduration="150">
+                      <gui-tooltip-trigger classname="cursor-default">
+                        <p class="truncate font-mono text-sm">
+                          John Doe
+                        </p>
+                      </gui-tooltip-trigger>
+                      <gui-tooltip-content>
+                        John Doe
+                      </gui-tooltip-content>
+                    </gui-tooltip>
+                  </gui-tooltip-provider>
+                </div>
               </div>
             </div>
           </div>

--- a/src/gui/test/components/explorer-grid/selected-item/tabs-versions.tsx
+++ b/src/gui/test/components/explorer-grid/selected-item/tabs-versions.tsx
@@ -118,6 +118,10 @@ vi.mock('recharts', () => ({
   CartesianGrid: 'gui-recharts-cartesian-grid',
 }))
 
+vi.mock('@/components/number-flow.jsx', () => ({
+  NumberFlow: 'gui-number-flow',
+}))
+
 expect.addSnapshotSerializer({
   serialize: v => html(v),
   test: () => true,

--- a/src/gui/test/components/number-flow.tsx
+++ b/src/gui/test/components/number-flow.tsx
@@ -1,0 +1,68 @@
+import React from 'react'
+import { test, expect, afterEach } from 'vitest'
+import { cleanup, render } from '@testing-library/react'
+import html from 'diffable-html'
+import { NumberFlow } from '@/components/number-flow.jsx'
+
+expect.addSnapshotSerializer({
+  serialize: v => html(v),
+  test: () => true,
+})
+
+afterEach(() => {
+  cleanup()
+})
+
+test('number-flow renders default', () => {
+  const Container = () => {
+    return <NumberFlow start={1} end={1} />
+  }
+
+  const { container } = render(<Container />)
+  expect(container.innerHTML).toMatchSnapshot()
+})
+
+test('number-flow renders with custom classes', () => {
+  const Container = () => {
+    return (
+      <NumberFlow
+        start={1}
+        end={1}
+        classNames={{
+          wrapper: 'custom-wrapper',
+          p: 'custom-p',
+          span: 'custom-span',
+        }}
+      />
+    )
+  }
+
+  const { container } = render(<Container />)
+
+  const wrapper = container.querySelector(
+    '[data-id="number-flow-wrapper"]',
+  )!
+  expect(wrapper).toBeTruthy()
+  expect(wrapper.className).toContain('custom-wrapper')
+
+  const p = container.querySelector('[data-id="number-flow-p"]')!
+  expect(p).toBeTruthy()
+  expect(p.className).toContain('custom-p')
+
+  const spans = container.querySelectorAll('span')
+  expect(spans.length).toBeGreaterThan(0)
+  spans.forEach(span => {
+    expect(span.className).toContain('custom-span')
+  })
+
+  expect(container.innerHTML).toMatchSnapshot()
+})
+
+test('number-flow renders with custom padding', () => {
+  const Container = () => {
+    return <NumberFlow format={{ pad: 0 }} start={1} end={1} />
+  }
+
+  const { container } = render(<Container />)
+  expect(container.innerHTML).toMatchSnapshot()
+})


### PR DESCRIPTION
Closes vltpkg/statusboard#152

This PR adds a new `number-flow` component to the gui, which is used for animating between a 'start' and 'end' value, and integrates it into the `@/selected-item/tabs-versions`'s `VersionHeader` component to nicely animate the amount of versions that have been filtered when a user applies a filter or searches in the search input.

This PR also adds some perfomance improvements by memoizing filter functions and components inside the `tabs-versions` which rely on the `versions` prop to optimize re-renders. It also removes some layout animations from motion to improve the stability of the animations.
