### PR TITLE
refactor query parser

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -646,6 +646,46 @@ importers:
         specifier: 'catalog:'
         version: 8.31.1(eslint@9.25.1(jiti@2.4.2))(typescript@5.7.3)
 
+  src/dss-parser:
+    dependencies:
+      '@vltpkg/dss-parser':
+        specifier: workspace:*
+        version: 'link:'
+      '@vltpkg/error-cause':
+        specifier: workspace:*
+        version: link:../error-cause
+      postcss-selector-parser:
+        specifier: ^7.1.0
+        version: 7.1.0
+    devDependencies:
+      '@eslint/js':
+        specifier: 'catalog:'
+        version: 9.25.1
+      '@types/node':
+        specifier: 'catalog:'
+        version: 22.15.24
+      eslint:
+        specifier: 'catalog:'
+        version: 9.25.1(jiti@2.4.2)
+      prettier:
+        specifier: 'catalog:'
+        version: 3.5.3
+      tap:
+        specifier: 'catalog:'
+        version: 21.1.0(@types/node@22.15.24)(@types/react@18.3.20)(react-devtools-core@4.28.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@10.0.0)(typescript@5.7.3)
+      tshy:
+        specifier: 'catalog:'
+        version: 3.0.2(patch_hash=bc476f29bbb76e36ec2746ee69d4ebe413b8ec54eaedfb0dd212d85e8719cc3e)
+      typedoc:
+        specifier: 'catalog:'
+        version: 0.27.9(typescript@5.7.3)
+      typescript:
+        specifier: 'catalog:'
+        version: 5.7.3
+      typescript-eslint:
+        specifier: 'catalog:'
+        version: 8.31.1(eslint@9.25.1(jiti@2.4.2))(typescript@5.7.3)
+
   src/error-cause:
     devDependencies:
       '@eslint/js':
@@ -1396,6 +1436,9 @@ importers:
       '@vltpkg/dep-id':
         specifier: workspace:*
         version: link:../dep-id
+      '@vltpkg/dss-parser':
+        specifier: workspace:*
+        version: link:../dss-parser
       '@vltpkg/error-cause':
         specifier: workspace:*
         version: link:../error-cause
@@ -5298,15 +5341,6 @@ packages:
 
   debug@3.2.7:
     resolution: {integrity: sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==}
-    peerDependencies:
-      supports-color: '*'
-    peerDependenciesMeta:
-      supports-color:
-        optional: true
-
-  debug@4.3.7:
-    resolution: {integrity: sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==}
-    engines: {node: '>=6.0'}
     peerDependencies:
       supports-color: '*'
     peerDependenciesMeta:
@@ -11645,7 +11679,7 @@ snapshots:
 
   agent-base@7.1.1(supports-color@10.0.0):
     dependencies:
-      debug: 4.3.7(supports-color@10.0.0)
+      debug: 4.4.0(supports-color@10.0.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -12297,12 +12331,6 @@ snapshots:
   debug@3.2.7:
     dependencies:
       ms: 2.1.3
-
-  debug@4.3.7(supports-color@10.0.0):
-    dependencies:
-      ms: 2.1.3
-    optionalDependencies:
-      supports-color: 10.0.0
 
   debug@4.4.0(supports-color@10.0.0):
     dependencies:
@@ -13268,7 +13296,7 @@ snapshots:
 
   hast-util-to-jsx-runtime@2.3.2:
     dependencies:
-      '@types/estree': 1.0.6
+      '@types/estree': 1.0.7
       '@types/hast': 3.0.4
       '@types/unist': 3.0.3
       comma-separated-tokens: 2.0.3
@@ -13363,14 +13391,14 @@ snapshots:
   http-proxy-agent@7.0.2(supports-color@10.0.0):
     dependencies:
       agent-base: 7.1.1(supports-color@10.0.0)
-      debug: 4.3.7(supports-color@10.0.0)
+      debug: 4.4.0(supports-color@10.0.0)
     transitivePeerDependencies:
       - supports-color
 
   https-proxy-agent@7.0.6(supports-color@10.0.0):
     dependencies:
       agent-base: 7.1.3
-      debug: 4.3.7(supports-color@10.0.0)
+      debug: 4.4.0(supports-color@10.0.0)
     transitivePeerDependencies:
       - supports-color
 

--- a/src/dss-parser/.tshy/build.json
+++ b/src/dss-parser/.tshy/build.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "../src",
+    "module": "nodenext",
+    "moduleResolution": "nodenext"
+  }
+}

--- a/src/dss-parser/.tshy/esm.json
+++ b/src/dss-parser/.tshy/esm.json
@@ -1,0 +1,15 @@
+{
+  "extends": "./build.json",
+  "include": [
+    "../src/**/*.ts",
+    "../src/**/*.mts",
+    "../src/**/*.tsx",
+    "../src/**/*.json"
+  ],
+  "exclude": [
+    "../src/package.json"
+  ],
+  "compilerOptions": {
+    "outDir": "../.tshy-build/esm"
+  }
+}

--- a/src/dss-parser/LICENSE
+++ b/src/dss-parser/LICENSE
@@ -1,0 +1,15 @@
+Copyright (c) vlt technology, Inc.
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+   Subject to the terms and conditions of this license, each copyright holder and contributor hereby grants to those receiving rights under this license a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable (except for failure to satisfy the conditions of this license) patent license to make, have made, use, offer to sell, sell, import, and otherwise transfer this software, where such license applies only to those patent claims, already acquired or hereafter acquired, licensable by such copyright holder or contributor that are necessarily infringed by:
+
+(a) their Contribution(s) (the licensed copyrights of copyright holders and non-copyrightable additions of contributors, in source or binary form) alone; or
+(b) combination of their Contribution(s) with the work of authorship to which such Contribution(s) was added by such copyright holder or contributor, if, at the time the Contribution is added, such addition causes such combination to be necessarily infringed. The patent license shall not apply to any other combinations which include the Contribution.
+Except as expressly stated above, no rights or licenses from any copyright holder or contributor is granted under this license, whether expressly, by implication, estoppel or otherwise.
+
+DISCLAIMER
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/src/dss-parser/README.md
+++ b/src/dss-parser/README.md
@@ -1,0 +1,16 @@
+# @vltpkg/dss-parser
+
+The Dependency Selector Syntax parser used by the vlt client.
+
+Uses
+[postcss-selector-parser](https://github.com/postcss/postcss-selector-parser)
+to parse a selector string into an AST.
+
+## Usage
+
+```js
+import { parse } from '@vltpkg/dss-parser'
+
+// Parse a selector string into an AST
+const ast = parse(':root > *')
+```

--- a/src/dss-parser/package.json
+++ b/src/dss-parser/package.json
@@ -1,0 +1,70 @@
+{
+  "name": "@vltpkg/dss-parser",
+  "description": "The Dependency Selector Syntax (DSS) parser",
+  "version": "0.0.0-13",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/vltpkg/vltpkg.git",
+    "directory": "src/dss-parser"
+  },
+  "tshy": {
+    "selfLink": false,
+    "liveDev": true,
+    "dialects": [
+      "esm"
+    ],
+    "exports": {
+      "./package.json": "./package.json",
+      ".": "./src/index.ts"
+    }
+  },
+  "dependencies": {
+    "@vltpkg/dss-parser": "workspace:*",
+    "@vltpkg/error-cause": "workspace:*",
+    "postcss-selector-parser": "^7.1.0"
+  },
+  "devDependencies": {
+    "@eslint/js": "catalog:",
+    "@types/node": "catalog:",
+    "eslint": "catalog:",
+    "prettier": "catalog:",
+    "tap": "catalog:",
+    "tshy": "catalog:",
+    "typedoc": "catalog:",
+    "typescript": "catalog:",
+    "typescript-eslint": "catalog:"
+  },
+  "license": "BSD-2-Clause-Patent",
+  "engines": {
+    "node": ">=22"
+  },
+  "scripts": {
+    "format": "prettier --write . --log-level warn --ignore-path ../../.prettierignore --cache",
+    "format:check": "prettier --check . --ignore-path ../../.prettierignore --cache",
+    "lint": "eslint . --fix",
+    "lint:check": "eslint .",
+    "prepack": "tshy",
+    "snap": "tap",
+    "test": "tap",
+    "posttest": "tsc --noEmit",
+    "tshy": "tshy",
+    "typecheck": "tsc --noEmit"
+  },
+  "tap": {
+    "extends": "../../tap-config.yaml"
+  },
+  "prettier": "../../.prettierrc.js",
+  "module": "./src/index.ts",
+  "type": "module",
+  "exports": {
+    "./package.json": "./package.json",
+    ".": {
+      "import": {
+        "default": "./src/index.ts"
+      }
+    }
+  },
+  "files": [
+    "dist"
+  ]
+}

