### PR TITLE
dep-id: fix double encoding in get id

### DIFF
--- a/src/dep-id/src/index.ts
+++ b/src/dep-id/src/index.ts
@@ -294,7 +294,7 @@ export const getTuple = (
         f.type,
         f.namedRegistry ?? reg,
         `${isPackageNameConfused(spec, mani.name) ? spec.name : (mani.name ?? f.name)}@${version}`,
-        encode(extra),
+        extra,
       ]
     }
     case 'git': {
@@ -316,17 +316,17 @@ export const getTuple = (
           f.type,
           `${namedGitHost}:${namedGitHostPath}`,
           gitSelector,
-          encode(extra),
+          extra,
         ]
       } else {
-        return [f.type, gitRemote, gitSelector, encode(extra)]
+        return [f.type, gitRemote, gitSelector, extra]
       }
     }
     case 'remote': {
       const { remoteURL } = f
       if (!remoteURL)
         throw error('no URL on remote specifier', { spec })
-      return [f.type, remoteURL, encode(extra)]
+      return [f.type, remoteURL, extra]
     }
     case 'file':
     case 'workspace':

--- a/src/dep-id/tap-snapshots/test/index.ts.test.cjs
+++ b/src/dep-id/tap-snapshots/test/index.ts.test.cjs
@@ -250,7 +250,7 @@ Array [
     "x@1.2.3",
     undefined,
   ],
-  "··x@1.2.3·deadbeef",
+  "··x@1.2.3·%3Aroot%20%3E%20%23extra",
 ]
 `
 
@@ -279,7 +279,7 @@ Array [
     "x@1.2.3",
     undefined,
   ],
-  "··x@1.2.3·deadbeef",
+  "··x@1.2.3·%3Aroot%20%3E%20%23extra",
 ]
 `
 
@@ -308,7 +308,7 @@ Array [
     "manifest-name@1.2.3",
     undefined,
   ],
-  "·a·manifest-name@1.2.3·deadbeef",
+  "·a·manifest-name@1.2.3·%3Aroot%20%3E%20%23extra",
 ]
 `
 
@@ -337,7 +337,7 @@ Array [
     "manifest-name@1.2.3",
     undefined,
   ],
-  "·b·manifest-name@1.2.3·deadbeef",
+  "·b·manifest-name@1.2.3·%3Aroot%20%3E%20%23extra",
 ]
 `
 
@@ -366,7 +366,7 @@ Array [
     "",
     undefined,
   ],
-  "git·git%2Bssh%3A§§host.com§x.git··deadbeef",
+  "git·git%2Bssh%3A§§host.com§x.git··%3Aroot%20%3E%20%23extra",
 ]
 `
 
@@ -395,7 +395,7 @@ Array [
     "branch",
     undefined,
   ],
-  "git·git%2Bssh%3A§§host.com§x.git·branch·deadbeef",
+  "git·git%2Bssh%3A§§host.com§x.git·branch·%3Aroot%20%3E%20%23extra",
 ]
 `
 
@@ -424,7 +424,7 @@ Array [
     "semver:1",
     undefined,
   ],
-  "git·git%2Bssh%3A§§host.com§x.git·semver%3A1·deadbeef",
+  "git·git%2Bssh%3A§§host.com§x.git·semver%3A1·%3Aroot%20%3E%20%23extra",
 ]
 `
 
@@ -453,7 +453,7 @@ Array [
     "",
     undefined,
   ],
-  "git·github%3Aa§b··deadbeef",
+  "git·github%3Aa§b··%3Aroot%20%3E%20%23extra",
 ]
 `
 
@@ -482,7 +482,7 @@ Array [
     "branch",
     undefined,
   ],
-  "git·github%3Aa§b·branch·deadbeef",
+  "git·github%3Aa§b·branch·%3Aroot%20%3E%20%23extra",
 ]
 `
 
@@ -511,7 +511,7 @@ Array [
     "semver:1",
     undefined,
   ],
-  "git·github%3Aa§b·semver%3A1·deadbeef",
+  "git·github%3Aa§b·semver%3A1·%3Aroot%20%3E%20%23extra",
 ]
 `
 
