### PR TITLE
dss-breadcrumb: add support to  `:semver` & `:v` selectors 

### DIFF
--- a/src/dss-breadcrumb/src/index.ts
+++ b/src/dss-breadcrumb/src/index.ts
@@ -4,19 +4,150 @@ import {
   isIdentifierNode,
   isCombinatorNode,
   isCommentNode,
+  isStringNode,
+  isTagNode,
+  asStringNode,
+  asTagNode,
   parse,
+  asPostcssNodeWithChildren,
 } from '@vltpkg/dss-parser'
+import type { PostcssNode } from '@vltpkg/dss-parser'
 import { error } from '@vltpkg/error-cause'
+import { satisfies } from '@vltpkg/semver'
 import type {
   ModifierBreadcrumb,
   ModifierBreadcrumbItem,
   ModifierInteractiveBreadcrumb,
   BreadcrumbSpecificity,
+  ModifierComparatorOptions,
+  InternalModifierComparatorOptions,
 } from './types.ts'
 
 export * from './types.ts'
 
+/**
+ * The returned pseudo selector parameters object.
+ */
+type ParsedPseudoParameters = {
+  semverValue?: string
+}
+
+/**
+ * The higher level function for pseudo selectors comparators.
+ */
+type PseudoSelectorsComparatorFn = (
+  internal: InternalModifierComparatorOptions,
+) => (opts: ModifierComparatorOptions) => boolean
+
+/**
+ * A comparator function that always returns true.
+ */
+const passthroughComparator = () => () => true
+
+/**
+ * A comparator function for semver pseudo selectors.
+ */
+const semverComparator =
+  ({ range }: InternalModifierComparatorOptions) =>
+  ({ version }: ModifierComparatorOptions) => {
+    if (range && version) {
+      return satisfies(version, range)
+    }
+    return false
+  }
+
+/**
+ * A map of pseudo selectors to their comparator functions.
+ */
+const pseudoSelectors = new Map<string, PseudoSelectorsComparatorFn>([
+  [':semver', semverComparator],
+  [':v', semverComparator],
+])
+
+/**
+ * The subset of importer pseudo selectors that are supported.
+ */
 const importerNames = new Set([':project', ':workspace', ':root'])
+
+// Add importer pseudo selectors to the list of supported selectors
+for (const importerName of importerNames) {
+  pseudoSelectors.set(importerName, passthroughComparator)
+}
+
+/**
+ * Helper function to remove quotes from a string value.
+ */
+export const removeQuotes = (value: string) =>
+  value.replace(/^"(.*?)"$/, '$1')
+
+/**
+ * Helper function to extract parameter value from pseudo selector nodes.
+ */
+export const extractPseudoParameter = (
+  item: any,
+): ParsedPseudoParameters => {
+  if (!isPostcssNodeWithChildren(item) || !item.nodes[0]) {
+    return {}
+  }
+
+  let first
+  try {
+    // Try to parse as string node first (quoted values)
+    const firstNode = asPostcssNodeWithChildren(item.nodes[0])
+      .nodes[0]
+
+    if (isStringNode(firstNode)) {
+      first = removeQuotes(firstNode.value)
+    }
+
+    // Handle tag node (unquoted values)
+    if (isTagNode(firstNode)) {
+      first = asTagNode(firstNode).value
+    }
+  } catch {}
+
+  if (item.value === ':semver' || item.value === ':v') {
+    return {
+      semverValue: first,
+    }
+  }
+
+  return {}
+}
+
+/**
+ * Helper function to get the full text representation
+ * of a pseudo selector including parameters
+ */
+export const getPseudoSelectorFullText = (
+  item: PostcssNode,
+): string => {
+  if (!isPostcssNodeWithChildren(item) || !item.nodes[0]) {
+    return item.value || ''
+  }
+
+  const baseValue = item.value
+  const paramNode = item.nodes[0]
+
+  let paramText = ''
+
+  if (isPostcssNodeWithChildren(paramNode)) {
+    // reconstruct the parameter by combining all child nodes
+    paramText = paramNode.nodes
+      .map(node => {
+        if (isStringNode(node)) {
+          return asStringNode(node).value
+        } else if (isTagNode(node)) {
+          return asTagNode(node).value
+        } else {
+          return node.value
+        }
+      })
+      .join('')
+  }
+
+  return `${baseValue}(${paramText})`
+}
 
 /**
  * The Breadcrumb class is used to represent a valid breadcrumb
@@ -43,6 +174,7 @@ export class Breadcrumb implements ModifierBreadcrumb {
   /**
    * Initializes the interactive breadcrumb with a query string.
    */
