### PR TITLE
query: add breadcrumb parser

### DIFF
--- a/src/query/src/index.ts
+++ b/src/query/src/index.ts
@@ -14,6 +14,8 @@ import {
   isPseudoNode,
   isIdentifierNode,
   isAttributeNode,
+  isCombinatorNode,
+  isCommentNode,
 } from './types.ts'
 import type {
   PostcssNode,
@@ -190,6 +192,190 @@ const setMethodToJSON = (node: QueryResponseNode) => {
     ...toJSON.call(node),
     insights,
   })
+}
+
+/**
+ * A valid item of a given breadcrumb.
+ */
+export type InteractiveBreadcrumbItem = {
+  value: string
+  type: string
+  prev: InteractiveBreadcrumbItem | undefined
+  next: InteractiveBreadcrumbItem | undefined
+  importer: boolean
+}
+
+/**
+ * The InteractiveBreadcrumb class is used to represent a valid breadcrumb.
+ *
+ * "Breadcrumb" is a term used to describe the subset of the query language
+ * that uses only root/workspace selectors, id selectors & combinators.
+ *
+ * It implements an iterable, doubly-linked list of items that can be used
+ * to navigate through the breadcrumb.
+ *
+ * It also validates that each element of the provided query string is
+ * valid according to the previous definition of a "breadcrumb".
+ */
+export class InteractiveBreadcrumb
+  implements Iterable<InteractiveBreadcrumbItem>
+{
+  #current: InteractiveBreadcrumbItem
+  #items: InteractiveBreadcrumbItem[]
+  comment: string | undefined
+
+  /**
+   * Initializes the interactive breadcrumb with a query string.
+   */
+  constructor(query: string) {
+    this.#items = []
+    const ast = parse(query)
+
+    // Keep track of the previous AST node for consolidation
+    let prevNode: PostcssNode | undefined
+
+    // iterates only at the first level of the AST since
+    // any nested nodes are invalid syntax
+    for (const item of ast.first.nodes) {
+      const isWorkspaceOrProject =
+        isPseudoNode(item) &&
+        (item.value === ':workspace' || item.value === ':project')
+
+      const allowedPseudoNodes =
+        isPseudoNode(item) &&
+        (item.value === ':root' ||
+          item.value === ':workspace' ||
+          item.value === ':project')
+
+      const allowedTypes =
+        isIdentifierNode(item) ||
+        allowedPseudoNodes ||
+        (isCombinatorNode(item) && item.value === '>') ||
+        isCommentNode(item)
+
+      // Check if this is a nested selector that's not an allowed pseudo
+      const isNestedSelector =
+        isPostcssNodeWithChildren(item) &&
+        !(allowedPseudoNodes && item.nodes.length === 0)
+
+      // validation, only the root/workspace selectors, id selectors
+      // and combinators are valid ast node items
+      if (isNestedSelector || !allowedTypes) {
+        throw error('Invalid query', { found: item })
+      }
+
+      // combinators and comments are skipped
+      if (isCombinatorNode(item)) {
+        prevNode = undefined
+        continue
+      } else if (isCommentNode(item)) {
+        const cleanComment = item.value
+          .replace(/^\/\*/, '')
+          .replace(/\*\/$/, '')
+          .trim()
+        this.comment = cleanComment
+        prevNode = undefined
+      } else {
+        // check if we need to consolidate with previous item
+        const isPrevWorkspaceOrProject =
+          prevNode &&
+          isPseudoNode(prevNode) &&
+          (prevNode.value === ':workspace' ||
+            prevNode.value === ':project')
+
+        const isPrevId = prevNode && isIdentifierNode(prevNode)
+        const isCurrentId = isIdentifierNode(item)
+        const lastItem =
+          this.#items.length > 0 ?
+            this.#items[this.#items.length - 1]
+          : null
+
+        // current node is ID, previous was workspace/project
+        if (isCurrentId && isPrevWorkspaceOrProject && lastItem) {
+          // Modify the last item to include the ID
+          lastItem.value = `${lastItem.value}#${item.value}`
+          prevNode = undefined
+          continue
+        }
+
+        // current node is workspace/project, previous was ID
+        if (isWorkspaceOrProject && isPrevId && lastItem) {
+          // Modify the last item to include the pseudo
+          lastItem.value = `${lastItem.value}${item.value}`
+          lastItem.importer = true
+          prevNode = undefined
+          continue
+        }
+
+        // Default case: create a new item normally
+        const prev = this.#items[this.#items.length - 1]
+        const newItem = {
+          value: item.value,
+          type: item.type,
+          prev,
+          next: undefined,
+          importer: allowedPseudoNodes,
+        }
+        if (prev) {
+          prev.next = newItem
+        }
+        this.#items.push(newItem)
+        prevNode = item
+      }
+    }
+    // the parsed query should have at least one item
+    // that is then going to be set as the current item
+    if (!this.#items[0]) {
+      throw error('Failed to parse query', {
+        found: query,
+      })
+    }
+    this.#current = this.#items[0]
+  }
+
+  /**
+   * The current breadcrumb item.
+   */
+  get current(): InteractiveBreadcrumbItem {
+    return this.#current
+  }
+
+  /**
+   * The next breadcrumb item.
+   */
+  next(): InteractiveBreadcrumbItem | undefined {
+    if (!this.#current.next) {
+      return
+    }
+    this.#current = this.#current.next
+    return this.#current
+  }
+
+  /**
+   * The previous breadcrumb item.
+   */
+  prev(): InteractiveBreadcrumbItem | undefined {
+    if (!this.#current.prev) {
+      return
+    }
+    this.#current = this.#current.prev
+    return this.#current
+  }
+
+  [Symbol.iterator]() {
+    return this.#items.values()
+  }
+
+  /**
+   * Empties the current breadcrumb list.
+   */
+  clear() {
+    for (const item of this.#items) {
+      item.prev = undefined
+      item.next = undefined
+    }
+    this.#items.length = 0
+  }
 }
 
 /**
@@ -579,5 +765,13 @@ export class Query {
 
     processNode(ast(query))
     return tokens
+  }
+
+  /**
+   * Returns an {@link InteractiveBreadcrumb} list of items
+   * for a given query string.
+   */
+  static getBreadcrumbItems(query: string): InteractiveBreadcrumb {
+    return new InteractiveBreadcrumb(query)
   }
 }

