### PR TITLE
pick-manifest: fix specs vs ranges confusion

### DIFF
--- a/src/pick-manifest/src/index.ts
+++ b/src/pick-manifest/src/index.ts
@@ -1,6 +1,13 @@
 import { error } from '@vltpkg/error-cause'
-import { parse, Range, satisfies, Version } from '@vltpkg/semver'
+import {
+  parse,
+  Range,
+  satisfies,
+  Version,
+  isRange,
+} from '@vltpkg/semver'
 import { Spec } from '@vltpkg/spec'
+import { isSpec } from '@vltpkg/spec/browser'
 import type {
   Manifest,
   Packument,
@@ -142,11 +149,11 @@ export function pickManifest<T extends Packumentish>(
   let range: Range | undefined = undefined
   let spec: Spec | undefined = undefined
   if (typeof wanted === 'object') {
-    if (wanted instanceof Spec) {
+    if (isSpec(wanted)) {
       const f = wanted.final
       range = f.range
       spec = f
-    } else {
+    } else if (isRange(wanted)) {
       range = wanted
     }
   } else {


### PR DESCRIPTION
When handling modifiers `@vltpkg/pick-manifest` gets confused about the object type being handled to it. This fixes the issue by using the more explicit type guard helper methods for both types.

Refs: https://github.com/vltpkg/statusboard/issues/64