### PR TITLE
fix: normalize `funding` information in managed "manifests"

### DIFF
--- a/src/package-info/src/index.ts
+++ b/src/package-info/src/index.ts
@@ -13,7 +13,11 @@ import type { SpecOptions } from '@vltpkg/spec'
 import { Spec } from '@vltpkg/spec'
 import { Pool } from '@vltpkg/tar'
 import type { Integrity, Manifest, Packument } from '@vltpkg/types'
-import { asPackument, isIntegrity } from '@vltpkg/types'
+import {
+  asPackument,
+  isIntegrity,
+  normalizeManifest,
+} from '@vltpkg/types'
 import { Monorepo } from '@vltpkg/workspaces'
 import { XDG } from '@vltpkg/xdg'
 import { randomBytes } from 'node:crypto'
@@ -433,7 +437,9 @@ export class PackageInfoClient {
             this.#trustedIntegrities.set(tarball, integrity)
           }
         }
-        return mani
+
+        // Normalize funding information to standard format while preserving the original
+        return normalizeManifest(mani)
       }
 
       case 'git': {

--- a/src/package-info/test/index.ts
+++ b/src/package-info/test/index.ts
@@ -1041,3 +1041,89 @@ t.test('path git selector', async t => {
     t.strictSame(found, pkg)
   })
 })
+
+t.test('funding normalization', async t => {
+  const mockManifest = {
+    name: 'test-package',
+    version: '1.0.0',
+    funding: 'https://github.com/sponsors/user', // String funding
+    dist: {
+      tarball:
+        'https://registry.npmjs.org/test-package/-/test-package-1.0.0.tgz',
+      integrity:
+        'sha512-6/mh1E2u2YgEsCHdY0Yx5oW+61gZU+1vXaoiHHrpKeuRNNgFvS+/jrwHiQhB5apAf5oB7UB7E19ol2R2LKH8hQ==' as const,
+    },
+  }
+
+  const { PackageInfoClient } = await t.mockImport<
+    typeof import('../src/index.ts')
+  >('../src/index.ts', {
+    '@vltpkg/pick-manifest': {
+      pickManifest: () => mockManifest,
+    },
+  })
+
+  const client = new PackageInfoClient(options)
+  // Mock the packument method to return a packument with our test manifest
+  client.packument = async () => ({
+    name: 'test-package',
+    'dist-tags': { latest: '1.0.0' },
+    versions: { '1.0.0': mockManifest },
+  })
+
+  const manifest = await client.manifest('test-package@1.0.0')
+
+  t.same(
+    manifest.funding,
+    [{ url: 'https://github.com/sponsors/user', type: 'github' }],
+    'string funding should be normalized to array format',
+  )
+
+  t.end()
+})
+
+t.test('funding normalization with array', async t => {
+  const mockManifest = {
+    name: 'test-package',
+    version: '1.0.0',
+    funding: [
+      'https://github.com/sponsors/user',
+      { url: 'https://patreon.com/user' },
+    ],
+    dist: {
+      tarball:
+        'https://registry.npmjs.org/test-package/-/test-package-1.0.0.tgz',
+      integrity:
+        'sha512-6/mh1E2u2YgEsCHdY0Yx5oW+61gZU+1vXaoiHHrpKeuRNNgFvS+/jrwHiQhB5apAf5oB7UB7E19ol2R2LKH8hQ==' as const,
+    },
+  }
+
+  const { PackageInfoClient } = await t.mockImport<
+    typeof import('../src/index.ts')
+  >('../src/index.ts', {
+    '@vltpkg/pick-manifest': {
+      pickManifest: () => mockManifest,
+    },
+  })
+
+  const client = new PackageInfoClient(options)
+  // Mock the packument method to return a packument with our test manifest
+  client.packument = async () => ({
+    name: 'test-package',
+    'dist-tags': { latest: '1.0.0' },
+    versions: { '1.0.0': mockManifest },
+  })
+
+  const manifest = await client.manifest('test-package@1.0.0')
+
+  t.same(
+    manifest.funding,
+    [
+      { url: 'https://github.com/sponsors/user', type: 'github' },
+      { url: 'https://patreon.com/user', type: 'patreon' },
+    ],
+    'mixed array funding should be normalized to object format',
+  )
+
+  t.end()
+})


### PR DESCRIPTION
PR normalizes funding information for manifests, ensuring consistency (ie. `funding` should always be an array of objects). Notably, the `rawManifest` remains untouched. Querying using funding values should now be more consistent/reliable. We'll likely want to do more of this in the future (maybe even write _the_ "package.json spec") but for now this is a good start/required for @ejkorol's UI additions to display aggregate funding information.

```bash
$ vlt query '[funding]' --view=json | jq '.[] | .to.manifest.funding'
$ vlt query ':attr(funding,[type=github])' --view=json | jq '.[] | .to.manifest.funding'
$ vlt query ':attr(funding,[url*="github.com/sponsors/ljharb"])' --view=json | jq '.[] | .to.manifest.funding'

```