### PR TITLE
gui: bugfix tooltip content overlay

### DIFF
--- a/src/gui/src/app/explorer.tsx
+++ b/src/gui/src/app/explorer.tsx
@@ -147,9 +147,13 @@ const ExplorerContent = () => {
   }
 
   return (
-    <section className="flex h-full max-h-[calc(100svh-65px-16px)] w-full grow flex-col justify-between overflow-y-auto rounded-b-lg border-x-[1px] border-b-[1px]">
-      <section className="absolute z-[20] flex w-[calc(100%-2px)] items-center bg-background px-8 pb-4 pt-1">
-        <div className="flex w-full max-w-8xl flex-row items-center gap-2">
+    <section className="relative flex h-full max-h-[calc(100svh-65px-16px)] w-full grow flex-col justify-between overflow-y-auto rounded-b-lg border-x-[1px] border-b-[1px]">
+      <section className="sticky top-0 z-[20] flex w-full items-center bg-background px-8 pt-1">
+        <div className="relative flex w-full max-w-8xl flex-row items-center gap-2">
+          {/* query bar blur */}
+          <div className="absolute inset-x-0 -bottom-1 h-1 w-full bg-background blur-sm" />
+          <div className="absolute inset-x-0 -bottom-4 h-4 w-full bg-gradient-to-b from-background/100 from-10% via-50% to-background/0 to-100%" />
+
           <RootButton />
           <QueryBar
             tabIndex={0}
@@ -170,7 +174,7 @@ const ExplorerContent = () => {
           />
         </div>
       </section>
-      <div className="z-[10] pt-12">
+      <div className="z-[10] pt-4">
         <ExplorerGrid />
       </div>
     </section>

--- a/src/gui/src/components/explorer-grid/dependency-sidebar/add-dependency.tsx
+++ b/src/gui/src/components/explorer-grid/dependency-sidebar/add-dependency.tsx
@@ -15,6 +15,7 @@ import {
   TooltipContent,
   TooltipProvider,
   TooltipTrigger,
+  TooltipPortal,
 } from '@/components/ui/tooltip.tsx'
 import {
   Popover,
@@ -236,7 +237,7 @@ export const AddDependenciesPopoverTrigger = () => {
         onOpenChange={setDependencyPopoverOpen}
         open={dependencyPopoverOpen}>
         <PopoverTrigger>
-          <Tooltip>
+          <Tooltip delayDuration={150}>
             <TooltipTrigger asChild>
               <div
                 onClick={toggleAddDepPopover}
@@ -244,7 +245,9 @@ export const AddDependenciesPopoverTrigger = () => {
                 <Plus ref={scope} />
               </div>
             </TooltipTrigger>
-            <TooltipContent>Add a new dependency</TooltipContent>
+            <TooltipPortal>
+              <TooltipContent>Add a new dependency</TooltipContent>
+            </TooltipPortal>
           </Tooltip>
         </PopoverTrigger>
         <PopoverContent

--- a/src/gui/src/components/explorer-grid/dependency-sidebar/filter.tsx
+++ b/src/gui/src/components/explorer-grid/dependency-sidebar/filter.tsx
@@ -21,6 +21,13 @@ import {
   DropdownMenuSubContent,
   DropdownMenuSubTrigger,
 } from '@/components/ui/dropdown-menu.tsx'
+import {
+  TooltipProvider,
+  Tooltip,
+  TooltipTrigger,
+  TooltipContent,
+  TooltipPortal,
+} from '@/components/ui/tooltip.tsx'
 import { labelClassNamesMap } from '@/components/explorer-grid/label-helper.ts'
 import { useDependencySidebarStore } from '@/components/explorer-grid/dependency-sidebar/context.tsx'
 import { cn } from '@/lib/utils.ts'
@@ -132,40 +139,50 @@ export const FilterButton = () => {
   }, [])
 
   return (
-    <DropdownMenu
-      open={dropdownOpen}
-      onOpenChange={handleDropdownOpenClose}>
-      <DropdownMenuTrigger asChild>
-        <Button
-          variant="outline"
-          className="aspect-square size-6 bg-white p-0 transition-colors dark:bg-black [&>svg]:size-4 [&>svg]:shrink-0"
-          onClick={() => setDropdownOpen(true)}>
-          <ListFilter />
-        </Button>
-      </DropdownMenuTrigger>
+    <TooltipProvider>
+      <Tooltip delayDuration={150}>
+        <DropdownMenu
+          open={dropdownOpen}
+          onOpenChange={handleDropdownOpenClose}>
+          <TooltipTrigger asChild>
+            <DropdownMenuTrigger asChild>
+              <Button
+                variant="outline"
+                className="aspect-square size-6 bg-white p-0 transition-colors dark:bg-black [&>svg]:size-4 [&>svg]:shrink-0"
+                onClick={() => setDropdownOpen(true)}>
+                <ListFilter />
+              </Button>
+            </DropdownMenuTrigger>
+          </TooltipTrigger>
 
-      <DropdownMenuContent
-        align="end"
-        className="w-[240px]"
-        onCloseAutoFocus={e => e.preventDefault()}>
-        <SearchInput setDropdownOpen={setDropdownOpen} />
-        <AnimatePresence>
-          {searchTerm ?
-            <SearchFilterList />
-          : <motion.div
-              initial={{ opacity: 0, filter: 'blur(2px)' }}
-              animate={{ opacity: 1, filter: 'blur(0px)' }}
-              exit={{ opacity: 0, filter: 'blur(2px)' }}
-              transition={{
-                ease: 'easeInOut',
-                duration: 0.2,
-              }}>
-              <DependencyFilters />
-            </motion.div>
-          }
-        </AnimatePresence>
-      </DropdownMenuContent>
-    </DropdownMenu>
+          <TooltipPortal>
+            <TooltipContent>Filter dependencies</TooltipContent>
+          </TooltipPortal>
+
+          <DropdownMenuContent
+            align="end"
+            className="w-[240px]"
+            onCloseAutoFocus={e => e.preventDefault()}>
+            <SearchInput setDropdownOpen={setDropdownOpen} />
+            <AnimatePresence>
+              {searchTerm ?
+                <SearchFilterList />
+              : <motion.div
+                  initial={{ opacity: 0, filter: 'blur(2px)' }}
+                  animate={{ opacity: 1, filter: 'blur(0px)' }}
+                  exit={{ opacity: 0, filter: 'blur(2px)' }}
+                  transition={{
+                    ease: 'easeInOut',
+                    duration: 0.2,
+                  }}>
+                  <DependencyFilters />
+                </motion.div>
+              }
+            </AnimatePresence>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </Tooltip>
+    </TooltipProvider>
   )
 }
 

--- a/src/gui/src/components/ui/sidebar.tsx
+++ b/src/gui/src/components/ui/sidebar.tsx
@@ -15,6 +15,7 @@ import {
   TooltipContent,
   TooltipProvider,
   TooltipTrigger,
+  TooltipPortal,
 } from '@/components/ui/tooltip.tsx'
 
 const SIDEBAR_COOKIE_NAME = 'sidebar:state'
@@ -581,12 +582,14 @@ const SidebarMenuButton = React.forwardRef<
     return (
       <Tooltip>
         <TooltipTrigger asChild>{button}</TooltipTrigger>
-        <TooltipContent
-          side="right"
-          align="center"
-          hidden={state !== 'collapsed' || isMobile}
-          {...tooltip}
-        />
+        <TooltipPortal>
+          <TooltipContent
+            side="right"
+            align="center"
+            hidden={state !== 'collapsed' || isMobile}
+            {...tooltip}
+          />
+        </TooltipPortal>
       </Tooltip>
     )
   },

--- a/src/gui/src/components/ui/tooltip.tsx
+++ b/src/gui/src/components/ui/tooltip.tsx
@@ -5,6 +5,8 @@ import { cn } from '@/lib/utils.ts'
 
 const TooltipProvider = TooltipPrimitive.Provider
 
+const TooltipPortal = TooltipPrimitive.Portal
+
 const Tooltip = TooltipPrimitive.Root
 
 const TooltipTrigger = TooltipPrimitive.Trigger
@@ -25,4 +27,10 @@ const TooltipContent = React.forwardRef<
 ))
 TooltipContent.displayName = TooltipPrimitive.Content.displayName
 
