### PR TITLE
dss-breadcrumb: interactive refactor

### DIFF
--- a/src/dss-breadcrumb/README.md
+++ b/src/dss-breadcrumb/README.md
@@ -11,10 +11,10 @@ given graph.
 ## Usage
 
 ```js
-import { getBreadcrumb } from '@vltpkg/dss-breadcrumb'
+import { parseBreadcrumb } from '@vltpkg/dss-breadcrumb'
 
 // Parse a selector string into a breadcrumb
-const breadcrumb = getBreadcrumb(':root > #a')
+const breadcrumb = parseBreadcrumb(':root > #a')
 
 // Use the breadcrumb to navigate through the query
 console.log(breadcrumb.current.value) // :root

--- a/src/dss-breadcrumb/src/types.ts
+++ b/src/dss-breadcrumb/src/types.ts
@@ -1,10 +1,34 @@
 /**
  * A valid item of a given breadcrumb.
  */
-export type InteractiveBreadcrumbItem = {
+export type ModifierBreadcrumbItem = {
+  name?: string
   value: string
   type: string
-  prev: InteractiveBreadcrumbItem | undefined
-  next: InteractiveBreadcrumbItem | undefined
   importer: boolean
+  prev: ModifierBreadcrumbItem | undefined
+  next: ModifierBreadcrumbItem | undefined
+}
+
+/**
+ * A breadcrumb is a linked list of items, where
+ * each item has a value and a type.
+ */
+export interface ModifierBreadcrumb
+  extends Iterable<ModifierBreadcrumbItem> {
+  clear(): void
+  comment: string | undefined
+  first: ModifierBreadcrumbItem
+  last: ModifierBreadcrumbItem
+  single: boolean
+  interactive: () => ModifierInteractiveBreadcrumb
+}
+
+/**
+ * An interactive breadcrumb that holds state on what is the current item.
+ */
+export type ModifierInteractiveBreadcrumb = {
+  current: ModifierBreadcrumbItem | undefined
+  done: boolean
+  next: () => ModifierInteractiveBreadcrumb
 }

--- a/src/dss-breadcrumb/test/index.ts
+++ b/src/dss-breadcrumb/test/index.ts
@@ -1,334 +1,389 @@
 import t from 'tap'
-import { getBreadcrumb } from '../src/index.ts'
+import {
+  parseBreadcrumb,
+  InteractiveBreadcrumb,
+} from '../src/index.ts'
 
-t.test('getBreadcrumb', async t => {
-  await t.test('valid cases', async t => {
+t.test('Breadcrumb', async t => {
+  await t.test('parseBreadcrumb', async t => {
     // Test the error cases properly since the function is designed to throw for most queries
 
     // Empty query should throw as expected
     t.throws(
-      () => getBreadcrumb(''),
+      () => parseBreadcrumb(''),
       /Failed to parse query/,
       'should throw on empty query',
     )
 
-    // Simple ID selector - one of the few valid cases
-    const idBreadcrumb = getBreadcrumb('#a')
-    t.equal(
-      idBreadcrumb.current.value,
-      'a', // Note: The # prefix is not included in the value
-      'should parse ID selector without # prefix',
-    )
-    t.equal(
-      idBreadcrumb.current.type,
-      'id',
-      'should have type "id" for ID selector',
-    )
-    t.equal(
-      idBreadcrumb.current.importer,
-      false,
-      'ID selector should have importer=false',
-    )
-    t.equal(
-      idBreadcrumb.next(),
-      undefined,
-      'ID selector should have no next item',
-    )
-    t.equal(
-      idBreadcrumb.prev(),
-      undefined,
-      'ID selector should have no prev item',
-    )
-
-    // Test :root pseudo selector (should have importer=true)
-    const rootBreadcrumb = getBreadcrumb(':root')
-    t.equal(
-      rootBreadcrumb.current.value,
-      ':root',
-      'should parse :root pseudo selector',
-    )
-    t.equal(
-      rootBreadcrumb.current.type,
-      'pseudo',
-      'should have type "pseudo" for :root',
-    )
-    t.equal(
-      rootBreadcrumb.current.importer,
-      true,
-      ':root should have importer=true',
-    )
-
-    // Test :workspace pseudo selector (should have importer=true)
-    const workspaceBreadcrumb = getBreadcrumb(':workspace')
-    t.equal(
-      workspaceBreadcrumb.current.value,
-      ':workspace',
-      'should parse :workspace pseudo selector',
-    )
-    t.equal(
-      workspaceBreadcrumb.current.importer,
-      true,
-      ':workspace should have importer=true',
-    )
-
-    // Test :project pseudo selector (should have importer=true)
-    const projectBreadcrumb = getBreadcrumb(':project')
-    t.equal(
-      projectBreadcrumb.current.value,
-      ':project',
-      'should parse :project pseudo selector',
-    )
-    t.equal(
-      projectBreadcrumb.current.importer,
-      true,
-      ':project should have importer=true',
-    )
-    t.equal(
-      projectBreadcrumb.current.type,
-      'pseudo',
-      ':project should have type=pseudo',
-    )
-
-    // Test with comment
-    const commentBreadcrumb = getBreadcrumb('/* test comment */ #a')
+    // Test comments extraction
+    const commentBreadcrumb = parseBreadcrumb('/* test comment */ #a')
     t.equal(
       commentBreadcrumb.comment,
       'test comment',
       'should extract full comment with delimiters',
     )
-    t.equal(
-      commentBreadcrumb.current.value,
-      'a', // Without # prefix
-      'should parse ID selector after comment',
-    )
-    t.equal(
-      commentBreadcrumb.current.importer,
-      false,
-      'ID selector after comment should have importer=false',
-    )
-
-    // Test complex query with multiple ID selectors
-    const complexBreadcrumb = getBreadcrumb('#foo > #bar > #baz')
-    t.equal(
-      complexBreadcrumb.current.value,
-      'foo',
-      'should start with first ID selector',
-    )
-    t.equal(
-      complexBreadcrumb.current.type,
-      'id',
-      'first item should have type "id"',
-    )
-    t.equal(
-      complexBreadcrumb.current.importer,
-      false,
-      'ID selector should have importer=false',
-    )
-
-    // Navigate forward
-    const firstNext = complexBreadcrumb.next()
-    t.ok(firstNext, 'should have a next item')
-    t.equal(
-      complexBreadcrumb.current.value,
-      'bar',
-      'current should now be the second ID',
-    )
-    t.equal(
-      complexBreadcrumb.current.type,
-      'id',
-      'second item should have type "id"',
-    )
-    t.equal(
-      complexBreadcrumb.current.importer,
-      false,
-      'second ID selector should have importer=false',
-    )
-
-    const secondNext = complexBreadcrumb.next()
-    t.ok(secondNext, 'should have a second next item')
-    t.equal(
-      complexBreadcrumb.current.value,
-      'baz',
-      'current should now be the third ID',
-    )
-    t.equal(
-      complexBreadcrumb.current.type,
-      'id',
-      'third item should have type "id"',
-    )
-    t.equal(
-      complexBreadcrumb.current.importer,
-      false,
-      'third ID selector should have importer=false',
-    )
-
-    t.equal(
-      complexBreadcrumb.next(),
-      undefined,
-      'should have no more next items',
-    )
-
-    // Navigate backward
-    const firstPrev = complexBreadcrumb.prev()
-    t.ok(firstPrev, 'should have a previous item')
-    t.equal(
-      complexBreadcrumb.current.value,
-      'bar',
-      'current should go back to the second ID',
-    )
-
-    const secondPrev = complexBreadcrumb.prev()
-    t.ok(secondPrev, 'should have a second previous item')
-    t.equal(
-      complexBreadcrumb.current.value,
-      'foo',
-      'current should go back to the first ID',
-    )
-
-    t.equal(
-      complexBreadcrumb.prev(),
-      undefined,
-      'should have no more previous items',
-    )
-
-    // Test workspace+ID consolidation (workspace first)
-    const workspaceIdBreadcrumb = getBreadcrumb(
-      ':workspace#a > #foo > #bar',
-    )
-    t.equal(
-      workspaceIdBreadcrumb.current.value,
-      ':workspace#a',
-      'should consolidate :workspace and ID into a single item',
-    )
-    t.equal(
-      workspaceIdBreadcrumb.current.type,
-      'pseudo',
-      'consolidated item should maintain pseudo type',
-    )
-    t.equal(
-      workspaceIdBreadcrumb.current.importer,
-      true,
-      'consolidated :workspace#id should have importer=true',
-    )
-
-    // Test ID+workspace consolidation (ID first)
-    const idWorkspaceBreadcrumb = getBreadcrumb(
-      '#a:workspace > #foo > #bar',
-    )
-    t.equal(
-      idWorkspaceBreadcrumb.current.value,
-      'a:workspace',
-      'should consolidate ID and :workspace into a single item',
-    )
-    t.equal(
-      idWorkspaceBreadcrumb.current.type,
-      'id',
-      'consolidated item should maintain ID type',
-    )
-    t.equal(
-      idWorkspaceBreadcrumb.current.importer,
-      true,
-      'consolidated id:workspace should have importer=true',
-    )
-    const nextWorkspaceBreadcrumb = idWorkspaceBreadcrumb.next()
-    t.ok(nextWorkspaceBreadcrumb, 'should have a second next item')
-    t.equal(
-      idWorkspaceBreadcrumb.current.value,
-      'foo',
-      'current should now point to #foo',
-    )
-    t.equal(
-      idWorkspaceBreadcrumb.current.type,
-      'id',
-      '#foo should have type "id"',
-    )
-    t.equal(
-      idWorkspaceBreadcrumb.current.importer,
-      false,
-      '#foo should have importer=false',
-    )
-
-    // Test project+ID consolidation (project first)
-    const projectIdBreadcrumb = getBreadcrumb(
-      ':project#b > #foo > #bar',
-    )
-    t.equal(
-      projectIdBreadcrumb.current.value,
-      ':project#b',
-      'should consolidate :project and ID into a single item',
-    )
-    t.equal(
-      projectIdBreadcrumb.current.type,
-      'pseudo',
-      'consolidated item should maintain pseudo type',
-    )
-    t.equal(
-      projectIdBreadcrumb.current.importer,
-      true,
-      'consolidated :project#id should have importer=true',
-    )
-
-    // Test ID+project consolidation (ID first)
-    const idProjectBreadcrumb = getBreadcrumb(
-      '#b:project > #foo > #bar',
-    )
-    t.equal(
-      idProjectBreadcrumb.current.value,
-      'b:project',
-      'should consolidate ID and :project into a single item',
-    )
-    t.equal(
-      idProjectBreadcrumb.current.type,
-      'id',
-      'consolidated item should maintain ID type',
-    )
-    t.equal(
-      idProjectBreadcrumb.current.importer,
-      true,
-      'consolidated id:project should have importer=true',
-    )
   })
 
   await t.test('error cases', async t => {
-    // Now only test selectors that should still throw "Invalid query"
+    // Test selectors that should throw "Invalid query"
     t.throws(
-      () => getBreadcrumb(':foo'),
+      () => parseBreadcrumb(':foo'),
       /Invalid query/,
       'should throw on invalid pseudo selector',
     )
 
     t.throws(
-      () => getBreadcrumb('[name=foo]'),
+      () => parseBreadcrumb('[name=foo]'),
       /Invalid query/,
       'should throw on attribute selector',
     )
 
     t.throws(
-      () => getBreadcrumb(':root:prod'),
+      () => parseBreadcrumb(':root:prod'),
       /Invalid query/,
       'should throw on non-allowed pseudo selector',
     )
 
     t.throws(
-      () => getBreadcrumb(':has(#a)'),
+      () => parseBreadcrumb(':has(#a)'),
       /Invalid query/,
       'should throw on nested selector',
     )
   })
 
-  await t.test('clear method', async t => {
-    // One of the few valid cases is a simple ID selector
-    const breadcrumb = getBreadcrumb('#a')
+  await t.test('first getter', async t => {
+    // Simple ID selector
+    const idBreadcrumb = parseBreadcrumb('#a')
     t.equal(
-      breadcrumb.current.value,
-      'a', // Without # prefix
-      'first item should be ID selector without # prefix',
+      idBreadcrumb.first.value,
+      '#a',
+      'should retrieve the first item in the breadcrumb',
+    )
+    t.equal(
+      idBreadcrumb.first.type,
+      'id',
+      'first item should have type "id"',
+    )
+    t.equal(
+      idBreadcrumb.first.importer,
+      false,
+      'ID selector should have importer=false',
+    )
+    t.equal(
+      idBreadcrumb.first.name,
+      'a',
+      'first item should have name "a"',
     )
 
-    breadcrumb.clear()
-    // After clear, the items array should be empty but we can't directly check it
-    // Check if iterating gives no items
-    const items = [...breadcrumb]
-    t.equal(items.length, 0, 'should have cleared all items')
+    // Root pseudo selector
+    const rootBreadcrumb = parseBreadcrumb(':root')
+    t.equal(
+      rootBreadcrumb.first.value,
+      ':root',
+      'should retrieve the first item in the breadcrumb',
+    )
+    t.equal(
+      rootBreadcrumb.first.type,
+      'pseudo',
+      'first item should have type "pseudo"',
+    )
+    t.equal(
+      rootBreadcrumb.first.importer,
+      true,
+      ':root should have importer=true',
+    )
   })
+
+  await t.test('last getter', async t => {
+    // Simple breadcrumb with one item
+    const idBreadcrumb = parseBreadcrumb('#a')
+    t.equal(
+      idBreadcrumb.last.value,
+      '#a',
+      'last should equal first for single item breadcrumb',
+    )
+
+    // Complex breadcrumb with multiple items
+    const complexBreadcrumb = parseBreadcrumb('#foo > #bar > #baz')
+    t.equal(
+      complexBreadcrumb.last.value,
+      '#baz',
+      'should retrieve the last item in the breadcrumb',
+    )
+    t.equal(
+      complexBreadcrumb.last.type,
+      'id',
+      'last item should have type "id"',
+    )
+    t.equal(
+      complexBreadcrumb.last.importer,
+      false,
+      'last ID selector should have importer=false',
+    )
+    t.equal(
+      complexBreadcrumb.last.name,
+      'baz',
+      'last item should have name "baz"',
+    )
+  })
+
+  await t.test('first/last getters on empty breadcrumb', async t => {
+    // Create a breadcrumb
+    const breadcrumb = parseBreadcrumb('#a')
+
+    // Clear the breadcrumb to make it empty
+    breadcrumb.clear()
+
+    // Verify it's empty
+    const items = [...breadcrumb]
+    t.equal(items.length, 0, 'breadcrumb should be empty')
+
+    // Accessing first on empty breadcrumb should throw
+    t.throws(
+      () => breadcrumb.first,
+      /Failed to find first breadcrumb item/,
+      'first getter should throw on empty breadcrumb',
+    )
+
+    // Accessing last on empty breadcrumb should throw
+    t.throws(
+      () => breadcrumb.last,
+      /Failed to find first breadcrumb item/,
+      'last getter should throw on empty breadcrumb',
+    )
+  })
+
+  await t.test('single getter', async t => {
+    // Single item breadcrumb
+    const singleBreadcrumb = parseBreadcrumb('#a')
+    t.equal(
+      singleBreadcrumb.single,
+      true,
+      'single should be true for breadcrumb with one item',
+    )
+
+    // Multiple items breadcrumb
+    const multipleBreadcrumb = parseBreadcrumb('#a > #b')
+    t.equal(
+      multipleBreadcrumb.single,
+      false,
+      'single should be false for breadcrumb with multiple items',
+    )
+  })
+
+  await t.test('clear method', async t => {
+    // Create a breadcrumb
+    const breadcrumb = parseBreadcrumb('#a > #b > #c')
+
+    // Verify it has items before clearing
+    const beforeItems = [...breadcrumb]
+    t.equal(
+      beforeItems.length,
+      3,
+      'should have 3 items before clearing',
+    )
+
+    // Clear the breadcrumb
+    breadcrumb.clear()
+
+    // After clear, the items array should be empty
+    const afterItems = [...breadcrumb]
+    t.equal(afterItems.length, 0, 'should have cleared all items')
+  })
+
+  await t.test('special consolidated selectors', async t => {
+    // Test workspace+ID consolidation (workspace first)
+    const workspaceIdBreadcrumb = parseBreadcrumb(
+      ':workspace#a > #foo > #bar',
+    )
+    t.equal(
+      workspaceIdBreadcrumb.first.value,
+      ':workspace#a',
+      'should consolidate :workspace and ID into a single item',
+    )
+    t.equal(
+      workspaceIdBreadcrumb.first.type,
+      'pseudo',
+      'consolidated item should maintain pseudo type',
+    )
+    t.equal(
+      workspaceIdBreadcrumb.first.importer,
+      true,
+      'consolidated :workspace#id should have importer=true',
+    )
+    t.equal(
+      workspaceIdBreadcrumb.first.name,
+      'a',
+      'consolidated :workspace#id should have name="a"',
+    )
+
+    // Test project+ID consolidation
+    const projectIdBreadcrumb = parseBreadcrumb(
+      ':project#a > #foo > #bar',
+    )
+    t.equal(
+      projectIdBreadcrumb.first.value,
+      ':project#a',
+      'should consolidate :project and ID into a single item',
+    )
+    t.equal(
+      projectIdBreadcrumb.first.type,
+      'pseudo',
+      'consolidated item should maintain pseudo type',
+    )
+    t.equal(
+      projectIdBreadcrumb.first.importer,
+      true,
+      'consolidated :project#id should have importer=true',
+    )
+    t.equal(
+      projectIdBreadcrumb.first.name,
+      'a',
+      'consolidated :project#id should have name="a"',
+    )
+
+    // Test ID+workspace consolidation (ID first)
+    const idWorkspaceBreadcrumb = parseBreadcrumb(
+      '#a:workspace > #foo > #bar',
+    )
+    t.equal(
+      idWorkspaceBreadcrumb.first.value,
+      '#a:workspace',
+      'should consolidate ID and :workspace into a single item',
+    )
+    t.equal(
+      idWorkspaceBreadcrumb.first.type,
+      'id',
+      'consolidated item should maintain ID type',
+    )
+    t.equal(
+      idWorkspaceBreadcrumb.first.importer,
+      true,
+      'consolidated id:workspace should have importer=true',
+    )
+  })
+
+  await t.test('iterator', async t => {
+    // Test iterating through breadcrumb items
+    const breadcrumb = parseBreadcrumb('#a > #b > #c')
+    const items = [...breadcrumb]
+
+    t.equal(items.length, 3, 'should iterate through all items')
+    t.equal(items[0]!.value, '#a', 'first item should be #a')
+    t.equal(items[1]!.value, '#b', 'second item should be #b')
+    t.equal(items[2]!.value, '#c', 'third item should be #c')
+  })
+})
+
+t.test('InteractiveBreadcrumb', async t => {
+  await t.test('interactive method and current getter', async t => {
+    // Create a breadcrumb and get an interactive instance
+    const breadcrumb = parseBreadcrumb('#a > #b > #c')
+    const interactive = breadcrumb.interactive()
+
+    t.ok(
+      interactive instanceof InteractiveBreadcrumb,
+      'should return an InteractiveBreadcrumb instance',
+    )
+    t.equal(
+      interactive.current?.value,
+      '#a',
+      'current should initially point to first item',
+    )
+    t.equal(
+      interactive.current?.type,
+      'id',
+      'current item should have correct type',
+    )
+    t.equal(
+      interactive.current?.name,
+      'a',
+      'current item should have correct name',
+    )
+  })
+
+  await t.test('next method', async t => {
+    // Create a breadcrumb and get an interactive instance
+    const breadcrumb = parseBreadcrumb('#a > #b > #c')
+    const interactive = breadcrumb.interactive()
+
+    // Initial state
+    t.equal(
+      interactive.current?.value,
+      '#a',
+      'should start at first item',
+    )
+    t.equal(interactive.done, false, 'done should be false initially')
+
+    // Move to next
+    interactive.next()
+    t.equal(
+      interactive.current?.value,
+      '#b',
+      'should move to second item',
+    )
+    t.equal(interactive.done, false, 'done should still be false')
+
+    // Move to next
+    interactive.next()
+    t.equal(
+      interactive.current?.value,
+      '#c',
+      'should move to third item',
+    )
+    t.equal(interactive.done, false, 'done should still be false')
+
+    // Move beyond the end
+    interactive.next()
+    t.equal(
+      interactive.current,
+      undefined,
+      'current should be undefined after the end',
+    )
+    t.equal(interactive.done, true, 'done should be true at the end')
+
+    // Move beyond the end again
+    interactive.next()
+    t.equal(
+      interactive.current,
+      undefined,
+      'current should remain undefined',
+    )
+    t.equal(interactive.done, true, 'done should remain true')
+  })
+
+  await t.test('method chaining', async t => {
+    // Test method chaining with next()
+    const breadcrumb = parseBreadcrumb('#a > #b > #c')
+    const interactive = breadcrumb.interactive()
+
+    // Chain next() calls
+    const result = interactive.next().next()
+    t.equal(
+      result,
+      interactive,
+      'next() should return the instance for chaining',
+    )
+    t.equal(
+      interactive.current?.value,
+      '#c',
+      'should have moved to third item after chaining',
+    )
+  })
+})
+
+t.test('linked list navigation', async t => {
+  // Test that the doubly-linked list is properly connected
+  const breadcrumb = parseBreadcrumb('#a > #b > #c')
+  const [first, second, third] = [...breadcrumb]
+
+  // Forward navigation
+  t.equal(first!.next, second, 'first.next should point to second')
+  t.equal(second!.next, third, 'second.next should point to third')
+  t.equal(third!.next, undefined, 'third.next should be undefined')
+
+  // Backward navigation
+  t.equal(third!.prev, second, 'third.prev should point to second')
+  t.equal(second!.prev, first, 'second.prev should point to first')
+  t.equal(first!.prev, undefined, 'first.prev should be undefined')
 })


### PR DESCRIPTION
Refactored the breadcrumb module to better manage state and the parsed result.

The exported class that represents the parsed result of a query is now named `Breadcrumb`, instances of this class now have a `interactive()` method that returns an `InteractiveBreadcrumb` which is now the object that is going to hold state on the current item and implements a `next()` method that allows for updating that state.

Refs: https://github.com/vltpkg/statusboard/issues/64