### PR TITLE
reify: save properly back to package.json

### DIFF
--- a/src/graph/src/reify/calculate-save-value.ts
+++ b/src/graph/src/reify/calculate-save-value.ts
@@ -1,0 +1,61 @@
+import type { Spec } from '@vltpkg/spec'
+const SAVE_PREFIX = '^'
+
+export const calculateSaveValue = (
+  nodeType: string,
+  spec: Spec,
+  existing: string | undefined,
+  nodeVersion: string | undefined,
+): string => {
+  if (
+    // if not from the registry, save whatever we requested
+    nodeType === 'registry' &&
+    // if we installed exactly what we already wanted, leave it untouched
+    spec.bareSpec !== existing &&
+    // if we installed a specific version, keep that specific version.
+    !spec.final.range?.isSingle
+  ) {
+    // if we had a single version, and got that version, then
+    // leave it as-is.
+    if (existing && existing === nodeVersion) {
+      // depend on 1.2.3, got 1.2.3, keep unchanged
+      return existing
+    } else if (existing && !spec.bareSpec) {
+      // if we had `"express": "5.1"` and did `vlt i express`,
+      // then leave it as-is, because we just installed our pj dep
+      return existing
+    } else {
+      const finalRange =
+        (spec.final.semver && spec.final.bareSpec) ||
+        `${SAVE_PREFIX}${nodeVersion}`
+      // didn't have dep previously, or depended on a different thing
+      // than what was requested. Update with the ^ range based on
+      // the node that landed in the graph, but preserve alias prefix
+      if (spec.subspec && spec.final.namedRegistry) {
+        return `${spec.final.namedRegistry}:${spec.final.name}@${finalRange}`
+      }
+
+      if (spec.final.namedJsrRegistry) {
+        // if we were given an alternative name, preserve that
+        // do this with a regexp because the Spec objects get a little
+        // weird here, and the string is relatively straightforward.
+        return spec.bareSpec
+          .replace(
+            new RegExp(
+              `^(?:.*?@)?${spec.final.namedJsrRegistry}:(@[^/]+/[^@]+)(@.*?)?$`,
+            ),
+            `${spec.final.namedJsrRegistry}:$1@${finalRange}`,
+          )
+          .replace(
+            // otherwise, swap out the final version for the save range
+            new RegExp(
+              `^(?:.*?@)?${spec.final.namedJsrRegistry}:([^@].*?)?$`,
+            ),
+            `${spec.final.namedJsrRegistry}:${finalRange}`,
+          )
+      }
+      return finalRange
+    }
+  }
+  return spec.bareSpec
+}

--- a/src/graph/test/reify/calculate-save-value.ts
+++ b/src/graph/test/reify/calculate-save-value.ts
@@ -1,0 +1,80 @@
+import { Spec } from '@vltpkg/spec'
+import t from 'tap'
+import { calculateSaveValue } from '../../src/reify/calculate-save-value.ts'
+
+t.test('non-registry type, just saved as-is', t => {
+  const s = Spec.parse('x', 'github:a/b')
+  t.equal(calculateSaveValue('git', s, 'a/b', '1.2.3'), 'github:a/b')
+  t.end()
+})
+
+// registry cases
+// nodeVersion is always 1.2.3
+const cases: [
+  spec: string,
+  existing: string | undefined,
+  expect: string,
+  comment: string,
+][] = [
+  ['1', undefined, '1', 'new dep, use specified range'],
+  ['', undefined, '^1.2.3', 'new dep, no spec, use caret range'],
+  ['npm:b@1', undefined, 'npm:b@1', 'alias preserved'],
+  ['npm:b', undefined, 'npm:b@^1.2.3', 'alias preserved with range'],
+  [
+    'npm:b@',
+    undefined,
+    'npm:b@^1.2.3',
+    'alias preserved with range with @',
+  ],
+  ['npm:b@npm:c@1', undefined, 'npm:c@1', 'chained alias shortened'],
+  [
+    'npm:b@npm:c',
+    undefined,
+    'npm:c@^1.2.3',
+    'chained alias shortened with save range',
+  ],
+  ['jsr:@a/b@1', undefined, 'jsr:@a/b@1', 'jsr alias'],
+  [
+    'jsr:@a/b@',
+    undefined,
+    'jsr:@a/b@^1.2.3',
+    'jsr alias with save range',
+  ],
+  [
+    'npm:@i/j@jsr:@a/b@1',
+    undefined,
+    'jsr:@a/b@1',
+    'jsr alias shorten',
+  ],
+  [
+    'npm:@i/j@jsr:@a/b',
+    undefined,
+    'jsr:@a/b@^1.2.3',
+    'jsr alias shorten with caret range',
+  ],
+  ['latest', 'latest', 'latest', 'spec matches manifest'],
+  ['', 'latest', 'latest', 'spec from manifest'],
+  ['1.2.3', 'latest', '1.2.3', 'requested specific version'],
+  ['', '1.2.3', '1.2.3', 'manifest needs specific version'],
+  ['1.2', '1.2', '1.2', 'got exactly what we wanted'],
+  ['jsr:', undefined, 'jsr:^1.2.3', 'jsr save range'],
+  [
+    '1.2 || 2.5',
+    undefined,
+    '1.2 || 2.5',
+    'saved what was requested, no existing dep',
+  ],
+  ['1.2 || 2.5', '1.2', '1.2 || 2.5', 'saved what was requested'],
+]
+
+t.test('registry cases', t => {
+  t.plan(cases.length)
+  for (const [bareSpec, existing, expect, comment] of cases) {
+    const spec = Spec.parse('@x/y', bareSpec)
+    t.equal(
+      calculateSaveValue('registry', spec, existing, '1.2.3'),
+      expect,
+      comment,
+    )
+  }
+})


### PR DESCRIPTION
This fixes a few overlooked issues in how we save dependencies back to package.json. The new logic is, in a nutshell:

- If the user provided a specific version or range in the installation, we save that back to package.json
- If the package.json specified a specific single version, then we save that (ie, keep it pinned).
- If the final registry alias or jsr specifier did not include a version, and the package.json _does_ include a version or range, leave it un-touched, because we were just installing what the package.json said to, and it remains the authority.
- If the final registry alias or jsr specifier did not include a version range, and the package.json does not include a version or range, then we use the `^{resulting version}` range.

Fix: #638
Fix: VLT-344