### PR TITLE
graph: add graph modifiers module

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -888,6 +888,9 @@ importers:
       '@vltpkg/dep-id':
         specifier: workspace:*
         version: link:../dep-id
+      '@vltpkg/dss-breadcrumb':
+        specifier: workspace:*
+        version: link:../dss-breadcrumb
       '@vltpkg/error-cause':
         specifier: workspace:*
         version: link:../error-cause
@@ -921,6 +924,9 @@ importers:
       '@vltpkg/types':
         specifier: workspace:*
         version: link:../types
+      '@vltpkg/vlt-json':
+        specifier: workspace:*
+        version: link:../vlt-json
       '@vltpkg/workspaces':
         specifier: workspace:*
         version: link:../workspaces
@@ -940,9 +946,6 @@ importers:
       '@types/node':
         specifier: 'catalog:'
         version: 22.15.29
-      '@vltpkg/vlt-json':
-        specifier: workspace:*
-        version: link:../vlt-json
       eslint:
         specifier: 'catalog:'
         version: 9.28.0(jiti@2.4.2)
@@ -3027,12 +3030,6 @@ packages:
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
-
-  '@eslint-community/eslint-utils@4.4.0':
-    resolution: {integrity: sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    peerDependencies:
-      eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
 
   '@eslint-community/eslint-utils@4.7.0':
     resolution: {integrity: sha512-dyybb3AcajC7uha6CvhdVRJqaKyn7w2YKqKyAN37NKYgZT36w+iRb0Dymmc5qEJ549c/S31cMMSFd75bteCpCw==}
@@ -7574,10 +7571,6 @@ packages:
     resolution: {integrity: sha512-xc0zuJ5FMqvW+DpiRkvxURlz98DdfDsZcFHdO699+oL+ykbFfgI7O4VDEgUyc07BSL2NHl3zdb8m/tZ/aaqUrw==}
     engines: {node: '>=16'}
 
-  prismjs@1.29.0:
-    resolution: {integrity: sha512-Kx/1w86q/epKcmte75LNrEoT+lX8pBpavuAbvJWRXar7Hz8jrtF+e3vY751p0R8H9HdArwaCTNDDzHg/ScJK1Q==}
-    engines: {node: '>=6'}
-
   prismjs@1.30.0:
     resolution: {integrity: sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==}
     engines: {node: '>=6'}
@@ -7980,11 +7973,6 @@ packages:
 
   semver@6.3.1:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
-    hasBin: true
-
-  semver@7.7.1:
-    resolution: {integrity: sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==}
-    engines: {node: '>=10'}
     hasBin: true
 
   semver@7.7.2:
@@ -9409,7 +9397,7 @@ snapshots:
   '@astrojs/telemetry@3.3.0':
     dependencies:
       ci-info: 4.2.0
-      debug: 4.4.1
+      debug: 4.4.1(supports-color@10.0.0)
       dlv: 1.1.3
       dset: 3.1.4
       is-docker: 3.0.0
@@ -9562,7 +9550,7 @@ snapshots:
       '@babel/parser': 7.27.0
       '@babel/template': 7.27.0
       '@babel/types': 7.27.0
-      debug: 4.4.0(supports-color@10.0.0)
+      debug: 4.4.1(supports-color@10.0.0)
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
@@ -9817,16 +9805,6 @@ snapshots:
   '@esbuild/win32-x64@0.25.5':
     optional: true
 
-  '@eslint-community/eslint-utils@4.4.0(eslint@9.28.0(jiti@2.4.2)(supports-color@10.0.0))':
-    dependencies:
-      eslint: 9.28.0(jiti@2.4.2)(supports-color@10.0.0)
-      eslint-visitor-keys: 3.4.3
-
-  '@eslint-community/eslint-utils@4.4.0(eslint@9.28.0(jiti@2.4.2))':
-    dependencies:
-      eslint: 9.28.0(jiti@2.4.2)
-      eslint-visitor-keys: 3.4.3
-
   '@eslint-community/eslint-utils@4.7.0(eslint@9.28.0(jiti@2.4.2)(supports-color@10.0.0))':
     dependencies:
       eslint: 9.28.0(jiti@2.4.2)(supports-color@10.0.0)
@@ -9842,7 +9820,7 @@ snapshots:
   '@eslint/config-array@0.20.0(supports-color@10.0.0)':
     dependencies:
       '@eslint/object-schema': 2.1.6
-      debug: 4.4.0(supports-color@10.0.0)
+      debug: 4.4.1(supports-color@10.0.0)
       minimatch: 3.1.2
     transitivePeerDependencies:
       - supports-color
@@ -9856,7 +9834,7 @@ snapshots:
   '@eslint/eslintrc@3.3.1(supports-color@10.0.0)':
     dependencies:
       ajv: 6.12.6
-      debug: 4.4.0(supports-color@10.0.0)
+      debug: 4.4.1(supports-color@10.0.0)
       espree: 10.3.0
       globals: 14.0.0
       ignore: 5.3.2
@@ -10197,7 +10175,7 @@ snapshots:
       https-proxy-agent: 7.0.6(supports-color@10.0.0)
       node-fetch: 2.7.0(encoding@0.1.13)
       nopt: 8.0.0
-      semver: 7.7.1
+      semver: 7.7.2
       tar: 7.4.3
     transitivePeerDependencies:
       - encoding
@@ -10292,11 +10270,11 @@ snapshots:
 
   '@npmcli/fs@3.1.1':
     dependencies:
-      semver: 7.7.1
+      semver: 7.7.2
 
   '@npmcli/fs@4.0.0':
     dependencies:
-      semver: 7.7.1
+      semver: 7.7.2
 
   '@npmcli/git@5.0.8':
     dependencies:
@@ -10307,7 +10285,7 @@ snapshots:
       proc-log: 4.2.0
       promise-inflight: 1.0.1
       promise-retry: 2.0.1
-      semver: 7.7.1
+      semver: 7.7.2
       which: 4.0.0
     transitivePeerDependencies:
       - bluebird
@@ -10320,7 +10298,7 @@ snapshots:
       npm-pick-manifest: 10.0.0
       proc-log: 5.0.0
       promise-retry: 2.0.1
-      semver: 7.7.1
+      semver: 7.7.2
       which: 5.0.0
 
   '@npmcli/installed-package-contents@2.1.0':
@@ -10345,7 +10323,7 @@ snapshots:
       json-parse-even-better-errors: 3.0.2
       normalize-package-data: 6.0.2
       proc-log: 4.2.0
-      semver: 7.7.1
+      semver: 7.7.2
     transitivePeerDependencies:
       - bluebird
 
@@ -10356,7 +10334,7 @@ snapshots:
       hosted-git-info: 8.1.0
       json-parse-even-better-errors: 4.0.0
       proc-log: 5.0.0
-      semver: 7.7.1
+      semver: 7.7.2
       validate-npm-package-license: 3.0.4
 
   '@npmcli/promise-spawn@7.0.2':
@@ -11355,7 +11333,7 @@ snapshots:
       path-scurry: 2.0.0
       resolve-import: 2.0.0
       rimraf: 6.0.1
-      semver: 7.7.1
+      semver: 7.7.2
       signal-exit: 4.1.0
       tap-parser: 18.0.0
       tap-yaml: 4.0.0
@@ -11724,7 +11702,7 @@ snapshots:
       '@typescript-eslint/types': 8.33.1
       '@typescript-eslint/typescript-estree': 8.33.1(supports-color@10.0.0)(typescript@5.7.3)
       '@typescript-eslint/visitor-keys': 8.33.1
-      debug: 4.4.0(supports-color@10.0.0)
+      debug: 4.4.1(supports-color@10.0.0)
       eslint: 9.28.0(jiti@2.4.2)(supports-color@10.0.0)
       typescript: 5.7.3
     transitivePeerDependencies:
@@ -11736,7 +11714,7 @@ snapshots:
       '@typescript-eslint/types': 8.33.1
       '@typescript-eslint/typescript-estree': 8.33.1(supports-color@10.0.0)(typescript@5.7.3)
       '@typescript-eslint/visitor-keys': 8.33.1
-      debug: 4.4.0(supports-color@10.0.0)
+      debug: 4.4.1(supports-color@10.0.0)
       eslint: 9.28.0(jiti@2.4.2)
       typescript: 5.7.3
     transitivePeerDependencies:
@@ -11746,7 +11724,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/tsconfig-utils': 8.33.1(typescript@5.7.3)
       '@typescript-eslint/types': 8.33.1
-      debug: 4.4.0(supports-color@10.0.0)
+      debug: 4.4.1(supports-color@10.0.0)
       typescript: 5.7.3
     transitivePeerDependencies:
       - supports-color
@@ -11764,7 +11742,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/typescript-estree': 8.33.1(supports-color@10.0.0)(typescript@5.7.3)
       '@typescript-eslint/utils': 8.33.1(eslint@9.28.0(jiti@2.4.2)(supports-color@10.0.0))(supports-color@10.0.0)(typescript@5.7.3)
-      debug: 4.4.0(supports-color@10.0.0)
+      debug: 4.4.1(supports-color@10.0.0)
       eslint: 9.28.0(jiti@2.4.2)(supports-color@10.0.0)
       ts-api-utils: 2.1.0(typescript@5.7.3)
       typescript: 5.7.3
@@ -11775,7 +11753,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/typescript-estree': 8.33.1(supports-color@10.0.0)(typescript@5.7.3)
       '@typescript-eslint/utils': 8.33.1(eslint@9.28.0(jiti@2.4.2))(typescript@5.7.3)
-      debug: 4.4.0(supports-color@10.0.0)
+      debug: 4.4.1(supports-color@10.0.0)
       eslint: 9.28.0(jiti@2.4.2)
       ts-api-utils: 2.1.0(typescript@5.7.3)
       typescript: 5.7.3
@@ -11790,7 +11768,7 @@ snapshots:
       '@typescript-eslint/tsconfig-utils': 8.33.1(typescript@5.7.3)
       '@typescript-eslint/types': 8.33.1
       '@typescript-eslint/visitor-keys': 8.33.1
-      debug: 4.4.0(supports-color@10.0.0)
+      debug: 4.4.1(supports-color@10.0.0)
       fast-glob: 3.3.3
       is-glob: 4.0.3
       minimatch: 9.0.5
@@ -12210,7 +12188,7 @@ snapshots:
       common-ancestor-path: 1.0.1
       cookie: 1.0.2
       cssesc: 3.0.0
-      debug: 4.4.1
+      debug: 4.4.1(supports-color@10.0.0)
       deterministic-object-hash: 2.0.2
       devalue: 5.1.1
       diff: 5.2.0
@@ -12706,9 +12684,11 @@ snapshots:
     optionalDependencies:
       supports-color: 10.0.0
 
-  debug@4.4.1:
+  debug@4.4.1(supports-color@10.0.0):
     dependencies:
       ms: 2.1.3
+    optionalDependencies:
+      supports-color: 10.0.0
 
   decimal.js-light@2.5.1: {}
 
@@ -13068,7 +13048,7 @@ snapshots:
       '@es-joy/jsdoccomment': 0.50.2
       are-docs-informative: 0.0.2
       comment-parser: 1.4.1
-      debug: 4.4.1
+      debug: 4.4.1(supports-color@10.0.0)
       escape-string-regexp: 4.0.0
       eslint: 9.28.0(jiti@2.4.2)
       espree: 10.3.0
@@ -13100,7 +13080,7 @@ snapshots:
 
   eslint@9.28.0(jiti@2.4.2):
     dependencies:
-      '@eslint-community/eslint-utils': 4.4.0(eslint@9.28.0(jiti@2.4.2))
+      '@eslint-community/eslint-utils': 4.7.0(eslint@9.28.0(jiti@2.4.2))
       '@eslint-community/regexpp': 4.12.1
       '@eslint/config-array': 0.20.0(supports-color@10.0.0)
       '@eslint/config-helpers': 0.2.1
@@ -13116,7 +13096,7 @@ snapshots:
       ajv: 6.12.6
       chalk: 4.1.2
       cross-spawn: 7.0.6
-      debug: 4.4.0(supports-color@10.0.0)
+      debug: 4.4.1(supports-color@10.0.0)
       escape-string-regexp: 4.0.0
       eslint-scope: 8.3.0
       eslint-visitor-keys: 4.2.0
@@ -13142,7 +13122,7 @@ snapshots:
 
   eslint@9.28.0(jiti@2.4.2)(supports-color@10.0.0):
     dependencies:
-      '@eslint-community/eslint-utils': 4.4.0(eslint@9.28.0(jiti@2.4.2)(supports-color@10.0.0))
+      '@eslint-community/eslint-utils': 4.7.0(eslint@9.28.0(jiti@2.4.2)(supports-color@10.0.0))
       '@eslint-community/regexpp': 4.12.1
       '@eslint/config-array': 0.20.0(supports-color@10.0.0)
       '@eslint/config-helpers': 0.2.1
@@ -13158,7 +13138,7 @@ snapshots:
       ajv: 6.12.6
       chalk: 4.1.2
       cross-spawn: 7.0.6
-      debug: 4.4.0(supports-color@10.0.0)
+      debug: 4.4.1(supports-color@10.0.0)
       escape-string-regexp: 4.0.0
       eslint-scope: 8.3.0
       eslint-visitor-keys: 4.2.0
@@ -14185,7 +14165,7 @@ snapshots:
 
   make-dir@4.0.0:
     dependencies:
-      semver: 7.7.1
+      semver: 7.7.2
 
   make-error@1.3.6: {}
 
@@ -14890,7 +14870,7 @@ snapshots:
       make-fetch-happen: 13.0.1(supports-color@10.0.0)
       nopt: 7.2.1
       proc-log: 4.2.0
-      semver: 7.7.1
+      semver: 7.7.2
       tar: 6.2.1
       which: 4.0.0
     transitivePeerDependencies:
@@ -14904,9 +14884,9 @@ snapshots:
       make-fetch-happen: 14.0.3
       nopt: 8.0.0
       proc-log: 5.0.0
-      semver: 7.7.1
+      semver: 7.7.2
       tar: 7.4.3
-      tinyglobby: 0.2.13
+      tinyglobby: 0.2.14
       which: 5.0.0
     transitivePeerDependencies:
       - supports-color
@@ -14931,7 +14911,7 @@ snapshots:
   normalize-package-data@6.0.2:
     dependencies:
       hosted-git-info: 7.0.2
-      semver: 7.7.1
+      semver: 7.7.2
       validate-npm-package-license: 3.0.4
 
   normalize-path@3.0.0: {}
@@ -14948,11 +14928,11 @@ snapshots:
 
   npm-install-checks@6.3.0:
     dependencies:
-      semver: 7.7.1
+      semver: 7.7.2
 
   npm-install-checks@7.1.1:
     dependencies:
-      semver: 7.7.1
+      semver: 7.7.2
 
   npm-normalize-package-bin@3.0.1: {}
 
@@ -14962,14 +14942,14 @@ snapshots:
     dependencies:
       hosted-git-info: 7.0.2
       proc-log: 4.2.0
-      semver: 7.7.1
+      semver: 7.7.2
       validate-npm-package-name: 5.0.1
 
   npm-package-arg@12.0.2:
     dependencies:
       hosted-git-info: 8.1.0
       proc-log: 5.0.0
-      semver: 7.7.1
+      semver: 7.7.2
       validate-npm-package-name: 6.0.0
 
   npm-packlist@10.0.0:
@@ -14985,14 +14965,14 @@ snapshots:
       npm-install-checks: 7.1.1
       npm-normalize-package-bin: 4.0.0
       npm-package-arg: 12.0.2
-      semver: 7.7.1
+      semver: 7.7.2
 
   npm-pick-manifest@9.1.0:
     dependencies:
       npm-install-checks: 6.3.0
       npm-normalize-package-bin: 3.0.1
       npm-package-arg: 11.0.3
-      semver: 7.7.1
+      semver: 7.7.2
 
   npm-registry-fetch@17.1.0(supports-color@10.0.0):
     dependencies:
@@ -15392,10 +15372,8 @@ snapshots:
   prismjs-terminal@1.2.3:
     dependencies:
       chalk: 5.4.1
-      prismjs: 1.29.0
+      prismjs: 1.30.0
       string-length: 6.0.0
-
-  prismjs@1.29.0: {}
 
   prismjs@1.30.0: {}
 
@@ -15917,8 +15895,6 @@ snapshots:
 
   semver@6.3.1: {}
 
-  semver@7.7.1: {}
-
   semver@7.7.2: {}
 
   serve-handler@6.1.6:
@@ -16097,7 +16073,7 @@ snapshots:
   socks-proxy-agent@8.0.4(supports-color@10.0.0):
     dependencies:
       agent-base: 7.1.3
-      debug: 4.4.0(supports-color@10.0.0)
+      debug: 4.4.1(supports-color@10.0.0)
       socks: 2.8.3
     transitivePeerDependencies:
       - supports-color
@@ -16538,7 +16514,7 @@ snapshots:
   tuf-js@2.2.1(supports-color@10.0.0):
     dependencies:
       '@tufjs/models': 2.0.1
-      debug: 4.4.0(supports-color@10.0.0)
+      debug: 4.4.1(supports-color@10.0.0)
       make-fetch-happen: 13.0.1(supports-color@10.0.0)
     transitivePeerDependencies:
       - supports-color
@@ -16546,7 +16522,7 @@ snapshots:
   tuf-js@3.0.1:
     dependencies:
       '@tufjs/models': 3.0.1
-      debug: 4.4.0(supports-color@10.0.0)
+      debug: 4.4.1(supports-color@10.0.0)
       make-fetch-happen: 14.0.3
     transitivePeerDependencies:
       - supports-color
@@ -16625,7 +16601,7 @@ snapshots:
 
   typescript-auto-import-cache@0.3.3:
     dependencies:
-      semver: 7.7.1
+      semver: 7.7.2
 
   typescript-eslint@8.33.1(eslint@9.28.0(jiti@2.4.2)(supports-color@10.0.0))(supports-color@10.0.0)(typescript@5.7.3):
     dependencies:
@@ -16905,7 +16881,7 @@ snapshots:
   vite-node@3.2.1(@types/node@22.15.29)(jiti@2.4.2)(tsx@4.19.2)(yaml@2.7.1):
     dependencies:
       cac: 6.7.14
-      debug: 4.4.1
+      debug: 4.4.1(supports-color@10.0.0)
       es-module-lexer: 1.7.0
       pathe: 2.0.3
       vite: 6.3.5(@types/node@22.15.29)(jiti@2.4.2)(tsx@4.19.2)(yaml@2.7.1)
@@ -16930,7 +16906,7 @@ snapshots:
       picomatch: 4.0.2
       postcss: 8.5.3
       rollup: 4.40.0
-      tinyglobby: 0.2.13
+      tinyglobby: 0.2.14
     optionalDependencies:
       '@types/node': 22.15.29
       fsevents: 2.3.3
@@ -16968,7 +16944,7 @@ snapshots:
       '@vitest/spy': 3.2.1
       '@vitest/utils': 3.2.1
       chai: 5.2.0
-      debug: 4.4.1
+      debug: 4.4.1(supports-color@10.0.0)
       expect-type: 1.2.1
       magic-string: 0.30.17
       pathe: 2.0.3
@@ -17041,7 +17017,7 @@ snapshots:
   volar-service-typescript@0.0.61(@volar/language-service@2.4.6):
     dependencies:
       path-browserify: 1.0.1
-      semver: 7.7.1
+      semver: 7.7.2
       typescript-auto-import-cache: 0.3.3
       vscode-languageserver-textdocument: 1.0.12
       vscode-nls: 5.2.0

--- a/src/graph/package.json
+++ b/src/graph/package.json
@@ -22,6 +22,7 @@
   "dependencies": {
     "@vltpkg/cmd-shim": "workspace:*",
     "@vltpkg/dep-id": "workspace:*",
+    "@vltpkg/dss-breadcrumb": "workspace:*",
     "@vltpkg/error-cause": "workspace:*",
     "@vltpkg/fast-split": "workspace:*",
     "@vltpkg/output": "workspace:*",
@@ -33,6 +34,7 @@
     "@vltpkg/satisfies": "workspace:*",
     "@vltpkg/spec": "workspace:*",
     "@vltpkg/types": "workspace:*",
+    "@vltpkg/vlt-json": "workspace:*",
     "@vltpkg/workspaces": "workspace:*",
     "graph-run": "catalog:",
     "path-scurry": "catalog:",

--- a/src/graph/src/index.ts
+++ b/src/graph/src/index.ts
@@ -11,6 +11,7 @@ export * from './types.ts'
 export * from './install.ts'
 export * from './uninstall.ts'
 export * from './diff.ts'
+export * from './modifiers.ts'
 
 import { load as actualLoad } from './actual/load.ts'
 import type { LoadOptions as ActualLoadOptions } from './actual/load.ts'

--- a/src/graph/src/modifiers.ts
+++ b/src/graph/src/modifiers.ts
@@ -1,6 +1,5 @@
 import { parseBreadcrumb } from '@vltpkg/dss-breadcrumb'
 import { error } from '@vltpkg/error-cause'
-import { PackageJson } from '@vltpkg/package-json'
 import { Spec } from '@vltpkg/spec'
 import { asManifest, assertManifest, isObject } from '@vltpkg/types'
 import { load } from '@vltpkg/vlt-json'
@@ -175,10 +174,6 @@ export type ModifierActiveEntry = {
  */
 export type GraphModifierOptions = {
   /**
-   * A {@link PackageJson} object, for sharing manifest caches
-   */
-  packageJson?: PackageJson
-  /**
    * Options for the {@link Spec} parser
    */
   specOptions?: SpecOptions
@@ -216,8 +211,6 @@ export type GraphModifierOptions = {
  * ```
  */
 export class GraphModifier {
-  /** The package.json object, for sharing manifest caches */
-  packageJson: PackageJson
   /** The loaded modifiers configuration */
   #config?: GraphModifierConfigObject
   /** A set of all modifiers loaded from vlt.json */
@@ -244,14 +237,12 @@ export class GraphModifier {
     ModifierEntry,
     Map<string, Map<Node, ModifierActiveEntry>>
   >()
-
   /**
    * A set of currently active modifiers, which are being parsed.
    */
   activeModifiers = new Set<ModifierActiveEntry>()
 
   constructor(options: GraphModifierOptions) {
-    this.packageJson = options.packageJson ?? new PackageJson()
     this.load(options)
   }
 

--- a/src/graph/src/modifiers.ts
+++ b/src/graph/src/modifiers.ts
@@ -1,0 +1,527 @@
+import { parseBreadcrumb } from '@vltpkg/dss-breadcrumb'
+import { error } from '@vltpkg/error-cause'
+import { PackageJson } from '@vltpkg/package-json'
+import { Spec } from '@vltpkg/spec'
+import { asManifest, assertManifest } from '@vltpkg/types'
+import { load } from '@vltpkg/vlt-json'
+import type {
+  ModifierBreadcrumb,
+  ModifierInteractiveBreadcrumb,
+} from '@vltpkg/dss-breadcrumb'
+import type { SpecOptions } from '@vltpkg/spec'
+import type { Manifest } from '@vltpkg/types'
+import type { Edge } from './edge.ts'
+import type { Node } from './node.ts'
+
+/**
+ * Loaded modifiers configuration as described in the `vlt.json` file.
+ */
+export type GraphModifierLoadedConfig = {
+  modifiers: GraphModiferConfig
+}
+
+/**
+ * Allowed datatype in the `modifiers` field of the `vlt.json` file.
+ */
+export type GraphModiferConfig = Record<
+  string,
+  string | Record<string, any>
+>
+
+/**
+ * Type definition for the modifiers configuration object
+ */
+export type GraphModifierConfigObject = Record<
+  string,
+  string | Manifest
+>
+
+/**
+ * Turn a {@link GraphModiferConfig} into a
+ * {@link GraphModifierConfigObject}, or throw if it's not valid.
+ */
+export const asGraphModifiersConfig = (
+  conf: unknown,
+  path?: string,
+): GraphModifierConfigObject => {
+  assertGraphModifiersConfig(conf, path)
+
+  // Convert to standardized format
+  const result: GraphModifierConfigObject = {}
+
+  for (const [key, value] of Object.entries(conf)) {
+    if (typeof value === 'string') {
+      result[key] = value
+    } else {
+      result[key] = asManifest(value)
+    }
+  }
+
+  return result
+}
+
+/**
+ * Throw if the provided value is not a valid {@link GraphModiferConfig}
+ */
+export const assertGraphModifiersConfig: (
+  conf: unknown,
+  path?: string,
+) => asserts conf is GraphModiferConfig = (
+  conf: unknown,
+  path?: string,
+) => {
+  if (!conf || typeof conf !== 'object' || Array.isArray(conf)) {
+    throw error('Invalid modifiers configuration', {
+      path,
+      found: conf,
+    })
+  }
+
+  for (const [key, value] of Object.entries(conf)) {
+    if (typeof value === 'string') {
+      // String values are valid as they represent edge modifiers
+      continue
+    } else if (typeof value === 'object' && !Array.isArray(value)) {
+      // Object values need to be valid manifests
+      try {
+        assertManifest(value)
+      } catch (err) {
+        throw error('Invalid modifier manifest', {
+          path,
+          name: key,
+          found: value,
+          wanted: 'Valid package manifest',
+          cause: err,
+        })
+      }
+    } else {
+      throw error('Invalid modifier value', {
+        path,
+        name: key,
+        found: value,
+        wanted: 'string | Manifest',
+      })
+    }
+  }
+}
+
+/**
+ * Info needed to define a graph modifier.
+ */
+export type BaseModifierEntry = {
+  type: 'edge' | 'node'
+  query: string
+  breadcrumb: ModifierBreadcrumb
+  value: string | Manifest
+  refs: Set<{
+    name: string
+    from: Node
+  }>
+}
+
+/**
+ * Extra info to define specifically a graph edge modifier.
+ */
+export type EdgeModifierEntry = BaseModifierEntry & {
+  type: 'edge'
+  spec: Spec
+  value: string
+}
+
+/**
+ * Extra info to define the graph node modifier.
+ */
+export type NodeModifierEntry = BaseModifierEntry & {
+  type: 'node'
+  manifest: Manifest
+}
+
+/**
+ * A graph modifier entry, which can be either an edge or a node modifier.
+ */
+export type ModifierEntry = EdgeModifierEntry | NodeModifierEntry
+
+/**
+ * An object to track modifiers that have matched an initial part of the
+ * breadcrumb. It holds pointers to both nodes and edges matched in the
+ * current traversed graph on top of the modifier info and the breadcrumb
+ * state that is used to track the current state of the parsing.
+ */
+export type ModifierActiveEntry = {
+  /**
+   * The modifier this active entry is working with.
+   */
+  modifier: ModifierEntry
+  /**
+   * The breadcrumb that is used to track the current state of the parsing.
+   */
+  interactiveBreadcrumb: ModifierInteractiveBreadcrumb
+  /**
+   * The first node to be affected by this modifier.
+   */
+  originalFrom: Node
+  /**
+   * The original edge that is being replaced with this entry.
+   */
+  originalEdge?: Edge
+  /**
+   * The modified edge that is being used to replace the original edge.
+   */
+  modifiedEdge?: Edge
+}
+
+/**
+ * Options for the GraphModifier class constructor
+ */
+export type GraphModifierOptions = {
+  /**
+   * A {@link PackageJson} object, for sharing manifest caches
+   */
+  packageJson?: PackageJson
+  /**
+   * Options for the {@link Spec} parser
+   */
+  specOptions?: SpecOptions
+  /**
+   * Parsed normalized contents of the modifiers from a `vlt.json` file
+   */
+  config?: GraphModifierConfigObject
+}
+
+/**
+ * Class representing loaded modifiers configuration for a project.
+ *
+ * Instances of this class can be used as a helper to modify the graph
+ * during the graph build ideal traversal time.
+ *
+ * ```
+ * const modifier = new GraphModifier(options)
+ * modifier.load(options)
+ * ```
+ *
+ * The `tryImporter` method can be used to register the initial importer
+ * node along with any modifier that includes an importer selector, e.g:
+ * `modifier.tryImporter(graph.mainImporter)`
+ *
+ * When traversing the graph, use the `tryNewDependency` method to check
+ * if a given dependency name to the current traversed node has matching
+ * registered modifiers, e.g:
+ * `const entries = modifier.tryNewDependency(fromNode, depName)`
+ *
+ * Use `updateActiveEntry` to update a given active modifier entry state
+ * with the current node of the graph being traversed. e.g:
+ * ```
+ * for (const entry of entries)
+ *   modifier.updateActiveEntry(fromNode, entry)
+ * ```
+ */
+export class GraphModifier {
+  /** The package.json object, for sharing manifest caches */
+  packageJson: PackageJson
+  /** The loaded modifiers configuration */
+  #config?: GraphModifierConfigObject
+  /** A set of all modifiers loaded from vlt.json */
+  #modifiers = new Set<ModifierEntry>()
+  /** A set of all edge modifiers loaded from vlt.json */
+  #edgeModifiers = new Set<EdgeModifierEntry>()
+  /** A set of all node modifiers loaded from vlt.json */
+  #nodeModifiers = new Set<NodeModifierEntry>()
+  /**
+   * A map of initial entries, keyed by the name of the first breadcrumb
+   * item to its modifier entry. Useful for checking for non-importer
+   * starting breadcrumbs, e.g: `#a > #b`
+   */
+  #initialEntries = new Map<string, Set<ModifierEntry>>()
+  /**
+   * A multi-level map of active entries, keyed by:
+   * - modifiers
+   * - edge name
+   * - from node
+   * that allows for retrieving seen {@link ModifierActiveEntry} instances
+   * in constant time.
+   */
+  #activeEntries = new Map<
+    ModifierEntry,
+    Map<string, Map<Node, ModifierActiveEntry>>
+  >()
+
+  /**
+   * A set of currently active modifiers, which are being parsed.
+   */
+  activeModifiers = new Set<ModifierActiveEntry>()
+
+  constructor(options: GraphModifierOptions) {
+    this.packageJson = options.packageJson ?? new PackageJson()
+    this.load(options)
+  }
+
+  /**
+   * Load the modifiers definitions from vlt.json,
+   * converting the result into a GraphModifierConfigObject
+   */
+  get config(): GraphModifierConfigObject {
+    if (this.#config) return this.#config
+    this.#config = asGraphModifiersConfig(
+      load('modifiers', assertGraphModifiersConfig) ?? {},
+    )
+    return this.#config
+  }
+
+  /**
+   * Loads the modifiers defined in `vlt.json` into memory.
+   */
+  load(options: GraphModifierOptions) {
+    for (const [key, value] of Object.entries(this.config)) {
+      const breadcrumb = parseBreadcrumb(key)
+      /* c8 ignore start - should not be possible */
+      if (!breadcrumb.last.name) {
+        throw error('Could not find name in breadcrumb', {
+          found: key,
+        })
+      }
+      /* c8 ignore stop */
+      let mod: ModifierEntry
+      if (typeof value === 'string') {
+        mod = {
+          breadcrumb,
+          query: key,
+          refs: new Set(),
+          spec: Spec.parse(
+            breadcrumb.last.name,
+            value,
+            options.specOptions,
+          ),
+          type: 'edge',
+          value,
+        } satisfies EdgeModifierEntry
+        this.#edgeModifiers.add(mod)
+      } else {
+        const manifest = asManifest(value)
+        mod = {
+          breadcrumb,
+          query: key,
+          manifest,
+          refs: new Set(),
+          type: 'node',
+          value: manifest,
+        } satisfies NodeModifierEntry
+        this.#nodeModifiers.add(mod)
+      }
+      this.#modifiers.add(mod)
+      // if the breadcrumb starts with an id, then add it to the
+      // map of initial entries, so that we can use it to match
+      if (breadcrumb.first.name) {
+        const initialSet =
+          this.#initialEntries.get(breadcrumb.first.name) ?? new Set()
+        initialSet.add(mod)
+        this.#initialEntries.set(breadcrumb.first.name, initialSet)
+      }
+    }
+  }
+
+  /**
+   * Check if a given importer dependency name has potentially a registered
+   * modifier. In case of an ambiguous modifier, the method will always
+   * return `true`, it only returns `false` in the case that only fully
+   * qualified modifiers are registered and none are targeting the given
+   * top-level dependency name.
+   *
+   * This method is useful to help avoiding traversing the sub graph of
+   * a direct dependency when we know that it's impossible to ever match
+   * beforehand.
+   */
+  maybeHasModifier(depName: string): boolean {
+    for (const mod of this.#modifiers) {
+      const matchingName =
+        mod.breadcrumb.first.importer &&
+        mod.breadcrumb.first.next?.name === depName
+      const rootlessBreadcrumb = !mod.breadcrumb.first.importer
+      if (rootlessBreadcrumb || matchingName) {
+        return true
+      }
+    }
+    return false
+  }
+
+  /**
+   * Try matching the provided node against the top-level selectors. In case
+   * a match is found it will also register the active entry modifier and
+   * update the active entry to the current importer node.
+   */
+  tryImporter(importer: Node) {
+    for (const modifier of this.#modifiers) {
+      // if the first item in the breadcrumb is an importer and it matches
+      // any of the valid top-level selectors, then register the modifier
+      const { first } = modifier.breadcrumb
+      const matchRoot =
+        first.value === ':root' && importer.mainImporter
+      const matchWorkspace =
+        first.value === ':workspace' && importer.importer
+      const matchAny =
+        first.value === ':project' || matchRoot || matchWorkspace
+      if (first.importer && matchAny) {
+        const active = this.newModifier(importer, modifier)
+        const single = active.modifier.breadcrumb.single
+        // only the importers will update the active entry right after
+        // registering it since tryImporter doesn't try to match from
+        // active dependencies
+        if (!single) {
+          this.updateActiveEntry(importer, active)
+        }
+      }
+    }
+  }
+
+  /**
+   * Try matching the provided node and dependency name to the current
+   * active parsing modifier entries along with possible starting-level
+   * modifiers.
+   *
+   * Any entries found are returned as a set of {@link ModifierActiveEntry}.
+   *
+   * This method works with the assumption that it's going to be called
+   * during a graph traversal, such that any ascendent has been checked
+   * and the active modifier entry state has been updated in the previous
+   * iteration.
+   */
+  tryNewDependency(
+    from: Node,
+    name: string,
+  ): Set<ModifierActiveEntry> {
+    const res = new Set<ModifierActiveEntry>()
+    for (const modifier of this.#modifiers) {
+      // if an active entry is found then returns that
+      const entry = this.#activeEntries
+        .get(modifier)
+        ?.get(name)
+        ?.get(from)
+      if (entry) {
+        res.add(entry)
+      }
+    }
+    // matches the name against the initial entries, this will make it so
+    // that modifier queries that start with a name (e.g: #a > #b) can
+    // match at any point of the graph traversal
+    const initialSet =
+      this.#initialEntries.get(name) ?? new Set<ModifierEntry>()
+    for (const initial of initialSet) {
+      const initialEntry =
+        /* c8 ignore next - difficult to test branch */
+        this.#activeEntries.get(initial)?.get(name)?.get(from) ??
+        this.newModifier(from, initial)
+      res.add(initialEntry)
+    }
+    return res
+  }
+
+  /**
+   * Updates an active entry state keeping track of items in the multi-level
+   * active entries map. If the current breadcrumb state shows there's no more
+   * items left, then we deregister the modifier.
+   */
+  updateActiveEntry(from: Node, active: ModifierActiveEntry): void {
+    const { modifier } = active
+    const interactiveBreadcrumb = active.interactiveBreadcrumb.next()
+    const name = interactiveBreadcrumb.current?.name
+
+    // if there's no name, or we're done parsing then we
+    // deregister the modifier instead of updating the entry
+    if (interactiveBreadcrumb.done || !name) {
+      this.deregisterModifier(modifier)
+      return
+    }
+
+    // register the active modifier
+    this.activeModifiers.add(active)
+    active.modifier.refs.add({ from, name })
+
+    // optionally read or create the nested maps
+    const nameMap =
+      this.#activeEntries.get(modifier) ??
+      new Map<string, Map<Node, ModifierActiveEntry>>()
+    this.#activeEntries.set(modifier, nameMap)
+    const nodeMap =
+      nameMap.get(name) ?? new Map<Node, ModifierActiveEntry>()
+    nameMap.set(name, nodeMap)
+
+    // sets the active entry in the map
+    nodeMap.set(from, active)
+  }
+
+  /**
+   * Creates a new active modifier.
+   */
+  newModifier(
+    from: Node,
+    modifier: ModifierEntry,
+  ): ModifierActiveEntry {
+    return {
+      modifier,
+      interactiveBreadcrumb: modifier.breadcrumb.interactive(),
+      originalFrom: from,
+    }
+  }
+
+  /**
+   * Removes a previously registered modifier from the active entries.
+   */
+  deregisterModifier(modifier: ModifierEntry): void {
+    for (const { from, name } of modifier.refs) {
+      const nodeMap = this.#activeEntries.get(modifier)?.get(name)
+      if (nodeMap) {
+        // if an entry is found, we remove it from the active set
+        const entry = nodeMap.get(from)
+        if (entry) {
+          this.activeModifiers.delete(entry)
+        }
+        // then we remove the entry from the map
+        nodeMap.delete(from)
+        // if the map is empty, we remove it from the active entries map
+        if (!nodeMap.size) {
+          this.#activeEntries.get(modifier)?.delete(name)
+        }
+      }
+    }
+  }
+
+  /**
+   * Operates in previously registered nodes and edges in order to put
+   * back in place any of the original edges that were referenced to in
+   * active (ongoing) breadcrumb parsing entries that were never completed.
+   *
+   * This method can be used to easily rollback any pending operations
+   * once the graph traversal is done.
+   */
+  rollbackActiveEntries(): void {
+    for (const modifier of this.activeModifiers) {
+      // if the modifier has an original edge, we can put it back in place
+      if (modifier.originalEdge) {
+        modifier.originalFrom.edgesOut.set(
+          modifier.originalEdge.spec.name,
+          modifier.originalEdge,
+        )
+      }
+      // then we deregister the modifier
+      this.deregisterModifier(modifier.modifier)
+    }
+  }
+
+  /**
+   * Convenience method to instantiate and load in one call.
+   * Returns undefined if the project does not have a vlt.json file,
+   * otherwise returns the loaded Modifiers instance.
+   */
+  static maybeLoad(options: GraphModifierOptions) {
+    const config = load('modifiers', assertGraphModifiersConfig)
+    if (!config) return
+    return new GraphModifier(options)
+  }
+
+  /**
+   * Convenience method to instantiate and load in one call.
+   * Throws if called on a directory that does not have a vlt.json file.
+   */
+  static load(options: GraphModifierOptions) {
+    return new GraphModifier(options)
+  }
+}

--- a/src/graph/src/modifiers.ts
+++ b/src/graph/src/modifiers.ts
@@ -2,7 +2,7 @@ import { parseBreadcrumb } from '@vltpkg/dss-breadcrumb'
 import { error } from '@vltpkg/error-cause'
 import { PackageJson } from '@vltpkg/package-json'
 import { Spec } from '@vltpkg/spec'
-import { asManifest, assertManifest } from '@vltpkg/types'
+import { asManifest, assertManifest, isObject } from '@vltpkg/types'
 import { load } from '@vltpkg/vlt-json'
 import type {
   ModifierBreadcrumb,
@@ -70,7 +70,7 @@ export const assertGraphModifiersConfig: (
   conf: unknown,
   path?: string,
 ) => {
-  if (!conf || typeof conf !== 'object' || Array.isArray(conf)) {
+  if (!isObject(conf) || Array.isArray(conf)) {
     throw error('Invalid modifiers configuration', {
       path,
       found: conf,

--- a/src/graph/test/modifiers.ts
+++ b/src/graph/test/modifiers.ts
@@ -23,7 +23,7 @@ const specOptions: SpecOptions = {
 
 const projectRoot = '.'
 
-export const newGraph = (rootName: string): GraphLike => {
+const newGraph = (rootName: string): GraphLike => {
   const graph = {} as GraphLike
   const addNode = newNode(graph)
   const mainImporter = addNode(rootName)
@@ -39,7 +39,7 @@ export const newGraph = (rootName: string): GraphLike => {
   return graph
 }
 
-export const newNode =
+const newNode =
   (graph: GraphLike) =>
   (name: string, version = '1.0.0'): NodeLike => ({
     projectRoot,
@@ -127,8 +127,7 @@ flowchart TD
   classDef optional fill:cornsilk
 ```
 */
-
-export const getSimpleGraph = (): GraphLike => {
+const getSimpleGraph = (): GraphLike => {
   const graph = newGraph('my-project')
   const addNode = newNode(graph)
   const [a, b, c, d, e, f, y] = [
@@ -240,7 +239,7 @@ flowchart TD
   b --> a
 ```
 */
-export const getCycleGraph = (): GraphLike => {
+const getCycleGraph = (): GraphLike => {
   const graph = newGraph('cycle-project')
   graph.mainImporter.manifest = {
     ...graph.mainImporter.manifest,
@@ -298,7 +297,7 @@ flowchart TD
   a --> f
 ```
 */
-export const getMultiWorkspaceGraph = (): GraphLike => {
+const getMultiWorkspaceGraph = (): GraphLike => {
   const graph = newGraph('ws')
   const addNode = newNode(graph)
   const a = addNode('a')

--- a/src/graph/test/modifiers.ts
+++ b/src/graph/test/modifiers.ts
@@ -1,0 +1,1097 @@
+import t from 'tap'
+import {
+  asGraphModifiersConfig,
+  assertGraphModifiersConfig,
+  GraphModifier,
+} from '../src/modifiers.ts'
+import { PackageJson } from '@vltpkg/package-json'
+import { Spec } from '@vltpkg/spec'
+import type { SpecOptions } from '@vltpkg/spec'
+import { reload } from '@vltpkg/vlt-json'
+import type { Node } from '../src/node.ts'
+import { Edge } from '../src/edge.ts'
+import type { GraphLike, NodeLike, EdgeLike } from '../src/types.ts'
+import type { DependencyTypeShort, Manifest } from '@vltpkg/types'
+import { joinDepIDTuple } from '@vltpkg/dep-id'
+
+// Graph fixtures code
+const specOptions: SpecOptions = {
+  registries: {
+    custom: 'http://example.com',
+  },
+}
+
+const projectRoot = '.'
+
+export const newGraph = (rootName: string): GraphLike => {
+  const graph = {} as GraphLike
+  const addNode = newNode(graph)
+  const mainImporter = addNode(rootName)
+  mainImporter.id = joinDepIDTuple(['file', '.'])
+  mainImporter.mainImporter = true
+  mainImporter.importer = true
+  mainImporter.graph = graph
+  graph.importers = new Set([mainImporter])
+  graph.mainImporter = mainImporter
+  graph.nodes = new Map([[mainImporter.id, mainImporter]])
+  graph.edges = new Set()
+
+  return graph
+}
+
+export const newNode =
+  (graph: GraphLike) =>
+  (name: string, version = '1.0.0'): NodeLike => ({
+    projectRoot,
+    confused: false,
+    edgesIn: new Set(),
+    edgesOut: new Map(),
+    importer: false,
+    mainImporter: false,
+    graph,
+    id: joinDepIDTuple(['registry', '', `${name}@${version}`]),
+    name,
+    version,
+    location:
+      'node_modules/.vlt/;;${name}@${version}/node_modules/${name}',
+    manifest: { name, version },
+    integrity: 'sha512-deadbeef',
+    resolved: undefined,
+    dev: false,
+    optional: false,
+    setConfusedManifest() {},
+    setResolved() {},
+    toJSON() {
+      return {
+        id: this.id,
+        name: this.name,
+        version: this.version,
+        location: this.location,
+        importer: this.importer,
+        manifest: this.manifest,
+        projectRoot: this.projectRoot,
+        integrity: this.integrity,
+        resolved: this.resolved,
+        dev: this.dev,
+        optional: this.optional,
+        confused: false,
+      }
+    },
+    toString() {
+      return `${this.name}@${this.version}`
+    },
+  })
+
+const newEdge = (
+  from: NodeLike,
+  spec: Spec,
+  type: DependencyTypeShort,
+  to?: NodeLike,
+) => {
+  const edge = {
+    name: spec.name,
+    from,
+    to,
+    spec,
+    type,
+    get optional() {
+      return this.type === 'peerOptional' || this.type === 'optional'
+    },
+    get peer() {
+      return this.type === 'peer' || this.type === 'peerOptional'
+    },
+  } as EdgeLike
+  from.edgesOut.set(spec.name, edge)
+  if (to) {
+    to.edgesIn.add(edge)
+  }
+  from.graph.edges.add(edge)
+  return edge
+}
+
+/*
+Returns a graph that looks like:
+
+```mermaid
+flowchart TD
+  root --> a
+  root --> b:::dev
+  root --> e
+  root --> y("@x/y"):::dev
+  b --> c
+  b --> d
+  d --> e
+  d --> f:::optional
+
+  classDef dev fill:palegreen
+  classDef optional fill:cornsilk
+```
+*/
+
+export const getSimpleGraph = (): GraphLike => {
+  const graph = newGraph('my-project')
+  const addNode = newNode(graph)
+  const [a, b, c, d, e, f, y] = [
+    'a',
+    'b',
+    'c',
+    'd',
+    'e',
+    'f',
+    '@x/y',
+  ].map(i => addNode(i)) as [
+    NodeLike,
+    NodeLike,
+    NodeLike,
+    NodeLike,
+    NodeLike,
+    NodeLike,
+    NodeLike,
+  ]
+  b.dev = c.dev = d.dev = e.dev = f.dev = y.dev = true // deps of dev deps
+  f.optional = true
+  y.id = joinDepIDTuple(['file', 'y'])
+  ;[a, b, c, d, e, f, y].forEach(i => {
+    graph.nodes.set(i.id, i)
+  })
+  newEdge(
+    graph.mainImporter,
+    Spec.parse('a', '^1.0.0', specOptions),
+    'prod',
+    a,
+  )
+  newEdge(
+    graph.mainImporter,
+    Spec.parse('b', '^1.0.0', specOptions),
+    'dev',
+    b,
+  )
+  newEdge(
+    graph.mainImporter,
+    Spec.parse('e', '^1.0.0', specOptions),
+    'prod',
+    e,
+  )
+  newEdge(
+    graph.mainImporter,
+    Spec.parse('@x/y', 'file:y', specOptions),
+    'dev',
+    y,
+  )
+  newEdge(b, Spec.parse('c', '^1.0.0', specOptions), 'prod', c)
+  newEdge(b, Spec.parse('d', '^1.0.0', specOptions), 'prod', d)
+  newEdge(d, Spec.parse('e', '^1.0.0', specOptions), 'prod', e)
+  newEdge(d, Spec.parse('f', '^1.0.0', specOptions), 'optional', f)
+
+  // give some nodes an expanded manifest so that we can test
+  // more attribute selector scenarios
+  b.manifest = {
+    ...b.manifest,
+    version: '2.0.0',
+    scripts: {
+      postinstall: 'postinstall',
+      test: 'test',
+    },
+    contributors: [
+      {
+        name: 'Ruy Adorno',
+        email: 'ruyadorno@example.com',
+      },
+    ],
+  } as Manifest
+
+  c.manifest = {
+    ...c.manifest,
+    peerDependenciesMeta: {
+      foo: {
+        optional: true,
+      },
+    },
+    keywords: ['something', 'someother'],
+  } as Manifest
+
+  d.manifest = {
+    ...d.manifest,
+    private: true,
+    a: {
+      b: [
+        {
+          c: {
+            d: 'foo',
+          },
+        },
+        {
+          c: {
+            d: 'bar',
+          },
+        },
+      ],
+      e: ['foo', 'bar'],
+    },
+  } as Manifest
+  return graph
+}
+
+/* Returns a graph that looks like:
+```mermaid
+flowchart TD
+  root --> a
+  a --> b
+  b --> a
+```
+*/
+export const getCycleGraph = (): GraphLike => {
+  const graph = newGraph('cycle-project')
+  graph.mainImporter.manifest = {
+    ...graph.mainImporter.manifest,
+    dependencies: {
+      a: '^1.0.0',
+    },
+  }
+  const addNode = newNode(graph)
+
+  const a = addNode('a')
+  a.manifest = {
+    ...a.manifest,
+    scripts: {
+      test: 'foo',
+    },
+    dependencies: {
+      b: '^1.0.0',
+    },
+  }
+  graph.nodes.set(a.id, a)
+  newEdge(
+    graph.mainImporter,
+    Spec.parse('a', '^1.0.0', specOptions),
+    'prod',
+    a,
+  )
+
+  const b = addNode('b')
+  b.manifest = {
+    ...b.manifest,
+    scripts: {
+      test: 'bar',
+    },
+    dependencies: {
+      a: '^1.0.0',
+    },
+  }
+  graph.nodes.set(b.id, b)
+  newEdge(a, Spec.parse('b', '^1.0.0', specOptions), 'prod', b)
+  newEdge(b, Spec.parse('a', '^1.0.0', specOptions), 'prod', a)
+
+  return graph
+}
+
+/* Returns a complex graph with multiple workspaces with dependencies:
+```mermaid
+flowchart TD
+  root --> y("@x/y")
+  root --> a
+  root --> b
+  root --> c
+  b --> a
+  b --> d
+  b --> e
+  a --> f
+```
+*/
+export const getMultiWorkspaceGraph = (): GraphLike => {
+  const graph = newGraph('ws')
+  const addNode = newNode(graph)
+  const a = addNode('a')
+  a.id = joinDepIDTuple(['workspace', 'a'])
+  graph.nodes.set(a.id, a)
+  graph.importers.add(a)
+  a.importer = true
+  const b = addNode('b')
+  b.id = joinDepIDTuple(['workspace', 'b'])
+  graph.nodes.set(b.id, b)
+  graph.importers.add(b)
+  b.importer = true
+  const c = addNode('c')
+  c.id = joinDepIDTuple(['workspace', 'c'])
+  graph.nodes.set(c.id, c)
+  graph.importers.add(c)
+  c.importer = true
+  const [d, e, f, y] = ['d', 'e', 'f', '@x/y'].map(i => {
+    const n = addNode(i)
+    graph.nodes.set(n.id, n)
+    return n
+  }) as [NodeLike, NodeLike, NodeLike, NodeLike]
+
+  newEdge(b, Spec.parse('a', 'workspace:*', specOptions), 'prod', a)
+  newEdge(b, Spec.parse('d', '^1.0.0', specOptions), 'prod', d)
+  newEdge(b, Spec.parse('e', '^1.0.0', specOptions), 'prod', e)
+  newEdge(a, Spec.parse('f', '^1.0.0', specOptions), 'prod', f)
+  newEdge(
+    graph.mainImporter,
+    Spec.parse('@x/y', '^1.0.0', specOptions),
+    'prod',
+    y,
+  )
+  return graph
+}
+
+// Test fixtures
+const validStringConfig = {
+  '#a > #c': '1.0.0',
+}
+
+const validObjectConfig = {
+  '#a > #c': {
+    name: 'test-package',
+    version: '1.0.0',
+  },
+}
+
+const invalidConfig = {
+  '#a > #c': 123, // Invalid value type
+}
+
+const invalidManifestConfig = {
+  '#a > #c': {
+    name: null,
+  },
+}
+
+// Mock options for tests
+const mockSpecOptions: SpecOptions = {
+  registry: 'https://registry.npmjs.org',
+}
+
+// Helper function to create a test edge
+const createMockEdge = (from: Node, to: Node, name: string): Edge => {
+  const spec = new Spec(name, '1.0.0')
+  return new Edge('prod' as DependencyTypeShort, spec, from, to)
+}
+
+t.test('asGraphModifiersConfig', async t => {
+  await t.test('should convert valid string config', async t => {
+    const result = asGraphModifiersConfig(validStringConfig)
+    t.same(
+      result,
+      validStringConfig,
+      'should return the same config for string values',
+    )
+  })
+
+  await t.test('should convert valid object config', async t => {
+    const result = asGraphModifiersConfig(validObjectConfig)
+    t.ok(result['#a > #c'], 'should have the expected key')
+    if (typeof result['#a > #c'] === 'object') {
+      t.equal(
+        result['#a > #c'].name,
+        'test-package',
+        'should convert object to manifest',
+      )
+      t.equal(
+        result['#a > #c'].version,
+        '1.0.0',
+        'should preserve version',
+      )
+    }
+  })
+
+  await t.test('should throw for invalid configs', async t => {
+    t.throws(
+      () => asGraphModifiersConfig(null),
+      /Invalid modifiers configuration/,
+      'should throw for null config',
+    )
+
+    t.throws(
+      () => asGraphModifiersConfig([]),
+      /Invalid modifiers configuration/,
+      'should throw for array config',
+    )
+
+    t.throws(
+      () => asGraphModifiersConfig(invalidConfig),
+      /Invalid modifier value/,
+      'should throw for invalid value types',
+    )
+  })
+})
+
+t.test('assertGraphModifiersConfig', async t => {
+  await t.test('should validate valid configs', async t => {
+    t.doesNotThrow(
+      () => assertGraphModifiersConfig(validStringConfig),
+      'should not throw for valid string config',
+    )
+
+    t.doesNotThrow(
+      () => assertGraphModifiersConfig(validObjectConfig),
+      'should not throw for valid object config',
+    )
+  })
+
+  await t.test('should throw for invalid configs', async t => {
+    t.throws(
+      () => assertGraphModifiersConfig(null),
+      /Invalid modifiers configuration/,
+      'should throw for null config',
+    )
+
+    t.throws(
+      () => assertGraphModifiersConfig(123 as any),
+      /Invalid modifiers configuration/,
+      'should throw for non-object config',
+    )
+
+    t.throws(
+      () => assertGraphModifiersConfig(invalidConfig),
+      /Invalid modifier value/,
+      'should throw for invalid value type',
+    )
+
+    t.throws(
+      () => assertGraphModifiersConfig(invalidManifestConfig),
+      /Invalid modifier manifest/,
+      'should throw for invalid manifest',
+    )
+  })
+})
+
+t.test('GraphModifier', async t => {
+  await t.test('constructor', async t => {
+    const testdir = t.testdir({
+      'vlt.json': JSON.stringify({ modifiers: validStringConfig }),
+    })
+
+    const options = {
+      packageJson: new PackageJson(),
+      specOptions: mockSpecOptions,
+    }
+    // Reload vlt.json to ensure we have the latest config
+    t.chdir(testdir)
+    reload('modifiers', 'project')
+
+    t.doesNotThrow(
+      () => new GraphModifier(options),
+      'should instantiate without errors',
+    )
+
+    const modifier = new GraphModifier(options)
+    t.ok(modifier.packageJson, 'should initialize packageJson')
+  })
+
+  await t.test('config getter', async t => {
+    const testdir = t.testdir({
+      'vlt.json': JSON.stringify({ modifiers: validStringConfig }),
+    })
+
+    const options = {
+      packageJson: new PackageJson(),
+      specOptions: mockSpecOptions,
+    }
+    // Reload vlt.json to ensure we have the latest config
+    t.chdir(testdir)
+    reload('modifiers', 'project')
+
+    // Create a GraphModifier instance
+    const modifier = new GraphModifier(options)
+
+    // Test with config from vlt.json
+    t.same(
+      modifier.config,
+      validStringConfig,
+      'should load config from vlt.json',
+    )
+
+    // Test cache behavior (accessing config property again)
+    t.same(
+      modifier.config,
+      validStringConfig,
+      'should return same cached config',
+    )
+  })
+
+  await t.test('empty config', async t => {
+    // Test with empty config
+    const emptyconfigDir = t.testdir({
+      'vlt.json': JSON.stringify({}), // No modifiers key
+    })
+    const options = {
+      packageJson: new PackageJson(),
+      specOptions: mockSpecOptions,
+    }
+    // Reload vlt.json to ensure we have the latest config
+    t.chdir(emptyconfigDir)
+    reload('modifiers', 'project')
+
+    const emptyModifier = new GraphModifier(options)
+    t.same(
+      emptyModifier.config,
+      {},
+      'should return empty object when no config is found',
+    )
+  })
+
+  await t.test('maybeHasModifier with simple graph', async t => {
+    // Test with importer modifier
+    const importerConfigDir = t.testdir({
+      'vlt.json': JSON.stringify({
+        modifiers: { ':root > #a': '1.0.0' },
+      }),
+    })
+    // Reload vlt.json to ensure we have the latest config
+    t.chdir(importerConfigDir)
+    reload('modifiers', 'project')
+
+    const importerOptions = {
+      packageJson: new PackageJson(),
+      specOptions: mockSpecOptions,
+    }
+
+    const importerModifier = new GraphModifier(importerOptions)
+    // Using actual node names from the fixtures
+    t.equal(
+      importerModifier.maybeHasModifier('a'),
+      true,
+      'should return true for matching dependency',
+    )
+    t.equal(
+      importerModifier.maybeHasModifier('nonexistent'),
+      false,
+      'should return false for non-matching dependency',
+    )
+  })
+
+  await t.test('non-importer modifier', async t => {
+    // Test with non-importer modifier
+    const nonImporterConfigDir = t.testdir({
+      'vlt.json': JSON.stringify({
+        modifiers: { '#a > #c': '1.0.0' },
+      }),
+    })
+
+    const nonImporterOptions = {
+      packageJson: new PackageJson(),
+      specOptions: mockSpecOptions,
+    }
+    // Reload vlt.json to ensure we have the latest config
+    t.chdir(nonImporterConfigDir)
+    reload('modifiers', 'project')
+
+    const nonImporterModifier = new GraphModifier(nonImporterOptions)
+    t.equal(
+      nonImporterModifier.maybeHasModifier('anything'),
+      true,
+      'should return true when rootless breadcrumb exists',
+    )
+  })
+
+  await t.test(
+    'tryImporter and tryNewDependency with simple graph',
+    async t => {
+      const testdir = t.testdir({
+        'vlt.json': JSON.stringify({
+          modifiers: {
+            ':root > #a': '1.0.0',
+            '#b > #c': '2.0.0',
+          },
+        }),
+      })
+
+      const options = {
+        packageJson: new PackageJson(),
+        specOptions: mockSpecOptions,
+      }
+      // Reload vlt.json to ensure we have the latest config
+      t.chdir(testdir)
+      reload('modifiers', 'project')
+
+      const modifier = new GraphModifier(options)
+
+      // Use nodes from the simple graph
+      const simpleGraph = getSimpleGraph()
+      const mainImporter = simpleGraph.mainImporter as Node
+      const nodeA = Array.from(simpleGraph.nodes.values()).find(
+        n => n.name === 'a',
+      )! as Node
+
+      // Test tryImporter
+      modifier.tryImporter(mainImporter)
+      t.pass(
+        'tryImporter should process main importer node without errors',
+      )
+
+      // Test tryNewDependency
+      const [result] = modifier.tryNewDependency(mainImporter, 'a')
+      t.ok(
+        result,
+        'should return a modifier active entry for matching name',
+      )
+      if (result) {
+        t.same(
+          result.originalFrom,
+          mainImporter,
+          'should set originalFrom to the provided parent node',
+        )
+      }
+
+      // Test with non-matching name
+      const [nonMatchingResult] = modifier.tryNewDependency(
+        nodeA,
+        'nonexistent',
+      )
+      t.equal(
+        nonMatchingResult,
+        undefined,
+        'should return undefined for non-matching name',
+      )
+    },
+  )
+
+  await t.test(
+    'three-level navigation and non-matching queries',
+    async t => {
+      const testdir = t.testdir({
+        'vlt.json': JSON.stringify({
+          modifiers: {
+            // Three-level navigation pattern
+            ':root > #b > #c': '3.0.0',
+            // Non-matching pattern (r doesn't exist)
+            ':root > #a > #r': '1.0.0',
+            // Another non-matching pattern
+            '#r': '1.0.0',
+            // Single node match
+            '#c': '4.0.0',
+          },
+        }),
+      })
+
+      const options = {
+        packageJson: new PackageJson(),
+        specOptions: mockSpecOptions,
+      }
+      // Reload vlt.json to ensure we have the latest config
+      t.chdir(testdir)
+      reload('modifiers', 'project')
+
+      const modifier = new GraphModifier(options)
+
+      // Use nodes from the simple graph
+      const simpleGraph = getSimpleGraph()
+      const mainImporter = simpleGraph.mainImporter as Node
+      const nodeA = Array.from(simpleGraph.nodes.values()).find(
+        n => n.name === 'a',
+      )! as Node
+      const nodeB = Array.from(simpleGraph.nodes.values()).find(
+        n => n.name === 'b',
+      )! as Node
+      const nodeC = Array.from(simpleGraph.nodes.values()).find(
+        n => n.name === 'c',
+      )! as Node
+
+      // Let's manually perform the graph traversal
+      // First, process the root
+      modifier.tryImporter(mainImporter)
+      t.equal(
+        modifier.activeModifiers.size,
+        2,
+        'should have two active entries that start with :root',
+      )
+      // try to match 'a' from root
+      const [resultA] = modifier.tryNewDependency(mainImporter, 'a')
+      t.strictSame(
+        resultA?.modifier.query,
+        ':root > #a > #r',
+        'should match modifier that contains a as a dep from root',
+      )
+      const [resultB] = modifier.tryNewDependency(mainImporter, 'b')
+      t.strictSame(
+        resultB?.modifier.query,
+        ':root > #b > #c',
+        'should match modifier that contains b as a dep from root',
+      )
+      const resultY = modifier.tryNewDependency(mainImporter, '@x/y')
+      t.equal(
+        resultY.size,
+        0,
+        'should return no entries for non-matching @x/y from root',
+      )
+      // update the active entries as we go a level deeper
+      modifier.updateActiveEntry(nodeA, resultA!)
+      modifier.updateActiveEntry(nodeB, resultB!)
+      t.equal(
+        modifier.activeModifiers.size,
+        2,
+        'should only update the existing active entries so the count remains the same',
+      )
+
+      // Now try to match deps of b
+      const resultC = modifier.tryNewDependency(nodeB, 'c')
+      t.strictSame(
+        [...resultC].map(i => i.modifier.query),
+        [':root > #b > #c', '#c'],
+        'should match modifiers that contains c as a breadcrumb item',
+      )
+      const resultD = modifier.tryNewDependency(nodeB, 'd')
+      t.equal(
+        resultD.size,
+        0,
+        'should return no results node with no matching breadcrumb item',
+      )
+      // Update the active entry for nodeC active modifiers
+      for (const entry of resultC) {
+        modifier.updateActiveEntry(nodeC, entry)
+      }
+
+      t.equal(
+        modifier.activeModifiers.size,
+        1,
+        'should add a leftover active modifier entry for non-matching r',
+      )
+      modifier.rollbackActiveEntries()
+      t.equal(
+        modifier.activeModifiers.size,
+        0,
+        'should remove the leftover active modifier entry after rollback',
+      )
+    },
+  )
+
+  await t.test('rollbackActiveEntries with cycle graph', async t => {
+    const testdir = t.testdir({
+      'vlt.json': JSON.stringify({
+        modifiers: {
+          '#a > #b': '1.0.0',
+        },
+      }),
+    })
+
+    const options = {
+      packageJson: new PackageJson(),
+      specOptions: mockSpecOptions,
+    }
+    // Reload vlt.json to ensure we have the latest config
+    t.chdir(testdir)
+    reload('modifiers', 'project')
+
+    const modifier = new GraphModifier(options)
+
+    // Use nodes from the cycle graph
+    const cycleGraph = getCycleGraph()
+    const nodes = Array.from(cycleGraph.nodes.values())
+    const mainImporter = cycleGraph.mainImporter as Node
+    const nodeA = nodes.find(n => n.name === 'a') as Node
+    const nodeB = nodes.find(n => n.name === 'b') as Node
+
+    const [resultA] = modifier.tryNewDependency(mainImporter, 'a')
+    // call updateActiveEntry to set an active entry for nodeA
+    modifier.updateActiveEntry(nodeA, resultA!)
+    t.equal(
+      modifier.activeModifiers.size,
+      1,
+      'should have one active entry after processing a',
+    )
+    // rollback unfinished parsed breadcrumb
+    t.doesNotThrow(
+      () => modifier.rollbackActiveEntries(),
+      'rollbackActiveEntries should not throw',
+    )
+    t.equal(
+      modifier.activeModifiers.size,
+      0,
+      'should have no active entry left after rollback',
+    )
+
+    // traverse again
+    const [newResultA] = modifier.tryNewDependency(mainImporter, 'a')
+    modifier.updateActiveEntry(nodeA, newResultA!)
+    t.equal(
+      modifier.activeModifiers.size,
+      1,
+      'should have one active entry after processing a again',
+    )
+    const [resultB] = modifier.tryNewDependency(nodeA, 'b')
+    modifier.updateActiveEntry(nodeB, resultB!)
+    t.equal(
+      modifier.activeModifiers.size,
+      0,
+      'should have no active entry left after completing b',
+    )
+  })
+
+  await t.test('more complex rollbackActiveEntries', async t => {
+    const testdir = t.testdir({
+      'vlt.json': JSON.stringify({
+        modifiers: {
+          ':root > #a': '2.0.0',
+          ':root > #b': '3.0.0',
+          ':root > #b > #c': '3.0.0',
+          '#b > #c': '4.0.0',
+          '#b > #d': '4.0.0',
+        },
+      }),
+    })
+
+    const options = {
+      packageJson: new PackageJson(),
+      specOptions: mockSpecOptions,
+    }
+    // Reload vlt.json to ensure we have the latest config
+    t.chdir(testdir)
+    reload('modifiers', 'project')
+
+    const modifier = new GraphModifier(options)
+
+    // Use nodes from the simple graph
+    const simpleGraph = getSimpleGraph()
+    const mainImporter = simpleGraph.mainImporter as Node
+    const nodeA = Array.from(simpleGraph.nodes.values()).find(
+      n => n.name === 'a',
+    )! as Node
+    const nodeB = Array.from(simpleGraph.nodes.values()).find(
+      n => n.name === 'b',
+    )! as Node
+
+    // Process the root
+    modifier.tryImporter(mainImporter)
+
+    // Process multiple paths to build up multiple active entries
+    const [resultA] = modifier.tryNewDependency(mainImporter, 'a')
+    t.strictSame(
+      resultA?.modifier.query,
+      ':root > #a',
+      'should match a from root with a single query',
+    )
+
+    const resultB = modifier.tryNewDependency(mainImporter, 'b')
+    t.strictSame(
+      [...resultB].map(i => i.modifier.query),
+      [':root > #b', ':root > #b > #c', '#b > #c', '#b > #d'],
+      'should match b from root with multiple queries',
+    )
+    for (const entry of resultB) {
+      modifier.updateActiveEntry(nodeB, entry)
+    }
+
+    const resultC = modifier.tryNewDependency(nodeB, 'c')
+    t.strictSame(
+      [...resultC].map(i => i.modifier.query),
+      [':root > #b > #c', '#b > #c'],
+      'should match c from b with multiple queries',
+    )
+
+    // Set up an edge to rollback
+    const newEdge = createMockEdge(nodeA, nodeB, 'test-edge')
+    nodeA.edgesOut.set('test-edge', newEdge)
+
+    // Simulate having an original edge in the active entry
+    if (resultA) {
+      resultA.originalEdge = newEdge
+    }
+
+    // Now rollback all active entries
+    modifier.rollbackActiveEntries()
+
+    // Check if the original edge was restored
+    t.equal(
+      nodeA.edgesOut.get('test-edge'),
+      newEdge,
+      'should restore original edge during rollback',
+    )
+  })
+
+  await t.test('static methods', async t => {
+    const testdir = t.testdir({
+      'vlt.json': JSON.stringify({
+        modifiers: validStringConfig,
+      }),
+    })
+
+    const options = {
+      packageJson: new PackageJson(),
+      specOptions: mockSpecOptions,
+    }
+    // Reload vlt.json to ensure we have the latest config
+    t.chdir(testdir)
+    reload('modifiers', 'project')
+
+    // Test maybeLoad with config
+    const loaded = GraphModifier.maybeLoad(options)
+    t.ok(
+      loaded instanceof GraphModifier,
+      'should return GraphModifier instance when config exists',
+    )
+
+    // Test load
+    const forcedLoad = GraphModifier.load(options)
+    t.ok(
+      forcedLoad instanceof GraphModifier,
+      'should return GraphModifier instance',
+    )
+  })
+
+  await t.test('missing config', async t => {
+    const emptyDir = t.testdir({
+      'vlt.json': JSON.stringify({}),
+    })
+    const options = {
+      specOptions: mockSpecOptions,
+    }
+    // Reload vlt.json to ensure we have the latest config
+    t.chdir(emptyDir)
+    reload('modifiers', 'project')
+    // Test maybeLoad with no config
+    const notLoaded = GraphModifier.maybeLoad(options)
+    t.equal(
+      notLoaded,
+      undefined,
+      'should return undefined when no config exists',
+    )
+
+    const mod = new GraphModifier(options)
+    t.match(
+      mod.config,
+      {},
+      'should return empty config when no config exists',
+    )
+  })
+
+  await t.test('load method with various config types', async t => {
+    // Test with a mix of edge and node modifiers
+    const configDir = t.testdir({
+      'vlt.json': JSON.stringify({
+        modifiers: {
+          // Edge modifier
+          ':root > #a': '2.0.0',
+          // Node modifier
+          ':root > #b': {
+            name: 'custom-b',
+            version: '3.0.0',
+          },
+          // Single non-importer selector
+          '#c': '1.0.0',
+        },
+      }),
+    })
+
+    const options = {
+      packageJson: new PackageJson(),
+      specOptions: mockSpecOptions,
+    }
+
+    // Reload vlt.json to ensure we have the latest config
+    t.chdir(configDir)
+    reload('modifiers', 'project')
+
+    // Create a new modifier to test loading various config types
+    const modifier = new GraphModifier(options)
+
+    // Check if the config was properly loaded
+    t.equal(
+      Object.keys(modifier.config).length,
+      3,
+      'should load all three modifiers',
+    )
+    t.equal(
+      typeof modifier.config[':root > #a'],
+      'string',
+      'should load edge modifier as string',
+    )
+    t.equal(
+      typeof modifier.config[':root > #b'],
+      'object',
+      'should load node modifier as object',
+    )
+    t.equal(
+      typeof modifier.config['#c'],
+      'string',
+      'should load single selector as string',
+    )
+  })
+
+  await t.test('workspaces modifiers', async t => {
+    const testdir = t.testdir({
+      'vlt.json': JSON.stringify({
+        modifiers: {
+          ':workspace > #d': '2.0.0',
+          ':workspace > #f': '3.0.0',
+          ':workspace > #a > #f': '4.0.0', // <- not matched since a is not a dep of another workspace
+        },
+      }),
+    })
+
+    const options = {
+      packageJson: new PackageJson(),
+      specOptions: mockSpecOptions,
+    }
+    // Reload vlt.json to ensure we have the latest config
+    t.chdir(testdir)
+    reload('modifiers', 'project')
+
+    const modifier = new GraphModifier(options)
+
+    // Use the multi-workspace graph
+    const multiWorkspaceGraph = getMultiWorkspaceGraph()
+    const mainImporter = multiWorkspaceGraph.mainImporter as Node
+    const importers = [...multiWorkspaceGraph.importers] as Node[]
+    const workspaceA = importers.find(n => n.name === 'a')!
+    const workspaceB = importers.find(n => n.name === 'b')!
+    const workspaceC = importers.find(n => n.name === 'c')!
+    const nodeD = [...multiWorkspaceGraph.nodes.values()].find(
+      n => n.name === 'd',
+    )! as Node
+    const nodeF = [...multiWorkspaceGraph.nodes.values()].find(
+      n => n.name === 'f',
+    )! as Node
+
+    // Process all importers
+    modifier.tryImporter(mainImporter)
+    modifier.tryImporter(workspaceA)
+    modifier.tryImporter(workspaceB)
+    modifier.tryImporter(workspaceC)
+
+    // Test :workspace modifier for dependency 'd' from workspace 'b'
+    const resultD = modifier.tryNewDependency(workspaceB, 'd')
+    t.strictSame(
+      [...resultD].map(i => i.modifier.query),
+      [':workspace > #d'],
+      'should match d from workspace b with :workspace query',
+    )
+
+    // Test :workspace modifier for dependency 'f' from workspace 'a'
+    const resultF = modifier.tryNewDependency(workspaceA, 'f')
+    t.strictSame(
+      [...resultF].map(i => i.modifier.query),
+      [':workspace > #f'],
+      'should match f from workspace a with both :workspace and :workspaces > #a queries',
+    )
+
+    // Test that no modifiers match for dependency 'e' from workspace 'b'
+    const resultE = modifier.tryNewDependency(workspaceB, 'e')
+    t.equal(
+      resultE.size,
+      0,
+      'should return no results for e with no matching query',
+    )
+
+    // Update active entries
+    for (const entry of resultD) {
+      modifier.updateActiveEntry(nodeD, entry)
+    }
+    for (const entry of resultF) {
+      modifier.updateActiveEntry(nodeF, entry)
+    }
+
+    // Test rollback
+    t.equal(
+      modifier.activeModifiers.size,
+      4,
+      'should have leftover activbe entries after processing',
+    )
+    modifier.rollbackActiveEntries()
+    t.equal(
+      modifier.activeModifiers.size,
+      0,
+      'should have no leftover active entries after rollback',
+    )
+  })
+})

--- a/src/graph/test/modifiers.ts
+++ b/src/graph/test/modifiers.ts
@@ -4,7 +4,6 @@ import {
   assertGraphModifiersConfig,
   GraphModifier,
 } from '../src/modifiers.ts'
-import { PackageJson } from '@vltpkg/package-json'
 import { Spec } from '@vltpkg/spec'
 import type { SpecOptions } from '@vltpkg/spec'
 import { reload } from '@vltpkg/vlt-json'
@@ -457,25 +456,23 @@ t.test('assertGraphModifiersConfig', async t => {
 
 t.test('GraphModifier', async t => {
   await t.test('constructor', async t => {
-    const testdir = t.testdir({
-      'vlt.json': JSON.stringify({ modifiers: validStringConfig }),
+    // Test with empty config
+    const emptyconfigDir = t.testdir({
+      'vlt.json': JSON.stringify({}), // No modifiers key
     })
-
     const options = {
-      packageJson: new PackageJson(),
       specOptions: mockSpecOptions,
     }
     // Reload vlt.json to ensure we have the latest config
-    t.chdir(testdir)
+    t.chdir(emptyconfigDir)
     reload('modifiers', 'project')
 
-    t.doesNotThrow(
-      () => new GraphModifier(options),
-      'should instantiate without errors',
+    const emptyModifier = new GraphModifier(options)
+    t.same(
+      emptyModifier.config,
+      {},
+      'should return empty object when no config is found',
     )
-
-    const modifier = new GraphModifier(options)
-    t.ok(modifier.packageJson, 'should initialize packageJson')
   })
 
   await t.test('config getter', async t => {
@@ -484,7 +481,6 @@ t.test('GraphModifier', async t => {
     })
 
     const options = {
-      packageJson: new PackageJson(),
       specOptions: mockSpecOptions,
     }
     // Reload vlt.json to ensure we have the latest config
@@ -509,27 +505,6 @@ t.test('GraphModifier', async t => {
     )
   })
 
-  await t.test('empty config', async t => {
-    // Test with empty config
-    const emptyconfigDir = t.testdir({
-      'vlt.json': JSON.stringify({}), // No modifiers key
-    })
-    const options = {
-      packageJson: new PackageJson(),
-      specOptions: mockSpecOptions,
-    }
-    // Reload vlt.json to ensure we have the latest config
-    t.chdir(emptyconfigDir)
-    reload('modifiers', 'project')
-
-    const emptyModifier = new GraphModifier(options)
-    t.same(
-      emptyModifier.config,
-      {},
-      'should return empty object when no config is found',
-    )
-  })
-
   await t.test('maybeHasModifier with simple graph', async t => {
     // Test with importer modifier
     const importerConfigDir = t.testdir({
@@ -542,7 +517,6 @@ t.test('GraphModifier', async t => {
     reload('modifiers', 'project')
 
     const importerOptions = {
-      packageJson: new PackageJson(),
       specOptions: mockSpecOptions,
     }
 
@@ -569,7 +543,6 @@ t.test('GraphModifier', async t => {
     })
 
     const nonImporterOptions = {
-      packageJson: new PackageJson(),
       specOptions: mockSpecOptions,
     }
     // Reload vlt.json to ensure we have the latest config
@@ -597,7 +570,6 @@ t.test('GraphModifier', async t => {
       })
 
       const options = {
-        packageJson: new PackageJson(),
         specOptions: mockSpecOptions,
       }
       // Reload vlt.json to ensure we have the latest config
@@ -665,7 +637,6 @@ t.test('GraphModifier', async t => {
       })
 
       const options = {
-        packageJson: new PackageJson(),
         specOptions: mockSpecOptions,
       }
       // Reload vlt.json to ensure we have the latest config
@@ -765,7 +736,6 @@ t.test('GraphModifier', async t => {
     })
 
     const options = {
-      packageJson: new PackageJson(),
       specOptions: mockSpecOptions,
     }
     // Reload vlt.json to ensure we have the latest config
@@ -831,7 +801,6 @@ t.test('GraphModifier', async t => {
     })
 
     const options = {
-      packageJson: new PackageJson(),
       specOptions: mockSpecOptions,
     }
     // Reload vlt.json to ensure we have the latest config
@@ -906,7 +875,6 @@ t.test('GraphModifier', async t => {
     })
 
     const options = {
-      packageJson: new PackageJson(),
       specOptions: mockSpecOptions,
     }
     // Reload vlt.json to ensure we have the latest config
@@ -973,7 +941,6 @@ t.test('GraphModifier', async t => {
     })
 
     const options = {
-      packageJson: new PackageJson(),
       specOptions: mockSpecOptions,
     }
 
@@ -1019,7 +986,6 @@ t.test('GraphModifier', async t => {
     })
 
     const options = {
-      packageJson: new PackageJson(),
       specOptions: mockSpecOptions,
     }
     // Reload vlt.json to ensure we have the latest config


### PR DESCRIPTION
Add the module that is responsible for loading and applying user-defined "modifiers" loaded from a vlt.json file into a graph at traversal time.

Instances of `GraphModifier` class can be used as a helper to modify the graph during the graph build ideal traversal time. e.g:

```ts
  const modifier = new GraphModifier(options)
  modifier.load(options)

  // The `tryImporter` method can be used to register the initial
  // importer node along with any modifier that includes an importer
  // selector, e.g:
  modifier.tryImporter(graph.mainImporter)

  // When traversing the graph, use the `tryNewDependency` method to
  // check if a given dependency name to the current traversed node
  // has matching registered modifiers, e.g:
  const entries = modifier.tryNewDependency(fromNode, depName)

  // Use `updateActiveEntry` to update a given active modifier entry
  // state with the current node of the graph being traversed. e.g:
  for (const entry of entries)
    modifier.updateActiveEntry(fromNode, entry)
```

Refs: https://github.com/vltpkg/statusboard/issues/64