-export { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider }
+export {
+  Tooltip,
+  TooltipPortal,
+  TooltipTrigger,
+  TooltipContent,
+  TooltipProvider,
+}

--- a/src/gui/test/app/__snapshots__/explorer.tsx.snap
+++ b/src/gui/test/app/__snapshots__/explorer.tsx.snap
@@ -3,9 +3,13 @@
 exports[`explorer has project root info 1`] = `
 
 <div>
-  <section class="flex h-full max-h-[calc(100svh-65px-16px)] w-full grow flex-col justify-between overflow-y-auto rounded-b-lg border-x-[1px] border-b-[1px]">
-    <section class="absolute z-[20] flex w-[calc(100%-2px)] items-center bg-background px-8 pb-4 pt-1">
-      <div class="flex w-full max-w-8xl flex-row items-center gap-2">
+  <section class="relative flex h-full max-h-[calc(100svh-65px-16px)] w-full grow flex-col justify-between overflow-y-auto rounded-b-lg border-x-[1px] border-b-[1px]">
+    <section class="sticky top-0 z-[20] flex w-full items-center bg-background px-8 pt-1">
+      <div class="relative flex w-full max-w-8xl flex-row items-center gap-2">
+        <div class="absolute inset-x-0 -bottom-1 h-1 w-full bg-background blur-sm">
+        </div>
+        <div class="absolute inset-x-0 -bottom-4 h-4 w-full bg-gradient-to-b from-background/100 from-10% via-50% to-background/0 to-100%">
+        </div>
         <gui-root-button>
         </gui-root-button>
         <gui-query-bar
@@ -16,7 +20,7 @@ exports[`explorer has project root info 1`] = `
         </gui-query-bar>
       </div>
     </section>
