### PR TITLE
chore(docs): update query examples

### DIFF
--- a/src/query/README.md
+++ b/src/query/README.md
@@ -17,16 +17,47 @@ const res = await query.search(':root > *')
 
 ## Examples
 
-Querying nodes from a local `node_modules` folder.
+### Querying against an ideal/virtual graph
+
+```js
+import { ideal } from '@vltpkg/graph'
+import { Query } from '@vltpkg/query'
+import { PackageJson } from '@vltpkg/package-json'
+const signal = new AbortController().signal
+const projectRoot = process.cwd()
+const packageJson = new PackageJson()
+const graph = await ideal.build({ projectRoot, packageJson })
+const query = new Query({ graph })
+const res = await query.search(':root > *', { signal })
+```
+
+### Querying against a local `node_modules` folder
 
 ```js
 import { actual } from '@vltpkg/graph'
 import { Query } from '@vltpkg/query'
+import { PackageJson } from '@vltpkg/package-json'
+import { PathScurry } from 'path-scurry'
+const signal = new AbortController().signal
+const projectRoot = process.cwd()
+const scurry = new PathScurry(projectRoot)
+const packageJson = new PackageJson()
+const graph = await actual.load({ projectRoot, packageJson, scurry })
+const query = new Query({ graph })
+const res = await query.search(':root > *', { signal })
+```
 
-const specOptions = {
-  registry: 'https://registry.npmjs.org',
-}
-const graph = await actual.load({ projectRoot: process.cwd() })
-const query = new Query({ graph, specOptions })
-const res = await query.search(':root > *')
+### Querying against a lockfile
+
+```js
+import { lockfile } from '@vltpkg/graph'
+import { Query } from '@vltpkg/query'
+const signal = new AbortController().signal
+const projectRoot = process.cwd()
+const graph = await lockfile.load({
+  mainManifest: 'package.json',
+  projectRoot,
+})
+const query = new Query({ graph })
+const res = await query.search(':root > *', { signal })
 ```


### PR DESCRIPTION
- docs were outdated
- this updates the "Examples" to show minimum reproduction cases for virtual/actual/lockfile graph querying
- afaict, this is the minimum code required for each scenario (pretty significant composition/overhead)
- please let me know if there's a way to get leaner examples