### PR TITLE
dogfood catalog bugfix

### DIFF
--- a/src/graph/src/ideal/get-importer-specs.ts
+++ b/src/graph/src/ideal/get-importer-specs.ts
@@ -17,10 +17,12 @@ import type { Node } from '../node.ts'
 import type { Graph } from '../graph.ts'
 import type { DepID } from '@vltpkg/dep-id'
 import { Spec } from '@vltpkg/spec'
+import type { SpecOptions } from '@vltpkg/spec'
 
 export type GetImporterSpecsOptions = BuildIdealAddOptions &
   BuildIdealFromGraphOptions &
-  BuildIdealRemoveOptions
+  BuildIdealRemoveOptions &
+  SpecOptions
 
 const hasDepName = (importer: Node, edge: Edge): boolean => {
   for (const depType of longDependencyTypes) {
@@ -50,11 +52,10 @@ class RemoveImportersDependenciesMapImpl
  * dependencies info found in the graph importers and returns the add & remove
  * results as a Map in which keys are {@link DepID} of each importer node.
  */
-export const getImporterSpecs = ({
-  add,
-  graph,
-  remove,
-}: GetImporterSpecsOptions) => {
+export const getImporterSpecs = (
+  options: GetImporterSpecsOptions,
+) => {
+  const { add, graph, remove } = options
   const addResult: AddImportersDependenciesMap =
     new AddImportersDependenciesMapImpl()
   const removeResult: RemoveImportersDependenciesMap =
@@ -87,7 +88,7 @@ export const getImporterSpecs = ({
           addDeps.set(
             depName,
             asDependency({
-              spec: Spec.parse(depName, depSpec),
+              spec: Spec.parse(depName, depSpec, options),
               type: shorten(depType, depName, importer.manifest),
             }),
           )

--- a/src/package-info/src/index.ts
+++ b/src/package-info/src/index.ts
@@ -426,7 +426,7 @@ export class PackageInfoClient {
         if (!mani) throw this.#resolveError(spec, options)
         const { integrity, tarball } = mani.dist ?? {}
         if (isIntegrity(integrity) && tarball) {
-          const registryOrigin = new URL(String(spec.registry)).origin
+          const registryOrigin = new URL(String(f.registry)).origin
           const tgzOrigin = new URL(tarball).origin
           // if it comes from the same origin, trust the integrity
           if (tgzOrigin === registryOrigin) {
@@ -605,7 +605,7 @@ export class PackageInfoClient {
     switch (f.type) {
       case 'file': {
         const { file } = f
-        if (!file || !spec.file) {
+        if (!file || !f.file) {
           throw this.#resolveError(
             spec,
             options,
@@ -613,7 +613,7 @@ export class PackageInfoClient {
           )
         }
         const { from = this.#projectRoot } = options
-        const resolved = pathResolve(from, spec.file)
+        const resolved = pathResolve(from, f.file)
         const r = { resolved, spec }
         this.#resolutions.set(memoKey, r)
         return r
@@ -673,7 +673,7 @@ export class PackageInfoClient {
             'no remote on git specifier',
           )
         }
-        const rev = await gitResolve(gitRemote, spec.gitCommittish, {
+        const rev = await gitResolve(gitRemote, f.gitCommittish, {
           spec,
         })
         if (rev) {

--- a/src/spec/src/browser.ts
+++ b/src/spec/src/browser.ts
@@ -325,12 +325,16 @@ export class Spec implements SpecLike<Spec> {
         : this.options.catalog
       if (!catalog) {
         throw this.#error('Named catalog not found', {
-          found: this.catalog,
+          name: this.catalog,
+          validOptions: Object.keys(this.options.catalogs),
         })
       }
       const sub = catalog[this.name]
       if (!sub) {
-        throw this.#error('Name not found in catalog', { found: sub })
+        throw this.#error('Name not found in catalog', {
+          name: this.name,
+          validOptions: Object.keys(catalog),
+        })
       }
       this.subspec = Spec.parse(this.name, sub)
       this.type = 'catalog'

--- a/src/spec/test/browser.ts
+++ b/src/spec/test/browser.ts
@@ -727,8 +727,18 @@ t.test('catalogs', async t => {
 
   t.throws(() => Spec.parse('b@catalog:', opts), {
     message: 'Name not found in catalog',
+    cause: {
+      name: 'b',
+      validOptions: ['a'],
+      spec: 'b@catalog:',
+    },
   })
   t.throws(() => Spec.parse('b@catalog:z', opts), {
     message: 'Named catalog not found',
+    cause: {
+      name: 'z',
+      validOptions: ['x', 'y'],
+      spec: 'b@catalog:z',
+    },
   })
 })


### PR DESCRIPTION
This fixes a few bugs that were preventing catalog support from functioning properly, as well as creating an explicit link to `astro` in the top level importer to address the occult dependency from `starlight-links-validator`.