--- a/src/dss-parser/src/index.ts
+++ b/src/dss-parser/src/index.ts
@@ -1,0 +1,122 @@
+import postcssSelectorParser from 'postcss-selector-parser'
+import type { Pseudo, Root } from 'postcss-selector-parser'
+import {
+  asSelectorNode,
+  isCombinatorNode,
+  isPseudoNode,
+  isTagNode,
+} from './types.ts'
+import type { PostcssNode } from './types.ts'
+
+export * from './types.ts'
+
+/**
+ * Escapes forward slashes in specific patterns matching @scoped/name paths
+ * This will allow usage of unescaped forward slashes necessary for scoped
+ * package names in the id selector.
+ */
+export const escapeScopedNamesSlashes = (query: string): string =>
+  query.replace(
+    /(#@(\w|-|\.)+)\//gm,
+    (_, scope: string) => `${scope}\\/`,
+  )
+
+export const escapeDots = (query: string): string =>
+  query.replaceAll('.', '\\.')
+
+export const unescapeDots = (query: string): string =>
+  query.replaceAll('\\.', '.')
+
+const pseudoCleanUpNeeded = new Set([
+  ':published',
+  ':score',
+  ':malware',
+  ':severity',
+  ':sev',
+  ':squat',
+  ':semver',
+  ':v',
+])
+
+const hasParamsToEscape = (node: Pseudo) =>
+  pseudoCleanUpNeeded.has(node.value)
+
+/**
+ * Parses a CSS selector string into an AST
+ * Handles escaping of forward slashes in specific patterns
+ */
+export const parse = (query: string): Root => {
+  const escapedQuery = escapeDots(escapeScopedNamesSlashes(query))
+  const transformAst = (root: Root) => {
+    root.walk((node: PostcssNode) => {
+      // clean up the escaped dots
+      if (node.value && typeof node.value === 'string') {
+        node.value = unescapeDots(node.value)
+      }
+      if (isPseudoNode(node) && hasParamsToEscape(node)) {
+        // these are pseudo nodes that should only take strings as
+        // parameters, so in this preparse step we clean up anything
+        // that was recognized as a postcss node and transform that
+        // into something that can be most likely parsed as a string
+        for (const n of node.nodes) {
+          // the parameters have a selector node that wraps them up
+          const selector = asSelectorNode(n)
+          selector.nodes.forEach((currentNode, index, arr) => {
+            // get the next node, we'll update it later
+            const nextNode = arr[index + 1]
+            // if the current node is a combinator node, we'll need to
+            // escape it, we do so by removing the node entirely and
+            // updating the contents of the next node with its value
+            if (
+              isCombinatorNode(currentNode) &&
+              isTagNode(nextNode)
+            ) {
+              nextNode.value = `${currentNode.spaces.before}${currentNode.value}${currentNode.spaces.after}${nextNode.value}`
+              // make sure to also update the source position
+              // references, those are used by the syntax highlighter
+              if (
+                nextNode.source?.start?.line &&
+                currentNode.source?.start?.line
+              ) {
+                nextNode.source.start.line =
+                  currentNode.source.start.line
+              }
+              if (
+                nextNode.source?.start?.column &&
+                currentNode.source?.start?.column
+              ) {
+                nextNode.source.start.column =
+                  currentNode.source.start.column
+              }
+              // removes the current node from the selector node
+              arr.splice(index, 1)
+            }
+          })
+          // after removing combinator nodes, if we end up with multiple
+          // tags in the selector node, we need to smush them together
+          selector.nodes.reduce((acc, currentNode) => {
+            if (currentNode === acc) return acc
+            acc.value = `${acc.value}${currentNode.spaces.before}${currentNode.value}${currentNode.spaces.after}`
+            // make sure to also update the source position refs
+            if (
+              currentNode.source?.end?.line &&
+              acc.source?.end?.line
+            ) {
+              acc.source.end.line = currentNode.source.end.line
+            }
+            if (
+              currentNode.source?.end?.column &&
+              acc.source?.end?.column
+            ) {
+              acc.source.end.column = currentNode.source.end.column
+            }
+            return acc
+          }, selector.first)
+          // the selector wrapper node should have a single node
+          selector.nodes.length = 1
+        }
+      }
+    })
+  }
+  return postcssSelectorParser(transformAst).astSync(escapedQuery)
+}

--- a/src/dss-parser/src/types.ts
+++ b/src/dss-parser/src/types.ts
@@ -1,0 +1,197 @@
+import { error } from '@vltpkg/error-cause'
+import type {
+  Tag,
+  String,
+  Selector,
+  Root,
+  Pseudo,
+  Nesting,
+  Identifier,
+  Comment,
+  Combinator,
+  ClassName,
+  Attribute,
+  Universal,
+} from 'postcss-selector-parser'
+
+export type PostcssNode =
+  | Tag
+  | String
+  | Selector
+  | Root
+  | Pseudo
+  | Nesting
+  | Identifier
+  | Comment
+  | Combinator
+  | ClassName
+  | Attribute
+  | Universal
+
+export type PostcssNodeWithChildren = Selector | Root | Pseudo
+
+export type ParsedSelectorToken = PostcssNode & {
+  token: string
+}
+
+export const isPostcssNodeWithChildren = (
+  node: any,
+): node is PostcssNodeWithChildren =>
+  'type' in node && 'nodes' in node
+
+export const asPostcssNodeWithChildren = (
+  node?: PostcssNode,
+): PostcssNodeWithChildren => {
+  if (!node) {
+    throw error('Expected a query node')
+  }
+
+  if (!isPostcssNodeWithChildren(node)) {
+    throw error('Not a query selector node with children', {
+      found: node,
+    })
+  }
+  return node
+}
+
+const isObj = (o: unknown): o is Record<string, unknown> =>
+  !!o && typeof o === 'object'
+
+export const isAttributeNode = (node: unknown): node is Attribute =>
+  isObj(node) && !!node.attribute && node.type === 'attribute'
+
+export const asAttributeNode = (node?: PostcssNode): Attribute => {
+  if (!node) {
+    throw error('Expected a query node')
+  }
+
+  if (!isAttributeNode(node)) {
+    throw error('Mismatching query node', {
+      wanted: 'attribute',
+      found: node.type,
+    })
+  }
+  return node
+}
+
+export const isCombinatorNode = (node: unknown): node is Combinator =>
+  isObj(node) && !!node.value && node.type === 'combinator'
+
+export const asCombinatorNode = (node?: PostcssNode): Combinator => {
+  if (!node) {
+    throw error('Expected a query node')
+  }
+
+  if (!isCombinatorNode(node)) {
+    throw error('Mismatching query node', {
+      wanted: 'combinator',
+      found: node.type,
+    })
+  }
+  return node
+}
+
+export const isIdentifierNode = (node: any): node is Identifier =>
+  isObj(node) && !!node.value && node.type === 'id'
+
+export const asIdentifierNode = (node?: PostcssNode): Identifier => {
+  if (!node) {
+    throw error('Expected a query node')
+  }
+
+  if (!isIdentifierNode(node)) {
+    throw error('Mismatching query node', {
+      wanted: 'id',
+      found: node.type,
+    })
+  }
+  return node
+}
+
+export const isSelectorNode = (node: any): node is Selector =>
+  isPostcssNodeWithChildren(node) && node.type === 'selector'
+
+export const asSelectorNode = (node?: PostcssNode): Selector => {
+  if (!node) {
+    throw error('Expected a query node')
+  }
+
+  if (!isSelectorNode(node)) {
+    throw error('Mismatching query node', {
+      wanted: 'selector',
+      found: node.type,
+    })
+  }
+  return node
+}
+
+export const isPseudoNode = (node: unknown): node is Pseudo =>
+  isObj(node) && !!node.value && node.type === 'pseudo'
+
+export const asPseudoNode = (node?: PostcssNode): Pseudo => {
+  if (!node) {
+    throw error('Expected a query node')
+  }
+
+  if (!isPseudoNode(node)) {
+    throw error('Mismatching query node', {
+      wanted: 'pseudo',
+      found: node.type,
+    })
+  }
+  return node
+}
+
+export const isTagNode = (node: unknown): node is Tag =>
+  isObj(node) && !!node.value && node.type === 'tag'
+
+export const asTagNode = (node?: PostcssNode): Tag => {
+  if (!node) {
+    throw error('Expected a query node')
+  }
+
+  if (!isTagNode(node)) {
+    throw error('Mismatching query node', {
+      wanted: 'tag',
+      found: node.type,
+    })
+  }
+
+  return node
+}
+
+export const isStringNode = (node: unknown): node is String =>
+  isObj(node) && !!node.value && node.type === 'string'
+
+export const asStringNode = (node?: PostcssNode): String => {
+  if (!node) {
+    throw error('Expected a query node')
+  }
+
+  if (!isStringNode(node)) {
+    throw error('Mismatching query node', {
+      wanted: 'string',
+      found: node.type,
+    })
+  }
+
+  return node
+}
+
+export const isCommentNode = (node: unknown): node is Comment =>
+  isObj(node) && !!node.value && node.type === 'comment'
+
+export const asCommentNode = (node?: PostcssNode): Comment => {
+  if (!node) {
+    throw error('Expected a query node')
+  }
+
+  if (!isCommentNode(node)) {
+    throw error('Mismatching query node', {
+      wanted: 'comment',
+      found: node.type,
+    })
+  }
+
+  return node
+}

--- a/src/dss-parser/tap-snapshots/test/index.ts.test.cjs
+++ b/src/dss-parser/tap-snapshots/test/index.ts.test.cjs
@@ -1,0 +1,344 @@
+/* IMPORTANT
+ * This snapshot file is auto-generated, but designed for humans.
+ * It should be checked into source control and tracked carefully.
+ * Re-generate by setting TAP_SNAPSHOT=1 and running tests.
+ * Make sure to inspect the output below.  Do not ignore changes!
+ */
+'use strict'
+exports[`test/index.ts > TAP > parse > should clean up usage of combinators params in pseudo selectors that accept only string values 1`] = `
+Array [
+  Object {
+    "source": Object {
+      "end": Object {
+        "column": 6,
+        "line": 1,
+      },
+      "start": Object {
+        "column": 1,
+        "line": 1,
+      },
+    },
+    "type": "selector",
+  },
+  Object {
+    "source": Object {
+      "end": Object {
+        "column": 6,
+        "line": 1,
+      },
+      "start": Object {
+        "column": 1,
+        "line": 1,
+      },
+    },
+    "type": "pseudo",
+    "value": ":v",
+  },
+  Object {
+    "source": Object {
+      "end": Object {
+        "column": 6,
+        "line": 1,
+      },
+      "start": Object {
+        "column": 4,
+        "line": 1,
+      },
+    },
+    "type": "selector",
+  },
+  Object {
+    "source": Object {
+      "end": Object {
+        "column": 5,
+        "line": 1,
+      },
+      "start": Object {
+        "column": 4,
+        "line": 1,
+      },
+    },
+    "type": "tag",
+    "value": ">2",
+  },
+]
+`
+
+exports[`test/index.ts > TAP > parse > should clean up usage of multiple pseudo selectors requiring cleaning up 1`] = `
+Array [
+  Object {
+    "source": Object {
+      "end": Object {
+        "column": 129,
+        "line": 1,
+      },
+      "start": Object {
+        "column": 1,
+        "line": 1,
+      },
+    },
+    "type": "selector",
+  },
+  Object {
+    "source": Object {
+      "end": Object {
+        "column": 5,
+        "line": 1,
+      },
+      "start": Object {
+        "column": 1,
+        "line": 1,
+      },
+    },
+    "type": "pseudo",
+    "value": ":root",
+  },
+  Object {
+    "source": Object {
+      "end": Object {
+        "column": 7,
+        "line": 1,
+      },
+      "start": Object {
+        "column": 7,
+        "line": 1,
+      },
+    },
+    "type": "combinator",
+    "value": ">",
+  },
+  Object {
+    "source": Object {
+      "end": Object {
+        "column": 20,
+        "line": 1,
+      },
+      "start": Object {
+        "column": 9,
+        "line": 1,
+      },
+    },
+    "type": "pseudo",
+    "value": ":v",
+  },
+  Object {
+    "source": Object {
+      "end": Object {
+        "column": 20,
+        "line": 1,
+      },
+      "start": Object {
+        "column": 12,
+        "line": 1,
+      },
+    },
+    "type": "selector",
+  },
+  Object {
+    "source": Object {
+      "end": Object {
+        "column": 19,
+        "line": 1,
+      },
+      "start": Object {
+        "column": 12,
+        "line": 1,
+      },
+    },
+    "type": "tag",
+    "value": ">1 >2 >3",
+  },
+  Object {
+    "source": Object {
+      "end": Object {
+        "column": 58,
+        "line": 1,
+      },
+      "start": Object {
+        "column": 21,
+        "line": 1,
+      },
+    },
+    "type": "pseudo",
+    "value": ":not",
+  },
+  Object {
+    "source": Object {
+      "end": Object {
+        "column": 58,
+        "line": 1,
+      },
+      "start": Object {
+        "column": 26,
+        "line": 1,
+      },
+    },
+    "type": "selector",
+  },
+  Object {
+    "source": Object {
+      "end": Object {
+        "column": 57,
+        "line": 1,
+      },
+      "start": Object {
+        "column": 26,
+        "line": 1,
+      },
+    },
+    "type": "pseudo",
+    "value": ":v",
+  },
+  Object {
+    "source": Object {
+      "end": Object {
+        "column": 57,
+        "line": 1,
+      },
+      "start": Object {
+        "column": 29,
+        "line": 1,
+      },
+    },
+    "type": "selector",
+  },
+  Object {
+    "source": Object {
+      "end": Object {
+        "column": 56,
+        "line": 1,
+      },
+      "start": Object {
+        "column": 29,
+        "line": 1,
+      },
+    },
+    "type": "tag",
+    "value": "2.0.0-pre+build0.13adsfa1",
+  },
+  Object {
+    "source": Object {
+      "end": Object {
+        "column": 60,
+        "line": 1,
+      },
+      "start": Object {
+        "column": 60,
+        "line": 1,
+      },
+    },
+    "type": "combinator",
+    "value": ">",
+  },
+  Object {
+    "source": Object {
+      "end": Object {
+        "column": 70,
+        "line": 1,
+      },
+      "start": Object {
+        "column": 62,
+        "line": 1,
+      },
+    },
+    "type": "tag",
+    "value": "published(<=2024-01-01T11:11:11.111Z)",
+  },
+  Object {
+    "source": Object {
+      "end": Object {
+        "column": 100,
+        "line": 1,
+      },
+      "start": Object {
+        "column": 100,
+        "line": 1,
+      },
+    },
+    "type": "combinator",
+    "value": " ",
+  },
+  Object {
+    "source": Object {
+      "end": Object {
+        "column": 114,
+        "line": 1,
+      },
+      "start": Object {
+        "column": 101,
+        "line": 1,
+      },
+    },
+    "type": "pseudo",
+    "value": ":severity",
+  },
+  Object {
+    "source": Object {
+      "end": Object {
+        "column": 114,
+        "line": 1,
+      },
+      "start": Object {
+        "column": 111,
+        "line": 1,
+      },
+    },
+    "type": "selector",
+  },
+  Object {
+    "source": Object {
+      "end": Object {
+        "column": 114,
+        "line": 1,
+      },
+      "start": Object {
+        "column": 111,
+        "line": 1,
+      },
+    },
+    "type": "tag",
+    "value": ">=0",
+  },
+  Object {
+    "source": Object {
+      "end": Object {
+        "column": 129,
+        "line": 1,
+      },
+      "start": Object {
+        "column": 115,
+        "line": 1,
+      },
+    },
+    "type": "pseudo",
+    "value": ":score",
+  },
+  Object {
+    "source": Object {
+      "end": Object {
+        "column": 129,
+        "line": 1,
+      },
+      "start": Object {
+        "column": 122,
+        "line": 1,
+      },
+    },
+    "type": "selector",
+  },
+  Object {
+    "source": Object {
+      "end": Object {
+        "column": 128,
+        "line": 1,
+      },
+      "start": Object {
+        "column": 123,
+        "line": 1,
+      },
+    },
+    "type": "tag",
+    "value": " > 0.9",
+  },
+]
+`

--- a/src/dss-parser/test/index.ts
+++ b/src/dss-parser/test/index.ts
@@ -1,0 +1,117 @@
+import t from 'tap'
+import postcssSelectorParser from 'postcss-selector-parser'
+import { parse, escapeScopedNamesSlashes } from '../src/index.ts'
+
+t.test('escapeScopedNamesSlashes', async t => {
+  t.equal(
+    escapeScopedNamesSlashes('#@scope/package'),
+    '#@scope\\/package',
+    'should escape forward slash in #@scope/package pattern',
+  )
+
+  t.equal(
+    escapeScopedNamesSlashes('#@scope-dash-sep/package'),
+    '#@scope-dash-sep\\/package',
+    'should escape forward slash with dashes',
+  )
+
+  t.equal(
+    escapeScopedNamesSlashes('#@scope.dot.sep/package'),
+    '#@scope.dot.sep\\/package',
+    'should escape forward slash with dots',
+  )
+
+  t.equal(
+    escapeScopedNamesSlashes('#@multiple/package #@another/pkg'),
+    '#@multiple\\/package #@another\\/pkg',
+    'should escape multiple instances of the pattern',
+  )
+
+  t.equal(
+    escapeScopedNamesSlashes('#@name/package[attr]'),
+    '#@name\\/package[attr]',
+    'should work with attribute selectors',
+  )
+
+  t.equal(
+    escapeScopedNamesSlashes('#regular #@123/456'),
+    '#regular #@123\\/456',
+    'should work with numeric components',
+  )
+
+  t.equal(
+    escapeScopedNamesSlashes('#regular-selector'),
+    '#regular-selector',
+    'should not modify strings without the specific pattern',
+  )
+
+  t.equal(
+    escapeScopedNamesSlashes('a > b #@xyz/abc'),
+    'a > b #@xyz\\/abc',
+    'should work with combinators',
+  )
+})
+
+t.test('parse', async t => {
+  // Test basic parsing
+  t.ok(parse(':root > *'), 'should parse simple selectors')
+
+  // Compare with direct postcss parser for equivalence (minus the escaping)
+  const simpleSelector = 'div > span'
+  const directAst = postcssSelectorParser().astSync(simpleSelector)
+  const ourAst = parse(simpleSelector)
+
+  t.same(
+    ourAst.toString(),
+    directAst.toString(),
+    'should produce equivalent AST to direct postcss parser',
+  )
+
+  // Test with a selector that needs escaping
+  const selectorWithScoped = '#@scope/package'
+  t.doesNotThrow(
+    () => parse(selectorWithScoped),
+    'should parse selectors with scoped packages without throwing',
+  )
+
+  // Test a complex selector
+  const complexSelector = 'a > #@scope/pkg.class:pseudo[attr=val]'
+  t.ok(
+    parse(complexSelector),
+    'should parse complex selectors with scoped packages',
+  )
+
+  t.ok(parse(':root > :v(2.0.0)'), 'should parse dots in parameters')
+  t.ok(
+    parse(':root > :v("2.0.0")'),
+    'should parse dots in string parameters',
+  )
+
+  const res: any[] = []
+  parse(':v(>2)').walk(node => {
+    res.push({
+      type: node.type,
+      source: node.source,
+      ...(node.value ? { value: node.value } : undefined),
+    })
+  })
+  t.matchSnapshot(
+    res,
+    'should clean up usage of combinators params in pseudo selectors that accept only string values',
+  )
+
+  res.length = 0
+  parse(
+    ':root > :v(>1 >2 >3):not(:v(2.0.0-pre+build0.13adsfa1)) > published(<=2024-01-01T11:11:11.111Z) :severity(>=0):score( > 0.9)',
+  ).walk(node => {
+    res.push({
+      type: node.type,
+      source: node.source,
+      ...(node.value ? { value: node.value } : undefined),
+    })
+  })
+  t.matchSnapshot(
+    res,
+    'should clean up usage of multiple pseudo selectors requiring cleaning up',
+  )
+})

--- a/src/dss-parser/tsconfig.json
+++ b/src/dss-parser/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../tsconfig.json"
+}

