### PR TITLE
dss-breadcrumb: add specificity and sort

### DIFF
--- a/src/dss-breadcrumb/src/types.ts
+++ b/src/dss-breadcrumb/src/types.ts
@@ -1,4 +1,12 @@
 /**
+ * The specificity of a breadcrumb, used for sorting.
+ */
+export type BreadcrumbSpecificity = {
+  idCounter: number
+  commonCounter: number
+}
+
+/**
  * A valid item of a given breadcrumb.
  */
 export type ModifierBreadcrumbItem = {
@@ -21,6 +29,7 @@ export interface ModifierBreadcrumb
   first: ModifierBreadcrumbItem
   last: ModifierBreadcrumbItem
   single: boolean
+  specificity: BreadcrumbSpecificity
   interactive: () => ModifierInteractiveBreadcrumb
 }
 


### PR DESCRIPTION
Add tracking of `specificity` data to `Breadcrumb` instances and a new helper method `specificitySort` to the module that helps with defining which query should take precedence over others.

Refs: https://github.com/vltpkg/statusboard/issues/64