### PR TITLE
graph: fix edge replacement

### DIFF
--- a/src/graph/src/graph.ts
+++ b/src/graph/src/graph.ts
@@ -217,6 +217,9 @@ export class Graph implements GraphLike {
         edge.spec.bareSpec === spec.bareSpec
       ) {
         if (to && to !== edge.to) {
+          // removes this edge from its destination edgesIn ref
+          edge.to?.edgesIn.delete(edge)
+          // now swap the destination to the new one
           edge.to = to as Node
           edge.to.edgesIn.add(edge)
         }


### PR DESCRIPTION
Replacing existing edges was resulting in missing nodes in the graph since the `removeNodes` method removes any edges going into the node that is about to be removed.

A straightforward and resilient solution is to make sure we remove any edge that is about to have its destination replaced from the `edgesIn` set in that original destination node.

Refs: https://github.com/vltpkg/statusboard/issues/64