### PR TITLE
cli-sdk: error on invalid workspace flags

### DIFF
--- a/src/cli-sdk/src/config/index.ts
+++ b/src/cli-sdk/src/config/index.ts
@@ -242,6 +242,10 @@ export class Config {
       monorepo: Monorepo.maybeLoad(this.projectRoot, {
         scurry,
         packageJson,
+        load: {
+          paths: asRecords.workspace,
+          groups: asRecords['workspace-group'],
+        },
       }),
       catalog: load<Record<string, string>>(
         'catalog',

--- a/src/cli-sdk/src/index.ts
+++ b/src/cli-sdk/src/index.ts
@@ -82,6 +82,26 @@ const run = async () => {
     }
   }
 
+  if (
+    (vlt.get('workspace') || vlt.get('workspace-group')) &&
+    ![...(monorepo?.values() ?? [])].length
+  ) {
+    stderr(
+      `Error: No matching workspaces found. Make sure the vlt.json config contains the correct workspaces.`,
+    )
+    if (vlt.get('workspace')) {
+      stderr(indent(`Workspace: ${format(vlt.get('workspace'))}`))
+    }
+    if (vlt.get('workspace-group')) {
+      stderr(
+        indent(
+          `Workspace Group: ${format(vlt.get('workspace-group'))}`,
+        ),
+      )
+    }
+    return process.exit(process.exitCode || 1)
+  }
+
   const command = await loadCommand(vlt.command)
   await outputCommand(command, vlt, { start })
 }

--- a/src/cli-sdk/tap-snapshots/test/index.ts.test.cjs
+++ b/src/cli-sdk/tap-snapshots/test/index.ts.test.cjs
@@ -14,6 +14,21 @@ Invalid value string for color, expected boolean
   Run 'vlt help' for more information about available options.
 `
 
+exports[`test/index.ts > TAP > invalid workspace - no vlt.json > must match snapshot 1`] = `
+Error: No matching workspaces found. Make sure the vlt.json config contains the correct workspaces.
+  Workspace: [ 'src/bar' ]
+`
+
+exports[`test/index.ts > TAP > invalid workspace > must match snapshot 1`] = `
+Error: No matching workspaces found. Make sure the vlt.json config contains the correct workspaces.
+  Workspace: [ 'src/bar' ]
+`
+
+exports[`test/index.ts > TAP > invalid workspace-group > must match snapshot 1`] = `
+Error: No matching workspaces found. Make sure the vlt.json config contains the correct workspaces.
+  Workspace Group: [ 'a' ]
+`
+
 exports[`test/index.ts > TAP > unknown config > must match snapshot 1`] = `
 Invalid Option Flag
 Unknown option '--unknown'. To specify a positional argument starting with a '-', place it at the end of the command after '--', as in '-- --unknown'


### PR DESCRIPTION
If a `--workspace` or `--workspace-group` flag is provided and no matching
workspaces are found in the monorepo, the CLI will now throw an error.

No workspaces might be found because either `vlt.json` is missing or
misconfigured, so the error message hints to check the `vlt.json` config
file.
