### PR TITLE
fix path resolution to directory c as shown in issue #781

### DIFF
--- a/src/package-info/src/index.ts
+++ b/src/package-info/src/index.ts
@@ -209,7 +209,7 @@ export class PackageInfoClient {
         if (file === undefined)
           throw this.#resolveError(spec, options, 'no file path')
         /* c8 ignore stop */
-        const path = pathResolve(from, file)
+        const path = pathResolve(process.cwd(), file)
         const st = await stat(path)
         if (st.isFile()) {
           try {
@@ -498,7 +498,7 @@ export class PackageInfoClient {
         const { file } = f
         if (file === undefined)
           throw this.#resolveError(spec, options, 'no file path')
-        const path = pathResolve(from, file)
+        const path = pathResolve(process.cwd(), file)
         const st = await stat(path)
         if (st.isDirectory()) {
           return this.packageJson.read(path)


### PR DESCRIPTION
This PR resolves the issue #781.

## Possible fix :
In the below line of code, path for directory `c` is resolved from project root, and not the directory where the command is initiated from.

So a possible fix could be, is to change `from` to `process.cwd()`.

https://github.com/vltpkg/vltpkg/blob/25dd21f5f9d9f4ce77d4fc70c3dce5ce1057ab5f/src/package-info/src/index.ts#L501
This PR is not yet complete as it thows multiple other errors. But for now, it is able to read directory `c`.

## Reasoning :
The first argument provided to [pathResolve](https://github.com/vltpkg/vltpkg/blob/25dd21f5f9d9f4ce77d4fc70c3dce5ce1057ab5f/src/package-info/src/index.ts#L24) function is the project root, which means that when resolving the absolute path for `c`, path becomes `./c/`.

## Initial problem :

Given the tree,
```
.
└── a
    ├── b
    │   └── package.json
    ├── c
    │   └── package.json
    │
    └── package.json
```
When adding dir 'c' as a dependency in 'b' using command
``` vlt install ../c ```, an error is thrown, `ENOENT: no such file or directory, stat './c'`

The directory `c` is resolved relative to the root of the directory `./c`, rather than its parent directory `./a/c`.