### PR TITLE
graph: minify mermaid output

### DIFF
--- a/src/graph/tap-snapshots/test/visualization/mermaid-output.ts.test.cjs
+++ b/src/graph/tap-snapshots/test/visualization/mermaid-output.ts.test.cjs
@@ -7,79 +7,79 @@
 'use strict'
 exports[`test/visualization/mermaid-output.ts > TAP > actual graph > selected packages > should print selected packages 1`] = `
 flowchart TD
-file%C2%B7.("root:my-project")
-file%C2%B7.("root:my-project") -->|"bar#64;^1.0.0 (optional)"| %C2%B7%C2%B7bar%401.0.0("npm:bar#64;1.0.0")
-%C2%B7%C2%B7bar%401.0.0("npm:bar#64;1.0.0")
-%C2%B7%C2%B7bar%401.0.0("npm:bar#64;1.0.0") -->|"baz#64;custom:baz#64;^1.0.0 (prod)"| %C2%B7custom%C2%B7baz%401.0.0("custom:baz#64;1.0.0")
-%C2%B7custom%C2%B7baz%401.0.0("custom:baz#64;1.0.0")
+a("root:my-project")
+a("root:my-project") -->|"bar#64;^1.0.0 (optional)"| g("npm:bar#64;1.0.0")
+g("npm:bar#64;1.0.0")
+g("npm:bar#64;1.0.0") -->|"baz#64;custom:baz#64;^1.0.0"| m("custom:baz#64;1.0.0")
+m("custom:baz#64;1.0.0")
 
 
 `
 
 exports[`test/visualization/mermaid-output.ts > TAP > actual graph > should print from an actual loaded graph 1`] = `
 flowchart TD
-file%C2%B7.("root:my-project")
-file%C2%B7.("root:my-project") -->|"link#64;file:./linked (prod)"| file%C2%B7linked("file(linked):linked#64;1.0.0")
-file%C2%B7linked("file(linked):linked#64;1.0.0")
-file%C2%B7.("root:my-project") -->|"foo#64;^1.0.0 (prod)"| %C2%B7%C2%B7foo%401.0.0("npm:foo#64;1.0.0")
-%C2%B7%C2%B7foo%401.0.0("npm:foo#64;1.0.0")
-file%C2%B7.("root:my-project") -->|"extraneous#64;* (prod)"| %C2%B7%C2%B7extraneous%401.0.0("npm:extraneous#64;1.0.0")
-%C2%B7%C2%B7extraneous%401.0.0("npm:extraneous#64;1.0.0")
-file%C2%B7.("root:my-project") -->|"bar#64;^1.0.0 (optional)"| %C2%B7%C2%B7bar%401.0.0("npm:bar#64;1.0.0")
-%C2%B7%C2%B7bar%401.0.0("npm:bar#64;1.0.0")
-%C2%B7%C2%B7bar%401.0.0("npm:bar#64;1.0.0") -->|"blooo#64;1 (prod)"| %C2%B7%C2%B7blooo%401.0.0("npm:blooo#64;1.0.0")
-%C2%B7%C2%B7blooo%401.0.0("npm:blooo#64;1.0.0")
-%C2%B7%C2%B7bar%401.0.0("npm:bar#64;1.0.0") -->|"baz#64;custom:baz#64;^1.0.0 (prod)"| %C2%B7custom%C2%B7baz%401.0.0("custom:baz#64;1.0.0")
-%C2%B7custom%C2%B7baz%401.0.0("custom:baz#64;1.0.0")
-file%C2%B7.("root:my-project") -->|"aliased#64;custom:foo#64;^1.0.0 (dev)"| %C2%B7custom%C2%B7foo%401.0.0("custom:foo#64;1.0.0")
-%C2%B7custom%C2%B7foo%401.0.0("custom:foo#64;1.0.0")
-file%C2%B7.("root:my-project") -->|"#64;scoped/b#64;^1.0.0 (prod)"| %C2%B7%C2%B7%40scoped%C2%A7b%401.0.0("npm:#64;scoped/b#64;1.0.0")
-%C2%B7%C2%B7%40scoped%C2%A7b%401.0.0("npm:#64;scoped/b#64;1.0.0")
-%C2%B7%C2%B7%40scoped%C2%A7b%401.0.0("npm:#64;scoped/b#64;1.0.0") -->|"#64;scoped/c#64;^1.0.0 (prod)"| %C2%B7%C2%B7%40scoped%C2%A7c%401.0.0("npm:#64;scoped/c#64;1.0.0")
-%C2%B7%C2%B7%40scoped%C2%A7c%401.0.0("npm:#64;scoped/c#64;1.0.0")
-file%C2%B7.("root:my-project") -->|"#64;scoped/a#64;^1.0.0 (prod)"| %C2%B7%C2%B7%40scoped%C2%A7a%401.0.0("npm:#64;scoped/a#64;1.0.0")
-%C2%B7%C2%B7%40scoped%C2%A7a%401.0.0("npm:#64;scoped/a#64;1.0.0")
-file%C2%B7.("root:my-project") -->|"missing#64;^1.0.0 (prod)"| missing-1(Missing)
+a("root:my-project")
+a("root:my-project") -->|"link#64;file:./linked"| d("file(linked):linked#64;1.0.0")
+d("file(linked):linked#64;1.0.0")
+a("root:my-project") -->|"foo#64;^1.0.0"| e("npm:foo#64;1.0.0")
+e("npm:foo#64;1.0.0")
+a("root:my-project") -->|"extraneous#64;*"| f("npm:extraneous#64;1.0.0")
+f("npm:extraneous#64;1.0.0")
+a("root:my-project") -->|"bar#64;^1.0.0 (optional)"| g("npm:bar#64;1.0.0")
+g("npm:bar#64;1.0.0")
+g("npm:bar#64;1.0.0") -->|"blooo#64;1"| l("npm:blooo#64;1.0.0")
+l("npm:blooo#64;1.0.0")
+g("npm:bar#64;1.0.0") -->|"baz#64;custom:baz#64;^1.0.0"| m("custom:baz#64;1.0.0")
+m("custom:baz#64;1.0.0")
+a("root:my-project") -->|"aliased#64;custom:foo#64;^1.0.0 (dev)"| h("custom:foo#64;1.0.0")
+h("custom:foo#64;1.0.0")
+a("root:my-project") -->|"#64;scoped/b#64;^1.0.0"| i("npm:#64;scoped/b#64;1.0.0")
+i("npm:#64;scoped/b#64;1.0.0")
+i("npm:#64;scoped/b#64;1.0.0") -->|"#64;scoped/c#64;^1.0.0"| n("npm:#64;scoped/c#64;1.0.0")
+n("npm:#64;scoped/c#64;1.0.0")
+a("root:my-project") -->|"#64;scoped/a#64;^1.0.0"| j("npm:#64;scoped/a#64;1.0.0")
+j("npm:#64;scoped/a#64;1.0.0")
+a("root:my-project") -->|"missing#64;^1.0.0"| missing-1(Missing)
 
-workspace%C2%B7packages%C2%A7workspace-b("workspace:workspace-b")
-workspace%C2%B7packages%C2%A7workspace-a("workspace:workspace-a")
-workspace%C2%B7packages%C2%A7workspace-a("workspace:workspace-a") -->|"workspace-b#64;workspace:* (dev)"| workspace%C2%B7packages%C2%A7workspace-b("workspace:workspace-b")
-workspace%C2%B7packages%C2%A7workspace-b("workspace:workspace-b")
-workspace%C2%B7packages%C2%A7workspace-a("workspace:workspace-a") -->|"ipsum#64;^1.0.0 (dev)"| %C2%B7%C2%B7ipsum%401.0.0("npm:ipsum#64;1.0.0")
-%C2%B7%C2%B7ipsum%401.0.0("npm:ipsum#64;1.0.0")
-workspace%C2%B7packages%C2%A7workspace-a("workspace:workspace-a") -->|"foo#64;^1.0.0 (dev)"| %C2%B7%C2%B7foo%401.0.0("npm:foo#64;1.0.0")
-%C2%B7%C2%B7foo%401.0.0("npm:foo#64;1.0.0")
+b("workspace:workspace-b")
+c("workspace:workspace-a")
+c("workspace:workspace-a") -->|"workspace-b#64;workspace:* (dev)"| b("workspace:workspace-b")
+b("workspace:workspace-b")
+c("workspace:workspace-a") -->|"ipsum#64;^1.0.0 (dev)"| k("npm:ipsum#64;1.0.0")
+k("npm:ipsum#64;1.0.0")
+c("workspace:workspace-a") -->|"foo#64;^1.0.0 (dev)"| e("npm:foo#64;1.0.0")
+e("npm:foo#64;1.0.0")
 `
 
 exports[`test/visualization/mermaid-output.ts > TAP > cycle > should print cycle mermaid output 1`] = `
 flowchart TD
-file%C2%B7.("root:my-project")
-file%C2%B7.("root:my-project") -->|"a#64;^1.0.0 (prod)"| %C2%B7%C2%B7a%401.0.0("npm:a#64;1.0.0")
-%C2%B7%C2%B7a%401.0.0("npm:a#64;1.0.0")
-%C2%B7%C2%B7a%401.0.0("npm:a#64;1.0.0") -->|"b#64;^1.0.0 (prod)"| %C2%B7%C2%B7b%401.0.0("npm:b#64;1.0.0")
-%C2%B7%C2%B7b%401.0.0("npm:b#64;1.0.0")
-%C2%B7%C2%B7b%401.0.0("npm:b#64;1.0.0") -->|"a#64;^1.0.0 (prod)"| %C2%B7%C2%B7a%401.0.0("npm:a#64;1.0.0")
+a("root:my-project")
+a("root:my-project") -->|"a#64;^1.0.0"| b("npm:a#64;1.0.0")
+b("npm:a#64;1.0.0")
+b("npm:a#64;1.0.0") -->|"b#64;^1.0.0"| c("npm:b#64;1.0.0")
+c("npm:b#64;1.0.0")
+c("npm:b#64;1.0.0") -->|"a#64;^1.0.0"| b("npm:a#64;1.0.0")
 
 `
 
 exports[`test/visualization/mermaid-output.ts > TAP > human-readable-output > should print mermaid output 1`] = `
 flowchart TD
-file%C2%B7.("root:my-project")
-file%C2%B7.("root:my-project") -->|"foo#64;^1.0.0 (prod)"| %C2%B7%C2%B7foo%401.0.0("npm:foo#64;1.0.0")
-%C2%B7%C2%B7foo%401.0.0("npm:foo#64;1.0.0")
-file%C2%B7.("root:my-project") -->|"bar#64;^1.0.0 (prod)"| %C2%B7%C2%B7bar%401.0.0("npm:bar#64;1.0.0")
-%C2%B7%C2%B7bar%401.0.0("npm:bar#64;1.0.0")
-%C2%B7%C2%B7bar%401.0.0("npm:bar#64;1.0.0") -->|"baz#64;^1.0.0 (prod)"| %C2%B7%C2%B7baz%401.0.0("npm:baz#64;1.0.0")
-%C2%B7%C2%B7baz%401.0.0("npm:baz#64;1.0.0")
-%C2%B7%C2%B7baz%401.0.0("npm:baz#64;1.0.0") -->|"foo#64;^1.0.0 (prod)"| %C2%B7%C2%B7foo%401.0.0("npm:foo#64;1.0.0")
+a("root:my-project")
+a("root:my-project") -->|"foo#64;^1.0.0"| b("npm:foo#64;1.0.0")
+b("npm:foo#64;1.0.0")
+a("root:my-project") -->|"bar#64;^1.0.0"| c("npm:bar#64;1.0.0")
+c("npm:bar#64;1.0.0")
+c("npm:bar#64;1.0.0") -->|"baz#64;^1.0.0"| d("npm:baz#64;1.0.0")
+d("npm:baz#64;1.0.0")
+d("npm:baz#64;1.0.0") -->|"foo#64;^1.0.0"| b("npm:foo#64;1.0.0")
 
-file%C2%B7.("root:my-project") -->|"missing#64;^1.0.0 (prod)"| missing-0(Missing)
+a("root:my-project") -->|"missing#64;^1.0.0"| missing-0(Missing)
 
 `
 
 exports[`test/visualization/mermaid-output.ts > TAP > workspaces > should print workspaces mermaid output 1`] = `
 flowchart TD
-file%C2%B7.("root:my-project")
-workspace%C2%B7packages%C2%A7b("workspace:b")
-workspace%C2%B7packages%C2%A7a("workspace:a")
+a("root:my-project")
+b("workspace:b")
+c("workspace:a")
 `


### PR DESCRIPTION
Replace DepID references with a short, string-only unique value for mermaid to key graph nodes. Also removes references to (prod) dependency types to better align with the same change in the GUI.