-    <div class="z-[10] pt-12">
+    <div class="z-[10] pt-4">
       <gui-explorer-grid>
       </gui-explorer-grid>
     </div>
@@ -44,9 +48,13 @@ exports[`render default 1`] = `
 exports[`render no results if search throws 1`] = `
 
 <div>
-  <section class="flex h-full max-h-[calc(100svh-65px-16px)] w-full grow flex-col justify-between overflow-y-auto rounded-b-lg border-x-[1px] border-b-[1px]">
-    <section class="absolute z-[20] flex w-[calc(100%-2px)] items-center bg-background px-8 pb-4 pt-1">
-      <div class="flex w-full max-w-8xl flex-row items-center gap-2">
+  <section class="relative flex h-full max-h-[calc(100svh-65px-16px)] w-full grow flex-col justify-between overflow-y-auto rounded-b-lg border-x-[1px] border-b-[1px]">
+    <section class="sticky top-0 z-[20] flex w-full items-center bg-background px-8 pt-1">
+      <div class="relative flex w-full max-w-8xl flex-row items-center gap-2">
+        <div class="absolute inset-x-0 -bottom-1 h-1 w-full bg-background blur-sm">
+        </div>
+        <div class="absolute inset-x-0 -bottom-4 h-4 w-full bg-gradient-to-b from-background/100 from-10% via-50% to-background/0 to-100%">
+        </div>
         <gui-root-button>
         </gui-root-button>
         <gui-query-bar
@@ -57,7 +65,7 @@ exports[`render no results if search throws 1`] = `
         </gui-query-bar>
       </div>
     </section>
-    <div class="z-[10] pt-12">
+    <div class="z-[10] pt-4">
       <gui-explorer-grid>
       </gui-explorer-grid>
     </div>

--- a/src/gui/test/components/explorer-grid/dependency-sidebar/__snapshots__/filter.tsx.snap
+++ b/src/gui/test/components/explorer-grid/dependency-sidebar/__snapshots__/filter.tsx.snap
@@ -2,100 +2,111 @@
 
 exports[`filter-button renders default 1`] = `
 