--- a/src/dss-parser/typedoc.mjs
+++ b/src/dss-parser/typedoc.mjs
@@ -1,0 +1,2 @@
+import config from '../../www/docs/typedoc.workspace.mjs'
+export default config(import.meta.dirname)

--- a/src/query/package.json
+++ b/src/query/package.json
@@ -20,6 +20,7 @@
   },
   "dependencies": {
     "@vltpkg/dep-id": "workspace:*",
+    "@vltpkg/dss-parser": "workspace:*",
     "@vltpkg/error-cause": "workspace:*",
     "@vltpkg/graph": "workspace:*",
     "@vltpkg/security-archive": "workspace:*",

--- a/src/query/src/attribute.ts
+++ b/src/query/src/attribute.ts
@@ -1,9 +1,9 @@
+import { asAttributeNode } from '@vltpkg/dss-parser'
 import { error } from '@vltpkg/error-cause'
+import { removeDanglingEdges } from './pseudo/helpers.ts'
 import type { NodeLike } from '@vltpkg/graph'
 import type { JSONField, Manifest } from '@vltpkg/types'
-import { asAttributeNode } from './types.ts'
 import type { ParserState } from './types.ts'
-import { removeDanglingEdges } from './pseudo/helpers.ts'
 
 export type ComparatorFn = (attr: string, value?: string) => boolean
 

--- a/src/query/src/combinator.ts
+++ b/src/query/src/combinator.ts
@@ -1,7 +1,7 @@
-import type { EdgeLike, NodeLike } from '@vltpkg/graph'
-import { asCombinatorNode } from './types.ts'
-import type { ParserState, ParserFn } from './types.ts'
+import { asCombinatorNode } from '@vltpkg/dss-parser'
 import { error } from '@vltpkg/error-cause'
+import type { EdgeLike, NodeLike } from '@vltpkg/graph'
+import type { ParserState, ParserFn } from './types.ts'
 
 /**
  * Returns a new set of nodes, containing all direct dependencies

--- a/src/query/src/id.ts
+++ b/src/query/src/id.ts
@@ -1,5 +1,5 @@
+import { asIdentifierNode } from '@vltpkg/dss-parser'
 import { error } from '@vltpkg/error-cause'
-import { asIdentifierNode } from './types.ts'
 import type { ParserState } from './types.ts'
 
 /**

--- a/src/query/src/index.ts
+++ b/src/query/src/index.ts
@@ -1,13 +1,7 @@
 import { error } from '@vltpkg/error-cause'
-import type { EdgeLike, GraphLike, NodeLike } from '@vltpkg/graph'
-import type { SpecOptions } from '@vltpkg/spec/browser'
-import type { SecurityArchiveLike } from '@vltpkg/security-archive'
-import { parse } from './parser.ts'
-import { attribute } from './attribute.ts'
-import { combinator } from './combinator.ts'
-import { id } from './id.ts'
-import { pseudo } from './pseudo.ts'
+import { joinDepIDTuple } from '@vltpkg/dep-id/browser'
 import {
+  parse,
   isPostcssNodeWithChildren,
   asPostcssNodeWithChildren,
   isSelectorNode,
@@ -16,18 +10,26 @@ import {
   isAttributeNode,
   isCombinatorNode,
   isCommentNode,
-} from './types.ts'
+} from '@vltpkg/dss-parser'
+import { attribute } from './attribute.ts'
+import { combinator } from './combinator.ts'
+import { id } from './id.ts'
+import { pseudo } from './pseudo.ts'
+import type { EdgeLike, GraphLike, NodeLike } from '@vltpkg/graph'
+import type { SpecOptions } from '@vltpkg/spec/browser'
+import type { SecurityArchiveLike } from '@vltpkg/security-archive'
 import type {
   PostcssNode,
-  ParsedSelectorToken,
   PostcssNodeWithChildren,
+} from '@vltpkg/dss-parser'
+import type {
+  ParsedSelectorToken,
   ParserState,
   ParserFn,
   QueryResponse,
   QueryResponseNode,
   QueryResponseEdge,
 } from './types.ts'
-import { joinDepIDTuple } from '@vltpkg/dep-id/browser'
 import type { DepID } from '@vltpkg/dep-id'
 
 export * from './types.ts'

--- a/src/query/src/parser.ts
+++ b/src/query/src/parser.ts
@@ -1,12 +1,12 @@
 import postcssSelectorParser from 'postcss-selector-parser'
-import type { Pseudo, Root } from 'postcss-selector-parser'
 import {
   asSelectorNode,
   isCombinatorNode,
   isPseudoNode,
   isTagNode,
-} from './types.ts'
-import type { PostcssNode } from './types.ts'
+} from '@vltpkg/dss-parser'
+import type { Pseudo, Root } from 'postcss-selector-parser'
+import type { PostcssNode } from '@vltpkg/dss-parser'
 
 /**
  * Escapes forward slashes in specific patterns matching @scoped/name paths

--- a/src/query/src/pseudo.ts
+++ b/src/query/src/pseudo.ts
@@ -1,13 +1,10 @@
 import { error } from '@vltpkg/error-cause'
-import type { EdgeLike, NodeLike } from '@vltpkg/graph'
-
 import { removeDanglingEdges, removeNode } from './pseudo/helpers.ts'
 import {
   asPostcssNodeWithChildren,
   asPseudoNode,
   isSelectorNode,
-} from './types.ts'
-import type { ParserFn, ParserState } from './types.ts'
+} from '@vltpkg/dss-parser'
 
 // imported pseudo selectors
 import { abandoned } from './pseudo/abandoned.ts'
@@ -57,6 +54,9 @@ import { unmaintained } from './pseudo/unmaintained.ts'
 import { unpopular } from './pseudo/unpopular.ts'
 import { unstable } from './pseudo/unstable.ts'
 import { workspace } from './pseudo/workspace.ts'
+
+import type { EdgeLike, NodeLike } from '@vltpkg/graph'
+import type { ParserFn, ParserState } from './types.ts'
 
 /**
  * :has Pseudo-Selector, matches only nodes that have valid results

--- a/src/query/src/pseudo/attr.ts
+++ b/src/query/src/pseudo/attr.ts
@@ -5,13 +5,14 @@ import {
   asStringNode,
   asTagNode,
   isStringNode,
-} from '../types.ts'
-import type { ParserState, PostcssNode } from '../types.ts'
+} from '@vltpkg/dss-parser'
 import {
   attributeSelectorsMap,
   filterAttributes,
 } from '../attribute.ts'
 import { removeQuotes } from './helpers.ts'
+import type { ParserState } from '../types.ts'
+import type { PostcssNode } from '@vltpkg/dss-parser'
 
 export type AttrInternals = {
   attribute: string

--- a/src/query/src/pseudo/cve.ts
+++ b/src/query/src/pseudo/cve.ts
@@ -5,14 +5,15 @@ import {
   asTagNode,
   isStringNode,
   isTagNode,
-} from '../types.ts'
-import type { ParserState, PostcssNode } from '../types.ts'
+} from '@vltpkg/dss-parser'
 import {
   assertSecurityArchive,
   removeDanglingEdges,
   removeNode,
   removeQuotes,
 } from './helpers.ts'
+import type { ParserState } from '../types.ts'
+import type { PostcssNode } from '@vltpkg/dss-parser'
 
 export type CveInternals = {
   cveId: string

--- a/src/query/src/pseudo/cwe.ts
+++ b/src/query/src/pseudo/cwe.ts
@@ -5,14 +5,15 @@ import {
   asTagNode,
   isStringNode,
   isTagNode,
-} from '../types.ts'
-import type { ParserState, PostcssNode } from '../types.ts'
+} from '@vltpkg/dss-parser'
 import {
   assertSecurityArchive,
   removeDanglingEdges,
   removeNode,
   removeQuotes,
 } from './helpers.ts'
+import type { ParserState } from '../types.ts'
+import type { PostcssNode } from '@vltpkg/dss-parser'
 
 export type CweInternals = {
   cweId: string

--- a/src/query/src/pseudo/helpers.ts
+++ b/src/query/src/pseudo/helpers.ts
@@ -1,6 +1,6 @@
+import { error } from '@vltpkg/error-cause'
 import type { EdgeLike, NodeLike } from '@vltpkg/graph'
 import type { ParserState } from '../types.js'
-import { error } from '@vltpkg/error-cause'
 
 /**
  * Removes a node and its incoming edges from the results.

--- a/src/query/src/pseudo/license.ts
+++ b/src/query/src/pseudo/license.ts
@@ -5,14 +5,15 @@ import {
   asTagNode,
   isStringNode,
   isTagNode,
-} from '../types.ts'
-import type { ParserState, PostcssNode } from '../types.ts'
+} from '@vltpkg/dss-parser'
 import {
   assertSecurityArchive,
   removeDanglingEdges,
   removeNode,
   removeQuotes,
 } from './helpers.ts'
+import type { ParserState } from '../types.ts'
+import type { PostcssNode } from '@vltpkg/dss-parser'
 
 export type LicenseKinds =
   | 'unlicensed'

--- a/src/query/src/pseudo/malware.ts
+++ b/src/query/src/pseudo/malware.ts
@@ -5,14 +5,15 @@ import {
   asTagNode,
   isStringNode,
   isTagNode,
-} from '../types.ts'
-import type { ParserState, PostcssNode } from '../types.ts'
+} from '@vltpkg/dss-parser'
 import {
   assertSecurityArchive,
   removeDanglingEdges,
   removeNode,
   removeQuotes,
 } from './helpers.ts'
+import type { ParserState } from '../types.ts'
+import type { PostcssNode } from '@vltpkg/dss-parser'
 
 export type MalwareKinds =
   | '0'

--- a/src/query/src/pseudo/outdated.ts
+++ b/src/query/src/pseudo/outdated.ts
@@ -2,8 +2,6 @@ import pRetry, { AbortError } from 'p-retry'
 import { hydrate, splitDepID } from '@vltpkg/dep-id/browser'
 import { error } from '@vltpkg/error-cause'
 import { asError } from '@vltpkg/types'
-import type { NodeLike } from '@vltpkg/graph'
-import type { SpecOptions } from '@vltpkg/spec/browser'
 import {
   compare,
   gt,
@@ -12,16 +10,19 @@ import {
   patch,
   satisfies,
 } from '@vltpkg/semver'
-import type { Packument } from '@vltpkg/types'
 import {
   asPostcssNodeWithChildren,
   asStringNode,
   asTagNode,
   isStringNode,
   isTagNode,
-} from '../types.ts'
-import type { ParserState, PostcssNode } from '../types.ts'
+} from '@vltpkg/dss-parser'
 import { removeNode, removeQuotes } from './helpers.ts'
+import type { NodeLike } from '@vltpkg/graph'
+import type { SpecOptions } from '@vltpkg/spec/browser'
+import type { Packument } from '@vltpkg/types'
+import type { ParserState } from '../types.ts'
+import type { PostcssNode } from '@vltpkg/dss-parser'
 
 /**
  * The possible values accepted by the :outdated() pseudo selector.

--- a/src/query/src/pseudo/published.ts
+++ b/src/query/src/pseudo/published.ts
@@ -1,22 +1,23 @@
 import pRetry, { AbortError } from 'p-retry'
 import { hydrate, splitDepID } from '@vltpkg/dep-id/browser'
 import { error } from '@vltpkg/error-cause'
-import type { NodeLike } from '@vltpkg/graph'
-import type { SpecOptions } from '@vltpkg/spec/browser'
-import type { Packument } from '@vltpkg/types'
 import {
   asPostcssNodeWithChildren,
   asStringNode,
   asTagNode,
   isStringNode,
   isTagNode,
-} from '../types.ts'
-import type { ParserState, PostcssNode } from '../types.ts'
+} from '@vltpkg/dss-parser'
 import {
   removeDanglingEdges,
   removeNode,
   removeQuotes,
 } from './helpers.ts'
+import type { NodeLike } from '@vltpkg/graph'
+import type { SpecOptions } from '@vltpkg/spec/browser'
+import type { Packument } from '@vltpkg/types'
+import type { ParserState } from '../types.ts'
+import type { PostcssNode } from '@vltpkg/dss-parser'
 
 /**
  * The possible comparator values accepted by the :published() pseudo selector.

--- a/src/query/src/pseudo/score.ts
+++ b/src/query/src/pseudo/score.ts
@@ -5,8 +5,7 @@ import {
   asTagNode,
   isStringNode,
   isTagNode,
-} from '../types.ts'
-import type { ParserState, PostcssNode } from '../types.ts'
+} from '@vltpkg/dss-parser'
 import {
   assertSecurityArchive,
   removeDanglingEdges,
@@ -14,6 +13,8 @@ import {
   removeQuotes,
 } from './helpers.ts'
 import type { PackageScore } from '@vltpkg/security-archive'
+import type { ParserState } from '../types.ts'
+import type { PostcssNode } from '@vltpkg/dss-parser'
 
 export type ScoreKinds = keyof PackageScore
 

--- a/src/query/src/pseudo/semver.ts
+++ b/src/query/src/pseudo/semver.ts
@@ -25,9 +25,10 @@ import {
   isPseudoNode,
   isStringNode,
   isTagNode,
-} from '../types.ts'
-import type { ParserState, PostcssNode } from '../types.ts'
+} from '@vltpkg/dss-parser'
 import { removeNode, removeQuotes } from './helpers.ts'
+import type { ParserState } from '../types.ts'
+import type { PostcssNode } from '@vltpkg/dss-parser'
 
 export type SemverInternals = {
   semverValue: string

--- a/src/query/src/pseudo/severity.ts
+++ b/src/query/src/pseudo/severity.ts
@@ -5,14 +5,15 @@ import {
   asTagNode,
   isStringNode,
   isTagNode,
-} from '../types.ts'
-import type { ParserState, PostcssNode } from '../types.ts'
+} from '@vltpkg/dss-parser'
 import {
   assertSecurityArchive,
   removeDanglingEdges,
   removeNode,
   removeQuotes,
 } from './helpers.ts'
+import type { ParserState } from '../types.ts'
+import type { PostcssNode } from '@vltpkg/dss-parser'
 
 export type SeverityKinds =
   | '0'

--- a/src/query/src/pseudo/squat.ts
+++ b/src/query/src/pseudo/squat.ts
@@ -5,14 +5,15 @@ import {
   asTagNode,
   isStringNode,
   isTagNode,
-} from '../types.ts'
-import type { ParserState, PostcssNode } from '../types.ts'
+} from '@vltpkg/dss-parser'
 import {
   assertSecurityArchive,
   removeDanglingEdges,
   removeNode,
   removeQuotes,
 } from './helpers.ts'
+import type { ParserState } from '../types.ts'
+import type { PostcssNode } from '@vltpkg/dss-parser'
 
 export type SquatKinds = '0' | '2' | 'critical' | 'medium' | undefined
 

--- a/src/query/src/pseudo/type.ts
+++ b/src/query/src/pseudo/type.ts
@@ -1,7 +1,10 @@
 import { splitDepID } from '@vltpkg/dep-id/browser'
-import type { ParserState } from '../types.ts'
-import { asPostcssNodeWithChildren, asTagNode } from '../types.ts'
+import {
+  asPostcssNodeWithChildren,
+  asTagNode,
+} from '@vltpkg/dss-parser'
 import { removeDanglingEdges, removeNode } from './helpers.ts'
+import type { ParserState } from '../types.ts'
 
 /**
  * :type(str) Pseudo-Element will match only nodes that are of

--- a/src/query/src/types.ts
+++ b/src/query/src/types.ts
@@ -1,4 +1,3 @@
-import { error } from '@vltpkg/error-cause'
 import type { EdgeLike, NodeLike } from '@vltpkg/graph'
 import type { SpecOptions } from '@vltpkg/spec/browser'
 import type {
@@ -6,41 +5,12 @@ import type {
   PackageScore,
 } from '@vltpkg/security-archive'
 import type { DepID } from '@vltpkg/dep-id'
-import type {
-  Tag,
-  String,
-  Selector,
-  Root,
-  Pseudo,
-  Nesting,
-  Identifier,
-  Comment,
-  Combinator,
-  ClassName,
-  Attribute,
-  Universal,
-} from 'postcss-selector-parser'
+import type { PostcssNode } from '@vltpkg/dss-parser'
 
 export type Specificity = {
   idCounter: number
   commonCounter: number
 }
-
-export type PostcssNode =
-  | Tag
-  | String
-  | Selector
-  | Root
-  | Pseudo
-  | Nesting
-  | Identifier
-  | Comment
-  | Combinator
-  | ClassName
-  | Attribute
-  | Universal
-
-export type PostcssNodeWithChildren = Selector | Root | Pseudo
 
 export type GraphSelectionState = {
   nodes: Set<NodeLike>
@@ -169,166 +139,4 @@ export type ParserFn = (opt: ParserState) => Promise<ParserState>
 
 export type ParsedSelectorToken = PostcssNode & {
   token: string
-}
-
-export const isPostcssNodeWithChildren = (
-  node: any,
-): node is PostcssNodeWithChildren =>
-  'type' in node && 'nodes' in node
-
-export const asPostcssNodeWithChildren = (
-  node?: PostcssNode,
-): PostcssNodeWithChildren => {
-  if (!node) {
-    throw error('Expected a query node')
-  }
-
-  if (!isPostcssNodeWithChildren(node)) {
-    throw error('Not a query selector node with children', {
-      found: node,
-    })
-  }
-  return node
-}
-
-const isObj = (o: unknown): o is Record<string, unknown> =>
-  !!o && typeof o === 'object'
-
-export const isAttributeNode = (node: unknown): node is Attribute =>
-  isObj(node) && !!node.attribute && node.type === 'attribute'
-
-export const asAttributeNode = (node?: PostcssNode): Attribute => {
-  if (!node) {
-    throw error('Expected a query node')
-  }
-
-  if (!isAttributeNode(node)) {
-    throw error('Mismatching query node', {
-      wanted: 'attribute',
-      found: node.type,
-    })
-  }
-  return node
-}
-
-export const isCombinatorNode = (node: unknown): node is Combinator =>
-  isObj(node) && !!node.value && node.type === 'combinator'
-
-export const asCombinatorNode = (node?: PostcssNode): Combinator => {
-  if (!node) {
-    throw error('Expected a query node')
-  }
-
-  if (!isCombinatorNode(node)) {
-    throw error('Mismatching query node', {
-      wanted: 'combinator',
-      found: node.type,
-    })
-  }
-  return node
-}
-
-export const isIdentifierNode = (node: any): node is Identifier =>
-  isObj(node) && !!node.value && node.type === 'id'
-
-export const asIdentifierNode = (node?: PostcssNode): Identifier => {
-  if (!node) {
-    throw error('Expected a query node')
-  }
-
-  if (!isIdentifierNode(node)) {
-    throw error('Mismatching query node', {
-      wanted: 'id',
-      found: node.type,
-    })
-  }
-  return node
-}
-
-export const isSelectorNode = (node: any): node is Selector =>
-  isPostcssNodeWithChildren(node) && node.type === 'selector'
-
-export const asSelectorNode = (node?: PostcssNode): Selector => {
-  if (!node) {
-    throw error('Expected a query node')
-  }
-
-  if (!isSelectorNode(node)) {
-    throw error('Mismatching query node', {
-      wanted: 'selector',
-      found: node.type,
-    })
-  }
-  return node
-}
-
-export const isPseudoNode = (node: unknown): node is Pseudo =>
-  isObj(node) && !!node.value && node.type === 'pseudo'
-
-export const asPseudoNode = (node?: PostcssNode): Pseudo => {
-  if (!node) {
-    throw error('Expected a query node')
-  }
-
-  if (!isPseudoNode(node)) {
-    throw error('Mismatching query node', {
-      wanted: 'pseudo',
-      found: node.type,
-    })
-  }
-  return node
-}
-
-export const isTagNode = (node: unknown): node is Tag =>
-  isObj(node) && !!node.value && node.type === 'tag'
-
-export const asTagNode = (node?: PostcssNode): Tag => {
-  if (!node) {
-    throw error('Expected a query node')
-  }
-
-  if (!isTagNode(node)) {
-    throw error('Mismatching query node', {
-      wanted: 'tag',
-      found: node.type,
-    })
-  }
-
-  return node
-}
-
-export const isStringNode = (node: unknown): node is String =>
-  isObj(node) && !!node.value && node.type === 'string'
-
-export const asStringNode = (node?: PostcssNode): String => {
-  if (!node) {
-    throw error('Expected a query node')
-  }
-
-  if (!isStringNode(node)) {
-    throw error('Mismatching query node', {
-      wanted: 'string',
-      found: node.type,
-    })
-  }
-
-  return node
-}
-
-export const isCommentNode = (node: unknown): node is Comment =>
-  isObj(node) && !!node.value && node.type === 'comment'
-
-export const asCommentNode = (node?: PostcssNode): Comment => {
-  if (!node) {
-    throw error('Expected a query node')
-  }
-
-  if (!isCommentNode(node)) {
-    throw error('Mismatching query node', {
-      wanted: 'comment',
-      found: node.type,
-    })
-  }
-
-  return node
 }

--- a/src/query/test/fixtures/selector.ts
+++ b/src/query/test/fixtures/selector.ts
@@ -1,14 +1,14 @@
-import { parse } from '../../src/parser.ts'
-import type { EdgeLike, GraphLike, NodeLike } from '@vltpkg/graph'
 import { joinDepIDTuple } from '@vltpkg/dep-id'
+import { parse } from '@vltpkg/dss-parser'
+import { walk } from '../../src/index.ts'
+import type { EdgeLike, GraphLike, NodeLike } from '@vltpkg/graph'
 import type { DepID } from '@vltpkg/dep-id'
+import type { PostcssNode } from '@vltpkg/dss-parser'
 import type {
   GraphSelectionState,
   ParserState,
-  PostcssNode,
   ParserFn,
 } from '../../src/types.ts'
-import { walk } from '../../src/index.ts'
 
 export type FixtureResult = {
   edges: EdgeLike[]

--- a/src/query/test/index.ts
+++ b/src/query/test/index.ts
@@ -5,18 +5,18 @@ import {
   getSimpleGraph,
   getSingleWorkspaceGraph,
 } from './fixtures/graph.ts'
-import type {
-  ParsedSelectorToken,
-  ParserState,
-  PostcssNode,
-  QueryResponse,
-} from '../src/types.ts'
 import { copyGraphSelectionState } from './fixtures/selector.ts'
 import { joinDepIDTuple } from '@vltpkg/dep-id'
 import {
   asPackageReportData,
   asSecurityArchiveLike,
 } from '@vltpkg/security-archive'
+import type {
+  ParsedSelectorToken,
+  ParserState,
+  QueryResponse,
+} from '../src/types.ts'
+import type { PostcssNode } from '@vltpkg/dss-parser'
 
 type TestCase = [string, string[]]
 

--- a/src/query/test/pseudo.ts
+++ b/src/query/test/pseudo.ts
@@ -1,4 +1,5 @@
 import t from 'tap'
+import { joinDepIDTuple } from '@vltpkg/dep-id'
 import { pseudo } from '../src/pseudo.ts'
 import {
   getCycleGraph,
@@ -13,13 +14,12 @@ import {
   getGraphSelectionState,
   selectorFixture,
 } from './fixtures/selector.ts'
+import type { PostcssNodeWithChildren } from '@vltpkg/dss-parser'
 import type { TestCase } from './fixtures/types.ts'
 import type {
   GraphSelectionState,
   ParserState,
-  PostcssNodeWithChildren,
 } from '../src/types.ts'
-import { joinDepIDTuple } from '@vltpkg/dep-id'
 
 const testPseudo = selectorFixture(pseudo)
 

--- a/src/query/test/pseudo/malware.ts
+++ b/src/query/test/pseudo/malware.ts
@@ -1,16 +1,15 @@
 import t from 'tap'
 import { joinDepIDTuple } from '@vltpkg/dep-id'
+import { parse, asPostcssNodeWithChildren } from '@vltpkg/dss-parser'
 import { asSecurityArchiveLike } from '@vltpkg/security-archive'
 import { getSimpleGraph } from '../fixtures/graph.ts'
-import type { ParserState } from '../../src/types.ts'
 import {
   malware,
   isMalwareKind,
   asMalwareKind,
   parseInternals,
 } from '../../src/pseudo/malware.ts'
-import { parse } from '../../src/parser.ts'
-import { asPostcssNodeWithChildren } from '../../src/types.ts'
+import type { ParserState } from '../../src/types.ts'
 
 t.test('selects packages with a specific malware kind', async t => {
   const getState = (query: string, graph = getSimpleGraph()) => {

--- a/src/query/test/pseudo/outdated.ts
+++ b/src/query/test/pseudo/outdated.ts
@@ -1,20 +1,19 @@
 import t from 'tap'
-import type { SpecOptions } from '@vltpkg/spec/browser'
 import { joinDepIDTuple } from '@vltpkg/dep-id'
-import type { NodeLike } from '@vltpkg/graph'
+import { parse, asPostcssNodeWithChildren } from '@vltpkg/dss-parser'
 import {
   outdated,
   parseInternals,
   queueNode,
   retrieveRemoteVersions,
 } from '../../src/pseudo/outdated.ts'
-import { asPostcssNodeWithChildren } from '../../src/types.ts'
-import type { ParserState } from '../../src/types.ts'
 import {
   getSemverRichGraph,
   getSimpleGraph,
 } from '../fixtures/graph.ts'
-import { parse } from '../../src/parser.ts'
+import type { NodeLike } from '@vltpkg/graph'
+import type { SpecOptions } from '@vltpkg/spec/browser'
+import type { ParserState } from '../../src/types.ts'
 
 const specOptions = {
   registry: 'https://registry.npmjs.org',

--- a/src/query/test/pseudo/published.ts
+++ b/src/query/test/pseudo/published.ts
@@ -1,17 +1,16 @@
 import t from 'tap'
-import type { SpecOptions } from '@vltpkg/spec/browser'
 import { joinDepIDTuple } from '@vltpkg/dep-id'
-import type { NodeLike } from '@vltpkg/graph'
-import { parse } from '../../src/parser.ts'
+import { asPostcssNodeWithChildren, parse } from '@vltpkg/dss-parser'
 import {
   published,
   parseInternals,
   queueNode,
   retrieveRemoteDate,
 } from '../../src/pseudo/published.ts'
-import { asPostcssNodeWithChildren } from '../../src/types.ts'
-import type { ParserState } from '../../src/types.ts'
 import { getSemverRichGraph } from '../fixtures/graph.ts'
+import type { NodeLike } from '@vltpkg/graph'
+import type { SpecOptions } from '@vltpkg/spec/browser'
+import type { ParserState } from '../../src/types.ts'
 
 const specOptions = {
   registry: 'https://registry.npmjs.org',

--- a/src/query/test/pseudo/semver.ts
+++ b/src/query/test/pseudo/semver.ts
@@ -1,17 +1,16 @@
 import t from 'tap'
+import { asPostcssNodeWithChildren, parse } from '@vltpkg/dss-parser'
 import {
   asSemverFunctionName,
   isSemverFunctionName,
   parseInternals,
   semverParser,
 } from '../../src/pseudo/semver.ts'
-import { asPostcssNodeWithChildren } from '../../src/types.ts'
-import type { ParserState } from '../../src/types.ts'
 import {
   getSemverRichGraph,
   getSimpleGraph,
 } from '../fixtures/graph.ts'
-import { parse } from '../../src/parser.ts'
+import type { ParserState } from '../../src/types.ts'
 
 t.test('select from semver definition', async t => {
   const getState = (query: string, graph = getSimpleGraph()) => {

--- a/src/query/test/pseudo/severity.ts
+++ b/src/query/test/pseudo/severity.ts
@@ -1,16 +1,15 @@
 import t from 'tap'
 import { joinDepIDTuple } from '@vltpkg/dep-id'
+import { asPostcssNodeWithChildren, parse } from '@vltpkg/dss-parser'
 import { asSecurityArchiveLike } from '@vltpkg/security-archive'
 import { getSimpleGraph } from '../fixtures/graph.ts'
-import type { ParserState } from '../../src/types.ts'
 import {
   severity,
   isSeverityKind,
   asSeverityKind,
   parseInternals,
 } from '../../src/pseudo/severity.ts'
-import { parse } from '../../src/parser.ts'
-import { asPostcssNodeWithChildren } from '../../src/types.ts'
+import type { ParserState } from '../../src/types.ts'
 
 t.test('selects packages with a specific severity kind', async t => {
   const getState = (query: string, graph = getSimpleGraph()) => {

--- a/src/query/test/pseudo/squat.ts
+++ b/src/query/test/pseudo/squat.ts
@@ -1,16 +1,15 @@
 import t from 'tap'
 import { joinDepIDTuple } from '@vltpkg/dep-id'
+import { asPostcssNodeWithChildren, parse } from '@vltpkg/dss-parser'
 import { asSecurityArchiveLike } from '@vltpkg/security-archive'
 import { getSimpleGraph } from '../fixtures/graph.ts'
-import type { ParserState } from '../../src/types.ts'
 import {
   squat,
   isSquatKind,
   asSquatKind,
   parseInternals,
 } from '../../src/pseudo/squat.ts'
-import { parse } from '../../src/parser.ts'
-import { asPostcssNodeWithChildren } from '../../src/types.ts'
+import type { ParserState } from '../../src/types.ts'
 
 t.test('selects packages with a specific squat kind', async t => {
   const getState = (query: string, graph = getSimpleGraph()) => {


### PR DESCRIPTION
Add a new module to handle the extra logic to parse Dependency Selectory Syntax query strings into AST performed by postcss-selector-parser.