@@ -539,7 +539,7 @@ Array [
     "https://x.com/x.tgz",
     undefined,
   ],
-  "remote·https%3A§§x.com§x.tgz·deadbeef",
+  "remote·https%3A§§x.com§x.tgz·%3Aroot%20%3E%20%23extra",
 ]
 `
 
@@ -568,7 +568,7 @@ Array [
     "manifest-name@1.2.3",
     undefined,
   ],
-  "·a·manifest-name@1.2.3·deadbeef",
+  "·a·manifest-name@1.2.3·%3Aroot%20%3E%20%23extra",
 ]
 `
 
@@ -597,7 +597,7 @@ Array [
     "manifest-name@1.2.3",
     undefined,
   ],
-  "·b·manifest-name@1.2.3·deadbeef",
+  "·b·manifest-name@1.2.3·%3Aroot%20%3E%20%23extra",
 ]
 `
 
@@ -626,7 +626,7 @@ Array [
     "manifest-name@1.2.3",
     undefined,
   ],
-  "·https%3A§§c.example.com§·manifest-name@1.2.3·deadbeef",
+  "·https%3A§§c.example.com§·manifest-name@1.2.3·%3Aroot%20%3E%20%23extra",
 ]
 `
 
@@ -655,7 +655,7 @@ Array [
     "y@1.2.3",
     undefined,
   ],
-  "··y@1.2.3·deadbeef",
+  "··y@1.2.3·%3Aroot%20%3E%20%23extra",
 ]
 `
 
@@ -712,7 +712,7 @@ Array [
     "manifest-name@1.2.3",
     undefined,
   ],
-  "·npm·manifest-name@1.2.3·deadbeef",
+  "·npm·manifest-name@1.2.3·%3Aroot%20%3E%20%23extra",
 ]
 `
 
@@ -741,7 +741,7 @@ Array [
     "manifest-name@1.2.3",
     undefined,
   ],
-  "·npm·manifest-name@1.2.3·deadbeef",
+  "·npm·manifest-name@1.2.3·%3Aroot%20%3E%20%23extra",
 ]
 `
 
@@ -770,7 +770,7 @@ Array [
     "branch",
     undefined,
   ],
-  "git·github%3Aa§b·branch·deadbeef",
+  "git·github%3Aa§b·branch·%3Aroot%20%3E%20%23extra",
 ]
 `
 
@@ -799,7 +799,7 @@ Array [
     "manifest-name@1.2.3",
     undefined,
   ],
-  "··manifest-name@1.2.3·deadbeef",
+  "··manifest-name@1.2.3·%3Aroot%20%3E%20%23extra",
 ]
 `
 
@@ -828,7 +828,7 @@ Array [
     "manifest-name@1.2.3",
     undefined,
   ],
-  "··manifest-name@1.2.3·deadbeef",
+  "··manifest-name@1.2.3·%3Aroot%20%3E%20%23extra",
 ]
 `
 
@@ -857,6 +857,6 @@ Array [
     "manifest-name@1.2.3",
     undefined,
   ],
-  "·https%3A§§x.com§·manifest-name@1.2.3·deadbeef",
+  "·https%3A§§x.com§·manifest-name@1.2.3·%3Aroot%20%3E%20%23extra",
 ]
 `

--- a/src/dep-id/test/index.ts
+++ b/src/dep-id/test/index.ts
@@ -50,7 +50,7 @@ t.test('valid specs', t => {
       const spec = Spec.parse(s, { registries })
       const tuple = getTuple(spec, mani)
       const id = getId(spec, mani)
-      const idWithExtra = getId(spec, mani, 'deadbeef')
+      const idWithExtra = getId(spec, mani, ':root > #extra')
       t.matchSnapshot([id, tuple, idWithExtra])
       t.equal(joinDepIDTuple(tuple), id)
       t.strictSame(splitDepID(id), tuple)


### PR DESCRIPTION
Encode should happen only during at `joinDepIDTuple` time and not on `getTuple`. This was causing DepIDs generated with `getId` to be double encoded.

Fixes the issue and update the test fixtures and snapshots to use characters that actually need escaping.

Refs: https://github.com/vltpkg/statusboard/issues/64