### PR TITLE
gui: result item condensed style

### DIFF
--- a/src/gui/src/components/explorer-grid/results/index.tsx
+++ b/src/gui/src/components/explorer-grid/results/index.tsx
@@ -11,11 +11,11 @@ export const Results = ({ items }: { items: GridItemData[] }) => {
 
   return (
     <div className="mt-8 grid w-full max-w-8xl gap-4">
-      <div className="mb-4 flex items-center gap-3">
+      <div className="flex items-center gap-3">
         <GridHeader className="h-fit">Results</GridHeader>
         <Badge variant="default">{items.length}</Badge>
       </div>
-      <div className="flex flex-col gap-6">
+      <div className="flex flex-col gap-5">
         {items.map(item => (
           <ResultItem item={item} key={item.id} />
         ))}

--- a/src/gui/src/components/explorer-grid/results/result-item.tsx
+++ b/src/gui/src/components/explorer-grid/results/result-item.tsx
@@ -1,8 +1,7 @@
-import type { MouseEvent } from 'react'
 import { stringifyNode } from '@vltpkg/graph/browser'
 import { useGraphStore } from '@/state/index.ts'
 import { Badge } from '@/components/ui/badge.tsx'
-import { Card, CardHeader, CardTitle } from '@/components/ui/card.tsx'
+import { Card, CardHeader } from '@/components/ui/card.tsx'
 import {
   Tooltip,
   TooltipContent,
@@ -10,19 +9,23 @@ import {
   TooltipTrigger,
 } from '@/components/ui/tooltip.tsx'
 import { labelClassNamesMap } from '@/components/explorer-grid/label-helper.ts'
-import type {
-  GridItemData,
-  GridItemOptions,
-} from '@/components/explorer-grid/types.ts'
 import { DataBadge } from '@/components/ui/data-badge.tsx'
 import { Scale, EyeOff } from 'lucide-react'
-import type { PackageScore } from '@vltpkg/security-archive'
 import { ProgressCircle } from '@/components/ui/progress-circle.tsx'
-import type { ProgressCircleVariant } from '@/components/ui/progress-circle.tsx'
 import {
   getScoreColor,
   scoreColors,
 } from '@/components/explorer-grid/selected-item/insight-score-helper.ts'
+import { LICENSE_TYPES } from '@/lib/constants/index.ts'
+import { cn } from '@/lib/utils.ts'
+
+import type { MouseEvent } from 'react'
+import type {
+  GridItemData,
+  GridItemOptions,
+} from '@/components/explorer-grid/types.ts'
+import type { ProgressCircleVariant } from '@/components/ui/progress-circle.tsx'
+import type { Insights } from '@vltpkg/query'
 
 export type ResultItemClickOptions = {
   item: GridItemData
@@ -30,54 +33,33 @@ export type ResultItemClickOptions = {
   updateQuery: (query: string) => void
 }
 
-const LICENSE_TYPES = [
-  'MIT',
-  'ISC',
-  'Apache-2.0',
-  'GPL-3.0',
-  'GPL-2.0',
-  'LGPL-3.0',
-  'BSD-2-Clause',
-  'BSD-3-Clause',
-  'MPL-2.0',
-  'Unlicense',
-  'CC0-1.0',
-]
-
 const PackageOverallScore = ({
   className,
-  packageScore,
+  insights,
 }: {
   className?: string
-  packageScore: PackageScore
+  insights: Insights | undefined
 }) => {
+  if (!insights || !insights.scanned || !insights.score) return null
+
+  const packageScore = insights.score
   const averageScore = packageScore.overall * 100
   const chartColor = getScoreColor(averageScore)
   const textColor = scoreColors[chartColor]
 
   return (
     <div className={className}>
-      <div className="duration-250 after:duration-250 relative z-[1] flex cursor-default flex-row gap-3 self-start transition-colors after:absolute after:inset-0 after:-left-[0.5rem] after:-top-[0.5rem] after:z-[-1] after:h-[calc(100%+1rem)] after:w-[calc(100%+1rem)] after:rounded-sm after:transition-all after:content-['']">
-        <ProgressCircle
-          value={averageScore}
-          variant={chartColor as ProgressCircleVariant}
-          strokeWidth={5}
-          className="size-9">
-          <p
-            className="font-mono text-xs font-medium tabular-nums"
-            style={{ color: textColor }}>
-            {averageScore}
-          </p>
-        </ProgressCircle>
-        <div className="flex flex-col">
-          <p className="text-sm font-semibold text-neutral-600 dark:text-neutral-300">
-            Package Score
-          </p>
-          <p className="font-mono text-xs font-medium tabular-nums text-neutral-400">
-            {averageScore}/100
-          </p>
-        </div>
-      </div>
+      <ProgressCircle
+        value={averageScore}
+        variant={chartColor as ProgressCircleVariant}
+        strokeWidth={5}
+        className="size-7">
+        <p
+          className="font-mono text-xs font-medium tabular-nums"
+          style={{ color: textColor }}>
+          {averageScore}
+        </p>
+      </ProgressCircle>
     </div>
   )
 }
@@ -122,34 +104,43 @@ export const ResultItem = ({ item }: GridItemOptions) => {
   const insights = item.to?.insights
   return (
     <div className="group relative z-10">
-      {item.stacked ?
+      {item.stacked && (
         <>
-          {item.size > 2 ?
+          {item.size > 2 && (
             <div className="absolute left-2 top-2 h-full w-[97.5%] rounded-lg border bg-card transition-all group-hover:border-neutral-400 dark:group-hover:border-neutral-600"></div>
-          : ''}
+          )}
           <div className="absolute left-1 top-1 h-full w-[99%] rounded-lg border bg-card transition-all group-hover:border-neutral-400 dark:group-hover:border-neutral-600"></div>
         </>
-      : ''}
+      )}
 
-      {/* Card Top */}
       <Card
-        renderAsLink={true}
-        className={`duration-250 relative cursor-default transition-all group-hover:border-neutral-400 dark:group-hover:border-neutral-600`}
+        renderAsLink
+        className="duration-250 relative cursor-default transition-all group-hover:border-neutral-400 dark:group-hover:border-neutral-600"
         onClick={onResultItemClick({ item, query, updateQuery })}>
-        <CardHeader className="m-0 flex flex-row items-center justify-between rounded-t-lg border-b-[1px] px-4 py-3">
-          <TooltipProvider>
-            <Tooltip>
-              <TooltipTrigger className="cursor-default truncate">
-                <CardTitle className="text-md truncate">
+        <CardHeader className="relative flex w-full max-w-full flex-wrap items-baseline justify-between gap-3 px-3 py-2 md:flex-row">
+          <div className="flex flex-col flex-wrap items-baseline gap-3 md:flex-row">
+            {item.version && (
+              <DataBadge
+                variant="mono"
+                classNames={{
+                  wrapperClassName: 'md:-ml-1',
+                  contentClassName: 'pt-0.5',
+                }}
+                tooltip={{ content: item.version }}
+                content={item.version}
+              />
+            )}
+            <TooltipProvider>
+              <Tooltip>
+                <TooltipTrigger className="grow cursor-default items-baseline justify-between overflow-hidden truncate text-left text-sm font-medium">
                   {item.title}
-                </CardTitle>
-              </TooltipTrigger>
-              <TooltipContent>
-                <p>{item.title}</p>
-              </TooltipContent>
-            </Tooltip>
-          </TooltipProvider>
-          <div className="flex flex-row items-center gap-2">
+                </TooltipTrigger>
+                <TooltipContent>{item.title}</TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
+          </div>
+
+          <div className="flex flex-row flex-wrap items-center gap-3">
             {item.type && (
               <DataBadge
                 classNames={{
@@ -177,38 +168,36 @@ export const ResultItem = ({ item }: GridItemOptions) => {
             {manifest?.type && (
               <DataBadge
                 content={manifest.type === 'module' ? 'ESM' : 'CJS'}
+                classNames={{
+                  wrapperClassName: 'h-[30px]',
+                }}
               />
             )}
-            {insights?.scanned && insights.score && (
-              <PackageOverallScore packageScore={insights.score} />
-            )}
-          </div>
-        </CardHeader>
-
-        {/* Card Bottom */}
-        <div className="flex h-12 w-full items-center justify-between gap-4 border-t-[1px] px-4 py-3">
-          {item.version && (
-            <DataBadge
-              variant="mono"
-              classNames={{
-                contentClassName: 'pt-0.5',
-              }}
-              tooltip={{ content: item.version }}
-              content={item.version}
+            <PackageOverallScore
+              className="hidden md:flex"
+              insights={insights}
             />
-          )}
-          <div className="flex gap-2">
-            {item.labels?.length ?
-              item.labels.map(i => (
-                <div key={i}>
-                  <Badge className={labelClassNamesMap.get(i) || ''}>
-                    {i}
-                  </Badge>
-                </div>
-              ))
-            : ''}
           </div>
-        </div>
+
+          <div className="absolute -bottom-3.5 right-2.5 flex gap-2">
+            {item.labels?.map(i => (
+              <div key={i}>
+                <Badge
+                  className={cn(
+                    labelClassNamesMap.get(i),
+                    'h-[18px] rounded-full text-xxs font-normal text-inherit backdrop-blur-md',
+                  )}>
+                  {i}
+                </Badge>
+              </div>
+            ))}
+          </div>
+
+          <PackageOverallScore
+            className="absolute right-2 top-2 flex md:hidden"
+            insights={insights}
+          />
+        </CardHeader>
       </Card>
     </div>
   )

--- a/src/gui/src/components/explorer-grid/selected-item/item-header.tsx
+++ b/src/gui/src/components/explorer-grid/selected-item/item-header.tsx
@@ -48,6 +48,7 @@ import {
 } from '@/components/icons/index.ts'
 import { ProgressCircle } from '@/components/ui/progress-circle.tsx'
 import { toHumanNumber } from '@/utils/human-number.ts'
+import { LICENSE_TYPES } from '@/lib/constants/index.ts'
 import type { ProgressCircleVariant } from '@/components/ui/progress-circle.tsx'
 import type { LucideIcon } from 'lucide-react'
 
@@ -186,20 +187,6 @@ const PackageMetadata = ({ className }: { className?: string }) => {
       manifest.license)
 
   if (!hasMetadata) return null
-
-  const LICENSE_TYPES = [
-    'MIT',
-    'ISC',
-    'Apache-2.0',
-    'GPL-3.0',
-    'GPL-2.0',
-    'LGPL-3.0',
-    'BSD-2-Clause',
-    'BSD-3-Clause',
-    'MPL-2.0',
-    'Unlicense',
-    'CC0-1.0',
-  ]
 
   return (
     <ScrollArea

--- a/src/gui/src/components/navigation/header.tsx
+++ b/src/gui/src/components/navigation/header.tsx
@@ -53,7 +53,7 @@ const Header = () => {
           </div>
         )}
         {appData?.buildVersion && (
-          <p className="ml-auto font-courier text-xs font-medium text-muted-foreground">
+          <p className="ml-auto hidden font-courier text-xs font-medium text-muted-foreground md:block">
             build: v{appData.buildVersion}
           </p>
         )}

--- a/src/gui/src/lib/constants/index.ts
+++ b/src/gui/src/lib/constants/index.ts
@@ -1,2 +1,3 @@
 export * from './socket.ts'
 export * from './selectors.ts'
+export * from './licenses.ts'

--- a/src/gui/src/lib/constants/licenses.ts
+++ b/src/gui/src/lib/constants/licenses.ts
@@ -1,0 +1,13 @@
+export const LICENSE_TYPES = [
+  'MIT',
+  'ISC',
+  'Apache-2.0',
+  'GPL-3.0',
+  'GPL-2.0',
+  'LGPL-3.0',
+  'BSD-2-Clause',
+  'BSD-3-Clause',
+  'MPL-2.0',
+  'Unlicense',
+  'CC0-1.0',
+]

--- a/src/gui/tailwind.config.ts
+++ b/src/gui/tailwind.config.ts
@@ -27,6 +27,9 @@ export default {
         xxs: '0.625rem',
         sm: '0.813rem',
       },
+      size: {
+        '7.5': '1.875rem',
+      },
       maxWidth: {
         '8xl': '92rem',
       },

--- a/src/gui/test/components/explorer-grid/__snapshots__/index.tsx.snap
+++ b/src/gui/test/components/explorer-grid/__snapshots__/index.tsx.snap
@@ -27,7 +27,7 @@ exports[`ExplorerGrid with results 1`] = `
 <div>
   <div class="h-full w-full grow px-8 pb-8">
     <div class="mt-8 grid w-full max-w-8xl gap-4">
-      <div class="mb-4 flex items-center gap-3">
+      <div class="flex items-center gap-3">
         <gui-grid-header classname="h-fit">
           Results
         </gui-grid-header>
@@ -35,7 +35,7 @@ exports[`ExplorerGrid with results 1`] = `
           2
         </gui-badge>
       </div>
-      <div class="flex flex-col gap-6">
+      <div class="flex flex-col gap-5">
         <gui-result-item item="[object Object]">
         </gui-result-item>
         <gui-result-item item="[object Object]">
@@ -52,7 +52,7 @@ exports[`ExplorerGrid with stack 1`] = `
 <div>
   <div class="h-full w-full grow px-8 pb-8">
     <div class="mt-8 grid w-full max-w-8xl gap-4">
-      <div class="mb-4 flex items-center gap-3">
+      <div class="flex items-center gap-3">
         <gui-grid-header classname="h-fit">
           Results
         </gui-grid-header>
@@ -60,7 +60,7 @@ exports[`ExplorerGrid with stack 1`] = `
           2
         </gui-badge>
       </div>
-      <div class="flex flex-col gap-6">
+      <div class="flex flex-col gap-5">
         <gui-result-item item="[object Object]">
         </gui-result-item>
         <gui-result-item item="[object Object]">

--- a/src/gui/test/components/explorer-grid/results/__snapshots__/result-item.tsx.snap
+++ b/src/gui/test/components/explorer-grid/results/__snapshots__/result-item.tsx.snap
@@ -8,20 +8,18 @@ exports[`ResultItem render missing version and labels 1`] = `
       href="#"
       class="block rounded-lg border bg-card text-card-foreground shadow-sm duration-250 relative cursor-default transition-all group-hover:border-neutral-400 dark:group-hover:border-neutral-600"
     >
-      <div class="p-6 m-0 flex flex-row items-center justify-between rounded-t-lg border-b-[1px] px-4 py-3">
-        <button
-          data-state="closed"
-          class="cursor-default truncate"
-        >
-          <h3 class="font-semibold tracking-tight text-md truncate">
+      <div class="flex-col p-6 relative flex w-full max-w-full flex-wrap items-baseline justify-between gap-3 px-3 py-2 md:flex-row">
+        <div class="flex flex-col flex-wrap items-baseline gap-3 md:flex-row">
+          <button
+            data-state="closed"
+            class="grow cursor-default items-baseline justify-between overflow-hidden truncate text-left text-sm font-medium"
+          >
             item
-          </h3>
-        </button>
-        <div class="flex flex-row items-center gap-2">
+          </button>
         </div>
-      </div>
-      <div class="flex h-12 w-full items-center justify-between gap-4 border-t-[1px] px-4 py-3">
-        <div class="flex gap-2">
+        <div class="flex flex-row flex-wrap items-center gap-3">
+        </div>
+        <div class="absolute -bottom-3.5 right-2.5 flex gap-2">
         </div>
       </div>
     </a>
@@ -42,30 +40,28 @@ exports[`ResultItem render stacked many 1`] = `
       href="#"
       class="block rounded-lg border bg-card text-card-foreground shadow-sm duration-250 relative cursor-default transition-all group-hover:border-neutral-400 dark:group-hover:border-neutral-600"
     >
-      <div class="p-6 m-0 flex flex-row items-center justify-between rounded-t-lg border-b-[1px] px-4 py-3">
-        <button
-          data-state="closed"
-          class="cursor-default truncate"
-        >
-          <h3 class="font-semibold tracking-tight text-md truncate">
+      <div class="flex-col p-6 relative flex w-full max-w-full flex-wrap items-baseline justify-between gap-3 px-3 py-2 md:flex-row">
+        <div class="flex flex-col flex-wrap items-baseline gap-3 md:flex-row">
+          <div
+            class="group font-courier relative z-[1] w-fit flex h-full cursor-default items-center justify-center gap-1.5 rounded border-[1px] border-neutral-200 bg-neutral-100 px-2 py-1 text-[0.75rem] font-medium text-muted-foreground dark:border-[#313131] dark:bg-neutral-800 md:-ml-1"
+            data-state="closed"
+          >
+            <span class="pt-0.5">
+              1.1.1
+            </span>
+          </div>
+          <button
+            data-state="closed"
+            class="grow cursor-default items-baseline justify-between overflow-hidden truncate text-left text-sm font-medium"
+          >
             many-edges-stacked
-          </h3>
-        </button>
-        <div class="flex flex-row items-center gap-2">
+          </button>
         </div>
-      </div>
-      <div class="flex h-12 w-full items-center justify-between gap-4 border-t-[1px] px-4 py-3">
-        <div
-          class="group font-courier relative z-[1] w-fit flex h-full cursor-default items-center justify-center gap-1.5 rounded border-[1px] border-neutral-200 bg-neutral-100 px-2 py-1 text-[0.75rem] font-medium text-muted-foreground dark:border-[#313131] dark:bg-neutral-800"
-          data-state="closed"
-        >
-          <span class="pt-0.5">
-            1.1.1
-          </span>
+        <div class="flex flex-row flex-wrap items-center gap-3">
         </div>
-        <div class="flex gap-2">
+        <div class="absolute -bottom-3.5 right-2.5 flex gap-2">
           <div>
-            <div class="inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 bg-lime-500/25 border-[1px] border-lime-600 dark:border-lime-400 text-lime-600 hover:bg-lime-400/40 dark:bg-lime-500/30 dark:text-lime-400 dark:hover:bg-lime-500/40">
+            <div class="inline-flex items-center px-2.5 py-0.5 text-xs transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 bg-lime-500/25 border-[1px] border-lime-600 dark:border-lime-400 hover:bg-lime-400/40 dark:bg-lime-500/30 dark:text-lime-400 dark:hover:bg-lime-500/40 h-[18px] rounded-full font-normal text-inherit backdrop-blur-md">
               peer
             </div>
           </div>
@@ -87,30 +83,28 @@ exports[`ResultItem render stacked two 1`] = `
       href="#"
       class="block rounded-lg border bg-card text-card-foreground shadow-sm duration-250 relative cursor-default transition-all group-hover:border-neutral-400 dark:group-hover:border-neutral-600"
     >
-      <div class="p-6 m-0 flex flex-row items-center justify-between rounded-t-lg border-b-[1px] px-4 py-3">
-        <button
-          data-state="closed"
-          class="cursor-default truncate"
-        >
-          <h3 class="font-semibold tracking-tight text-md truncate">
+      <div class="flex-col p-6 relative flex w-full max-w-full flex-wrap items-baseline justify-between gap-3 px-3 py-2 md:flex-row">
+        <div class="flex flex-col flex-wrap items-baseline gap-3 md:flex-row">
+          <div
+            class="group font-courier relative z-[1] w-fit flex h-full cursor-default items-center justify-center gap-1.5 rounded border-[1px] border-neutral-200 bg-neutral-100 px-2 py-1 text-[0.75rem] font-medium text-muted-foreground dark:border-[#313131] dark:bg-neutral-800 md:-ml-1"
+            data-state="closed"
+          >
+            <span class="pt-0.5">
+              1.0.0
+            </span>
+          </div>
+          <button
+            data-state="closed"
+            class="grow cursor-default items-baseline justify-between overflow-hidden truncate text-left text-sm font-medium"
+          >
             two-edges-stacked
-          </h3>
-        </button>
-        <div class="flex flex-row items-center gap-2">
+          </button>
         </div>
-      </div>
-      <div class="flex h-12 w-full items-center justify-between gap-4 border-t-[1px] px-4 py-3">
-        <div
-          class="group font-courier relative z-[1] w-fit flex h-full cursor-default items-center justify-center gap-1.5 rounded border-[1px] border-neutral-200 bg-neutral-100 px-2 py-1 text-[0.75rem] font-medium text-muted-foreground dark:border-[#313131] dark:bg-neutral-800"
-          data-state="closed"
-        >
-          <span class="pt-0.5">
-            1.0.0
-          </span>
+        <div class="flex flex-row flex-wrap items-center gap-3">
         </div>
-        <div class="flex gap-2">
+        <div class="absolute -bottom-3.5 right-2.5 flex gap-2">
           <div>
-            <div class="inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 bg-fuchsia-500/20 border-[1px] dark:border-fuchsia-400 border-fuchsia-500 text-fuchsia-500 hover:bg-fuchsia-400/30 dark:bg-fuchsia-500/30 dark:text-fuchsia-400 dark:hover:bg-fuchsia-500/40">
+            <div class="inline-flex items-center px-2.5 py-0.5 text-xs transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 bg-fuchsia-500/20 border-[1px] dark:border-fuchsia-400 border-fuchsia-500 hover:bg-fuchsia-400/30 dark:bg-fuchsia-500/30 dark:text-fuchsia-400 dark:hover:bg-fuchsia-500/40 h-[18px] rounded-full font-normal text-inherit backdrop-blur-md">
               dev
             </div>
           </div>
@@ -130,30 +124,28 @@ exports[`ResultItem render with item 1`] = `
       href="#"
       class="block rounded-lg border bg-card text-card-foreground shadow-sm duration-250 relative cursor-default transition-all group-hover:border-neutral-400 dark:group-hover:border-neutral-600"
     >
-      <div class="p-6 m-0 flex flex-row items-center justify-between rounded-t-lg border-b-[1px] px-4 py-3">
-        <button
-          data-state="closed"
-          class="cursor-default truncate"
-        >
-          <h3 class="font-semibold tracking-tight text-md truncate">
+      <div class="flex-col p-6 relative flex w-full max-w-full flex-wrap items-baseline justify-between gap-3 px-3 py-2 md:flex-row">
+        <div class="flex flex-col flex-wrap items-baseline gap-3 md:flex-row">
+          <div
+            class="group font-courier relative z-[1] w-fit flex h-full cursor-default items-center justify-center gap-1.5 rounded border-[1px] border-neutral-200 bg-neutral-100 px-2 py-1 text-[0.75rem] font-medium text-muted-foreground dark:border-[#313131] dark:bg-neutral-800 md:-ml-1"
+            data-state="closed"
+          >
+            <span class="pt-0.5">
+              1.0.0
+            </span>
+          </div>
+          <button
+            data-state="closed"
+            class="grow cursor-default items-baseline justify-between overflow-hidden truncate text-left text-sm font-medium"
+          >
             item
-          </h3>
-        </button>
-        <div class="flex flex-row items-center gap-2">
+          </button>
         </div>
-      </div>
-      <div class="flex h-12 w-full items-center justify-between gap-4 border-t-[1px] px-4 py-3">
-        <div
-          class="group font-courier relative z-[1] w-fit flex h-full cursor-default items-center justify-center gap-1.5 rounded border-[1px] border-neutral-200 bg-neutral-100 px-2 py-1 text-[0.75rem] font-medium text-muted-foreground dark:border-[#313131] dark:bg-neutral-800"
-          data-state="closed"
-        >
-          <span class="pt-0.5">
-            1.0.0
-          </span>
+        <div class="flex flex-row flex-wrap items-center gap-3">
         </div>
-        <div class="flex gap-2">
+        <div class="absolute -bottom-3.5 right-2.5 flex gap-2">
           <div>
-            <div class="inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 bg-cyan-500/25 text-cyan-600 border-[1px] border-cyan-600 dark:border-cyan-500 hover:bg-cyan-500/40 dark:bg-cyan-500/30 dark:text-cyan-500 dark:hover:bg-cyan-500/40">
+            <div class="inline-flex items-center px-2.5 py-0.5 text-xs transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 bg-cyan-500/25 border-[1px] border-cyan-600 dark:border-cyan-500 hover:bg-cyan-500/40 dark:bg-cyan-500/30 dark:text-cyan-500 dark:hover:bg-cyan-500/40 h-[18px] rounded-full font-normal text-inherit backdrop-blur-md">
               prod
             </div>
           </div>
@@ -173,16 +165,24 @@ exports[`ResultItem render with type 1`] = `
       href="#"
       class="block rounded-lg border bg-card text-card-foreground shadow-sm duration-250 relative cursor-default transition-all group-hover:border-neutral-400 dark:group-hover:border-neutral-600"
     >
-      <div class="p-6 m-0 flex flex-row items-center justify-between rounded-t-lg border-b-[1px] px-4 py-3">
-        <button
-          data-state="closed"
-          class="cursor-default truncate"
-        >
-          <h3 class="font-semibold tracking-tight text-md truncate">
+      <div class="flex-col p-6 relative flex w-full max-w-full flex-wrap items-baseline justify-between gap-3 px-3 py-2 md:flex-row">
+        <div class="flex flex-col flex-wrap items-baseline gap-3 md:flex-row">
+          <div
+            class="group font-courier relative z-[1] w-fit flex h-full cursor-default items-center justify-center gap-1.5 rounded border-[1px] border-neutral-200 bg-neutral-100 px-2 py-1 text-[0.75rem] font-medium text-muted-foreground dark:border-[#313131] dark:bg-neutral-800 md:-ml-1"
+            data-state="closed"
+          >
+            <span class="pt-0.5">
+              1.0.0
+            </span>
+          </div>
+          <button
+            data-state="closed"
+            class="grow cursor-default items-baseline justify-between overflow-hidden truncate text-left text-sm font-medium"
+          >
             item
-          </h3>
-        </button>
-        <div class="flex flex-row items-center gap-2">
+          </button>
+        </div>
+        <div class="flex flex-row flex-wrap items-center gap-3">
           <div class="group font-sans relative z-[1] w-fit flex h-full cursor-default items-center justify-center gap-1.5 rounded border-[1px] border-neutral-200 bg-neutral-100 px-2 py-1 text-[0.75rem] font-medium text-muted-foreground dark:border-[#313131] dark:bg-neutral-800">
             <span
               data-id="info-badge-value"
@@ -196,19 +196,9 @@ exports[`ResultItem render with type 1`] = `
             </span>
           </div>
         </div>
-      </div>
-      <div class="flex h-12 w-full items-center justify-between gap-4 border-t-[1px] px-4 py-3">
-        <div
-          class="group font-courier relative z-[1] w-fit flex h-full cursor-default items-center justify-center gap-1.5 rounded border-[1px] border-neutral-200 bg-neutral-100 px-2 py-1 text-[0.75rem] font-medium text-muted-foreground dark:border-[#313131] dark:bg-neutral-800"
-          data-state="closed"
-        >
-          <span class="pt-0.5">
-            1.0.0
-          </span>
-        </div>
-        <div class="flex gap-2">
+        <div class="absolute -bottom-3.5 right-2.5 flex gap-2">
           <div>
-            <div class="inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 bg-cyan-500/25 text-cyan-600 border-[1px] border-cyan-600 dark:border-cyan-500 hover:bg-cyan-500/40 dark:bg-cyan-500/30 dark:text-cyan-500 dark:hover:bg-cyan-500/40">
+            <div class="inline-flex items-center px-2.5 py-0.5 text-xs transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 bg-cyan-500/25 border-[1px] border-cyan-600 dark:border-cyan-500 hover:bg-cyan-500/40 dark:bg-cyan-500/30 dark:text-cyan-500 dark:hover:bg-cyan-500/40 h-[18px] rounded-full font-normal text-inherit backdrop-blur-md">
               prod
             </div>
           </div>

--- a/src/gui/test/components/navigation/__snapshots__/header.tsx.snap
+++ b/src/gui/test/components/navigation/__snapshots__/header.tsx.snap
@@ -7,7 +7,7 @@ exports[`header renders with build version 1`] = `
     <h3 class="text-md font-medium">
       Dashboard
     </h3>
-    <p class="ml-auto font-courier text-xs font-medium text-muted-foreground">
+    <p class="ml-auto hidden font-courier text-xs font-medium text-muted-foreground md:block">
       build: v1.0.0
     </p>
   </div>


### PR DESCRIPTION
| Desktop | Mobile |
| --- | --- |
| <img width="500" alt="Screenshot 2025-06-03 at 12 14 48" src="https://github.com/user-attachments/assets/54c4454b-6e98-4583-9a81-d525962fd412" /> | <img width="500" alt="Screenshot 2025-06-03 at 11 59 25" src="https://github.com/user-attachments/assets/bdb8c8ae-28c3-4025-8dd0-c7d16b176d82" /> |

Continues on the `result-item` component for the gui search results view.

This PR condenses the cards from a '2-tier' card into a single card with a more compact layout,
and updates some classes to improve the cards on smaller viewports.

### Changes
**updates** `header` style on mobile
**moves** `LICENSE_TYPES` into `@/lib/constants`
**updates** `result-item` style