-<gui-dropdown-menu open="false">
-  <gui-dropdown-menu-trigger aschild="true">
-    <gui-button
-      variant="outline"
-      classname="aspect-square size-6 bg-white p-0 transition-colors dark:bg-black [&amp;>svg]:size-4 [&amp;>svg]:shrink-0"
-    >
-      <gui-list-filter>
-      </gui-list-filter>
-    </gui-button>
-  </gui-dropdown-menu-trigger>
-  <gui-dropdown-menu-content
-    align="end"
-    classname="w-[240px]"
-  >
-    <div class="relative pb-1.5">
-      <div class="absolute left-[9px] z-[10] flex h-[30px] items-center justify-center">
-        <gui-search
-          classname="text-neutral-500"
-          size="14"
-        >
-        </gui-search>
-      </div>
-      <gui-input
-        value
-        classname="relative h-[30px] pl-[30px] pr-[70px] ring-transparent focus-visible:ring-0 focus-visible:ring-offset-0"
-        placeholder="Filter..."
+<gui-tooltip-provider>
+  <gui-tooltip delayduration="150">
+    <gui-dropdown-menu open="false">
+      <gui-tooltip-trigger aschild="true">
+        <gui-dropdown-menu-trigger aschild="true">
+          <gui-button
+            variant="outline"
+            classname="aspect-square size-6 bg-white p-0 transition-colors dark:bg-black [&amp;>svg]:size-4 [&amp;>svg]:shrink-0"
+          >
+            <gui-list-filter>
+            </gui-list-filter>
+          </gui-button>
+        </gui-dropdown-menu-trigger>
+      </gui-tooltip-trigger>
+      <gui-tooltip-portal>
+        <gui-tooltip-content>
+          Filter dependencies
+        </gui-tooltip-content>
+      </gui-tooltip-portal>
+      <gui-dropdown-menu-content
+        align="end"
+        classname="w-[240px]"
       >
