### PR TITLE
gui: dependency sidebar empty states

### DIFF
--- a/src/gui/src/app/explorer.tsx
+++ b/src/gui/src/app/explorer.tsx
@@ -153,7 +153,6 @@ const ExplorerContent = () => {
           {/* query bar blur */}
           <div className="absolute inset-x-0 -bottom-1 h-1 w-full bg-background blur-sm" />
           <div className="absolute inset-x-0 -bottom-4 h-4 w-full bg-gradient-to-b from-background/100 from-10% via-50% to-background/0 to-100%" />
-
           <RootButton />
           <QueryBar
             tabIndex={0}

--- a/src/gui/src/app/explorer.tsx
+++ b/src/gui/src/app/explorer.tsx
@@ -147,7 +147,7 @@ const ExplorerContent = () => {
   }
 
   return (
-    <section className="relative flex h-full max-h-[calc(100svh-65px-16px)] w-full grow flex-col justify-between overflow-y-auto rounded-b-lg border-x-[1px] border-b-[1px]">
+    <section className="relative flex h-full max-h-[calc(100svh-65px-16px)] w-full grow flex-col overflow-y-auto rounded-b-lg border-x-[1px] border-b-[1px]">
       <section className="sticky top-0 z-[20] flex w-full items-center bg-background px-8 pt-1">
         <div className="relative flex w-full max-w-8xl flex-row items-center gap-2">
           {/* query bar blur */}

--- a/src/gui/src/components/explorer-grid/dependency-sidebar/add-dependency.tsx
+++ b/src/gui/src/components/explorer-grid/dependency-sidebar/add-dependency.tsx
@@ -1,11 +1,11 @@
-import { useEffect, useState } from 'react'
+import { useState } from 'react'
 import {
   Plus,
   BatteryLow,
   PackageCheck,
   PackagePlus,
 } from 'lucide-react'
-import { useAnimate } from 'framer-motion'
+import { motion } from 'framer-motion'
 import { Button } from '@/components/ui/button.tsx'
 import { CardHeader, CardTitle } from '@/components/ui/card.tsx'
 import { Input } from '@/components/ui/input.tsx'
@@ -215,21 +215,6 @@ export const AddDependenciesPopoverTrigger = () => {
     dependencyPopoverOpen,
     setDependencyPopoverOpen,
   } = usePopover()
-  const [scope, animate] = useAnimate()
-
-  useEffect(() => {
-    if (scope.current) {
-      if (dependencyPopoverOpen) {
-        animate(scope.current, {
-          rotate: -45,
-        })
-      } else {
-        animate(scope.current, {
-          rotate: 0,
-        })
-      }
-    }
-  }, [dependencyPopoverOpen, scope])
 
   return (
     <TooltipProvider>
@@ -242,7 +227,12 @@ export const AddDependenciesPopoverTrigger = () => {
               <div
                 onClick={toggleAddDepPopover}
                 className="inline-flex size-6 cursor-default items-center justify-center gap-2 whitespace-nowrap rounded-md border border-input bg-white text-sm font-medium ring-offset-background transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 dark:bg-black [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0">
-                <Plus ref={scope} />
+                <motion.span
+                  animate={{
+                    rotate: dependencyPopoverOpen ? 45 : 0,
+                  }}>
+                  <Plus />
+                </motion.span>
               </div>
             </TooltipTrigger>
             <TooltipPortal>
@@ -252,7 +242,8 @@ export const AddDependenciesPopoverTrigger = () => {
         </PopoverTrigger>
         <PopoverContent
           align="end"
-          className="right-0 top-0 w-96 p-0">
+          className="right-0 top-0 w-96 p-0"
+          onCloseAutoFocus={e => e.preventDefault()}>
           <AddDependenciesPopover />
         </PopoverContent>
       </Popover>

--- a/src/gui/src/components/explorer-grid/dependency-sidebar/context.tsx
+++ b/src/gui/src/components/explorer-grid/dependency-sidebar/context.tsx
@@ -98,7 +98,7 @@ export const DependencySidebarProvider = ({
   const dependencySidebarStore = useRef(
     createStore<DependencySidebarStore>(set => ({
       dependencies,
-      filteredDependencies: [],
+      filteredDependencies: dependencies,
       uninstalledDependencies,
       importerId,
       filters: [],

--- a/src/gui/src/components/explorer-grid/dependency-sidebar/empty-state.tsx
+++ b/src/gui/src/components/explorer-grid/dependency-sidebar/empty-state.tsx
@@ -27,6 +27,7 @@ export const DependencyEmptyState = () => {
     <AnimatePresence mode="popLayout" initial={false}>
       {dependencies.length === 0 && (
         <motion.div
+          layout
           initial={{ opacity: 0, filter: 'blur(2px)' }}
           animate={{ opacity: 1, filter: 'blur(0px)' }}
           exit={{ opacity: 0, filter: 'blur(2px)' }}

--- a/src/gui/src/components/explorer-grid/dependency-sidebar/empty-state.tsx
+++ b/src/gui/src/components/explorer-grid/dependency-sidebar/empty-state.tsx
@@ -1,0 +1,92 @@
+import { AnimatePresence, motion } from 'framer-motion'
+import { AddDependenciesPopover } from '@/components/explorer-grid/dependency-sidebar/add-dependency.tsx'
+import {
+  Popover,
+  PopoverTrigger,
+  PopoverContent,
+} from '@/components/ui/popover.tsx'
+import { Button } from '@/components/ui/button.tsx'
+import { Plus } from 'lucide-react'
+import {
+  useDependencySidebarStore,
+  usePopover,
+} from '@/components/explorer-grid/dependency-sidebar/context.tsx'
+
+export const DependencyEmptyState = () => {
+  const {
+    dependencyPopoverOpen,
+    setDependencyPopoverOpen,
+    toggleAddDepPopover,
+  } = usePopover()
+
+  const dependencies = useDependencySidebarStore(
+    state => state.dependencies,
+  )
+
+  return (
+    <AnimatePresence mode="popLayout" initial={false}>
+      {dependencies.length === 0 && (
+        <motion.div
+          initial={{ opacity: 0, filter: 'blur(2px)' }}
+          animate={{ opacity: 1, filter: 'blur(0px)' }}
+          exit={{ opacity: 0, filter: 'blur(2px)' }}
+          transition={{
+            ease: 'easeInOut',
+            duration: 0.25,
+          }}
+          className="flex min-h-96 w-full cursor-default flex-col items-center justify-center rounded-sm border-[1px] border-dashed border-muted py-12">
+          <div className="mb-6 flex justify-center">
+            <div className="relative">
+              <div className="relative space-y-2">
+                <div className="h-12 w-64 rotate-1 transform rounded-lg border-[1px] border-dashed border-muted-foreground/20 bg-muted/30" />
+
+                <div className="-mt-10 h-12 w-64 -rotate-1 transform rounded-lg border-[1px] border-dashed border-muted-foreground/30 bg-muted/50" />
+
+                <div className="relative z-10 -mt-10 flex h-12 w-64 items-center justify-between rounded-lg border-[1px] border-dashed border-muted-foreground/40 bg-background px-4">
+                  <div className="flex items-center gap-3">
+                    <div className="h-6 w-12 rounded border-[1px] border-dashed border-muted-foreground/30 bg-muted/60" />
+                    <div className="h-4 w-24 rounded border-[1px] border-dashed border-muted-foreground/30 bg-muted/60" />
+                  </div>
+                  <div className="h-4 w-12 rounded border-[1px] border-dashed border-muted-foreground/30 bg-muted/60" />
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <div className="flex flex-col items-center justify-center gap-1 text-center">
+            <h3 className="text-base font-medium tracking-tight text-foreground">
+              No dependencies
+            </h3>
+            <p className="w-4/5 text-sm font-normal tracking-normal text-muted-foreground">
+              Your project's dependencies will appear here, install
+              one to see it appear
+            </p>
+            <Popover
+              open={dependencyPopoverOpen}
+              onOpenChange={setDependencyPopoverOpen}>
+              <PopoverTrigger asChild>
+                <Button
+                  onClick={toggleAddDepPopover}
+                  className="mt-2 h-8 w-fit border-[1px] border-muted">
+                  Install a dependency
+                  <motion.span
+                    animate={{
+                      rotate: dependencyPopoverOpen ? 45 : 0,
+                    }}>
+                    <Plus />
+                  </motion.span>
+                </Button>
+              </PopoverTrigger>
+              <PopoverContent
+                align="center"
+                side="top"
+                className="right-0 top-0 w-96 p-0">
+                <AddDependenciesPopover />
+              </PopoverContent>
+            </Popover>
+          </div>
+        </motion.div>
+      )}
+    </AnimatePresence>
+  )
+}

--- a/src/gui/src/components/explorer-grid/dependency-sidebar/filter.tsx
+++ b/src/gui/src/components/explorer-grid/dependency-sidebar/filter.tsx
@@ -357,9 +357,10 @@ export const FilterList = () => {
   }
 
   return (
-    <AnimatePresence initial={false} mode="sync">
+    <AnimatePresence initial={false} mode="popLayout">
       {hasFilters && (
         <motion.section
+          layout
           initial={{
             opacity: 0,
             height: 0,
@@ -383,7 +384,7 @@ export const FilterList = () => {
             duration: 0.28,
             bounce: 0.02,
           }}
-          className="flex gap-2 overflow-hidden">
+          className="flex flex-wrap gap-2 overflow-hidden">
           <AnimatePresence initial={false} mode="popLayout">
             {filters.map((filter, idx) => (
               <motion.div
@@ -454,7 +455,7 @@ const EmptyStateDependency = ({
       )}>
       <div className="flex h-full items-center justify-between px-4">
         <div className="flex items-center gap-3">
-          <div className="flex h-6 items-center justify-center rounded border-[1px] border-muted-foreground/20 bg-muted-foreground/20 px-2 font-mono text-xxs tabular-nums text-muted-foreground/60">
+          <div className="flex h-6 max-w-12 items-center justify-center truncate rounded border-[1px] border-muted-foreground/20 bg-muted-foreground/20 px-2 font-mono text-xxs tabular-nums text-muted-foreground/60">
             {spec}
           </div>
           <div className="text-xs font-medium text-muted-foreground/60">
@@ -499,14 +500,15 @@ export const FilterListEmptyState = () => {
       spec: String(dep.spec?.semver ?? '^1.0.0'),
       version: String(dep.version),
     })),
-  ]
+  ].splice(0, 3)
 
   const handleClear = () => clearFilters()
 
   return (
-    <AnimatePresence>
+    <AnimatePresence initial={false} mode="popLayout">
       {filters.length > 0 && filteredDependencies.length === 0 && (
         <motion.div
+          layout
           initial={{ opacity: 0, filter: 'blur(2px)' }}
           animate={{ opacity: 1, filter: 'blur(0px)' }}
           exit={{ opacity: 0, filter: 'blur(2px)' }}

--- a/src/gui/src/components/explorer-grid/dependency-sidebar/index.tsx
+++ b/src/gui/src/components/explorer-grid/dependency-sidebar/index.tsx
@@ -13,7 +13,7 @@ import {
   FilterListEmptyState,
 } from '@/components/explorer-grid/dependency-sidebar/filter.tsx'
 import { DependencyEmptyState } from '@/components/explorer-grid/dependency-sidebar/empty-state.tsx'
-import { AnimatePresence, motion } from 'framer-motion'
+import { AnimatePresence, LayoutGroup, motion } from 'framer-motion'
 
 import type { DepID } from '@vltpkg/dep-id/browser'
 import type { GridItemData } from '@/components/explorer-grid/types.ts'
@@ -116,37 +116,43 @@ const DependencyList = () => {
   const { operation } = useOperation()
 
   return (
-    <>
-      <div className="flex flex-col gap-4">
-        {[
-          // added dependencies should come first
-          ...filteredDependencies
-            .filter(item => addedDependencies.includes(item.name))
-            .sort((a, b) => a.name.localeCompare(b.name, 'en')),
-          // then we display the rest of dependencies, sorted by name
-          ...filteredDependencies
-            .filter(item => !addedDependencies.includes(item.name))
-            .sort((a, b) => a.name.localeCompare(b.name, 'en')),
-        ].map(item => (
-          <SideItem
-            item={item}
-            key={item.id}
-            dependencies={true}
-            onSelect={onDependencyClick(item)}
-            onUninstall={() =>
-              operation({
-                item: {
-                  name: item.name,
-                  version: item.version,
-                },
-                operationType: 'uninstall',
-              })
-            }
-          />
-        ))}
-      </div>
+    <LayoutGroup>
+      <FilterListEmptyState />
+      <motion.div layout="position" className="flex flex-col gap-4">
+        <AnimatePresence initial={false} mode="popLayout">
+          {[
+            // added dependencies should come first
+            ...filteredDependencies
+              .filter(item => addedDependencies.includes(item.name))
+              .sort((a, b) => a.name.localeCompare(b.name, 'en')),
+            // then we display the rest of dependencies, sorted by name
+            ...filteredDependencies
+              .filter(item => !addedDependencies.includes(item.name))
+              .sort((a, b) => a.name.localeCompare(b.name, 'en')),
+          ].map(item => (
+            <SideItem
+              item={item}
+              key={item.id}
+              dependencies={true}
+              onSelect={onDependencyClick(item)}
+              onUninstall={() =>
+                operation({
+                  item: {
+                    name: item.name,
+                    version: item.version,
+                  },
+                  operationType: 'uninstall',
+                })
+              }
+            />
+          ))}
+        </AnimatePresence>
+      </motion.div>
+      <DependencyEmptyState />
       {uninstalledDependencies.length > 0 && (
-        <div className="mt-8 flex flex-col gap-4">
+        <motion.div
+          layout="position"
+          className="mt-8 flex flex-col gap-4">
           <GridHeader className="h-fit">
             Uninstalled Dependencies
           </GridHeader>
@@ -161,10 +167,8 @@ const DependencyList = () => {
               dependencies={false}
             />
           ))}
-        </div>
+        </motion.div>
       )}
-      <DependencyEmptyState />
-      <FilterListEmptyState />
-    </>
+    </LayoutGroup>
   )
 }

--- a/src/gui/src/components/explorer-grid/dependency-sidebar/index.tsx
+++ b/src/gui/src/components/explorer-grid/dependency-sidebar/index.tsx
@@ -10,7 +10,10 @@ import { NumberFlow } from '@/components/number-flow.tsx'
 import {
   FilterButton,
   FilterList,
+  FilterListEmptyState,
 } from '@/components/explorer-grid/dependency-sidebar/filter.tsx'
+import { DependencyEmptyState } from '@/components/explorer-grid/dependency-sidebar/empty-state.tsx'
+import { AnimatePresence, motion } from 'framer-motion'
 
 import type { DepID } from '@vltpkg/dep-id/browser'
 import type { GridItemData } from '@/components/explorer-grid/types.ts'
@@ -38,21 +41,17 @@ const SidebarHeader = () => {
   const dependencies = useDependencySidebarStore(
     state => state.dependencies,
   )
-  const addedDependencies = useDependencySidebarStore(
-    state => state.addedDependencies,
-  )
   const filteredDependencies = useDependencySidebarStore(
     state => state.filteredDependencies,
   )
-  const totalLength = dependencies.length + addedDependencies.length
 
   return (
     <>
       <GridHeader className="flex w-full">
         <span className="mr-2">Dependencies</span>
         <NumberFlow
-          start={totalLength}
-          end={filteredDependencies.length + addedDependencies.length}
+          start={dependencies.length}
+          end={filteredDependencies.length}
           format={{
             pad: 0,
           }}
@@ -68,7 +67,7 @@ const SidebarHeader = () => {
         </span>
         <NumberFlow
           start={filteredDependencies.length}
-          end={totalLength}
+          end={dependencies.length}
           format={{
             pad: 0,
           }}
@@ -79,10 +78,22 @@ const SidebarHeader = () => {
             span: 'text-muted-foreground',
           }}
         />
-        <div className="flex grow justify-end gap-2">
-          <FilterButton />
-          {importerId && <AddDependenciesPopoverTrigger />}
-        </div>
+        <AnimatePresence mode="popLayout" initial={false}>
+          {dependencies.length !== 0 && (
+            <motion.div
+              initial={{ opacity: 0, filter: 'blur(2px)' }}
+              animate={{ opacity: 1, filter: 'blur(0px)' }}
+              exit={{ opacity: 0, filter: 'blur(4px)' }}
+              transition={{
+                ease: 'easeInOut',
+                duration: 0.25,
+              }}
+              className="flex grow justify-end gap-2">
+              {importerId && <AddDependenciesPopoverTrigger />}
+              <FilterButton />
+            </motion.div>
+          )}
+        </AnimatePresence>
       </GridHeader>
       <FilterList />
     </>
@@ -152,6 +163,8 @@ const DependencyList = () => {
           ))}
         </div>
       )}
+      <DependencyEmptyState />
+      <FilterListEmptyState />
     </>
   )
 }

--- a/src/gui/src/components/explorer-grid/side-item.tsx
+++ b/src/gui/src/components/explorer-grid/side-item.tsx
@@ -1,3 +1,4 @@
+import { forwardRef } from 'react'
 import { PackageMinus } from 'lucide-react'
 import { Card, CardHeader } from '@/components/ui/card.tsx'
 import { DataBadge } from '@/components/ui/data-badge.tsx'
@@ -27,26 +28,30 @@ export type SideItemOptions = GridItemOptions & {
   isWorkspace?: boolean
 }
 
-export const SideItem = ({
-  dependencies,
-  item,
-  highlight,
-  onSelect,
-  parent,
-  isWorkspace,
-  onUninstall,
-}: SideItemOptions) => {
-  const uninstallItem = (e: MouseEvent) => {
-    e.stopPropagation()
-    e.preventDefault()
-    if (onUninstall) {
-      onUninstall(item)
+export const SideItem = forwardRef<HTMLDivElement, SideItemOptions>(
+  (
+    {
+      dependencies,
+      item,
+      highlight,
+      onSelect,
+      parent,
+      isWorkspace,
+      onUninstall,
+    },
+    ref,
+  ) => {
+    const uninstallItem = (e: MouseEvent) => {
+      e.stopPropagation()
+      e.preventDefault()
+      if (onUninstall) {
+        onUninstall(item)
+      }
     }
-  }
 
-  const uninstallAvailable = !!onUninstall && item.from?.importer
+    const uninstallAvailable = !!onUninstall && item.from?.importer
 
-  const connectorStyles = `
+    const connectorStyles = `
     pointer-events-none
     absolute
 
@@ -80,70 +85,74 @@ export const SideItem = ({
     group-has-[.parent]:rounded-none
   `
 
-  const itemName =
-    item.depName && item.depName !== item.name ?
-      item.depName
-    : item.name
+    const itemName =
+      item.depName && item.depName !== item.name ?
+        item.depName
+      : item.name
 
-  return (
-    <div className="group relative">
-      <div
-        style={
-          {
-            '--column-gap-y': '1rem',
-            '--column-gap-x': '1rem',
-          } as React.CSSProperties
-        }
-        className={cn(
-          connectorStyles,
-          parent && 'parent',
-          !dependencies && !parent && 'hidden',
-        )}
-      />
-      <ContextMenu>
-        <ContextMenuTrigger>
-          <Card
-            role="article"
-            className={cn(
-              'group relative z-[10] cursor-default transition-all',
-              highlight && 'border-muted',
-              onSelect && 'hover:border-muted hover:bg-card-accent',
-            )}
-            onClick={onSelect}>
-            <CardHeader className="relative flex w-full max-w-full flex-row items-baseline gap-3 px-3 py-2">
-              {!isWorkspace && (
-                <SideItemSpec spec={item.spec} itemSize={item.size} />
+    return (
+      <div ref={ref} className="group relative">
+        <div
+          style={
+            {
+              '--column-gap-y': '1rem',
+              '--column-gap-x': '1rem',
+            } as React.CSSProperties
+          }
+          className={cn(
+            connectorStyles,
+            parent && 'parent',
+            !dependencies && !parent && 'hidden',
+          )}
+        />
+        <ContextMenu>
+          <ContextMenuTrigger>
+            <Card
+              role="article"
+              className={cn(
+                'group relative z-[10] cursor-default transition-all',
+                highlight && 'border-muted',
+                onSelect && 'hover:border-muted hover:bg-card-accent',
               )}
-              <TooltipProvider>
-                <Tooltip delayDuration={150}>
-                  <TooltipTrigger className="w-full max-w-full cursor-default items-baseline justify-between overflow-hidden truncate text-left text-sm font-medium">
-                    {itemName}
-                  </TooltipTrigger>
-                  <TooltipContent>{itemName}</TooltipContent>
-                </Tooltip>
-              </TooltipProvider>
-              {!item.id.startsWith('uninstalled-dep:') && (
-                <span className="ml-auto font-courier text-sm font-normal text-muted-foreground">
-                  {`v${item.version}`}
-                </span>
-              )}
+              onClick={onSelect}>
+              <CardHeader className="relative flex w-full max-w-full flex-row items-baseline gap-3 px-3 py-2">
+                {!isWorkspace && (
+                  <SideItemSpec
+                    spec={item.spec}
+                    itemSize={item.size}
+                  />
+                )}
+                <TooltipProvider>
+                  <Tooltip delayDuration={150}>
+                    <TooltipTrigger className="w-full max-w-full cursor-default items-baseline justify-between overflow-hidden truncate text-left text-sm font-medium">
+                      {itemName}
+                    </TooltipTrigger>
+                    <TooltipContent>{itemName}</TooltipContent>
+                  </Tooltip>
+                </TooltipProvider>
+                {!item.id.startsWith('uninstalled-dep:') && (
+                  <span className="ml-auto font-courier text-sm font-normal text-muted-foreground">
+                    {`v${item.version}`}
+                  </span>
+                )}
 
-              <SideItemBadges labels={item.labels} />
-            </CardHeader>
-          </Card>
-        </ContextMenuTrigger>
-        <ContextMenuContent>
-          <ContextMenuItem
-            onClick={uninstallItem}
-            disabled={!uninstallAvailable}>
-            <PackageMinus />
-            Remove dependency
-          </ContextMenuItem>
-        </ContextMenuContent>
-      </ContextMenu>
-    </div>
-  )
-}
+                <SideItemBadges labels={item.labels} />
+              </CardHeader>
+            </Card>
+          </ContextMenuTrigger>
+          <ContextMenuContent>
+            <ContextMenuItem
+              onClick={uninstallItem}
+              disabled={!uninstallAvailable}>
+              <PackageMinus />
+              Remove dependency
+            </ContextMenuItem>
+          </ContextMenuContent>
+        </ContextMenu>
+      </div>
+    )
+  },
+)
 
 const SideItemBadges = ({
   labels,

--- a/src/gui/test/app/__snapshots__/explorer.tsx.snap
+++ b/src/gui/test/app/__snapshots__/explorer.tsx.snap
@@ -3,7 +3,7 @@
 exports[`explorer has project root info 1`] = `
 
 <div>
-  <section class="relative flex h-full max-h-[calc(100svh-65px-16px)] w-full grow flex-col justify-between overflow-y-auto rounded-b-lg border-x-[1px] border-b-[1px]">
+  <section class="relative flex h-full max-h-[calc(100svh-65px-16px)] w-full grow flex-col overflow-y-auto rounded-b-lg border-x-[1px] border-b-[1px]">
     <section class="sticky top-0 z-[20] flex w-full items-center bg-background px-8 pt-1">
       <div class="relative flex w-full max-w-8xl flex-row items-center gap-2">
         <div class="absolute inset-x-0 -bottom-1 h-1 w-full bg-background blur-sm">
@@ -48,7 +48,7 @@ exports[`render default 1`] = `
 exports[`render no results if search throws 1`] = `
 
 <div>
-  <section class="relative flex h-full max-h-[calc(100svh-65px-16px)] w-full grow flex-col justify-between overflow-y-auto rounded-b-lg border-x-[1px] border-b-[1px]">
+  <section class="relative flex h-full max-h-[calc(100svh-65px-16px)] w-full grow flex-col overflow-y-auto rounded-b-lg border-x-[1px] border-b-[1px]">
     <section class="sticky top-0 z-[20] flex w-full items-center bg-background px-8 pt-1">
       <div class="relative flex w-full max-w-8xl flex-row items-center gap-2">
         <div class="absolute inset-x-0 -bottom-1 h-1 w-full bg-background blur-sm">

--- a/src/gui/test/components/explorer-grid/dependency-sidebar/__snapshots__/empty-state.tsx.snap
+++ b/src/gui/test/components/explorer-grid/dependency-sidebar/__snapshots__/empty-state.tsx.snap
@@ -1,0 +1,58 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`dependency-empty-state renders default 1`] = `
+
+<div
+  class="flex min-h-96 w-full cursor-default flex-col items-center justify-center rounded-sm border-[1px] border-dashed border-muted py-12"
+  style="opacity: 1; filter: blur(0px);"
+>
+  <div class="mb-6 flex justify-center">
+    <div class="relative">
+      <div class="relative space-y-2">
+        <div class="h-12 w-64 rotate-1 transform rounded-lg border-[1px] border-dashed border-muted-foreground/20 bg-muted/30">
+        </div>
+        <div class="-mt-10 h-12 w-64 -rotate-1 transform rounded-lg border-[1px] border-dashed border-muted-foreground/30 bg-muted/50">
+        </div>
+        <div class="relative z-10 -mt-10 flex h-12 w-64 items-center justify-between rounded-lg border-[1px] border-dashed border-muted-foreground/40 bg-background px-4">
+          <div class="flex items-center gap-3">
+            <div class="h-6 w-12 rounded border-[1px] border-dashed border-muted-foreground/30 bg-muted/60">
+            </div>
+            <div class="h-4 w-24 rounded border-[1px] border-dashed border-muted-foreground/30 bg-muted/60">
+            </div>
+          </div>
+          <div class="h-4 w-12 rounded border-[1px] border-dashed border-muted-foreground/30 bg-muted/60">
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="flex flex-col items-center justify-center gap-1 text-center">
+    <h3 class="text-base font-medium tracking-tight text-foreground">
+      No dependencies
+    </h3>
+    <p class="w-4/5 text-sm font-normal tracking-normal text-muted-foreground">
+      Your project's dependencies will appear here, install one to see it appear
+    </p>
+    <gui-popover open="true">
+      <gui-popover-trigger aschild="true">
+        <gui-button classname="mt-2 h-8 w-fit border-[1px] border-muted">
+          Install a dependency
+          <span style="transform: rotate(45deg);">
+            <gui-plus-icon>
+            </gui-plus-icon>
+          </span>
+        </gui-button>
+      </gui-popover-trigger>
+      <gui-popover-content
+        align="center"
+        side="top"
+        classname="right-0 top-0 w-96 p-0"
+      >
+        <gui-add-dependencies-popover>
+        </gui-add-dependencies-popover>
+      </gui-popover-content>
+    </gui-popover>
+  </div>
+</div>
+
+`;

--- a/src/gui/test/components/explorer-grid/dependency-sidebar/__snapshots__/filter.tsx.snap
+++ b/src/gui/test/components/explorer-grid/dependency-sidebar/__snapshots__/filter.tsx.snap
@@ -155,3 +155,64 @@ exports[`filter-list renders with filters 1`] = `
 </section>
 
 `;
+
+exports[`filter-list-empty-state renders when no matching filters are found 1`] = `
+
+<div
+  class="flex min-h-96 w-full cursor-default flex-col items-center justify-center gap-4 rounded-sm border-[1px] border-dashed border-muted py-12"
+  style="opacity: 0; filter: blur(2px);"
+>
+  <div class="mb-6 flex justify-center">
+    <div class="relative">
+      <div class="relative space-y-2">
+        <div class="h-12 w-64 rounded-lg border border-muted bg-muted/60 rotate-1 transform opacity-40">
+          <div class="flex h-full items-center justify-between px-4">
+            <div class="flex items-center gap-3">
+              <div class="flex h-6 items-center justify-center rounded border-[1px] border-muted-foreground/20 bg-muted-foreground/20 px-2 font-mono text-xxs tabular-nums text-muted-foreground/60">
+                ^21.0.0
+              </div>
+              <div class="text-xs font-medium text-muted-foreground/60">
+                tap
+              </div>
+            </div>
+            <div class="font-mono text-xxs tabular-nums text-muted-foreground/60">
+              v21.1.0
+            </div>
+          </div>
+        </div>
+        <div class="h-12 w-64 rounded-lg border border-muted bg-muted/60 -mt-10 -rotate-1 transform opacity-40">
+          <div class="flex h-full items-center justify-between px-4">
+            <div class="flex items-center gap-3">
+              <div class="flex h-6 items-center justify-center rounded border-[1px] border-muted-foreground/20 bg-muted-foreground/20 px-2 font-mono text-xxs tabular-nums text-muted-foreground/60">
+                ^1.0.0
+              </div>
+              <div class="text-xs font-medium text-muted-foreground/60">
+                reproduce
+              </div>
+            </div>
+            <div class="font-mono text-xxs tabular-nums text-muted-foreground/60">
+              v1.1.4
+            </div>
+          </div>
+        </div>
+      </div>
+      <div class="pointer-events-none absolute inset-0 rounded-lg bg-background/30">
+      </div>
+    </div>
+  </div>
+  <div class="flex flex-col items-center justify-center gap-1 text-center">
+    <h3 class="text-base font-medium tracking-tight text-foreground">
+      No matching dependencies
+    </h3>
+    <p class="w-4/5 text-sm font-normal tracking-normal text-muted-foreground">
+      There were no dependencies matching your current filters.
+    </p>
+    <gui-button classname="mt-2 h-8 w-fit border-[1px] border-muted">
+      <gui-rotate-ccw>
+      </gui-rotate-ccw>
+      Clear Filters
+    </gui-button>
+  </div>
+</div>
+
+`;

--- a/src/gui/test/components/explorer-grid/dependency-sidebar/__snapshots__/filter.tsx.snap
+++ b/src/gui/test/components/explorer-grid/dependency-sidebar/__snapshots__/filter.tsx.snap
@@ -113,7 +113,7 @@ exports[`filter-button renders default 1`] = `
 exports[`filter-list renders with filters 1`] = `
 
 <section
-  class="flex gap-2 overflow-hidden"
+  class="flex flex-wrap gap-2 overflow-hidden"
   style="opacity: 1; height: auto; filter: blur(0px); margin-bottom: 16px;"
 >
   <div
@@ -160,7 +160,7 @@ exports[`filter-list-empty-state renders when no matching filters are found 1`] 
 
 <div
   class="flex min-h-96 w-full cursor-default flex-col items-center justify-center gap-4 rounded-sm border-[1px] border-dashed border-muted py-12"
-  style="opacity: 0; filter: blur(2px);"
+  style="opacity: 1; filter: blur(0px);"
 >
   <div class="mb-6 flex justify-center">
     <div class="relative">
@@ -168,7 +168,7 @@ exports[`filter-list-empty-state renders when no matching filters are found 1`] 
         <div class="h-12 w-64 rounded-lg border border-muted bg-muted/60 rotate-1 transform opacity-40">
           <div class="flex h-full items-center justify-between px-4">
             <div class="flex items-center gap-3">
-              <div class="flex h-6 items-center justify-center rounded border-[1px] border-muted-foreground/20 bg-muted-foreground/20 px-2 font-mono text-xxs tabular-nums text-muted-foreground/60">
+              <div class="flex h-6 max-w-12 items-center justify-center truncate rounded border-[1px] border-muted-foreground/20 bg-muted-foreground/20 px-2 font-mono text-xxs tabular-nums text-muted-foreground/60">
                 ^21.0.0
               </div>
               <div class="text-xs font-medium text-muted-foreground/60">
@@ -183,7 +183,7 @@ exports[`filter-list-empty-state renders when no matching filters are found 1`] 
         <div class="h-12 w-64 rounded-lg border border-muted bg-muted/60 -mt-10 -rotate-1 transform opacity-40">
           <div class="flex h-full items-center justify-between px-4">
             <div class="flex items-center gap-3">
-              <div class="flex h-6 items-center justify-center rounded border-[1px] border-muted-foreground/20 bg-muted-foreground/20 px-2 font-mono text-xxs tabular-nums text-muted-foreground/60">
+              <div class="flex h-6 max-w-12 items-center justify-center truncate rounded border-[1px] border-muted-foreground/20 bg-muted-foreground/20 px-2 font-mono text-xxs tabular-nums text-muted-foreground/60">
                 ^1.0.0
               </div>
               <div class="text-xs font-medium text-muted-foreground/60">

--- a/src/gui/test/components/explorer-grid/dependency-sidebar/__snapshots__/index.tsx.snap
+++ b/src/gui/test/components/explorer-grid/dependency-sidebar/__snapshots__/index.tsx.snap
@@ -39,6 +39,8 @@ exports[`dependency-side-bar 1`] = `
   </gui-grid-header>
   <gui-filter-list>
   </gui-filter-list>
+  <gui-filter-list-empty-state>
+  </gui-filter-list-empty-state>
   <div class="flex flex-col gap-4">
     <gui-side-item
       item="GridItemData { @vltpkg/semver }"
@@ -58,8 +60,6 @@ exports[`dependency-side-bar 1`] = `
   </div>
   <gui-dependency-empty-state>
   </gui-dependency-empty-state>
-  <gui-filter-list-empty-state>
-  </gui-filter-list-empty-state>
 </gui-dependency-sidebar-provider>
 
 `;
@@ -103,6 +103,8 @@ exports[`dependency-side-bar has both installed and uninstalled deps 1`] = `
   </gui-grid-header>
   <gui-filter-list>
   </gui-filter-list>
+  <gui-filter-list-empty-state>
+  </gui-filter-list-empty-state>
   <div class="flex flex-col gap-4">
     <gui-side-item
       item="GridItemData { @vltpkg/semver }"
@@ -120,6 +122,8 @@ exports[`dependency-side-bar has both installed and uninstalled deps 1`] = `
     >
     </gui-side-item>
   </div>
+  <gui-dependency-empty-state>
+  </gui-dependency-empty-state>
   <div class="mt-8 flex flex-col gap-4">
     <gui-grid-header classname="h-fit">
       Uninstalled Dependencies
@@ -135,10 +139,6 @@ exports[`dependency-side-bar has both installed and uninstalled deps 1`] = `
     >
     </gui-side-item>
   </div>
-  <gui-dependency-empty-state>
-  </gui-dependency-empty-state>
-  <gui-filter-list-empty-state>
-  </gui-filter-list-empty-state>
 </gui-dependency-sidebar-provider>
 
 `;
@@ -175,6 +175,8 @@ exports[`dependency-side-bar has uninstalled deps only 1`] = `
   </gui-grid-header>
   <gui-filter-list>
   </gui-filter-list>
+  <gui-filter-list-empty-state>
+  </gui-filter-list-empty-state>
   <div class="flex flex-col gap-4">
     <gui-side-item
       item="GridItemData { @vltpkg/semver }"
@@ -192,6 +194,8 @@ exports[`dependency-side-bar has uninstalled deps only 1`] = `
     >
     </gui-side-item>
   </div>
+  <gui-dependency-empty-state>
+  </gui-dependency-empty-state>
   <div class="mt-8 flex flex-col gap-4">
     <gui-grid-header classname="h-fit">
       Uninstalled Dependencies
@@ -212,10 +216,6 @@ exports[`dependency-side-bar has uninstalled deps only 1`] = `
     >
     </gui-side-item>
   </div>
-  <gui-dependency-empty-state>
-  </gui-dependency-empty-state>
-  <gui-filter-list-empty-state>
-  </gui-filter-list-empty-state>
 </gui-dependency-sidebar-provider>
 
 `;
@@ -252,12 +252,12 @@ exports[`dependency-side-bar no items 1`] = `
   </gui-grid-header>
   <gui-filter-list>
   </gui-filter-list>
+  <gui-filter-list-empty-state>
+  </gui-filter-list-empty-state>
   <div class="flex flex-col gap-4">
   </div>
   <gui-dependency-empty-state>
   </gui-dependency-empty-state>
-  <gui-filter-list-empty-state>
-  </gui-filter-list-empty-state>
 </gui-dependency-sidebar-provider>
 
 `;

--- a/src/gui/test/components/explorer-grid/dependency-sidebar/__snapshots__/index.tsx.snap
+++ b/src/gui/test/components/explorer-grid/dependency-sidebar/__snapshots__/index.tsx.snap
@@ -29,7 +29,10 @@ exports[`dependency-side-bar 1`] = `
       classnames="[object Object]"
     >
     </gui-number-flow>
-    <div class="flex grow justify-end gap-2">
+    <div
+      class="flex grow justify-end gap-2"
+      style="opacity: 1; filter: blur(0px);"
+    >
       <gui-filter-button>
       </gui-filter-button>
     </div>
@@ -53,6 +56,10 @@ exports[`dependency-side-bar 1`] = `
     >
     </gui-side-item>
   </div>
+  <gui-dependency-empty-state>
+  </gui-dependency-empty-state>
+  <gui-filter-list-empty-state>
+  </gui-filter-list-empty-state>
 </gui-dependency-sidebar-provider>
 
 `;
@@ -86,7 +93,10 @@ exports[`dependency-side-bar has both installed and uninstalled deps 1`] = `
       classnames="[object Object]"
     >
     </gui-number-flow>
-    <div class="flex grow justify-end gap-2">
+    <div
+      class="flex grow justify-end gap-2"
+      style="opacity: 1; filter: blur(0px);"
+    >
       <gui-filter-button>
       </gui-filter-button>
     </div>
@@ -125,6 +135,10 @@ exports[`dependency-side-bar has both installed and uninstalled deps 1`] = `
     >
     </gui-side-item>
   </div>
+  <gui-dependency-empty-state>
+  </gui-dependency-empty-state>
+  <gui-filter-list-empty-state>
+  </gui-filter-list-empty-state>
 </gui-dependency-sidebar-provider>
 
 `;
@@ -158,10 +172,6 @@ exports[`dependency-side-bar has uninstalled deps only 1`] = `
       classnames="[object Object]"
     >
     </gui-number-flow>
-    <div class="flex grow justify-end gap-2">
-      <gui-filter-button>
-      </gui-filter-button>
-    </div>
   </gui-grid-header>
   <gui-filter-list>
   </gui-filter-list>
@@ -202,6 +212,10 @@ exports[`dependency-side-bar has uninstalled deps only 1`] = `
     >
     </gui-side-item>
   </div>
+  <gui-dependency-empty-state>
+  </gui-dependency-empty-state>
+  <gui-filter-list-empty-state>
+  </gui-filter-list-empty-state>
 </gui-dependency-sidebar-provider>
 
 `;
@@ -235,15 +249,15 @@ exports[`dependency-side-bar no items 1`] = `
       classnames="[object Object]"
     >
     </gui-number-flow>
-    <div class="flex grow justify-end gap-2">
-      <gui-filter-button>
-      </gui-filter-button>
-    </div>
   </gui-grid-header>
   <gui-filter-list>
   </gui-filter-list>
   <div class="flex flex-col gap-4">
   </div>
+  <gui-dependency-empty-state>
+  </gui-dependency-empty-state>
+  <gui-filter-list-empty-state>
+  </gui-filter-list-empty-state>
 </gui-dependency-sidebar-provider>
 
 `;

--- a/src/gui/test/components/explorer-grid/dependency-sidebar/empty-state.tsx
+++ b/src/gui/test/components/explorer-grid/dependency-sidebar/empty-state.tsx
@@ -1,0 +1,90 @@
+import { vi, test, expect, afterEach } from 'vitest'
+import { cleanup, render } from '@testing-library/react'
+import html from 'diffable-html'
+import { useGraphStore as useStore } from '@/state/index.ts'
+import { useDependencySidebarStore } from '@/components/explorer-grid/dependency-sidebar/context.tsx'
+import { DependencyEmptyState } from '@/components/explorer-grid/dependency-sidebar/empty-state.tsx'
+import type { DependencySidebarStore } from '@/components/explorer-grid/dependency-sidebar/context.tsx'
+
+vi.mock(
+  '@/components/explorer-grid/dependency-sidebar/context',
+  () => ({
+    useDependencySidebarStore: vi.fn(),
+    DependencySidebarProvider: 'gui-dependency-sidebar-provider',
+    usePopover: vi.fn().mockReturnValue({
+      toggleAddDepPopover: vi.fn(),
+      dependencyPopoverOpen: true,
+      setDependencyPopoverOpen: vi.fn(),
+    }),
+    useOperation: vi.fn().mockReturnValue({
+      operation: vi.fn(),
+    }),
+  }),
+)
+
+vi.mock(
+  '@/components/explorer-grid/dependency-sidebar/add-dependency.tsx',
+  () => ({
+    AddDependenciesPopover: 'gui-add-dependencies-popover',
+  }),
+)
+
+vi.mock('@/components/ui/popover.tsx', () => ({
+  Popover: 'gui-popover',
+  PopoverTrigger: 'gui-popover-trigger',
+  PopoverContent: 'gui-popover-content',
+}))
+
+vi.mock('@/components/ui/button.tsx', () => ({
+  Button: 'gui-button',
+}))
+
+vi.mock('lucide-react', () => ({
+  Plus: 'gui-plus-icon',
+}))
+
+expect.addSnapshotSerializer({
+  serialize: v => html(v),
+  test: () => true,
+})
+
+afterEach(() => {
+  const CleanUp = () => (useStore(state => state.reset)(), '')
+  render(<CleanUp />)
+  cleanup()
+  vi.clearAllMocks()
+})
+
+test('dependency-empty-state renders default', () => {
+  const mockState = {
+    dependencies: [],
+    importerId: undefined,
+    addedDependencies: [],
+    uninstalledDependencies: [],
+    inProgress: false,
+    error: undefined,
+    dependencyPopoverOpen: false,
+    onDependencyClick: () => () => {},
+    setDependencyPopoverOpen: vi.fn(),
+    setInProgress: vi.fn(),
+    setError: vi.fn(),
+    setAddedDependencies: vi.fn(),
+    filteredDependencies: [],
+    filters: [],
+    searchTerm: '',
+    setSearchTerm: vi.fn(),
+    setFilters: vi.fn(),
+    setFilteredDependencies: vi.fn(),
+  } satisfies DependencySidebarStore
+
+  vi.mocked(useDependencySidebarStore).mockImplementation(selector =>
+    selector(mockState),
+  )
+
+  const Container = () => {
+    return <DependencyEmptyState />
+  }
+
+  const { container } = render(<Container />)
+  expect(container.innerHTML).toMatchSnapshot()
+})

--- a/src/gui/test/components/explorer-grid/dependency-sidebar/filter.tsx
+++ b/src/gui/test/components/explorer-grid/dependency-sidebar/filter.tsx
@@ -6,6 +6,7 @@ import { useDependencySidebarStore } from '@/components/explorer-grid/dependency
 import {
   FilterButton,
   FilterList,
+  FilterListEmptyState,
 } from '@/components/explorer-grid/dependency-sidebar/filter.tsx'
 import type { DependencySidebarStore } from '@/components/explorer-grid/dependency-sidebar/context.tsx'
 import type { Filter } from '@/components/explorer-grid/dependency-sidebar/filter-config.tsx'
@@ -32,6 +33,7 @@ vi.mock('lucide-react', () => ({
   ListFilter: 'gui-list-filter',
   CircleDot: 'gui-circle-dot',
   Search: 'gui-search',
+  RotateCcw: 'gui-rotate-ccw',
 }))
 
 vi.mock('@/components/ui/button.tsx', () => ({
@@ -147,6 +149,42 @@ test('filter-list renders with filters', () => {
 
   const Container = () => {
     return <FilterList />
+  }
+
+  const { container } = render(<Container />)
+  expect(container.innerHTML).toMatchSnapshot()
+})
+
+test('filter-list-empty-state renders when no matching filters are found', () => {
+  const filters = ['prod'] as Filter[]
+
+  const mockState = {
+    dependencies: [],
+    importerId: undefined,
+    addedDependencies: [],
+    uninstalledDependencies: [],
+    inProgress: false,
+    error: undefined,
+    dependencyPopoverOpen: false,
+    onDependencyClick: () => () => {},
+    setDependencyPopoverOpen: vi.fn(),
+    setInProgress: vi.fn(),
+    setError: vi.fn(),
+    setAddedDependencies: vi.fn(),
+    filteredDependencies: [],
+    filters,
+    searchTerm: '',
+    setSearchTerm: vi.fn(),
+    setFilters: vi.fn(),
+    setFilteredDependencies: vi.fn(),
+  } satisfies DependencySidebarStore
+
+  vi.mocked(useDependencySidebarStore).mockImplementation(selector =>
+    selector(mockState),
+  )
+
+  const Container = () => {
+    return <FilterListEmptyState />
   }
 
   const { container } = render(<Container />)

--- a/src/gui/test/components/explorer-grid/dependency-sidebar/index.tsx
+++ b/src/gui/test/components/explorer-grid/dependency-sidebar/index.tsx
@@ -49,6 +49,14 @@ vi.mock(
   () => ({
     FilterButton: 'gui-filter-button',
     FilterList: 'gui-filter-list',
+    FilterListEmptyState: 'gui-filter-list-empty-state',
+  }),
+)
+
+vi.mock(
+  '@/components/explorer-grid/dependency-sidebar/empty-state.tsx',
+  () => ({
+    DependencyEmptyState: 'gui-dependency-empty-state',
   }),
 )
 


### PR DESCRIPTION
<img width="1470" alt="Screenshot 2025-06-03 at 22 35 24" src="https://github.com/user-attachments/assets/22b97bde-8482-4763-bf74-b11fce251326" />

https://github.com/user-attachments/assets/ccaec0b1-004f-421c-9c93-91cc097fab29

This PR introduces new empty states for the dependency sidebar when there are no dependencies present, and an empty state for when filters are applied but no results are found.

### Other Changes
- simplifies the animation logic for the `add-dependency`'s trigger
- bugfixes the `number-flow` on the `dependency-sidebar` header when adding new dependencies
- changes the `filteredDependencies` default to `dependencies` instead of an empty array to avoid the empty state flashing