--- a/src/query/src/types.ts
+++ b/src/query/src/types.ts
@@ -314,3 +314,21 @@ export const asStringNode = (node?: PostcssNode): String => {
 
   return node
 }
+
+export const isCommentNode = (node: unknown): node is Comment =>
+  isObj(node) && !!node.value && node.type === 'comment'
+
+export const asCommentNode = (node?: PostcssNode): Comment => {
+  if (!node) {
+    throw error('Expected a query node')
+  }
+
+  if (!isCommentNode(node)) {
+    throw error('Mismatching query node', {
+      wanted: 'comment',
+      found: node.type,
+    })
+  }
+
+  return node
+}

--- a/src/query/test/index.ts
+++ b/src/query/test/index.ts
@@ -973,3 +973,339 @@ t.test('specificitySort', async t => {
     'should preserve original order for equal specificity values',
   )
 })
+
+t.test('getBreadcrumbItems', async t => {
+  await t.test('valid cases', async t => {
+    // Test the error cases properly since the function is designed to throw for most queries
+
+    // Empty query should throw as expected
+    t.throws(
+      () => Query.getBreadcrumbItems(''),
+      /Failed to parse query/,
+      'should throw on empty query',
+    )
+
+    // Simple ID selector - one of the few valid cases
+    const idBreadcrumb = Query.getBreadcrumbItems('#a')
+    t.equal(
+      idBreadcrumb.current.value,
+      'a', // Note: The # prefix is not included in the value
+      'should parse ID selector without # prefix',
+    )
+    t.equal(
+      idBreadcrumb.current.type,
+      'id',
+      'should have type "id" for ID selector',
+    )
+    t.equal(
+      idBreadcrumb.current.importer,
+      false,
+      'ID selector should have importer=false',
+    )
+    t.equal(
+      idBreadcrumb.next(),
+      undefined,
+      'ID selector should have no next item',
+    )
+    t.equal(
+      idBreadcrumb.prev(),
+      undefined,
+      'ID selector should have no prev item',
+    )
+
+    // Test :root pseudo selector (should have importer=true)
+    const rootBreadcrumb = Query.getBreadcrumbItems(':root')
+    t.equal(
+      rootBreadcrumb.current.value,
+      ':root',
+      'should parse :root pseudo selector',
+    )
+    t.equal(
+      rootBreadcrumb.current.type,
+      'pseudo',
+      'should have type "pseudo" for :root',
+    )
+    t.equal(
+      rootBreadcrumb.current.importer,
+      true,
+      ':root should have importer=true',
+    )
+
+    // Test :workspace pseudo selector (should have importer=true)
+    const workspaceBreadcrumb = Query.getBreadcrumbItems(':workspace')
+    t.equal(
+      workspaceBreadcrumb.current.value,
+      ':workspace',
+      'should parse :workspace pseudo selector',
+    )
+    t.equal(
+      workspaceBreadcrumb.current.importer,
+      true,
+      ':workspace should have importer=true',
+    )
+
+    // Test :project pseudo selector (should have importer=true)
+    const projectBreadcrumb = Query.getBreadcrumbItems(':project')
+    t.equal(
+      projectBreadcrumb.current.value,
+      ':project',
+      'should parse :project pseudo selector',
+    )
+    t.equal(
+      projectBreadcrumb.current.importer,
+      true,
+      ':project should have importer=true',
+    )
+    t.equal(
+      projectBreadcrumb.current.type,
+      'pseudo',
+      ':project should have type=pseudo',
+    )
+
+    // Test with comment
+    const commentBreadcrumb = Query.getBreadcrumbItems(
+      '/* test comment */ #a',
+    )
+    t.equal(
+      commentBreadcrumb.comment,
+      'test comment',
+      'should extract full comment with delimiters',
+    )
+    t.equal(
+      commentBreadcrumb.current.value,
+      'a', // Without # prefix
+      'should parse ID selector after comment',
+    )
+    t.equal(
+      commentBreadcrumb.current.importer,
+      false,
+      'ID selector after comment should have importer=false',
+    )
+
+    // Test complex query with multiple ID selectors
+    const complexBreadcrumb = Query.getBreadcrumbItems(
+      '#foo > #bar > #baz',
+    )
+    t.equal(
+      complexBreadcrumb.current.value,
+      'foo',
+      'should start with first ID selector',
+    )
+    t.equal(
+      complexBreadcrumb.current.type,
+      'id',
+      'first item should have type "id"',
+    )
+    t.equal(
+      complexBreadcrumb.current.importer,
+      false,
+      'ID selector should have importer=false',
+    )
+
+    // Navigate forward
+    const firstNext = complexBreadcrumb.next()
+    t.ok(firstNext, 'should have a next item')
+    t.equal(
+      complexBreadcrumb.current.value,
+      'bar',
+      'current should now be the second ID',
+    )
+    t.equal(
+      complexBreadcrumb.current.type,
+      'id',
+      'second item should have type "id"',
+    )
+    t.equal(
+      complexBreadcrumb.current.importer,
+      false,
+      'second ID selector should have importer=false',
+    )
+
+    const secondNext = complexBreadcrumb.next()
+    t.ok(secondNext, 'should have a second next item')
+    t.equal(
+      complexBreadcrumb.current.value,
+      'baz',
+      'current should now be the third ID',
+    )
+    t.equal(
+      complexBreadcrumb.current.type,
+      'id',
+      'third item should have type "id"',
+    )
+    t.equal(
+      complexBreadcrumb.current.importer,
+      false,
+      'third ID selector should have importer=false',
+    )
+
+    t.equal(
+      complexBreadcrumb.next(),
+      undefined,
+      'should have no more next items',
+    )
+
+    // Navigate backward
+    const firstPrev = complexBreadcrumb.prev()
+    t.ok(firstPrev, 'should have a previous item')
+    t.equal(
+      complexBreadcrumb.current.value,
+      'bar',
+      'current should go back to the second ID',
+    )
+
+    const secondPrev = complexBreadcrumb.prev()
+    t.ok(secondPrev, 'should have a second previous item')
+    t.equal(
+      complexBreadcrumb.current.value,
+      'foo',
+      'current should go back to the first ID',
+    )
+
+    t.equal(
+      complexBreadcrumb.prev(),
+      undefined,
+      'should have no more previous items',
+    )
+
+    // Test workspace+ID consolidation (workspace first)
+    const workspaceIdBreadcrumb = Query.getBreadcrumbItems(
+      ':workspace#a > #foo > #bar',
+    )
+    t.equal(
+      workspaceIdBreadcrumb.current.value,
+      ':workspace#a',
+      'should consolidate :workspace and ID into a single item',
+    )
+    t.equal(
+      workspaceIdBreadcrumb.current.type,
+      'pseudo',
+      'consolidated item should maintain pseudo type',
+    )
+    t.equal(
+      workspaceIdBreadcrumb.current.importer,
+      true,
+      'consolidated :workspace#id should have importer=true',
+    )
+
+    // Test ID+workspace consolidation (ID first)
+    const idWorkspaceBreadcrumb = Query.getBreadcrumbItems(
+      '#a:workspace > #foo > #bar',
+    )
+    t.equal(
+      idWorkspaceBreadcrumb.current.value,
+      'a:workspace',
+      'should consolidate ID and :workspace into a single item',
+    )
+    t.equal(
+      idWorkspaceBreadcrumb.current.type,
+      'id',
+      'consolidated item should maintain ID type',
+    )
+    t.equal(
+      idWorkspaceBreadcrumb.current.importer,
+      true,
+      'consolidated id:workspace should have importer=true',
+    )
+    const nextWorkspaceBreadcrumb = idWorkspaceBreadcrumb.next()
+    t.ok(nextWorkspaceBreadcrumb, 'should have a second next item')
+    t.equal(
+      idWorkspaceBreadcrumb.current.value,
+      'foo',
+      'current should now point to #foo',
+    )
+    t.equal(
+      idWorkspaceBreadcrumb.current.type,
+      'id',
+      '#foo should have type "id"',
+    )
+    t.equal(
+      idWorkspaceBreadcrumb.current.importer,
+      false,
+      '#foo should have importer=false',
+    )
+
+    // Test project+ID consolidation (project first)
+    const projectIdBreadcrumb = Query.getBreadcrumbItems(
+      ':project#b > #foo > #bar',
+    )
+    t.equal(
+      projectIdBreadcrumb.current.value,
+      ':project#b',
+      'should consolidate :project and ID into a single item',
+    )
+    t.equal(
+      projectIdBreadcrumb.current.type,
+      'pseudo',
+      'consolidated item should maintain pseudo type',
+    )
+    t.equal(
+      projectIdBreadcrumb.current.importer,
+      true,
+      'consolidated :project#id should have importer=true',
+    )
+
+    // Test ID+project consolidation (ID first)
+    const idProjectBreadcrumb = Query.getBreadcrumbItems(
+      '#b:project > #foo > #bar',
+    )
+    t.equal(
+      idProjectBreadcrumb.current.value,
+      'b:project',
+      'should consolidate ID and :project into a single item',
+    )
+    t.equal(
+      idProjectBreadcrumb.current.type,
+      'id',
+      'consolidated item should maintain ID type',
+    )
+    t.equal(
+      idProjectBreadcrumb.current.importer,
+      true,
+      'consolidated id:project should have importer=true',
+    )
+  })
+
+  await t.test('error cases', async t => {
+    // Now only test selectors that should still throw "Invalid query"
+    t.throws(
+      () => Query.getBreadcrumbItems(':foo'),
+      /Invalid query/,
+      'should throw on invalid pseudo selector',
+    )
+
+    t.throws(
+      () => Query.getBreadcrumbItems('[name=foo]'),
+      /Invalid query/,
+      'should throw on attribute selector',
+    )
+
+    t.throws(
+      () => Query.getBreadcrumbItems(':root:prod'),
+      /Invalid query/,
+      'should throw on non-allowed pseudo selector',
+    )
+
+    t.throws(
+      () => Query.getBreadcrumbItems(':has(#a)'),
+      /Invalid query/,
+      'should throw on nested selector',
+    )
+  })
+
+  await t.test('clear method', async t => {
+    // One of the few valid cases is a simple ID selector
+    const breadcrumb = Query.getBreadcrumbItems('#a')
+    t.equal(
+      breadcrumb.current.value,
+      'a', // Without # prefix
+      'first item should be ID selector without # prefix',
+    )
+
+    breadcrumb.clear()
+    // After clear, the items array should be empty but we can't directly check it
+    // Check if iterating gives no items
+    const items = [...breadcrumb]
+    t.equal(items.length, 0, 'should have cleared all items')
+  })
+})


### PR DESCRIPTION
Adds a new `Query.getBreadcrumbItems` method that returns a helper object to interactively navigate a given "breadcrumb".

The "breadcrumb" is a subset of the query language that only takes root/workspaces selectors along with id selectors and combinators, allowing for usage of queries that look like a breadcrumb UI, e.g:

  :root > #foo > #bar > #baz

Refs: https://github.com/vltpkg/vltpkg/issues/663
Refs: https://github.com/vltpkg/statusboard/issues/133
Refs: https://github.com/vltpkg/statusboard/issues/64