-      </gui-input>
-      <div class="absolute bottom-[6px] right-[5px] flex h-[30px] cursor-default items-center justify-center">
-        <gui-kbd classname="inline-flex h-[20px] w-fit items-center justify-center gap-1 border-[1px] border-muted bg-white px-1 text-xxs dark:bg-black">
-          ctrl
-        </gui-kbd>
-        <gui-kbd classname="inline-flex h-[20px] w-fit items-center justify-center gap-1 border-[1px] border-muted bg-white px-1 text-xxs dark:bg-black">
-          F
-        </gui-kbd>
-      </div>
-    </div>
-    <div style="opacity: 0; filter: blur(2px);">
-      <gui-dropdown-menu-group>
-        <gui-dropdown-menu-sub>
-          <gui-dropdown-menu-sub-trigger>
-            <gui-circle-dot>
-            </gui-circle-dot>
-            Relationship
-          </gui-dropdown-menu-sub-trigger>
-          <gui-dropdown-menu-portal>
-            <gui-dropdown-menu-sub-content>
-              <gui-dropdown-menu-item
-                classname="gap-2"
-                tabindex="1"
-              >
-                <div class="size-2 rounded-full bg-cyan-500/25 text-cyan-600 border-[1px] border-cyan-600 dark:border-cyan-500 hover:bg-cyan-500/40 dark:bg-cyan-500/30 dark:text-cyan-500 dark:hover:bg-cyan-500/40">
-                </div>
-                prod
-              </gui-dropdown-menu-item>
-              <gui-dropdown-menu-item
-                classname="gap-2"
-                tabindex="2"
-              >
-                <div class="size-2 rounded-full bg-fuchsia-500/20 border-[1px] dark:border-fuchsia-400 border-fuchsia-500 text-fuchsia-500 hover:bg-fuchsia-400/30 dark:bg-fuchsia-500/30 dark:text-fuchsia-400 dark:hover:bg-fuchsia-500/40">
-                </div>
-                dev
-              </gui-dropdown-menu-item>
-              <gui-dropdown-menu-item
-                classname="gap-2"
-                tabindex="3"
-              >
-                <div class="size-2 rounded-full bg-lime-500/25 border-[1px] border-lime-600 dark:border-lime-400 text-lime-600 hover:bg-lime-400/40 dark:bg-lime-500/30 dark:text-lime-400 dark:hover:bg-lime-500/40">
-                </div>
-                peer
-              </gui-dropdown-menu-item>
-              <gui-dropdown-menu-item
-                classname="gap-2"
-                tabindex="4"
-              >
-                <div class="size-2 rounded-full bg-orange-500/20 border-[1px] border-orange-500 dark:border-orange-400 text-orange-500 hover:bg-orange-400/30 dark:bg-orange-500/30 dark:text-orange-400 dark:hover:bg-orange-500/40">
-                </div>
-                optional
-              </gui-dropdown-menu-item>
-              <gui-dropdown-menu-item
-                classname="gap-2"
-                tabindex="5"
-              >
-                <div class="size-2 rounded-full bg-yellow-500/25 border-[1px] border-yellow-600 dark:border-yellow-400 text-yellow-600 hover:bg-yellow-400/40 dark:bg-yellow-500/30 dark:text-yellow-400 dark:hover:bg-yellow-500/40">
-                </div>
-                peerOptional
-              </gui-dropdown-menu-item>
-            </gui-dropdown-menu-sub-content>
-          </gui-dropdown-menu-portal>
-        </gui-dropdown-menu-sub>
-      </gui-dropdown-menu-group>
-    </div>
-  </gui-dropdown-menu-content>
-</gui-dropdown-menu>
+        <div class="relative pb-1.5">
+          <div class="absolute left-[9px] z-[10] flex h-[30px] items-center justify-center">
+            <gui-search
+              classname="text-neutral-500"
+              size="14"
+            >
+            </gui-search>
+          </div>
+          <gui-input
+            value
+            classname="relative h-[30px] pl-[30px] pr-[70px] ring-transparent focus-visible:ring-0 focus-visible:ring-offset-0"
+            placeholder="Filter..."
+          >
+          </gui-input>
+          <div class="absolute bottom-[6px] right-[5px] flex h-[30px] cursor-default items-center justify-center">
+            <gui-kbd classname="inline-flex h-[20px] w-fit items-center justify-center gap-1 border-[1px] border-muted bg-white px-1 text-xxs dark:bg-black">
+              ctrl
+            </gui-kbd>
+            <gui-kbd classname="inline-flex h-[20px] w-fit items-center justify-center gap-1 border-[1px] border-muted bg-white px-1 text-xxs dark:bg-black">
+              F
+            </gui-kbd>
+          </div>
+        </div>
+        <div style="opacity: 0; filter: blur(2px);">
+          <gui-dropdown-menu-group>
+            <gui-dropdown-menu-sub>
+              <gui-dropdown-menu-sub-trigger>
+                <gui-circle-dot>
+                </gui-circle-dot>
+                Relationship
+              </gui-dropdown-menu-sub-trigger>
+              <gui-dropdown-menu-portal>
+                <gui-dropdown-menu-sub-content>
+                  <gui-dropdown-menu-item
+                    classname="gap-2"
+                    tabindex="1"
+                  >
+                    <div class="size-2 rounded-full bg-cyan-500/25 text-cyan-600 border-[1px] border-cyan-600 dark:border-cyan-500 hover:bg-cyan-500/40 dark:bg-cyan-500/30 dark:text-cyan-500 dark:hover:bg-cyan-500/40">
+                    </div>
+                    prod
+                  </gui-dropdown-menu-item>
+                  <gui-dropdown-menu-item
+                    classname="gap-2"
+                    tabindex="2"
+                  >
+                    <div class="size-2 rounded-full bg-fuchsia-500/20 border-[1px] dark:border-fuchsia-400 border-fuchsia-500 text-fuchsia-500 hover:bg-fuchsia-400/30 dark:bg-fuchsia-500/30 dark:text-fuchsia-400 dark:hover:bg-fuchsia-500/40">
+                    </div>
+                    dev
+                  </gui-dropdown-menu-item>
+                  <gui-dropdown-menu-item
+                    classname="gap-2"
+                    tabindex="3"
+                  >
+                    <div class="size-2 rounded-full bg-lime-500/25 border-[1px] border-lime-600 dark:border-lime-400 text-lime-600 hover:bg-lime-400/40 dark:bg-lime-500/30 dark:text-lime-400 dark:hover:bg-lime-500/40">
+                    </div>
+                    peer
+                  </gui-dropdown-menu-item>
+                  <gui-dropdown-menu-item
+                    classname="gap-2"
+                    tabindex="4"
+                  >
+                    <div class="size-2 rounded-full bg-orange-500/20 border-[1px] border-orange-500 dark:border-orange-400 text-orange-500 hover:bg-orange-400/30 dark:bg-orange-500/30 dark:text-orange-400 dark:hover:bg-orange-500/40">
+                    </div>
+                    optional
+                  </gui-dropdown-menu-item>
+                  <gui-dropdown-menu-item
+                    classname="gap-2"
+                    tabindex="5"
+                  >
+                    <div class="size-2 rounded-full bg-yellow-500/25 border-[1px] border-yellow-600 dark:border-yellow-400 text-yellow-600 hover:bg-yellow-400/40 dark:bg-yellow-500/30 dark:text-yellow-400 dark:hover:bg-yellow-500/40">
+                    </div>
+                    peerOptional
+                  </gui-dropdown-menu-item>
+                </gui-dropdown-menu-sub-content>
+              </gui-dropdown-menu-portal>
+            </gui-dropdown-menu-sub>
+          </gui-dropdown-menu-group>
+        </div>
+      </gui-dropdown-menu-content>
+    </gui-dropdown-menu>
+  </gui-tooltip>
+</gui-tooltip-provider>
 
 `;
 

--- a/src/gui/test/components/explorer-grid/dependency-sidebar/add-dependency.tsx
+++ b/src/gui/test/components/explorer-grid/dependency-sidebar/add-dependency.tsx
@@ -51,6 +51,7 @@ vi.mock('@/components/ui/tooltip.tsx', () => ({
   TooltipContent: 'gui-tooltip-content',
   TooltipProvider: 'gui-tooltip-provider',
   TooltipTrigger: 'gui-tooltip-trigger',
+  TooltipPortal: 'gui-tooltip-portal',
 }))
 
 vi.mock('@/components/ui/popover.tsx', () => ({

--- a/src/gui/test/components/explorer-grid/dependency-sidebar/filter.tsx
+++ b/src/gui/test/components/explorer-grid/dependency-sidebar/filter.tsx
@@ -59,6 +59,14 @@ vi.mock('@/components/ui/dropdown-menu.tsx', () => ({
   DropdownMenuSeparator: 'gui-dropdown-menu-separator',
 }))
 
+vi.mock('@/components/ui/tooltip.tsx', () => ({
+  TooltipProvider: 'gui-tooltip-provider',
+  Tooltip: 'gui-tooltip',
+  TooltipTrigger: 'gui-tooltip-trigger',
+  TooltipContent: 'gui-tooltip-content',
+  TooltipPortal: 'gui-tooltip-portal',
+}))
+
 vi.mock('@/components/ui/kbd.tsx', () => ({
   Kbd: 'gui-kbd',
 }))


### PR DESCRIPTION
| Before | After |
| --- | --- |
| <img width="100%" alt="Screenshot 2025-06-04 at 10 59 18" src="https://github.com/user-attachments/assets/23204ddb-8c46-4faf-8c63-eb1c03b097b6" /> | <img width="100%" alt="Screenshot 2025-06-04 at 12 54 19" src="https://github.com/user-attachments/assets/0dc42eec-484e-40bc-944f-a11bee4c21ba" /> |

This PR fixes the issue with the `sidebar`'s link tooltips incorrectly being rendered on the `explorer` view.

### Bug Explanation
When we updated the `query-bar` component to have an absolute position in order to stick to the top of the screen when scrolling, the z-indexes collided with tooltips in the gui which were rendered on the `explorer` view.

### Bug Fix
Exported a primitive `TooltipPortal` from `Radix` in `tooltip.tsx` and wrapped the `TooltipContent` with it. This allows the content to be rendered on the `document.body` instead of being constrained by the parent element's z-index.

### Other Changes
- updates styles on `explorer` view
- adds a `tooltip` to the `filter` button
