### PR TITLE
gui: fix infinite loop when closing save queries popover

### DIFF
--- a/src/gui/src/components/explorer-grid/save-query.tsx
+++ b/src/gui/src/components/explorer-grid/save-query.tsx
@@ -208,17 +208,15 @@ const SaveQueryPopover = ({
         updateQuery(item)
       }
     }
-    // queryName and selectedLabels are updated in the useEffect below so including them causes an infinite loop
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- causes infinite loop
   }, [
     isOpen,
     activeQuery,
     nodes,
-    savedQueries,
     updateQuery,
     editContext,
-    // queryName,
-    // selectedLabels,
+    queryName,
+    selectedLabels,
   ])
 
   /**


### PR DESCRIPTION
This was caused by effect deps added during e4ecea1. Removing the dep is a stop-gap
and there should be a more React-ish way of fixing this, but I couldn't figure it out
