### PR TITLE
fix: Handle jsr: without a name like yarn, pnpm do

### DIFF
--- a/src/graph/tap-snapshots/test/lockfile/save.ts.test.cjs
+++ b/src/graph/tap-snapshots/test/lockfile/save.ts.test.cjs
@@ -90,7 +90,7 @@ exports[`test/lockfile/save.ts > TAP > jsr-registries > must match snapshot 2`] 
     ]
   },
   "edges": {
-    "file·. @foo/bar": "prod intl:@foo/bar@1 ·https%3A§§jsr.example.com§·@foo§bar@1.0.0"
+    "file·. @foo/bar": "prod intl:1 ·https%3A§§jsr.example.com§·@foo§bar@1.0.0"
   }
 }
 `

--- a/src/spec/src/browser.ts
+++ b/src/spec/src/browser.ts
@@ -103,6 +103,7 @@ const startsWithSpecIdentifier = (
   spec.startsWith('git+file://') ||
   spec.startsWith('git@github.com') ||
   spec.startsWith('registry:') ||
+  spec.startsWith('npm:') ||
   // anything that starts with a known git host key, or a
   // custom registered registry protocol e.g: `github:`, `custom:`
   [

--- a/src/spec/tap-snapshots/test/browser.ts.test.cjs
+++ b/src/spec/tap-snapshots/test/browser.ts.test.cjs
@@ -477,13 +477,126 @@ exports[`test/browser.ts > TAP > basic parsing tests > @foo/bar@git+ssh://notgit
 @foo/bar@git+ssh://notgithub.com/user/foo
 `
 
+exports[`test/browser.ts > TAP > basic parsing tests > @luca/cases@jsr: > inspect deep 1`] = `
+@vltpkg/spec.Spec {
+  type: 'registry',
+  spec: '@luca/cases@jsr:',
+  name: '@luca/cases',
+  scope: '@luca',
+  bareSpec: 'jsr:',
+  namedJsrRegistry: 'jsr',
+  registry: 'https://npm.jsr.io/',
+  subspec: @vltpkg/spec.Spec {
+    type: 'registry',
+    spec: '@jsr/luca__cases@',
+    name: '@jsr/luca__cases',
+    scope: '@jsr',
+    scopeRegistry: 'https://npm.jsr.io/',
+    bareSpec: '',
+    namedJsrRegistry: 'jsr',
+    registry: 'https://npm.jsr.io/',
+    registrySpec: '',
+    semver: '',
+    range: Range {
+      raw: '',
+      isAny: true,
+      isSingle: false,
+      set: [
+        Comparator {
+          includePrerelease: false,
+          raw: '',
+          tokens: [],
+          tuples: [
+            {
+              isAny: true,
+              toString: [Function: toString],
+              includePrerelease: false,
+              test: [Function: test]
+            }
+          ],
+          isNone: false,
+          isAny: true
+        }
+      ],
+      includePrerelease: false
+    }
+  }
+}
+`
+
+exports[`test/browser.ts > TAP > basic parsing tests > @luca/cases@jsr: > inspect default 1`] = `
+@vltpkg/spec.Spec {
+  type: 'registry',
+  spec: '@luca/cases@jsr:',
+  name: '@luca/cases',
+  scope: '@luca',
+  bareSpec: 'jsr:',
+  namedJsrRegistry: 'jsr',
+  registry: 'https://npm.jsr.io/',
+  subspec: @vltpkg/spec.Spec {
+    type: 'registry',
+    spec: '@jsr/luca__cases@',
+    name: '@jsr/luca__cases',
+    scope: '@jsr',
+    scopeRegistry: 'https://npm.jsr.io/',
+    bareSpec: '',
+    namedJsrRegistry: 'jsr',
+    registry: 'https://npm.jsr.io/',
+    registrySpec: '',
+    semver: '',
+    range: Range {
+      raw: '',
+      isAny: true,
+      isSingle: false,
+      set: [ [Comparator] ],
+      includePrerelease: false
+    }
+  }
+}
+`
+
+exports[`test/browser.ts > TAP > basic parsing tests > @luca/cases@jsr: > inspect with color 1`] = `
+@vltpkg/spec.Spec {
+  type: [32m'registry'[39m,
+  spec: [32m'@luca/cases@jsr:'[39m,
+  name: [32m'@luca/cases'[39m,
+  scope: [32m'@luca'[39m,
+  bareSpec: [32m'jsr:'[39m,
+  namedJsrRegistry: [32m'jsr'[39m,
+  registry: [32m'https://npm.jsr.io/'[39m,
+  subspec: @vltpkg/spec.Spec {
+    type: [32m'registry'[39m,
+    spec: [32m'@jsr/luca__cases@'[39m,
+    name: [32m'@jsr/luca__cases'[39m,
+    scope: [32m'@jsr'[39m,
+    scopeRegistry: [32m'https://npm.jsr.io/'[39m,
+    bareSpec: [32m''[39m,
+    namedJsrRegistry: [32m'jsr'[39m,
+    registry: [32m'https://npm.jsr.io/'[39m,
+    registrySpec: [32m''[39m,
+    semver: [32m''[39m,
+    range: Range {
+      raw: [32m''[39m,
+      isAny: [33mtrue[39m,
+      isSingle: [33mfalse[39m,
+      set: [ [36m[Comparator][39m ],
+      includePrerelease: [33mfalse[39m
+    }
+  }
+}
+`
+
+exports[`test/browser.ts > TAP > basic parsing tests > @luca/cases@jsr: > toString 1`] = `
+@luca/cases@jsr:
+`
+
 exports[`test/browser.ts > TAP > basic parsing tests > @luca/cases@jsr:@luca/cases > inspect deep 1`] = `
 @vltpkg/spec.Spec {
   type: 'registry',
-  spec: '@luca/cases@jsr:@luca/cases',
+  spec: '@luca/cases@jsr:',
   name: '@luca/cases',
   scope: '@luca',
-  bareSpec: 'jsr:@luca/cases',
+  bareSpec: 'jsr:',
   namedJsrRegistry: 'jsr',
   registry: 'https://npm.jsr.io/',
   subspec: @vltpkg/spec.Spec {
@@ -527,10 +640,10 @@ exports[`test/browser.ts > TAP > basic parsing tests > @luca/cases@jsr:@luca/cas
 exports[`test/browser.ts > TAP > basic parsing tests > @luca/cases@jsr:@luca/cases > inspect default 1`] = `
 @vltpkg/spec.Spec {
   type: 'registry',
-  spec: '@luca/cases@jsr:@luca/cases',
+  spec: '@luca/cases@jsr:',
   name: '@luca/cases',
   scope: '@luca',
-  bareSpec: 'jsr:@luca/cases',
+  bareSpec: 'jsr:',
   namedJsrRegistry: 'jsr',
   registry: 'https://npm.jsr.io/',
   subspec: @vltpkg/spec.Spec {
@@ -558,10 +671,10 @@ exports[`test/browser.ts > TAP > basic parsing tests > @luca/cases@jsr:@luca/cas
 exports[`test/browser.ts > TAP > basic parsing tests > @luca/cases@jsr:@luca/cases > inspect with color 1`] = `
 @vltpkg/spec.Spec {
   type: [32m'registry'[39m,
-  spec: [32m'@luca/cases@jsr:@luca/cases'[39m,
+  spec: [32m'@luca/cases@jsr:'[39m,
   name: [32m'@luca/cases'[39m,
   scope: [32m'@luca'[39m,
-  bareSpec: [32m'jsr:@luca/cases'[39m,
+  bareSpec: [32m'jsr:'[39m,
   namedJsrRegistry: [32m'jsr'[39m,
   registry: [32m'https://npm.jsr.io/'[39m,
   subspec: @vltpkg/spec.Spec {
@@ -587,16 +700,16 @@ exports[`test/browser.ts > TAP > basic parsing tests > @luca/cases@jsr:@luca/cas
 `
 
 exports[`test/browser.ts > TAP > basic parsing tests > @luca/cases@jsr:@luca/cases > toString 1`] = `
-@luca/cases@jsr:@luca/cases
+@luca/cases@jsr:
 `
 
 exports[`test/browser.ts > TAP > basic parsing tests > @luca/cases@jsr:@luca/cases@1 > inspect deep 1`] = `
 @vltpkg/spec.Spec {
   type: 'registry',
-  spec: '@luca/cases@jsr:@luca/cases@1',
+  spec: '@luca/cases@jsr:1',
   name: '@luca/cases',
   scope: '@luca',
-  bareSpec: 'jsr:@luca/cases@1',
+  bareSpec: 'jsr:1',
   namedJsrRegistry: 'jsr',
   registry: 'https://npm.jsr.io/',
   subspec: @vltpkg/spec.Spec {
@@ -656,10 +769,10 @@ exports[`test/browser.ts > TAP > basic parsing tests > @luca/cases@jsr:@luca/cas
 exports[`test/browser.ts > TAP > basic parsing tests > @luca/cases@jsr:@luca/cases@1 > inspect default 1`] = `
 @vltpkg/spec.Spec {
   type: 'registry',
-  spec: '@luca/cases@jsr:@luca/cases@1',
+  spec: '@luca/cases@jsr:1',
   name: '@luca/cases',
   scope: '@luca',
-  bareSpec: 'jsr:@luca/cases@1',
+  bareSpec: 'jsr:1',
   namedJsrRegistry: 'jsr',
   registry: 'https://npm.jsr.io/',
   subspec: @vltpkg/spec.Spec {
@@ -687,10 +800,10 @@ exports[`test/browser.ts > TAP > basic parsing tests > @luca/cases@jsr:@luca/cas
 exports[`test/browser.ts > TAP > basic parsing tests > @luca/cases@jsr:@luca/cases@1 > inspect with color 1`] = `
 @vltpkg/spec.Spec {
   type: [32m'registry'[39m,
-  spec: [32m'@luca/cases@jsr:@luca/cases@1'[39m,
+  spec: [32m'@luca/cases@jsr:1'[39m,
   name: [32m'@luca/cases'[39m,
   scope: [32m'@luca'[39m,
-  bareSpec: [32m'jsr:@luca/cases@1'[39m,
+  bareSpec: [32m'jsr:1'[39m,
   namedJsrRegistry: [32m'jsr'[39m,
   registry: [32m'https://npm.jsr.io/'[39m,
   subspec: @vltpkg/spec.Spec {
@@ -716,7 +829,378 @@ exports[`test/browser.ts > TAP > basic parsing tests > @luca/cases@jsr:@luca/cas
 `
 
 exports[`test/browser.ts > TAP > basic parsing tests > @luca/cases@jsr:@luca/cases@1 > toString 1`] = `
-@luca/cases@jsr:@luca/cases@1
+@luca/cases@jsr:1
+`
+
+exports[`test/browser.ts > TAP > basic parsing tests > @luca/cases@jsr:1 > inspect deep 1`] = `
+@vltpkg/spec.Spec {
+  type: 'registry',
+  spec: '@luca/cases@jsr:1',
+  name: '@luca/cases',
+  scope: '@luca',
+  bareSpec: 'jsr:1',
+  namedJsrRegistry: 'jsr',
+  registry: 'https://npm.jsr.io/',
+  subspec: @vltpkg/spec.Spec {
+    type: 'registry',
+    spec: '@jsr/luca__cases@1',
+    name: '@jsr/luca__cases',
+    scope: '@jsr',
+    scopeRegistry: 'https://npm.jsr.io/',
+    bareSpec: '1',
+    namedJsrRegistry: 'jsr',
+    registry: 'https://npm.jsr.io/',
+    registrySpec: '1',
+    semver: '1',
+    range: Range {
+      raw: '1',
+      isAny: false,
+      isSingle: false,
+      set: [
+        Comparator {
+          includePrerelease: false,
+          raw: '1',
+          tokens: [ '1' ],
+          tuples: [
+            [
+              '>=',
+              Version {
+                raw: '1',
+                major: 1,
+                minor: 0,
+                patch: 0,
+                prerelease: undefined,
+                build: undefined
+              }
+            ],
+            [
+              '<',
+              Version {
+                raw: '1',
+                major: 2,
+                minor: 0,
+                patch: 0,
+                prerelease: [ 0 ],
+                build: undefined
+              }
+            ]
+          ],
+          isNone: false,
+          isAny: false
+        }
+      ],
+      includePrerelease: false
+    }
+  }
+}
+`
+
+exports[`test/browser.ts > TAP > basic parsing tests > @luca/cases@jsr:1 > inspect default 1`] = `
+@vltpkg/spec.Spec {
+  type: 'registry',
+  spec: '@luca/cases@jsr:1',
+  name: '@luca/cases',
+  scope: '@luca',
+  bareSpec: 'jsr:1',
+  namedJsrRegistry: 'jsr',
+  registry: 'https://npm.jsr.io/',
+  subspec: @vltpkg/spec.Spec {
+    type: 'registry',
+    spec: '@jsr/luca__cases@1',
+    name: '@jsr/luca__cases',
+    scope: '@jsr',
+    scopeRegistry: 'https://npm.jsr.io/',
+    bareSpec: '1',
+    namedJsrRegistry: 'jsr',
+    registry: 'https://npm.jsr.io/',
+    registrySpec: '1',
+    semver: '1',
+    range: Range {
+      raw: '1',
+      isAny: false,
+      isSingle: false,
+      set: [ [Comparator] ],
+      includePrerelease: false
+    }
+  }
+}
+`
+
+exports[`test/browser.ts > TAP > basic parsing tests > @luca/cases@jsr:1 > inspect with color 1`] = `
+@vltpkg/spec.Spec {
+  type: [32m'registry'[39m,
+  spec: [32m'@luca/cases@jsr:1'[39m,
+  name: [32m'@luca/cases'[39m,
+  scope: [32m'@luca'[39m,
+  bareSpec: [32m'jsr:1'[39m,
+  namedJsrRegistry: [32m'jsr'[39m,
+  registry: [32m'https://npm.jsr.io/'[39m,
+  subspec: @vltpkg/spec.Spec {
+    type: [32m'registry'[39m,
+    spec: [32m'@jsr/luca__cases@1'[39m,
+    name: [32m'@jsr/luca__cases'[39m,
+    scope: [32m'@jsr'[39m,
+    scopeRegistry: [32m'https://npm.jsr.io/'[39m,
+    bareSpec: [32m'1'[39m,
+    namedJsrRegistry: [32m'jsr'[39m,
+    registry: [32m'https://npm.jsr.io/'[39m,
+    registrySpec: [32m'1'[39m,
+    semver: [32m'1'[39m,
+    range: Range {
+      raw: [32m'1'[39m,
+      isAny: [33mfalse[39m,
+      isSingle: [33mfalse[39m,
+      set: [ [36m[Comparator][39m ],
+      includePrerelease: [33mfalse[39m
+    }
+  }
+}
+`
+
+exports[`test/browser.ts > TAP > basic parsing tests > @luca/cases@jsr:1 > toString 1`] = `
+@luca/cases@jsr:1
+`
+
+exports[`test/browser.ts > TAP > basic parsing tests > @other/xyz@jsr:@luca/cases > inspect deep 1`] = `
+@vltpkg/spec.Spec {
+  type: 'registry',
+  spec: '@other/xyz@jsr:@luca/cases',
+  name: '@other/xyz',
+  scope: '@other',
+  bareSpec: 'jsr:@luca/cases',
+  namedJsrRegistry: 'jsr',
+  registry: 'https://npm.jsr.io/',
+  subspec: @vltpkg/spec.Spec {
+    type: 'registry',
+    spec: '@jsr/luca__cases',
+    name: '@jsr/luca__cases',
+    scope: '@jsr',
+    scopeRegistry: 'https://npm.jsr.io/',
+    bareSpec: '',
+    namedJsrRegistry: 'jsr',
+    registry: 'https://npm.jsr.io/',
+    registrySpec: '',
+    semver: '',
+    range: Range {
+      raw: '',
+      isAny: true,
+      isSingle: false,
+      set: [
+        Comparator {
+          includePrerelease: false,
+          raw: '',
+          tokens: [],
+          tuples: [
+            {
+              isAny: true,
+              toString: [Function: toString],
+              includePrerelease: false,
+              test: [Function: test]
+            }
+          ],
+          isNone: false,
+          isAny: true
+        }
+      ],
+      includePrerelease: false
+    }
+  }
+}
+`
+
+exports[`test/browser.ts > TAP > basic parsing tests > @other/xyz@jsr:@luca/cases > inspect default 1`] = `
+@vltpkg/spec.Spec {
+  type: 'registry',
+  spec: '@other/xyz@jsr:@luca/cases',
+  name: '@other/xyz',
+  scope: '@other',
+  bareSpec: 'jsr:@luca/cases',
+  namedJsrRegistry: 'jsr',
+  registry: 'https://npm.jsr.io/',
+  subspec: @vltpkg/spec.Spec {
+    type: 'registry',
+    spec: '@jsr/luca__cases',
+    name: '@jsr/luca__cases',
+    scope: '@jsr',
+    scopeRegistry: 'https://npm.jsr.io/',
+    bareSpec: '',
+    namedJsrRegistry: 'jsr',
+    registry: 'https://npm.jsr.io/',
+    registrySpec: '',
+    semver: '',
+    range: Range {
+      raw: '',
+      isAny: true,
+      isSingle: false,
+      set: [ [Comparator] ],
+      includePrerelease: false
+    }
+  }
+}
+`
+
+exports[`test/browser.ts > TAP > basic parsing tests > @other/xyz@jsr:@luca/cases > inspect with color 1`] = `
+@vltpkg/spec.Spec {
+  type: [32m'registry'[39m,
+  spec: [32m'@other/xyz@jsr:@luca/cases'[39m,
+  name: [32m'@other/xyz'[39m,
+  scope: [32m'@other'[39m,
+  bareSpec: [32m'jsr:@luca/cases'[39m,
+  namedJsrRegistry: [32m'jsr'[39m,
+  registry: [32m'https://npm.jsr.io/'[39m,
+  subspec: @vltpkg/spec.Spec {
+    type: [32m'registry'[39m,
+    spec: [32m'@jsr/luca__cases'[39m,
+    name: [32m'@jsr/luca__cases'[39m,
+    scope: [32m'@jsr'[39m,
+    scopeRegistry: [32m'https://npm.jsr.io/'[39m,
+    bareSpec: [32m''[39m,
+    namedJsrRegistry: [32m'jsr'[39m,
+    registry: [32m'https://npm.jsr.io/'[39m,
+    registrySpec: [32m''[39m,
+    semver: [32m''[39m,
+    range: Range {
+      raw: [32m''[39m,
+      isAny: [33mtrue[39m,
+      isSingle: [33mfalse[39m,
+      set: [ [36m[Comparator][39m ],
+      includePrerelease: [33mfalse[39m
+    }
+  }
+}
+`
+
+exports[`test/browser.ts > TAP > basic parsing tests > @other/xyz@jsr:@luca/cases > toString 1`] = `
+@other/xyz@jsr:@luca/cases
+`
+
+exports[`test/browser.ts > TAP > basic parsing tests > @other/xyz@jsr:@luca/cases@1 > inspect deep 1`] = `
+@vltpkg/spec.Spec {
+  type: 'registry',
+  spec: '@other/xyz@jsr:@luca/cases@1',
+  name: '@other/xyz',
+  scope: '@other',
+  bareSpec: 'jsr:@luca/cases@1',
+  namedJsrRegistry: 'jsr',
+  registry: 'https://npm.jsr.io/',
+  subspec: @vltpkg/spec.Spec {
+    type: 'registry',
+    spec: '@jsr/luca__cases@1',
+    name: '@jsr/luca__cases',
+    scope: '@jsr',
+    scopeRegistry: 'https://npm.jsr.io/',
+    bareSpec: '1',
+    namedJsrRegistry: 'jsr',
+    registry: 'https://npm.jsr.io/',
+    registrySpec: '1',
+    semver: '1',
+    range: Range {
+      raw: '1',
+      isAny: false,
+      isSingle: false,
+      set: [
+        Comparator {
+          includePrerelease: false,
+          raw: '1',
+          tokens: [ '1' ],
+          tuples: [
+            [
+              '>=',
+              Version {
+                raw: '1',
+                major: 1,
+                minor: 0,
+                patch: 0,
+                prerelease: undefined,
+                build: undefined
+              }
+            ],
+            [
+              '<',
+              Version {
+                raw: '1',
+                major: 2,
+                minor: 0,
+                patch: 0,
+                prerelease: [ 0 ],
+                build: undefined
+              }
+            ]
+          ],
+          isNone: false,
+          isAny: false
+        }
+      ],
+      includePrerelease: false
+    }
+  }
+}
+`
+
+exports[`test/browser.ts > TAP > basic parsing tests > @other/xyz@jsr:@luca/cases@1 > inspect default 1`] = `
+@vltpkg/spec.Spec {
+  type: 'registry',
+  spec: '@other/xyz@jsr:@luca/cases@1',
+  name: '@other/xyz',
+  scope: '@other',
+  bareSpec: 'jsr:@luca/cases@1',
+  namedJsrRegistry: 'jsr',
+  registry: 'https://npm.jsr.io/',
+  subspec: @vltpkg/spec.Spec {
+    type: 'registry',
+    spec: '@jsr/luca__cases@1',
+    name: '@jsr/luca__cases',
+    scope: '@jsr',
+    scopeRegistry: 'https://npm.jsr.io/',
+    bareSpec: '1',
+    namedJsrRegistry: 'jsr',
+    registry: 'https://npm.jsr.io/',
+    registrySpec: '1',
+    semver: '1',
+    range: Range {
+      raw: '1',
+      isAny: false,
+      isSingle: false,
+      set: [ [Comparator] ],
+      includePrerelease: false
+    }
+  }
+}
+`
+
+exports[`test/browser.ts > TAP > basic parsing tests > @other/xyz@jsr:@luca/cases@1 > inspect with color 1`] = `
+@vltpkg/spec.Spec {
+  type: [32m'registry'[39m,
+  spec: [32m'@other/xyz@jsr:@luca/cases@1'[39m,
+  name: [32m'@other/xyz'[39m,
+  scope: [32m'@other'[39m,
+  bareSpec: [32m'jsr:@luca/cases@1'[39m,
+  namedJsrRegistry: [32m'jsr'[39m,
+  registry: [32m'https://npm.jsr.io/'[39m,
+  subspec: @vltpkg/spec.Spec {
+    type: [32m'registry'[39m,
+    spec: [32m'@jsr/luca__cases@1'[39m,
+    name: [32m'@jsr/luca__cases'[39m,
+    scope: [32m'@jsr'[39m,
+    scopeRegistry: [32m'https://npm.jsr.io/'[39m,
+    bareSpec: [32m'1'[39m,
+    namedJsrRegistry: [32m'jsr'[39m,
+    registry: [32m'https://npm.jsr.io/'[39m,
+    registrySpec: [32m'1'[39m,
+    semver: [32m'1'[39m,
+    range: Range {
+      raw: [32m'1'[39m,
+      isAny: [33mfalse[39m,
+      isSingle: [33mfalse[39m,
+      set: [ [36m[Comparator][39m ],
+      includePrerelease: [33mfalse[39m
+    }
+  }
+}
+`
+
+exports[`test/browser.ts > TAP > basic parsing tests > @other/xyz@jsr:@luca/cases@1 > toString 1`] = `
+@other/xyz@jsr:@luca/cases@1
 `
 
 exports[`test/browser.ts > TAP > basic parsing tests > @x/y@workspace:@a/b@ > inspect deep 1`] = `
@@ -757,6 +1241,242 @@ exports[`test/browser.ts > TAP > basic parsing tests > @x/y@workspace:@a/b@ > in
 
 exports[`test/browser.ts > TAP > basic parsing tests > @x/y@workspace:@a/b@ > toString 1`] = `
 @x/y@workspace:@a/b@
+`
+
+exports[`test/browser.ts > TAP > basic parsing tests > cases@jsr:@luca/cases > inspect deep 1`] = `
+@vltpkg/spec.Spec {
+  type: 'registry',
+  spec: 'cases@jsr:@luca/cases',
+  name: 'cases',
+  bareSpec: 'jsr:@luca/cases',
+  namedJsrRegistry: 'jsr',
+  registry: 'https://npm.jsr.io/',
+  subspec: @vltpkg/spec.Spec {
+    type: 'registry',
+    spec: '@jsr/luca__cases',
+    name: '@jsr/luca__cases',
+    scope: '@jsr',
+    scopeRegistry: 'https://npm.jsr.io/',
+    bareSpec: '',
+    namedJsrRegistry: 'jsr',
+    registry: 'https://npm.jsr.io/',
+    registrySpec: '',
+    semver: '',
+    range: Range {
+      raw: '',
+      isAny: true,
+      isSingle: false,
+      set: [
+        Comparator {
+          includePrerelease: false,
+          raw: '',
+          tokens: [],
+          tuples: [
+            {
+              isAny: true,
+              toString: [Function: toString],
+              includePrerelease: false,
+              test: [Function: test]
+            }
+          ],
+          isNone: false,
+          isAny: true
+        }
+      ],
+      includePrerelease: false
+    }
+  }
+}
+`
+
+exports[`test/browser.ts > TAP > basic parsing tests > cases@jsr:@luca/cases > inspect default 1`] = `
+@vltpkg/spec.Spec {
+  type: 'registry',
+  spec: 'cases@jsr:@luca/cases',
+  name: 'cases',
+  bareSpec: 'jsr:@luca/cases',
+  namedJsrRegistry: 'jsr',
+  registry: 'https://npm.jsr.io/',
+  subspec: @vltpkg/spec.Spec {
+    type: 'registry',
+    spec: '@jsr/luca__cases',
+    name: '@jsr/luca__cases',
+    scope: '@jsr',
+    scopeRegistry: 'https://npm.jsr.io/',
+    bareSpec: '',
+    namedJsrRegistry: 'jsr',
+    registry: 'https://npm.jsr.io/',
+    registrySpec: '',
+    semver: '',
+    range: Range {
+      raw: '',
+      isAny: true,
+      isSingle: false,
+      set: [ [Comparator] ],
+      includePrerelease: false
+    }
+  }
+}
+`
+
+exports[`test/browser.ts > TAP > basic parsing tests > cases@jsr:@luca/cases > inspect with color 1`] = `
+@vltpkg/spec.Spec {
+  type: [32m'registry'[39m,
+  spec: [32m'cases@jsr:@luca/cases'[39m,
+  name: [32m'cases'[39m,
+  bareSpec: [32m'jsr:@luca/cases'[39m,
+  namedJsrRegistry: [32m'jsr'[39m,
+  registry: [32m'https://npm.jsr.io/'[39m,
+  subspec: @vltpkg/spec.Spec {
+    type: [32m'registry'[39m,
+    spec: [32m'@jsr/luca__cases'[39m,
+    name: [32m'@jsr/luca__cases'[39m,
+    scope: [32m'@jsr'[39m,
+    scopeRegistry: [32m'https://npm.jsr.io/'[39m,
+    bareSpec: [32m''[39m,
+    namedJsrRegistry: [32m'jsr'[39m,
+    registry: [32m'https://npm.jsr.io/'[39m,
+    registrySpec: [32m''[39m,
+    semver: [32m''[39m,
+    range: Range {
+      raw: [32m''[39m,
+      isAny: [33mtrue[39m,
+      isSingle: [33mfalse[39m,
+      set: [ [36m[Comparator][39m ],
+      includePrerelease: [33mfalse[39m
+    }
+  }
+}
+`
+
+exports[`test/browser.ts > TAP > basic parsing tests > cases@jsr:@luca/cases > toString 1`] = `
+cases@jsr:@luca/cases
+`
+
+exports[`test/browser.ts > TAP > basic parsing tests > cases@jsr:@luca/cases@1 > inspect deep 1`] = `
+@vltpkg/spec.Spec {
+  type: 'registry',
+  spec: 'cases@jsr:@luca/cases@1',
+  name: 'cases',
+  bareSpec: 'jsr:@luca/cases@1',
+  namedJsrRegistry: 'jsr',
+  registry: 'https://npm.jsr.io/',
+  subspec: @vltpkg/spec.Spec {
+    type: 'registry',
+    spec: '@jsr/luca__cases@1',
+    name: '@jsr/luca__cases',
+    scope: '@jsr',
+    scopeRegistry: 'https://npm.jsr.io/',
+    bareSpec: '1',
+    namedJsrRegistry: 'jsr',
+    registry: 'https://npm.jsr.io/',
+    registrySpec: '1',
+    semver: '1',
+    range: Range {
+      raw: '1',
+      isAny: false,
+      isSingle: false,
+      set: [
+        Comparator {
+          includePrerelease: false,
+          raw: '1',
+          tokens: [ '1' ],
+          tuples: [
+            [
+              '>=',
+              Version {
+                raw: '1',
+                major: 1,
+                minor: 0,
+                patch: 0,
+                prerelease: undefined,
+                build: undefined
+              }
+            ],
+            [
+              '<',
+              Version {
+                raw: '1',
+                major: 2,
+                minor: 0,
+                patch: 0,
+                prerelease: [ 0 ],
+                build: undefined
+              }
+            ]
+          ],
+          isNone: false,
+          isAny: false
+        }
+      ],
+      includePrerelease: false
+    }
+  }
+}
+`
+
+exports[`test/browser.ts > TAP > basic parsing tests > cases@jsr:@luca/cases@1 > inspect default 1`] = `
+@vltpkg/spec.Spec {
+  type: 'registry',
+  spec: 'cases@jsr:@luca/cases@1',
+  name: 'cases',
+  bareSpec: 'jsr:@luca/cases@1',
+  namedJsrRegistry: 'jsr',
+  registry: 'https://npm.jsr.io/',
+  subspec: @vltpkg/spec.Spec {
+    type: 'registry',
+    spec: '@jsr/luca__cases@1',
+    name: '@jsr/luca__cases',
+    scope: '@jsr',
+    scopeRegistry: 'https://npm.jsr.io/',
+    bareSpec: '1',
+    namedJsrRegistry: 'jsr',
+    registry: 'https://npm.jsr.io/',
+    registrySpec: '1',
+    semver: '1',
+    range: Range {
+      raw: '1',
+      isAny: false,
+      isSingle: false,
+      set: [ [Comparator] ],
+      includePrerelease: false
+    }
+  }
+}
+`
+
+exports[`test/browser.ts > TAP > basic parsing tests > cases@jsr:@luca/cases@1 > inspect with color 1`] = `
+@vltpkg/spec.Spec {
+  type: [32m'registry'[39m,
+  spec: [32m'cases@jsr:@luca/cases@1'[39m,
+  name: [32m'cases'[39m,
+  bareSpec: [32m'jsr:@luca/cases@1'[39m,
+  namedJsrRegistry: [32m'jsr'[39m,
+  registry: [32m'https://npm.jsr.io/'[39m,
+  subspec: @vltpkg/spec.Spec {
+    type: [32m'registry'[39m,
+    spec: [32m'@jsr/luca__cases@1'[39m,
+    name: [32m'@jsr/luca__cases'[39m,
+    scope: [32m'@jsr'[39m,
+    scopeRegistry: [32m'https://npm.jsr.io/'[39m,
+    bareSpec: [32m'1'[39m,
+    namedJsrRegistry: [32m'jsr'[39m,
+    registry: [32m'https://npm.jsr.io/'[39m,
+    registrySpec: [32m'1'[39m,
+    semver: [32m'1'[39m,
+    range: Range {
+      raw: [32m'1'[39m,
+      isAny: [33mfalse[39m,
+      isSingle: [33mfalse[39m,
+      set: [ [36m[Comparator][39m ],
+      includePrerelease: [33mfalse[39m
+    }
+  }
+}
+`
+
+exports[`test/browser.ts > TAP > basic parsing tests > cases@jsr:@luca/cases@1 > toString 1`] = `
+cases@jsr:@luca/cases@1
 `
 
 exports[`test/browser.ts > TAP > basic parsing tests > foo > inspect deep 1`] = `
@@ -1874,6 +2594,162 @@ exports[`test/browser.ts > TAP > basic parsing tests > foo@latest > inspect with
 
 exports[`test/browser.ts > TAP > basic parsing tests > foo@latest > toString 1`] = `
 foo@latest
+`
+
+exports[`test/browser.ts > TAP > basic parsing tests > foo@npm:@luca/cases@jsr:1 > inspect deep 1`] = `
+@vltpkg/spec.Spec {
+  type: 'registry',
+  spec: 'foo@npm:@luca/cases@jsr:1',
+  name: 'foo',
+  bareSpec: 'npm:@luca/cases@jsr:1',
+  namedRegistry: 'npm',
+  registry: 'https://registry.npmjs.org/',
+  subspec: @vltpkg/spec.Spec {
+    type: 'registry',
+    spec: '@luca/cases@jsr:1',
+    name: '@luca/cases',
+    scope: '@luca',
+    bareSpec: 'jsr:1',
+    namedRegistry: 'npm',
+    namedJsrRegistry: 'jsr',
+    registry: 'https://npm.jsr.io/',
+    subspec: @vltpkg/spec.Spec {
+      type: 'registry',
+      spec: '@jsr/luca__cases@1',
+      name: '@jsr/luca__cases',
+      scope: '@jsr',
+      scopeRegistry: 'https://npm.jsr.io/',
+      bareSpec: '1',
+      namedJsrRegistry: 'jsr',
+      registry: 'https://npm.jsr.io/',
+      registrySpec: '1',
+      semver: '1',
+      range: Range {
+        raw: '1',
+        isAny: false,
+        isSingle: false,
+        set: [
+          Comparator {
+            includePrerelease: false,
+            raw: '1',
+            tokens: [ '1' ],
+            tuples: [
+              [
+                '>=',
+                Version {
+                  raw: '1',
+                  major: 1,
+                  minor: 0,
+                  patch: 0,
+                  prerelease: undefined,
+                  build: undefined
+                }
+              ],
+              [
+                '<',
+                Version {
+                  raw: '1',
+                  major: 2,
+                  minor: 0,
+                  patch: 0,
+                  prerelease: [ 0 ],
+                  build: undefined
+                }
+              ]
+            ],
+            isNone: false,
+            isAny: false
+          }
+        ],
+        includePrerelease: false
+      }
+    }
+  }
+}
+`
+
+exports[`test/browser.ts > TAP > basic parsing tests > foo@npm:@luca/cases@jsr:1 > inspect default 1`] = `
+@vltpkg/spec.Spec {
+  type: 'registry',
+  spec: 'foo@npm:@luca/cases@jsr:1',
+  name: 'foo',
+  bareSpec: 'npm:@luca/cases@jsr:1',
+  namedRegistry: 'npm',
+  registry: 'https://registry.npmjs.org/',
+  subspec: @vltpkg/spec.Spec {
+    type: 'registry',
+    spec: '@luca/cases@jsr:1',
+    name: '@luca/cases',
+    scope: '@luca',
+    bareSpec: 'jsr:1',
+    namedRegistry: 'npm',
+    namedJsrRegistry: 'jsr',
+    registry: 'https://npm.jsr.io/',
+    subspec: @vltpkg/spec.Spec {
+      type: 'registry',
+      spec: '@jsr/luca__cases@1',
+      name: '@jsr/luca__cases',
+      scope: '@jsr',
+      scopeRegistry: 'https://npm.jsr.io/',
+      bareSpec: '1',
+      namedJsrRegistry: 'jsr',
+      registry: 'https://npm.jsr.io/',
+      registrySpec: '1',
+      semver: '1',
+      range: Range {
+        raw: '1',
+        isAny: false,
+        isSingle: false,
+        set: [ [Comparator] ],
+        includePrerelease: false
+      }
+    }
+  }
+}
+`
+
+exports[`test/browser.ts > TAP > basic parsing tests > foo@npm:@luca/cases@jsr:1 > inspect with color 1`] = `
+@vltpkg/spec.Spec {
+  type: [32m'registry'[39m,
+  spec: [32m'foo@npm:@luca/cases@jsr:1'[39m,
+  name: [32m'foo'[39m,
+  bareSpec: [32m'npm:@luca/cases@jsr:1'[39m,
+  namedRegistry: [32m'npm'[39m,
+  registry: [32m'https://registry.npmjs.org/'[39m,
+  subspec: @vltpkg/spec.Spec {
+    type: [32m'registry'[39m,
+    spec: [32m'@luca/cases@jsr:1'[39m,
+    name: [32m'@luca/cases'[39m,
+    scope: [32m'@luca'[39m,
+    bareSpec: [32m'jsr:1'[39m,
+    namedRegistry: [32m'npm'[39m,
+    namedJsrRegistry: [32m'jsr'[39m,
+    registry: [32m'https://npm.jsr.io/'[39m,
+    subspec: @vltpkg/spec.Spec {
+      type: [32m'registry'[39m,
+      spec: [32m'@jsr/luca__cases@1'[39m,
+      name: [32m'@jsr/luca__cases'[39m,
+      scope: [32m'@jsr'[39m,
+      scopeRegistry: [32m'https://npm.jsr.io/'[39m,
+      bareSpec: [32m'1'[39m,
+      namedJsrRegistry: [32m'jsr'[39m,
+      registry: [32m'https://npm.jsr.io/'[39m,
+      registrySpec: [32m'1'[39m,
+      semver: [32m'1'[39m,
+      range: Range {
+        raw: [32m'1'[39m,
+        isAny: [33mfalse[39m,
+        isSingle: [33mfalse[39m,
+        set: [ [36m[Comparator][39m ],
+        includePrerelease: [33mfalse[39m
+      }
+    }
+  }
+}
+`
+
+exports[`test/browser.ts > TAP > basic parsing tests > foo@npm:@luca/cases@jsr:1 > toString 1`] = `
+foo@jsr:1
 `
 
 exports[`test/browser.ts > TAP > basic parsing tests > foo@npm:bar@ > inspect deep 1`] = `
@@ -6499,6 +7375,212 @@ exports[`test/browser.ts > TAP > parse args > @foo/bar@git+ssh://notgithub.com/u
 }
 `
 
+exports[`test/browser.ts > TAP > parse args > @luca/cases@jsr: > inspect default 1`] = `
+@vltpkg/spec.Spec {
+  type: 'registry',
+  spec: '@luca/cases@jsr:',
+  name: '@luca/cases',
+  scope: '@luca',
+  bareSpec: 'jsr:',
+  namedJsrRegistry: 'jsr',
+  registry: 'https://npm.jsr.io/',
+  subspec: @vltpkg/spec.Spec {
+    type: 'registry',
+    spec: '@jsr/luca__cases@',
+    name: '@jsr/luca__cases',
+    scope: '@jsr',
+    scopeRegistry: 'https://npm.jsr.io/',
+    bareSpec: '',
+    namedJsrRegistry: 'jsr',
+    registry: 'https://npm.jsr.io/',
+    registrySpec: '',
+    semver: '',
+    range: Range {
+      raw: '',
+      isAny: true,
+      isSingle: false,
+      set: [ [Comparator] ],
+      includePrerelease: false
+    }
+  }
+}
+`
+
+exports[`test/browser.ts > TAP > parse args > @luca/cases@jsr:@a/b@jsr:1 > inspect default 1`] = `
+@vltpkg/spec.Spec {
+  type: 'registry',
+  spec: '@luca/cases@jsr:@a/b@jsr:1',
+  name: '@luca/cases',
+  scope: '@luca',
+  bareSpec: 'jsr:@a/b@jsr:1',
+  namedJsrRegistry: 'jsr',
+  registry: 'https://npm.jsr.io/',
+  subspec: @vltpkg/spec.Spec {
+    type: 'registry',
+    spec: '@jsr/a__b@jsr:1',
+    name: '@jsr/a__b',
+    scope: '@jsr',
+    scopeRegistry: 'https://npm.jsr.io/',
+    bareSpec: 'jsr:1',
+    namedJsrRegistry: 'jsr',
+    registry: 'https://npm.jsr.io/',
+    subspec: @vltpkg/spec.Spec {
+      type: 'registry',
+      spec: '@jsr/jsr__a__b@1',
+      name: '@jsr/jsr__a__b',
+      scope: '@jsr',
+      scopeRegistry: 'https://npm.jsr.io/',
+      bareSpec: '1',
+      namedJsrRegistry: 'jsr',
+      registry: 'https://npm.jsr.io/',
+      registrySpec: '1',
+      semver: '1',
+      range: Range {
+        raw: '1',
+        isAny: false,
+        isSingle: false,
+        set: [ [Comparator] ],
+        includePrerelease: false
+      }
+    }
+  }
+}
+`
+
+exports[`test/browser.ts > TAP > parse args > @luca/cases@jsr:@luca/cases@1 > inspect default 1`] = `
+@vltpkg/spec.Spec {
+  type: 'registry',
+  spec: '@luca/cases@jsr:1',
+  name: '@luca/cases',
+  scope: '@luca',
+  bareSpec: 'jsr:1',
+  namedJsrRegistry: 'jsr',
+  registry: 'https://npm.jsr.io/',
+  subspec: @vltpkg/spec.Spec {
+    type: 'registry',
+    spec: '@jsr/luca__cases@1',
+    name: '@jsr/luca__cases',
+    scope: '@jsr',
+    scopeRegistry: 'https://npm.jsr.io/',
+    bareSpec: '1',
+    namedJsrRegistry: 'jsr',
+    registry: 'https://npm.jsr.io/',
+    registrySpec: '1',
+    semver: '1',
+    range: Range {
+      raw: '1',
+      isAny: false,
+      isSingle: false,
+      set: [ [Comparator] ],
+      includePrerelease: false
+    }
+  }
+}
+`
+
+exports[`test/browser.ts > TAP > parse args > @luca/cases@jsr:@luca/cases@jsr:@x/y@1 > inspect default 1`] = `
+@vltpkg/spec.Spec {
+  type: 'registry',
+  spec: '@luca/cases@jsr:jsr:@x/y@1',
+  name: '@luca/cases',
+  scope: '@luca',
+  bareSpec: 'jsr:jsr:@x/y@1',
+  namedJsrRegistry: 'jsr',
+  registry: 'https://npm.jsr.io/',
+  subspec: @vltpkg/spec.Spec {
+    type: 'registry',
+    spec: '@jsr/luca__cases@jsr:@x/y@1',
+    name: '@jsr/luca__cases',
+    scope: '@jsr',
+    scopeRegistry: 'https://npm.jsr.io/',
+    bareSpec: 'jsr:@x/y@1',
+    namedJsrRegistry: 'jsr',
+    registry: 'https://npm.jsr.io/',
+    subspec: @vltpkg/spec.Spec {
+      type: 'registry',
+      spec: '@jsr/x__y@1',
+      name: '@jsr/x__y',
+      scope: '@jsr',
+      scopeRegistry: 'https://npm.jsr.io/',
+      bareSpec: '1',
+      namedJsrRegistry: 'jsr',
+      registry: 'https://npm.jsr.io/',
+      registrySpec: '1',
+      semver: '1',
+      range: Range {
+        raw: '1',
+        isAny: false,
+        isSingle: false,
+        set: [ [Comparator] ],
+        includePrerelease: false
+      }
+    }
+  }
+}
+`
+
+exports[`test/browser.ts > TAP > parse args > @luca/cases@jsr:1 > inspect default 1`] = `
+@vltpkg/spec.Spec {
+  type: 'registry',
+  spec: '@luca/cases@jsr:1',
+  name: '@luca/cases',
+  scope: '@luca',
+  bareSpec: 'jsr:1',
+  namedJsrRegistry: 'jsr',
+  registry: 'https://npm.jsr.io/',
+  subspec: @vltpkg/spec.Spec {
+    type: 'registry',
+    spec: '@jsr/luca__cases@1',
+    name: '@jsr/luca__cases',
+    scope: '@jsr',
+    scopeRegistry: 'https://npm.jsr.io/',
+    bareSpec: '1',
+    namedJsrRegistry: 'jsr',
+    registry: 'https://npm.jsr.io/',
+    registrySpec: '1',
+    semver: '1',
+    range: Range {
+      raw: '1',
+      isAny: false,
+      isSingle: false,
+      set: [ [Comparator] ],
+      includePrerelease: false
+    }
+  }
+}
+`
+
+exports[`test/browser.ts > TAP > parse args > @luca/cases@jsr:1 > inspect default 2`] = `
+@vltpkg/spec.Spec {
+  type: 'registry',
+  spec: '@luca/cases@jsr:1',
+  name: '@luca/cases',
+  scope: '@luca',
+  bareSpec: 'jsr:1',
+  namedJsrRegistry: 'jsr',
+  registry: 'https://npm.jsr.io/',
+  subspec: @vltpkg/spec.Spec {
+    type: 'registry',
+    spec: '@jsr/luca__cases@1',
+    name: '@jsr/luca__cases',
+    scope: '@jsr',
+    scopeRegistry: 'https://npm.jsr.io/',
+    bareSpec: '1',
+    namedJsrRegistry: 'jsr',
+    registry: 'https://npm.jsr.io/',
+    registrySpec: '1',
+    semver: '1',
+    range: Range {
+      raw: '1',
+      isAny: false,
+      isSingle: false,
+      set: [ [Comparator] ],
+      includePrerelease: false
+    }
+  }
+}
+`
+
 exports[`test/browser.ts > TAP > parse args > @x/y@workspace:@a/b@ > inspect default 1`] = `
 @vltpkg/spec.Spec {
   type: 'workspace',
@@ -6538,6 +7620,66 @@ exports[`test/browser.ts > TAP > parse args > /path/to/foo.tgz > inspect default
   name: '(unknown)',
   bareSpec: 'file:.//path/to/foo.tgz',
   file: './/path/to/foo.tgz'
+}
+`
+
+exports[`test/browser.ts > TAP > parse args > cases@jsr:@luca/cases > inspect default 1`] = `
+@vltpkg/spec.Spec {
+  type: 'registry',
+  spec: 'cases@jsr:@luca/cases',
+  name: 'cases',
+  bareSpec: 'jsr:@luca/cases',
+  namedJsrRegistry: 'jsr',
+  registry: 'https://npm.jsr.io/',
+  subspec: @vltpkg/spec.Spec {
+    type: 'registry',
+    spec: '@jsr/luca__cases',
+    name: '@jsr/luca__cases',
+    scope: '@jsr',
+    scopeRegistry: 'https://npm.jsr.io/',
+    bareSpec: '',
+    namedJsrRegistry: 'jsr',
+    registry: 'https://npm.jsr.io/',
+    registrySpec: '',
+    semver: '',
+    range: Range {
+      raw: '',
+      isAny: true,
+      isSingle: false,
+      set: [ [Comparator] ],
+      includePrerelease: false
+    }
+  }
+}
+`
+
+exports[`test/browser.ts > TAP > parse args > cases@jsr:@luca/cases@1 > inspect default 1`] = `
+@vltpkg/spec.Spec {
+  type: 'registry',
+  spec: 'cases@jsr:@luca/cases@1',
+  name: 'cases',
+  bareSpec: 'jsr:@luca/cases@1',
+  namedJsrRegistry: 'jsr',
+  registry: 'https://npm.jsr.io/',
+  subspec: @vltpkg/spec.Spec {
+    type: 'registry',
+    spec: '@jsr/luca__cases@1',
+    name: '@jsr/luca__cases',
+    scope: '@jsr',
+    scopeRegistry: 'https://npm.jsr.io/',
+    bareSpec: '1',
+    namedJsrRegistry: 'jsr',
+    registry: 'https://npm.jsr.io/',
+    registrySpec: '1',
+    semver: '1',
+    range: Range {
+      raw: '1',
+      isAny: false,
+      isSingle: false,
+      set: [ [Comparator] ],
+      includePrerelease: false
+    }
+  }
 }
 `
 
@@ -7081,6 +8223,46 @@ exports[`test/browser.ts > TAP > parse args > foo@latest > inspect default 1`] =
 }
 `
 
+exports[`test/browser.ts > TAP > parse args > foo@npm:@luca/cases@jsr:1 > inspect default 1`] = `
+@vltpkg/spec.Spec {
+  type: 'registry',
+  spec: 'foo@npm:@luca/cases@jsr:1',
+  name: 'foo',
+  bareSpec: 'npm:@luca/cases@jsr:1',
+  namedRegistry: 'npm',
+  registry: 'https://registry.npmjs.org/',
+  subspec: @vltpkg/spec.Spec {
+    type: 'registry',
+    spec: '@luca/cases@jsr:1',
+    name: '@luca/cases',
+    scope: '@luca',
+    bareSpec: 'jsr:1',
+    namedRegistry: 'npm',
+    namedJsrRegistry: 'jsr',
+    registry: 'https://npm.jsr.io/',
+    subspec: @vltpkg/spec.Spec {
+      type: 'registry',
+      spec: '@jsr/luca__cases@1',
+      name: '@jsr/luca__cases',
+      scope: '@jsr',
+      scopeRegistry: 'https://npm.jsr.io/',
+      bareSpec: '1',
+      namedJsrRegistry: 'jsr',
+      registry: 'https://npm.jsr.io/',
+      registrySpec: '1',
+      semver: '1',
+      range: Range {
+        raw: '1',
+        isAny: false,
+        isSingle: false,
+        set: [ [Comparator] ],
+        includePrerelease: false
+      }
+    }
+  }
+}
+`
+
 exports[`test/browser.ts > TAP > parse args > foo@npm:bar@ > inspect default 1`] = `
 @vltpkg/spec.Spec {
   type: 'registry',
@@ -7391,9 +8573,9 @@ exports[`test/browser.ts > TAP > parse args > github:a/b > inspect default 1`] =
 exports[`test/browser.ts > TAP > parse args > jsr:@luca/cases > inspect default 1`] = `
 @vltpkg/spec.Spec {
   type: 'registry',
-  spec: '@luca/cases@jsr:@luca/cases',
+  spec: '@luca/cases@jsr:',
   name: '@luca/cases',
-  bareSpec: 'jsr:@luca/cases',
+  bareSpec: 'jsr:',
   namedJsrRegistry: 'jsr',
   registry: 'https://npm.jsr.io/',
   subspec: @vltpkg/spec.Spec {
@@ -7421,9 +8603,39 @@ exports[`test/browser.ts > TAP > parse args > jsr:@luca/cases > inspect default 
 exports[`test/browser.ts > TAP > parse args > jsr:@luca/cases@1 > inspect default 1`] = `
 @vltpkg/spec.Spec {
   type: 'registry',
-  spec: '@luca/cases@jsr:@luca/cases@1',
+  spec: '@luca/cases@jsr:1',
   name: '@luca/cases',
-  bareSpec: 'jsr:@luca/cases@1',
+  bareSpec: 'jsr:1',
+  namedJsrRegistry: 'jsr',
+  registry: 'https://npm.jsr.io/',
+  subspec: @vltpkg/spec.Spec {
+    type: 'registry',
+    spec: '@jsr/luca__cases@1',
+    name: '@jsr/luca__cases',
+    scope: '@jsr',
+    scopeRegistry: 'https://npm.jsr.io/',
+    bareSpec: '1',
+    namedJsrRegistry: 'jsr',
+    registry: 'https://npm.jsr.io/',
+    registrySpec: '1',
+    semver: '1',
+    range: Range {
+      raw: '1',
+      isAny: false,
+      isSingle: false,
+      set: [ [Comparator] ],
+      includePrerelease: false
+    }
+  }
+}
+`
+
+exports[`test/browser.ts > TAP > parse args > jsr:@luca/cases@1 > inspect default 2`] = `
+@vltpkg/spec.Spec {
+  type: 'registry',
+  spec: '@luca/cases@jsr:1',
+  name: '@luca/cases',
+  bareSpec: 'jsr:1',
   namedJsrRegistry: 'jsr',
   registry: 'https://npm.jsr.io/',
   subspec: @vltpkg/spec.Spec {
@@ -7463,6 +8675,46 @@ exports[`test/browser.ts > TAP > parse args > no options > no options 1`] = `
     isSingle: false,
     set: [ [Comparator] ],
     includePrerelease: false
+  }
+}
+`
+
+exports[`test/browser.ts > TAP > parse args > npm:@luca/cases@jsr:1 > inspect default 1`] = `
+@vltpkg/spec.Spec {
+  type: 'registry',
+  spec: '@luca/cases@npm:@luca/cases@jsr:1',
+  name: '@luca/cases',
+  bareSpec: 'npm:@luca/cases@jsr:1',
+  namedRegistry: 'npm',
+  registry: 'https://registry.npmjs.org/',
+  subspec: @vltpkg/spec.Spec {
+    type: 'registry',
+    spec: '@luca/cases@jsr:1',
+    name: '@luca/cases',
+    scope: '@luca',
+    bareSpec: 'jsr:1',
+    namedRegistry: 'npm',
+    namedJsrRegistry: 'jsr',
+    registry: 'https://npm.jsr.io/',
+    subspec: @vltpkg/spec.Spec {
+      type: 'registry',
+      spec: '@jsr/luca__cases@1',
+      name: '@jsr/luca__cases',
+      scope: '@jsr',
+      scopeRegistry: 'https://npm.jsr.io/',
+      bareSpec: '1',
+      namedJsrRegistry: 'jsr',
+      registry: 'https://npm.jsr.io/',
+      registrySpec: '1',
+      semver: '1',
+      range: Range {
+        raw: '1',
+        isAny: false,
+        isSingle: false,
+        set: [ [Comparator] ],
+        includePrerelease: false
+      }
+    }
   }
 }
 `

--- a/src/spec/tap-snapshots/test/browser.ts.test.cjs
+++ b/src/spec/tap-snapshots/test/browser.ts.test.cjs
@@ -8719,6 +8719,62 @@ exports[`test/browser.ts > TAP > parse args > npm:@luca/cases@jsr:1 > inspect de
 }
 `
 
+exports[`test/browser.ts > TAP > parse args > npm:abbrev > inspect default 1`] = `
+@vltpkg/spec.Spec {
+  type: 'registry',
+  spec: 'abbrev@npm:abbrev',
+  name: 'abbrev',
+  bareSpec: 'npm:abbrev',
+  namedRegistry: 'npm',
+  registry: 'https://registry.npmjs.org/',
+  subspec: @vltpkg/spec.Spec {
+    type: 'registry',
+    spec: 'abbrev',
+    name: 'abbrev',
+    bareSpec: '',
+    namedRegistry: 'npm',
+    registry: 'https://registry.npmjs.org/',
+    registrySpec: '',
+    semver: '',
+    range: Range {
+      raw: '',
+      isAny: true,
+      isSingle: false,
+      set: [ [Comparator] ],
+      includePrerelease: false
+    }
+  }
+}
+`
+
+exports[`test/browser.ts > TAP > parse args > npm:abbrev@1 > inspect default 1`] = `
+@vltpkg/spec.Spec {
+  type: 'registry',
+  spec: 'abbrev@npm:abbrev@1',
+  name: 'abbrev',
+  bareSpec: 'npm:abbrev@1',
+  namedRegistry: 'npm',
+  registry: 'https://registry.npmjs.org/',
+  subspec: @vltpkg/spec.Spec {
+    type: 'registry',
+    spec: 'abbrev@1',
+    name: 'abbrev',
+    bareSpec: '1',
+    namedRegistry: 'npm',
+    registry: 'https://registry.npmjs.org/',
+    registrySpec: '1',
+    semver: '1',
+    range: Range {
+      raw: '1',
+      isAny: false,
+      isSingle: false,
+      set: [ [Comparator] ],
+      includePrerelease: false
+    }
+  }
+}
+`
+
 exports[`test/browser.ts > TAP > parse args > npm:foo > inspect default 1`] = `
 @vltpkg/spec.Spec {
   type: 'registry',

--- a/src/spec/test/browser.ts
+++ b/src/spec/test/browser.ts
@@ -387,6 +387,8 @@ t.test('parse args', t => {
     '@luca/cases@jsr:1',
     '@luca/cases@jsr:@a/b@jsr:1',
     '@luca/cases@jsr:@luca/cases@jsr:@x/y@1',
+    'npm:abbrev',
+    'npm:abbrev@1',
   ]
 
   const specOptions: SpecOptions = {

--- a/src/spec/test/browser.ts
+++ b/src/spec/test/browser.ts
@@ -158,7 +158,15 @@ t.test('basic parsing tests', t => {
     'foo@https://bitbucket.org/user/project/a/s/d/f/#semver:1.x::path:src/foo',
     '@a/b@npm:@y/z@1.2.3',
     '@luca/cases@jsr:@luca/cases@1',
+    '@luca/cases@jsr:1',
     '@luca/cases@jsr:@luca/cases',
+    '@luca/cases@jsr:',
+    'cases@jsr:@luca/cases',
+    'cases@jsr:@luca/cases@1',
+    '@other/xyz@jsr:@luca/cases',
+    '@other/xyz@jsr:@luca/cases@1',
+    // little bit confusing, but worth testing
+    'foo@npm:@luca/cases@jsr:1',
   ]
 
   t.plan(specs.length)
@@ -367,6 +375,18 @@ t.test('parse args', t => {
     '@a/b@npm:@y/z@1.2.3',
     'jsr:@luca/cases@1',
     'jsr:@luca/cases',
+    '@luca/cases@jsr:1',
+    '@luca/cases@jsr:',
+    'cases@jsr:@luca/cases@1',
+    'cases@jsr:@luca/cases',
+    'foo@npm:@luca/cases@jsr:1',
+    // little bit confusing, but worth testing
+    'npm:@luca/cases@jsr:1',
+    'jsr:@luca/cases@1',
+    '@luca/cases@jsr:@luca/cases@1',
+    '@luca/cases@jsr:1',
+    '@luca/cases@jsr:@a/b@jsr:1',
+    '@luca/cases@jsr:@luca/cases@jsr:@x/y@1',
   ]
 
   const specOptions: SpecOptions = {


### PR DESCRIPTION
That is, `@a/b@jsr:1.x` should be the same as `@a/b@jsr:@a/b@1.x`.