### PR TITLE
vlx: infer a reasonable name from nameless spec

### DIFF
--- a/src/vlx/src/infer-name.ts
+++ b/src/vlx/src/infer-name.ts
@@ -1,0 +1,30 @@
+import type { SpecOptions } from '@vltpkg/spec'
+import { Spec } from '@vltpkg/spec'
+
+/**
+ * If the final spec is unnamed, infer a name by slugifying the bareSpec.
+ *
+ * This is a bit less "correct" than how install does it, because we don't
+ * actually need to get the "true" name from the manifest, we just need
+ * something intelligible that works, and will want to avoid the performance
+ * hit of having to fetch the manifest a second time, especially for git
+ * deps where that can be quite slow.
+ */
+export const inferName = (
+  s: Spec | string,
+  options: SpecOptions,
+): Spec => {
+  const spec = typeof s === 'string' ? Spec.parseArgs(s, options) : s
+  const { name } = spec
+  return !name || name === '(unknown)' ?
+      Spec.parse(
+        spec.bareSpec
+          .replace(/[^a-zA-Z0-9/]/g, ' ')
+          .trim()
+          .replace(/ /g, '-')
+          .replace('/', '§'),
+        spec.bareSpec,
+        spec.options,
+      )
+    : spec
+}

--- a/src/vlx/src/install.ts
+++ b/src/vlx/src/install.ts
@@ -1,7 +1,7 @@
 import { error } from '@vltpkg/error-cause'
 import { install } from '@vltpkg/graph'
 import { PackageInfoClient } from '@vltpkg/package-info'
-import type {Spec} from '@vltpkg/spec';
+import type { Spec } from '@vltpkg/spec'
 import { XDG } from '@vltpkg/xdg'
 import { createHash } from 'node:crypto'
 import { mkdir, writeFile } from 'node:fs/promises'

--- a/src/vlx/src/install.ts
+++ b/src/vlx/src/install.ts
@@ -1,7 +1,7 @@
 import { error } from '@vltpkg/error-cause'
 import { install } from '@vltpkg/graph'
 import { PackageInfoClient } from '@vltpkg/package-info'
-import { Spec } from '@vltpkg/spec'
+import type {Spec} from '@vltpkg/spec';
 import { XDG } from '@vltpkg/xdg'
 import { createHash } from 'node:crypto'
 import { mkdir, writeFile } from 'node:fs/promises'
@@ -10,6 +10,7 @@ import { PathScurry } from 'path-scurry'
 import { dirExists } from './dir-exists.ts'
 import { doPrompt } from './do-prompt.ts'
 import type { PromptFn, VlxInfo, VlxOptions } from './index.ts'
+import { inferName } from './infer-name.ts'
 import { vlxInfo } from './info.ts'
 
 /**
@@ -21,9 +22,8 @@ export const vlxInstall = async (
   options: VlxOptions,
   promptFn?: PromptFn,
 ): Promise<VlxInfo> => {
-  const pkgSpec =
-    typeof spec === 'string' ? Spec.parseArgs(spec) : spec
-  const { name } = pkgSpec.final
+  const pkgSpec = inferName(spec, options)
+
   // We always use the cache as much as possible, to prevent unnecessarily
   // waiting to run a command while installing something. The one we used
   // last time is almost certainly fine.
@@ -34,6 +34,7 @@ export const vlxInstall = async (
   const packageInfo = (options.packageInfo = new PackageInfoClient(
     options,
   ))
+
   const resolution = await packageInfo.resolve(pkgSpec, options)
   const hash = createHash('sha512')
     .update(resolution.resolved)
@@ -55,7 +56,7 @@ export const vlxInstall = async (
   const manifest = {
     name: 'vlx',
     dependencies: {
-      [name]: resolution.resolved,
+      [pkgSpec.name]: resolution.resolved,
     },
     vlx: {
       integrity: resolution.integrity,

--- a/src/vlx/test/infer-name.ts
+++ b/src/vlx/test/infer-name.ts
@@ -1,0 +1,16 @@
+import { Spec } from '@vltpkg/spec'
+import t from 'tap'
+import { inferName } from '../src/infer-name.ts'
+
+t.match(
+  inferName('github:a/b#main', {}),
+  Spec.parse('github-a§b-main', 'github:a/b#main'),
+)
+t.match(
+  inferName(Spec.parseArgs('github:a/b#main'), {}),
+  Spec.parse('github-a§b-main', 'github:a/b#main'),
+)
+t.match(
+  inferName(Spec.parseArgs('a@1.2.3'), {}),
+  Spec.parse('a', '1.2.3'),
+)


### PR DESCRIPTION
Fix: #819