+
   constructor(query: string) {
     this.#items = []
     this.specificity = { idCounter: 0, commonCounter: 0 }
@@ -51,10 +183,18 @@ export class Breadcrumb implements ModifierBreadcrumb {
     // Track whether we encountered a combinator since the last item
     let afterCombinator = true
 
-    // iterates only at the first level of the AST since
-    // any nested nodes are invalid syntax
+    // iterates only at the first level of the AST since any
+    // pseudo selectors that relies on nested nodes are invalid syntax
     for (const item of ast.first.nodes) {
       const pseudoNode = isPseudoNode(item)
+
+      // checks for only supported pseudo selectors
+      if (pseudoNode && !pseudoSelectors.has(item.value)) {
+        throw error('Invalid pseudo selector', {
+          found: item.value,
+        })
+      }
+
       const allowedTypes =
         isIdentifierNode(item) ||
         pseudoNode ||
@@ -62,10 +202,14 @@ export class Breadcrumb implements ModifierBreadcrumb {
         isCommentNode(item)
       const hasChildren =
         isPostcssNodeWithChildren(item) && item.nodes.length > 0
+      const semverNode =
+        pseudoNode &&
+        (item.value === ':semver' || item.value === ':v')
 
       // validation, only pseudo selectors, id selectors
       // and combinators are valid ast node items
-      if (hasChildren || !allowedTypes) {
+      // pseudo selectors are allowed to have children (parameters)
+      if ((hasChildren && !pseudoNode) || !allowedTypes) {
         throw error('Invalid query', { found: query })
       }
 
@@ -89,6 +233,23 @@ export class Breadcrumb implements ModifierBreadcrumb {
             this.#items[this.#items.length - 1]
           : undefined
 
+        // Extract parameter before potential consolidation
+        const providedRange: string =
+          (
+            pseudoNode &&
+            (item.value === ':semver' || item.value === ':v')
+          ) ?
+            (extractPseudoParameter(item).semverValue ?? '')
+          : ''
+
+        // get the comparator function for a given pseudo selector item
+        const internalOptions: InternalModifierComparatorOptions = {
+          ...(semverNode ? { range: providedRange } : {}),
+        }
+        const comparator = (
+          pseudoSelectors.get(item.value) ?? passthroughComparator
+        )(internalOptions)
+
         // If we have a previous item and we haven't encountered a combinator
         // since then, consolidate with the previous item
         if (lastItem && !afterCombinator) {
@@ -98,8 +259,12 @@ export class Breadcrumb implements ModifierBreadcrumb {
           }
 
           // determine how to combine the values based on selector types
-          const currentValue =
-            item.type === 'id' ? `#${item.value}` : item.value
+          let currentValue: string = item.value
+          if (item.type === 'id') {
+            currentValue = `#${item.value}`
+          } else if (pseudoNode) {
+            currentValue = getPseudoSelectorFullText(item)
+          }
           lastItem.value = `${lastItem.value}${currentValue}`
 
           // if current item is an ID, update the name property
@@ -107,8 +272,11 @@ export class Breadcrumb implements ModifierBreadcrumb {
             lastItem.name = item.value
           }
 
-          // mark item as importer if it's an importer pseudo node
+          // Handle comparator and importer when consolidating with pseudo node
           if (pseudoNode) {
+            const lastItemComparator = lastItem.comparator
+            lastItem.comparator = (opts: ModifierComparatorOptions) =>
+              comparator(opts) && lastItemComparator(opts)
             lastItem.importer ||= importerNames.has(item.value)
           }
 
@@ -124,8 +292,16 @@ export class Breadcrumb implements ModifierBreadcrumb {
         }
 
         // Create a new breadcrumb item
+        let itemValue: string = item.value
+        if (item.type === 'id') {
+          itemValue = `#${item.value}`
+        } else if (pseudoNode) {
+          itemValue = getPseudoSelectorFullText(item)
+        }
+
         const newItem = {
-          value: item.type === 'id' ? `#${item.value}` : item.value,
+          comparator,
+          value: itemValue,
           name: item.type === 'id' ? item.value : undefined,
           type: item.type,
           prev: lastItem,

--- a/src/dss-breadcrumb/src/types.ts
+++ b/src/dss-breadcrumb/src/types.ts
@@ -7,9 +7,24 @@ export type BreadcrumbSpecificity = {
 }
 
 /**
+ * Options for the higher-level comparing breadcrumbs function.
+ */
+export type InternalModifierComparatorOptions = {
+  range?: string
+}
+
+/**
+ * Options for comparing breadcrumbs.
+ */
+export type ModifierComparatorOptions = {
+  version?: string
+}
+
+/**
  * A valid item of a given breadcrumb.
  */
 export type ModifierBreadcrumbItem = {
+  comparator: (opts: ModifierComparatorOptions) => boolean
   name?: string
   value: string
   type: string

--- a/src/dss-breadcrumb/test/index.ts
+++ b/src/dss-breadcrumb/test/index.ts
@@ -3,6 +3,9 @@ import {
   parseBreadcrumb,
   InteractiveBreadcrumb,
   specificitySort,
+  extractPseudoParameter,
+  getPseudoSelectorFullText,
+  removeQuotes,
 } from '../src/index.ts'
 
 t.test('Breadcrumb', async t => {
@@ -36,14 +39,29 @@ t.test('Breadcrumb', async t => {
 
     t.throws(
       () => parseBreadcrumb(':root:prod'),
-      /Invalid query/,
+      /Invalid pseudo selector/,
       'should throw on chained pseudo selectors',
     )
 
+    // Test invalid pseudo selector (not in supported list)
     t.throws(
-      () => parseBreadcrumb(':has(#a)'),
+      () => parseBreadcrumb(':unknown'),
+      /Invalid pseudo selector/,
+      'should throw on unsupported pseudo selector',
+    )
+
+    // Test chained pseudo selectors during consolidation
+    t.throws(
+      () => parseBreadcrumb(':root:workspace'),
       /Invalid query/,
-      'should throw on nested selector',
+      'should throw on chained pseudo selectors during consolidation',
+    )
+
+    const semverBreadcrumb = parseBreadcrumb(':semver(1)')
+    t.equal(
+      semverBreadcrumb.first.value,
+      ':semver(1)',
+      'should accept :semver pseudo selector with parameter',
     )
   })
 
@@ -91,32 +109,8 @@ t.test('Breadcrumb', async t => {
   })
 
   await t.test('pseudo selector support', async t => {
-    // Test that any pseudo selector starting with : is now valid
-    const fooBreadcrumb = parseBreadcrumb(':foo')
-    t.equal(
-      fooBreadcrumb.first.value,
-      ':foo',
-      'should accept :foo pseudo selector',
-    )
-    t.equal(
-      fooBreadcrumb.first.type,
-      'pseudo',
-      ':foo should have type "pseudo"',
-    )
-    t.equal(
-      fooBreadcrumb.first.importer,
-      false,
-      ':foo should have importer=false',
-    )
-
     // Test other custom pseudo selectors
-    const customPseudos = [
-      ':custom',
-      ':dev',
-      ':prod',
-      ':staging',
-      ':test',
-    ]
+    const customPseudos = [':semver', ':v']
     for (const pseudo of customPseudos) {
       const breadcrumb = parseBreadcrumb(pseudo)
       t.equal(
@@ -136,12 +130,11 @@ t.test('Breadcrumb', async t => {
       )
     }
 
-    // Test pseudo selectors in complex queries
-    const complexPseudo = parseBreadcrumb(':custom > #a > #b')
+    const complexPseudo = parseBreadcrumb(':project > #a > #b')
     t.equal(
       complexPseudo.first.value,
-      ':custom',
-      'should handle :custom in complex query',
+      ':project',
+      'should handle :project in complex query',
     )
     t.equal(
       complexPseudo.last.value,
@@ -150,34 +143,34 @@ t.test('Breadcrumb', async t => {
     )
 
     // Test pseudo selector consolidation with custom pseudo
-    const customIdBreadcrumb = parseBreadcrumb(':custom#a')
+    const customIdBreadcrumb = parseBreadcrumb(':project#a')
     t.equal(
       customIdBreadcrumb.first.value,
-      ':custom#a',
-      'should consolidate :custom and ID into a single item',
+      ':project#a',
+      'should consolidate :project and ID into a single item',
     )
     t.equal(
       customIdBreadcrumb.first.type,
       'pseudo',
-      'consolidated custom pseudo item should maintain pseudo type',
+      'consolidated project pseudo item should maintain pseudo type',
     )
     t.equal(
       customIdBreadcrumb.first.importer,
-      false,
-      'consolidated :custom#id should have importer=false',
+      true,
+      'consolidated :project#id should have importer=true',
     )
     t.equal(
       customIdBreadcrumb.first.name,
       'a',
-      'consolidated :custom#id should have name="a"',
+      'consolidated :project#id should have name="a"',
     )
 
     // Test ID + custom pseudo consolidation
-    const idCustomBreadcrumb = parseBreadcrumb('#a:custom')
+    const idCustomBreadcrumb = parseBreadcrumb('#a:workspace')
     t.equal(
       idCustomBreadcrumb.first.value,
-      '#a:custom',
-      'should consolidate ID and :custom into a single item',
+      '#a:workspace',
+      'should consolidate ID and :workspace into a single item',
     )
     t.equal(
       idCustomBreadcrumb.first.type,
@@ -186,14 +179,420 @@ t.test('Breadcrumb', async t => {
     )
     t.equal(
       idCustomBreadcrumb.first.importer,
-      false,
-      'consolidated id:custom should have importer=false',
+      true,
+      'consolidated id:workspace should have importer=true',
     )
     t.equal(
       idCustomBreadcrumb.first.name,
       'a',
-      'consolidated id:custom should have name="a"',
+      'consolidated id:workspace should have name="a"',
     )
+  })
+
+  await t.test('semver selector support', async t => {
+    // Test basic semver selector without parameters
+    const semverBreadcrumb = parseBreadcrumb(':semver')
+    t.equal(
+      semverBreadcrumb.first.value,
+      ':semver',
+      'should accept :semver pseudo selector',
+    )
+    t.equal(
+      semverBreadcrumb.first.type,
+      'pseudo',
+      ':semver should have type "pseudo"',
+    )
+    t.equal(
+      semverBreadcrumb.first.importer,
+      false,
+      ':semver should have importer=false',
+    )
+
+    // Test :v alias
+    const vBreadcrumb = parseBreadcrumb(':v')
+    t.equal(
+      vBreadcrumb.first.value,
+      ':v',
+      'should accept :v pseudo selector',
+    )
+
+    // Test semver comparator with no version provided
+    t.equal(
+      semverBreadcrumb.first.comparator({}),
+      false,
+      'comparator should return false when no version is provided',
+    )
+
+    // Test semver comparator without range parameter (should return false when no range)
+    t.equal(
+      semverBreadcrumb.first.comparator({ version: '1.0.0' }),
+      false,
+      'comparator should return false when no range parameter is provided',
+    )
+
+    // Test comparator functionality
+    const customBreadcrumb = parseBreadcrumb(':workspace')
+    t.equal(
+      customBreadcrumb.first.comparator({}),
+      true,
+      'non-semver selector comparator should return true',
+    )
+    t.equal(
+      customBreadcrumb.first.comparator({ version: '1.0.0' }),
+      true,
+      'non-semver selector comparator should return true even with version',
+    )
+
+    // Test semver selectors in complex queries
+    const complexSemver = parseBreadcrumb(':semver > #a > #b')
+    t.equal(
+      complexSemver.first.value,
+      ':semver',
+      'should handle :semver in complex query',
+    )
+    t.equal(
+      complexSemver.last.value,
+      '#b',
+      'should handle rest of complex query with semver',
+    )
+
+    // Test semver selector consolidation with ID
+    const semverIdBreadcrumb = parseBreadcrumb(':semver#test')
+    t.equal(
+      semverIdBreadcrumb.first.value,
+      ':semver#test',
+      'should consolidate :semver and ID into a single item',
+    )
+    t.equal(
+      semverIdBreadcrumb.first.type,
+      'pseudo',
+      'consolidated semver item should maintain pseudo type',
+    )
+    t.equal(
+      semverIdBreadcrumb.first.importer,
+      false,
+      'consolidated :semver#id should have importer=false',
+    )
+    t.equal(
+      semverIdBreadcrumb.first.name,
+      'test',
+      'consolidated :semver#id should have name="test"',
+    )
+
+    // Test ID + semver consolidation
+    const idSemverBreadcrumb = parseBreadcrumb('#test:v')
+    t.equal(
+      idSemverBreadcrumb.first.value,
+      '#test:v',
+      'should consolidate ID and :v into a single item',
+    )
+    t.equal(
+      idSemverBreadcrumb.first.type,
+      'id',
+      'consolidated item should maintain ID type',
+    )
+    t.equal(
+      idSemverBreadcrumb.first.importer,
+      false,
+      'consolidated id:v should have importer=false',
+    )
+    t.equal(
+      idSemverBreadcrumb.first.name,
+      'test',
+      'consolidated id:v should have name="test"',
+    )
+
+    // Test semver selectors with actual parameters
+    await t.test('semver with range parameters', async t => {
+      // Test case 1: #foo > #bar:semver(^1.0.0)
+      const breadcrumb1 = parseBreadcrumb(
+        '#foo > #bar:semver(^1.0.0)',
+      )
+      const lastItem1 = breadcrumb1.last
+
+      t.equal(
+        lastItem1.value,
+        '#bar:semver(^1.0.0)',
+        'should parse consolidated selector with semver parameter',
+      )
+      t.equal(
+        lastItem1.type,
+        'id',
+        'consolidated item should maintain ID type',
+      )
+      t.equal(lastItem1.name, 'bar', 'should extract correct name')
+
+      // Test comparator with versions that should match ^1.0.0
+      t.equal(
+        lastItem1.comparator({ version: '1.0.0' }),
+        true,
+        'should match 1.0.0 for ^1.0.0 range',
+      )
+      t.equal(
+        lastItem1.comparator({ version: '1.2.3' }),
+        true,
+        'should match 1.2.3 for ^1.0.0 range',
+      )
+      t.equal(
+        lastItem1.comparator({ version: '2.0.0' }),
+        false,
+        'should not match 2.0.0 for ^1.0.0 range',
+      )
+
+      // Test case 2: :root > #foo:semver(">=2")
+      const breadcrumb2 = parseBreadcrumb(
+        ':root > #foo:semver(">=2")',
+      )
+      const lastItem2 = breadcrumb2.last
+
+      t.equal(
+        lastItem2.value,
+        '#foo:semver(">=2")',
+        'should parse quoted parameter',
+      )
+      t.equal(
+        lastItem2.type,
+        'id',
+        'consolidated item should maintain ID type',
+      )
+      t.equal(lastItem2.name, 'foo', 'should extract correct name')
+
+      // Test comparator with versions for >=2 range
+      t.equal(
+        lastItem2.comparator({ version: '2.0.0' }),
+        true,
+        'should match 2.0.0 for >=2 range',
+      )
+      t.equal(
+        lastItem2.comparator({ version: '3.3.3' }),
+        true,
+        'should match 3.3.3 for >=2 range',
+      )
+      t.equal(
+        lastItem2.comparator({ version: '1.0.0' }),
+        false,
+        'should not match 1.0.0 for >=2 range',
+      )
+
+      // Test case 3: #bar:v(1) > #baz > #lorem:semver("~2.0.0")
+      const breadcrumb3 = parseBreadcrumb(
+        '#bar:v(1) > #baz > #lorem:semver("~2.0.0")',
+      )
+      const firstItem3 = breadcrumb3.first
+      const lastItem3 = breadcrumb3.last
+
+      // Test first item with :v(1)
+      t.equal(
+        firstItem3.value,
+        '#bar:v(1)',
+        'should parse :v selector with parameter',
+      )
+      t.equal(
+        firstItem3.type,
+        'id',
+        'first item should maintain ID type',
+      )
+      t.equal(
+        firstItem3.name,
+        'bar',
+        'should extract correct name from first item',
+      )
+
+      // Test comparator for first item with version 1
+      t.equal(
+        firstItem3.comparator({ version: '1.0.0' }),
+        true,
+        'should match 1.0.0 for version 1',
+      )
+      t.equal(
+        firstItem3.comparator({ version: '1.2.3' }),
+        true,
+        'should match 1.2.3 for version 1',
+      )
+      t.equal(
+        firstItem3.comparator({ version: '2.0.0' }),
+        false,
+        'should not match 2.0.0 for version 1',
+      )
+      t.equal(
+        firstItem3.comparator({ version: '0.0.1' }),
+        false,
+        'should not match 0.0.1 for version 1',
+      )
+
+      // Test last item with :semver("~2.0.0")
+      t.equal(
+        lastItem3.value,
+        '#lorem:semver("~2.0.0")',
+        'should parse last item with quoted semver parameter',
+      )
+      t.equal(
+        lastItem3.type,
+        'id',
+        'last item should maintain ID type',
+      )
+      t.equal(
+        lastItem3.name,
+        'lorem',
+        'should extract correct name from last item',
+      )
+
+      // Test comparator for last item with ~2.0.0 range
+      t.equal(
+        lastItem3.comparator({ version: '2.0.0' }),
+        true,
+        'should match 2.0.0 for ~2.0.0 range',
+      )
+      t.equal(
+        lastItem3.comparator({ version: '2.0.5' }),
+        true,
+        'should match 2.0.5 for ~2.0.0 range',
+      )
+      t.equal(
+        lastItem3.comparator({ version: '2.2.2' }),
+        false,
+        'should not match 2.2.2 for ~2.0.0 range (minor bump)',
+      )
+      t.equal(
+        lastItem3.comparator({ version: '1.0.0' }),
+        false,
+        'should not match 1.0.0 for ~2.0.0 range',
+      )
+      t.equal(
+        lastItem3.comparator({ version: '3.0.0' }),
+        false,
+        'should not match 3.0.0 for ~2.0.0 range',
+      )
+
+      // Test middle item (should have default comparator)
+      const middleItem3 = [...breadcrumb3][1]
+      t.equal(
+        middleItem3!.value,
+        '#baz',
+        'middle item should be parsed correctly',
+      )
+      t.equal(
+        middleItem3!.comparator({ version: '1.0.0' }),
+        true,
+        'middle item should have default comparator returning true',
+      )
+    })
+
+    // Test edge cases for semver parameters
+    await t.test('semver parameter edge cases', async t => {
+      // Test unquoted parameter
+      const breadcrumb1 = parseBreadcrumb(':semver(>=1.0.0)')
+      t.equal(
+        breadcrumb1.first.value,
+        ':semver(>=1.0.0)',
+        'should handle unquoted parameter',
+      )
+      t.equal(
+        breadcrumb1.first.comparator({ version: '1.5.0' }),
+        true,
+        'should work with unquoted parameter',
+      )
+      t.equal(
+        breadcrumb1.first.comparator({ version: '0.9.0' }),
+        false,
+        'should correctly reject with unquoted parameter',
+      )
+
+      // Test parameter with spaces (quoted)
+      const breadcrumb2 = parseBreadcrumb(':semver(" >= 2.0.0 ")')
+      t.equal(
+        breadcrumb2.first.value,
+        ':semver(" >= 2.0.0 ")',
+        'should handle parameter with spaces',
+      )
+      t.equal(
+        breadcrumb2.first.comparator({ version: '2.1.0' }),
+        true,
+        'should work with spaced parameter',
+      )
+
+      // Test complex range
+      const breadcrumb3 = parseBreadcrumb('#test:v("1.0.0 - 2.0.0")')
+      t.equal(
+        breadcrumb3.first.value,
+        '#test:v("1.0.0 - 2.0.0")',
+        'should handle range parameter',
+      )
+      t.equal(
+        breadcrumb3.first.comparator({ version: '1.5.0' }),
+        true,
+        'should match version in range',
+      )
+      t.equal(
+        breadcrumb3.first.comparator({ version: '2.5.0' }),
+        false,
+        'should not match version outside range',
+      )
+    })
+
+    // Test chained semver selectors
+    await t.test('chained semver selectors', async t => {
+      // Test case: #bar:semver(">1"):semver("<=2.5.0")
+      // This should match versions that are both >1 AND <=2.5.0
+      const chainedBreadcrumb = parseBreadcrumb(
+        '#bar:semver(">1"):semver("<=2.5.0")',
+      )
+
+      t.equal(
+        chainedBreadcrumb.first.value,
+        '#bar:semver(">1"):semver("<=2.5.0")',
+        'should parse chained semver selectors correctly',
+      )
+      t.equal(
+        chainedBreadcrumb.first.type,
+        'id',
+        'chained item should maintain ID type',
+      )
+      t.equal(
+        chainedBreadcrumb.first.name,
+        'bar',
+        'chained item should have correct name',
+      )
+
+      // Test version combinations with AND logic
+      t.equal(
+        chainedBreadcrumb.first.comparator({ version: '1.2.3' }),
+        false,
+        'should reject 1.2.3 (not > 1)',
+      )
+      t.equal(
+        chainedBreadcrumb.first.comparator({ version: '3.0.0' }),
+        false,
+        'should reject 3.0.0 (not <= 2.5.0)',
+      )
+      t.equal(
+        chainedBreadcrumb.first.comparator({ version: '2.0.0' }),
+        true,
+        'should accept 2.0.0 (> 1 AND <= 2.5.0)',
+      )
+      t.equal(
+        chainedBreadcrumb.first.comparator({ version: '2.4.9' }),
+        true,
+        'should accept 2.4.9 (> 1 AND <= 2.5.0)',
+      )
+      t.equal(
+        chainedBreadcrumb.first.comparator({ version: '2.6.0' }),
+        false,
+        'should reject 2.6.0 (not <= 2.5.0)',
+      )
+
+      // Test edge case: version exactly at boundary
+      t.equal(
+        chainedBreadcrumb.first.comparator({ version: '1.0.0' }),
+        false,
+        'should reject 1.0.0 (not > 1)',
+      )
+      t.equal(
+        chainedBreadcrumb.first.comparator({ version: '2.5.0' }),
+        true,
+        'should accept 2.5.0 (> 1 AND <= 2.5.0)',
+      )
+    })
   })
 
   await t.test('last getter', async t => {
@@ -445,7 +844,7 @@ t.test('Breadcrumb', async t => {
     )
 
     // Test custom pseudo selector specificity
-    const customBreadcrumb = parseBreadcrumb(':custom')
+    const customBreadcrumb = parseBreadcrumb(':semver(*)')
     t.equal(
       customBreadcrumb.specificity.idCounter,
       0,
@@ -459,7 +858,7 @@ t.test('Breadcrumb', async t => {
 
     // Test complex custom pseudo selector
     const complexCustomBreadcrumb = parseBreadcrumb(
-      ':custom > #a > #b:dev',
+      ':root > #a > #b:semver(1)',
     )
     t.equal(
       complexCustomBreadcrumb.specificity.idCounter,
@@ -471,6 +870,40 @@ t.test('Breadcrumb', async t => {
       2,
       'should count two pseudo selectors (:custom and :dev) in complex query',
     )
+
+    // Test edge cases for better coverage
+    await t.test('edge cases for coverage', async t => {
+      // Test combination of non-semver pseudo selector with ID - should use AND logic
+      const combinedBreadcrumb = parseBreadcrumb(':project#test')
+      const combinedComparator = combinedBreadcrumb.first.comparator
+      t.equal(
+        combinedComparator({ version: '1.0.0' }),
+        true,
+        'combined non-semver pseudo selector should use AND logic (true && true = true)',
+      )
+      t.equal(
+        combinedComparator({}),
+        true,
+        'combined non-semver pseudo selector should return true without version',
+      )
+
+      // Test helper function edge cases for getPseudoSelectorFullText
+      // These test the fallback paths and edge cases
+      const hasSelector = parseBreadcrumb(':semver(1)')
+      t.equal(
+        hasSelector.first.value,
+        ':semver(1)',
+        'should reconstruct complex pseudo selector with child selectors',
+      )
+
+      // Test a pseudo selector without children
+      const simplePseudo = parseBreadcrumb(':root')
+      t.equal(
+        simplePseudo.first.value,
+        ':root',
+        'should handle simple pseudo selector without parameters',
+      )
+    })
   })
 })
 
@@ -765,4 +1198,112 @@ t.test('linked list navigation', async t => {
   t.equal(third!.prev, second, 'third.prev should point to second')
   t.equal(second!.prev, first, 'second.prev should point to first')
   t.equal(first!.prev, undefined, 'first.prev should be undefined')
+})
+
+t.test('Helper Functions', async t => {
+  await t.test('removeQuotes', async t => {
+    // Test removing double quotes
+    t.equal(
+      removeQuotes('"hello"'),
+      'hello',
+      'should remove double quotes',
+    )
+
+    // Test with no quotes
+    t.equal(
+      removeQuotes('hello'),
+      'hello',
+      'should return unchanged if no quotes',
+    )
+
+    // Test with partial quotes
+    t.equal(
+      removeQuotes('"hello'),
+      '"hello',
+      'should not remove partial quotes',
+    )
+
+    // Test with empty string
+    t.equal(removeQuotes(''), '', 'should handle empty string')
+
+    // Test with only quotes
+    t.equal(
+      removeQuotes('""'),
+      '',
+      'should handle empty quoted string',
+    )
+  })
+
+  await t.test('extractPseudoParameter edge cases', async t => {
+    // Test with item that has no children
+    const itemNoChildren = {
+      value: ':test',
+    }
+    t.same(
+      extractPseudoParameter(itemNoChildren),
+      {},
+      'should return empty object for item with no children',
+    )
+
+    // Test with item that has no first node
+    const itemNoFirstNode = {
+      value: ':test',
+      nodes: [],
+    }
+    t.same(
+      extractPseudoParameter(itemNoFirstNode),
+      {},
+      'should return empty object for item with no first node',
+    )
+
+    // Test with non-semver pseudo selector
+    const itemNonSemver = {
+      value: ':custom',
+      type: 'pseudo',
+      nodes: ['something'],
+    }
+    t.same(
+      extractPseudoParameter(itemNonSemver),
+      {},
+      'should return empty object for non-semver selector',
+    )
+  })
+
+  await t.test('getPseudoSelectorFullText edge cases', async t => {
+    // Test with item that has no children
+    const itemNoChildren = {
+      value: ':root',
+    } as any
+    t.equal(
+      getPseudoSelectorFullText(itemNoChildren),
+      ':root',
+      'should return base value for item with no children',
+    )
+
+    // Test with item that has undefined value
+    const itemUndefinedValue = {
+      value: undefined,
+    } as any
+    t.equal(
+      getPseudoSelectorFullText(itemUndefinedValue),
+      '',
+      'should return empty string for undefined value',
+    )
+
+    // Test with a selector that has comments in parameters to potentially trigger different node types
+    const commentSelector = parseBreadcrumb(':semver(/* test */1)')
+    t.equal(
+      commentSelector.first.value,
+      ':semver(/* test */1)',
+      'should handle selectors with comments in parameters',
+    )
+
+    // Use real parsed selectors to test the actual function behavior
+    const realSelector = parseBreadcrumb(':semver(/*comment*/1)')
+    t.equal(
+      realSelector.first.value,
+      ':semver(/*comment*/1)',
+      'should handle real parsed selector with parameters',
+    )
+  })
 })


### PR DESCRIPTION
`ModifierBreadcrumbItem` objects will now expose a `comparator()` method that will allow for checking extra values, enabling the usage of a more diverse set of pseudo selectors.

This implements the initial `:semver` and its shortcut `:v` to allow for fine tuning breadcrumb matching based on the versions of packages and user defined semver values, e.g:

    :root > #eslint > #minimatch:v(3)

Refs: https://github.com/vltpkg/statusboard/issues/176