### PR TITLE
gui: dependencies funding tab

### DIFF
--- a/src/gui/src/components/explorer-grid/selected-item/tabs-dependencies/index.tsx
+++ b/src/gui/src/components/explorer-grid/selected-item/tabs-dependencies/index.tsx
@@ -22,6 +22,10 @@ import {
   DuplicatesTabContent,
   DuplicatesTabButton,
 } from '@/components/explorer-grid/selected-item/tabs-dependencies/tabs-duplicates.tsx'
+import {
+  FundingTabButton,
+  FundingTabContent,
+} from '@/components/explorer-grid/selected-item/tabs-dependencies/tabs-funding.tsx'
 
 type Tabs = 'insights' | 'licenses' | 'funding' | 'duplicates'
 
@@ -63,10 +67,12 @@ export const DependenciesTabContent = () => {
               <InsightsTabButton />
               <LicensesTabButton />
               <DuplicatesTabButton />
+              <FundingTabButton />
             </TabsList>
             <InsightsTabContent />
             <LicensesTabContent />
             <DuplicatesTabContent />
+            <FundingTabContent />
           </Tabs>
         </>
       : <EmptyState

--- a/src/gui/src/components/explorer-grid/selected-item/tabs-dependencies/tabs-funding.tsx
+++ b/src/gui/src/components/explorer-grid/selected-item/tabs-dependencies/tabs-funding.tsx
@@ -1,0 +1,255 @@
+import React, { useMemo } from 'react'
+import { TabsTrigger, TabsContent } from '@/components/ui/tabs.tsx'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table.tsx'
+import {
+  flexRender,
+  getCoreRowModel,
+  getFilteredRowModel,
+  getSortedRowModel,
+  useReactTable,
+} from '@tanstack/react-table'
+import type { ColumnDef } from '@tanstack/react-table'
+import { useSelectedItemStore } from '@/components/explorer-grid/selected-item/context.tsx'
+import { HeartHandshake } from 'lucide-react'
+import { cn } from '@/lib/utils.ts'
+import { useGraphStore } from '@/state/index.ts'
+import { EmptyState } from '@/components/explorer-grid/selected-item/tabs-dependencies/empty-state.tsx'
+import {
+  SortingHeader,
+  tableClassNames,
+} from '@/components/explorer-grid/selected-item/tabs-dependencies/table-utilities.tsx'
+import { DataBadge } from '@/components/ui/data-badge.tsx'
+
+export const FundingTabButton = () => {
+  const depFunding = useSelectedItemStore(state => state.depFunding)
+  const fundingCount = Object.entries(depFunding ?? {}).reduce(
+    (acc, [, { count }]) => acc + count,
+    0,
+  )
+  return (
+    <TabsTrigger
+      value="funding"
+      variant="nestedCard"
+      className="flex">
+      Funding
+      {fundingCount > 0 && (
+        <DataBadge
+          variant="count"
+          classNames={{ wrapperClassName: 'ml-1' }}
+          content={String(fundingCount)}
+        />
+      )}
+    </TabsTrigger>
+  )
+}
+
+export const FundingTabContent = () => {
+  const depFunding = useSelectedItemStore(state => state.depFunding)
+  const updateQuery = useGraphStore(state => state.updateQuery)
+
+  const queryFunding = (url: string) =>
+    updateQuery(`:attr(funding,[url*="${url}"])`)
+
+  const fundingCount = Object.entries(depFunding ?? {}).reduce(
+    (acc, [, { count }]) => acc + count,
+    0,
+  )
+
+  const fundingTableData = useMemo(() => {
+    return Object.entries(depFunding ?? {}).map(([url, funding]) => ({
+      count: funding.count,
+      type: funding.type,
+      origin: url,
+    }))
+  }, [depFunding])
+
+  const columns = useMemo<
+    ColumnDef<{
+      count: number
+      type: string | undefined
+      origin: string
+    }>[]
+  >(
+    () => [
+      {
+        id: 'count',
+        accessorKey: 'count',
+        header: ({ column }) => (
+          <SortingHeader
+            header="Count"
+            column={column}
+            className={tableClassNames.cell}
+          />
+        ),
+        cell: ({ row }) => (
+          <p className="font-mono text-sm font-medium tabular-nums">
+            {row.original.count}
+          </p>
+        ),
+        enableSorting: true,
+        sortingFn: (a, b) => {
+          return a.original.count - b.original.count
+        },
+        minSize: 80,
+        size: 80,
+        maxSize: 80,
+      },
+      {
+        id: 'type',
+        accessorKey: 'type',
+        header: ({ column }) => (
+          <SortingHeader
+            header="Type"
+            column={column}
+            className={tableClassNames.cell}
+          />
+        ),
+        cell: ({ row }) => {
+          const { type } = row.original
+          return type ? type : '-'
+        },
+        enableSorting: true,
+        minSize: 150,
+        size: 150,
+        maxSize: 150,
+      },
+      {
+        id: 'origin',
+        accessorKey: 'origin',
+        header: ({ column }) => (
+          <SortingHeader
+            header="Type"
+            column={column}
+            className={tableClassNames.cell}
+          />
+        ),
+        cell: ({ row }) => (
+          <span className="lowercase">{row.original.origin}</span>
+        ),
+        enableSorting: true,
+        minSize: 200,
+        size: 200,
+        maxSize: 200,
+      },
+    ],
+    [],
+  )
+
+  const table = useReactTable<{
+    count: number
+    type: string | undefined
+    origin: string
+  }>({
+    data: fundingTableData,
+    columns,
+    getCoreRowModel: getCoreRowModel(),
+    getSortedRowModel: getSortedRowModel(),
+    getFilteredRowModel: getFilteredRowModel(),
+  })
+
+  return (
+    <TabsContent value="funding">
+      {depFunding && fundingCount > 0 ?
+        <div className="flex flex-col gap-3 py-4">
+          <div className="flex flex-col gap-3 px-6">
+            <div className="duration-250 relative flex w-full cursor-default flex-col gap-2 rounded-sm border-[1px] border-muted bg-secondary/30 px-3 py-3 transition-colors">
+              <p className="font-regular text-xs tracking-wide text-muted-foreground">
+                Packages looking for funding
+              </p>
+              <p className="inline-flex items-center gap-1 font-mono text-2xl font-medium tabular-nums text-foreground">
+                <span>
+                  <HeartHandshake
+                    className="text-pink-500"
+                    size={24}
+                  />
+                </span>
+                {fundingCount}
+              </p>
+            </div>
+
+            <div className="my-2 flex w-2/3 flex-col gap-1 text-pretty">
+              <p className="text-medium text-sm capitalize text-foreground">
+                support the tools you rely on
+              </p>
+              <p className="text-sm font-medium text-muted-foreground">
+                Some of the packages you're using have funding options
+                available. Supporting them helps ensure these projects
+                remain maintained and sustainable for the community.
+              </p>
+            </div>
+          </div>
+
+          <Table className="cursor-default border-t-[1px] border-muted">
+            <TableHeader>
+              {table.getHeaderGroups().map(headerGroup => (
+                <TableRow key={headerGroup.id}>
+                  {headerGroup.headers.map(header => (
+                    <TableHead
+                      key={header.id}
+                      className={cn(
+                        tableClassNames.cell,
+                        'h-fit px-0 py-1 align-middle first-of-type:pl-8 last-of-type:pr-8 [&>button]:first-of-type:pl-0 [&>p]:last-of-type:pl-3',
+                      )}
+                      style={{ width: `${header.getSize()}px` }}>
+                      {flexRender(
+                        header.column.columnDef.header,
+                        header.getContext(),
+                      )}
+                    </TableHead>
+                  ))}
+                </TableRow>
+              ))}
+            </TableHeader>
+            <TableBody>
+              {table.getRowModel().rows.length ?
+                table.getRowModel().rows.map(row => (
+                  <TableRow
+                    key={row.id}
+                    role="button"
+                    className="cursor-default"
+                    onClick={() => queryFunding(row.original.origin)}
+                    data-state={row.getIsSelected() && 'selected'}>
+                    {row.getVisibleCells().map(cell => (
+                      <TableCell
+                        key={cell.id}
+                        className={cn(
+                          tableClassNames.cell,
+                          'first-of-type:pl-8 last-of-type:pr-8',
+                        )}
+                        style={{
+                          width: `${cell.column.getSize()}px`,
+                        }}>
+                        {flexRender(
+                          cell.column.columnDef.cell,
+                          cell.getContext(),
+                        )}
+                      </TableCell>
+                    ))}
+                  </TableRow>
+                ))
+              : <TableRow>
+                  <TableCell>
+                    <p className="text-sm text-muted-foreground">
+                      No warnings found
+                    </p>
+                  </TableCell>
+                </TableRow>
+              }
+            </TableBody>
+          </Table>
+        </div>
+      : <EmptyState
+          icon={HeartHandshake}
+          message="No dependencies are looking for funding"
+        />
+      }
+    </TabsContent>
+  )
+}

--- a/src/gui/test/components/explorer-grid/selected-item/item-header.tsx
+++ b/src/gui/test/components/explorer-grid/selected-item/item-header.tsx
@@ -128,6 +128,8 @@ test('ItemHeader renders with default item', () => {
     setDepWarnings: vi.fn(),
     duplicatedDeps: undefined,
     setDuplicatedDeps: vi.fn(),
+    depFunding: undefined,
+    setDepFunding: vi.fn(),
     ...SELECTED_ITEM_DETAILS,
   } satisfies SelectedItemStore
 
@@ -166,6 +168,8 @@ test('ItemHeader renders with custom registry item', () => {
     setDepWarnings: vi.fn(),
     duplicatedDeps: undefined,
     setDuplicatedDeps: vi.fn(),
+    depFunding: undefined,
+    setDepFunding: vi.fn(),
     ...SELECTED_ITEM_DETAILS,
   } satisfies SelectedItemStore
 
@@ -210,6 +214,8 @@ test('ItemHeader renders with scoped registry item', () => {
     setDepWarnings: vi.fn(),
     duplicatedDeps: undefined,
     setDuplicatedDeps: vi.fn(),
+    depFunding: undefined,
+    setDepFunding: vi.fn(),
     ...SELECTED_ITEM_DETAILS,
   } satisfies SelectedItemStore
 
@@ -259,6 +265,8 @@ test('ItemHeader renders with default git host item', () => {
     setDepWarnings: vi.fn(),
     duplicatedDeps: undefined,
     setDuplicatedDeps: vi.fn(),
+    depFunding: undefined,
+    setDepFunding: vi.fn(),
     ...SELECTED_ITEM_DETAILS,
   } satisfies SelectedItemStore
 
@@ -303,6 +311,8 @@ test('ItemHeader renders with a package score', () => {
     setDepWarnings: vi.fn(),
     duplicatedDeps: undefined,
     setDuplicatedDeps: vi.fn(),
+    depFunding: undefined,
+    setDepFunding: vi.fn(),
     ...SELECTED_ITEM_DETAILS,
   } satisfies SelectedItemStore
 
@@ -341,6 +351,8 @@ test('ItemHeader renders with insights', () => {
     setDepWarnings: vi.fn(),
     duplicatedDeps: undefined,
     setDuplicatedDeps: vi.fn(),
+    depFunding: undefined,
+    setDepFunding: vi.fn(),
     ...SELECTED_ITEM_DETAILS,
   } satisfies SelectedItemStore
 
@@ -399,6 +411,8 @@ test('ItemHeader renders with a version information', () => {
     setDepWarnings: vi.fn(),
     duplicatedDeps: undefined,
     setDuplicatedDeps: vi.fn(),
+    depFunding: undefined,
+    setDepFunding: vi.fn(),
     ...SELECTED_ITEM_DETAILS,
   } satisfies SelectedItemStore
 

--- a/src/gui/test/components/explorer-grid/selected-item/item.tsx
+++ b/src/gui/test/components/explorer-grid/selected-item/item.tsx
@@ -112,6 +112,8 @@ test('Item renders with the default structure', () => {
     setDepWarnings: vi.fn(),
     duplicatedDeps: undefined,
     setDuplicatedDeps: vi.fn(),
+    depFunding: undefined,
+    setDepFunding: vi.fn(),
   } satisfies SelectedItemStore)
 
   const Container = () => {
@@ -148,6 +150,8 @@ test('Item renders connection lines', () => {
     setDepWarnings: vi.fn(),
     duplicatedDeps: undefined,
     setDuplicatedDeps: vi.fn(),
+    depFunding: undefined,
+    setDepFunding: vi.fn(),
   } satisfies SelectedItemStore)
 
   const Container = () => {

--- a/src/gui/test/components/explorer-grid/selected-item/tabs-dependencies/__snapshots__/index.tsx.snap
+++ b/src/gui/test/components/explorer-grid/selected-item/tabs-dependencies/__snapshots__/index.tsx.snap
@@ -11,6 +11,8 @@ exports[`DependenciesTabContent renders an empty state 1`] = `
       </gui-licenses-tab-button>
       <gui-duplicates-tab-button>
       </gui-duplicates-tab-button>
+      <gui-funding-tab-button>
+      </gui-funding-tab-button>
     </gui-tabs-list>
     <gui-insights-tab-content>
     </gui-insights-tab-content>
@@ -18,6 +20,8 @@ exports[`DependenciesTabContent renders an empty state 1`] = `
     </gui-licenses-tab-content>
     <gui-duplicates-tab-content>
     </gui-duplicates-tab-content>
+    <gui-funding-tab-content>
+    </gui-funding-tab-content>
   </gui-tabs>
 </gui-tabs-content>
 
@@ -34,6 +38,8 @@ exports[`DependenciesTabContent renders default 1`] = `
       </gui-licenses-tab-button>
       <gui-duplicates-tab-button>
       </gui-duplicates-tab-button>
+      <gui-funding-tab-button>
+      </gui-funding-tab-button>
     </gui-tabs-list>
     <gui-insights-tab-content>
     </gui-insights-tab-content>
@@ -41,6 +47,8 @@ exports[`DependenciesTabContent renders default 1`] = `
     </gui-licenses-tab-content>
     <gui-duplicates-tab-content>
     </gui-duplicates-tab-content>
+    <gui-funding-tab-content>
+    </gui-funding-tab-content>
   </gui-tabs>
 </gui-tabs-content>
 

--- a/src/gui/test/components/explorer-grid/selected-item/tabs-dependencies/__snapshots__/tabs-funding.tsx.snap
+++ b/src/gui/test/components/explorer-grid/selected-item/tabs-dependencies/__snapshots__/tabs-funding.tsx.snap
@@ -1,0 +1,174 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`FundingTabButton renders correctly 1`] = `
+
+<gui-tabs-trigger
+  value="funding"
+  variant="nestedCard"
+  classname="flex"
+>
+  Funding
+</gui-tabs-trigger>
+
+`;
+
+exports[`FundingTabButton renders with a count 1`] = `
+
+<gui-tabs-trigger
+  value="funding"
+  variant="nestedCard"
+  classname="flex"
+>
+  Funding
+  <gui-data-badge
+    variant="count"
+    classnames="[object Object]"
+    content="8"
+  >
+  </gui-data-badge>
+</gui-tabs-trigger>
+
+`;
+
+exports[`FundingTabContent renders with an empty state  1`] = `
+
+<gui-tabs-content value="funding">
+  <gui-empty-state
+    icon="gui-heart-handshake-icon"
+    message="No dependencies are looking for funding"
+  >
+  </gui-empty-state>
+</gui-tabs-content>
+
+`;
+
+exports[`FundingTabContent renders with an funding 1`] = `
+
+<gui-tabs-content value="funding">
+  <div class="flex flex-col gap-3 py-4">
+    <div class="flex flex-col gap-3 px-6">
+      <div class="duration-250 relative flex w-full cursor-default flex-col gap-2 rounded-sm border-[1px] border-muted bg-secondary/30 px-3 py-3 transition-colors">
+        <p class="font-regular text-xs tracking-wide text-muted-foreground">
+          Packages looking for funding
+        </p>
+        <p class="inline-flex items-center gap-1 font-mono text-2xl font-medium tabular-nums text-foreground">
+          <span>
+            <gui-heart-handshake-icon
+              classname="text-pink-500"
+              size="24"
+            >
+            </gui-heart-handshake-icon>
+          </span>
+          8
+        </p>
+      </div>
+      <div class="my-2 flex w-2/3 flex-col gap-1 text-pretty">
+        <p class="text-medium text-sm capitalize text-foreground">
+          support the tools you rely on
+        </p>
+        <p class="text-sm font-medium text-muted-foreground">
+          Some of the packages you're using have funding options available. Supporting them helps ensure these projects remain maintained and sustainable for the community.
+        </p>
+      </div>
+    </div>
+    <gui-table classname="cursor-default border-t-[1px] border-muted">
+      <gui-table-header>
+        <gui-table-row>
+          <gui-table-head
+            classname="cursor-default capitalize h-fit px-0 py-1 align-middle first-of-type:pl-8 last-of-type:pr-8 [&amp;>button]:first-of-type:pl-0 [&amp;>p]:last-of-type:pl-3"
+            style="width: 80px;"
+          >
+            <gui-sorting-header
+              header="Count"
+              column="[object Object]"
+              classname="px-3 py-3 align-top cursor-default capitalize"
+            >
+            </gui-sorting-header>
+          </gui-table-head>
+          <gui-table-head
+            classname="cursor-default capitalize h-fit px-0 py-1 align-middle first-of-type:pl-8 last-of-type:pr-8 [&amp;>button]:first-of-type:pl-0 [&amp;>p]:last-of-type:pl-3"
+            style="width: 150px;"
+          >
+            <gui-sorting-header
+              header="Type"
+              column="[object Object]"
+              classname="px-3 py-3 align-top cursor-default capitalize"
+            >
+            </gui-sorting-header>
+          </gui-table-head>
+          <gui-table-head
+            classname="cursor-default capitalize h-fit px-0 py-1 align-middle first-of-type:pl-8 last-of-type:pr-8 [&amp;>button]:first-of-type:pl-0 [&amp;>p]:last-of-type:pl-3"
+            style="width: 200px;"
+          >
+            <gui-sorting-header
+              header="Type"
+              column="[object Object]"
+              classname="px-3 py-3 align-top cursor-default capitalize"
+            >
+            </gui-sorting-header>
+          </gui-table-head>
+        </gui-table-row>
+      </gui-table-header>
+      <gui-table-body>
+        <gui-table-row
+          role="button"
+          classname="cursor-default"
+          data-state="false"
+        >
+          <gui-table-cell
+            classname="px-3 py-3 align-top cursor-default capitalize first-of-type:pl-8 last-of-type:pr-8"
+            style="width: 80px;"
+          >
+            <p class="font-mono text-sm font-medium tabular-nums">
+              4
+            </p>
+          </gui-table-cell>
+          <gui-table-cell
+            classname="px-3 py-3 align-top cursor-default capitalize first-of-type:pl-8 last-of-type:pr-8"
+            style="width: 150px;"
+          >
+            github
+          </gui-table-cell>
+          <gui-table-cell
+            classname="px-3 py-3 align-top cursor-default capitalize first-of-type:pl-8 last-of-type:pr-8"
+            style="width: 200px;"
+          >
+            <span class="lowercase">
+              darcyclake
+            </span>
+          </gui-table-cell>
+        </gui-table-row>
+        <gui-table-row
+          role="button"
+          classname="cursor-default"
+          data-state="false"
+        >
+          <gui-table-cell
+            classname="px-3 py-3 align-top cursor-default capitalize first-of-type:pl-8 last-of-type:pr-8"
+            style="width: 80px;"
+          >
+            <p class="font-mono text-sm font-medium tabular-nums">
+              4
+            </p>
+          </gui-table-cell>
+          <gui-table-cell
+            classname="px-3 py-3 align-top cursor-default capitalize first-of-type:pl-8 last-of-type:pr-8"
+            style="width: 150px;"
+          >
+            github
+          </gui-table-cell>
+          <gui-table-cell
+            classname="px-3 py-3 align-top cursor-default capitalize first-of-type:pl-8 last-of-type:pr-8"
+            style="width: 200px;"
+          >
+            <span class="lowercase">
+              ruyadorno
+            </span>
+          </gui-table-cell>
+        </gui-table-row>
+      </gui-table-body>
+    </gui-table>
+  </div>
+</gui-tabs-content>
+
+`;

--- a/src/gui/test/components/explorer-grid/selected-item/tabs-dependencies/index.tsx
+++ b/src/gui/test/components/explorer-grid/selected-item/tabs-dependencies/index.tsx
@@ -107,6 +107,8 @@ test('DependenciesTabsButton renders correctly', () => {
       setDepWarnings: vi.fn(),
       duplicatedDeps: undefined,
       setDuplicatedDeps: vi.fn(),
+      depFunding: undefined,
+      setDepFunding: vi.fn(),
     }),
   )
 
@@ -145,6 +147,8 @@ test('DependenciesTabContent renders default', () => {
       setDepWarnings: vi.fn(),
       duplicatedDeps: undefined,
       setDuplicatedDeps: vi.fn(),
+      depFunding: undefined,
+      setDepFunding: vi.fn(),
     }),
   )
 
@@ -183,6 +187,8 @@ test('DependenciesTabContent renders an empty state', () => {
       setDepWarnings: vi.fn(),
       duplicatedDeps: undefined,
       setDuplicatedDeps: vi.fn(),
+      depFunding: undefined,
+      setDepFunding: vi.fn(),
     }),
   )
 

--- a/src/gui/test/components/explorer-grid/selected-item/tabs-dependencies/tabs-funding.tsx
+++ b/src/gui/test/components/explorer-grid/selected-item/tabs-dependencies/tabs-funding.tsx
@@ -5,10 +5,10 @@ import { useGraphStore as useStore } from '@/state/index.ts'
 import { useSelectedItemStore } from '@/components/explorer-grid/selected-item/context.tsx'
 import { SELECTED_ITEM } from '../__fixtures__/item.ts'
 import {
-  DuplicatesTabButton,
-  DuplicatesTabContent,
-} from '@/components/explorer-grid/selected-item/tabs-dependencies/tabs-duplicates.tsx'
-import type { DuplicatedDeps } from '@/components/explorer-grid/selected-item/context.tsx'
+  FundingTabButton,
+  FundingTabContent,
+} from '@/components/explorer-grid/selected-item/tabs-dependencies/tabs-funding.tsx'
+import type { DepFunding } from '@/components/explorer-grid/selected-item/context.tsx'
 
 vi.mock(
   '@/components/explorer-grid/selected-item/context.tsx',
@@ -29,12 +29,17 @@ vi.mock('@/components/ui/tabs.tsx', () => ({
   TabsContent: 'gui-tabs-content',
 }))
 
-vi.mock('@/components/ui/data-badge.tsx', () => ({
-  DataBadge: 'gui-data-badge',
+vi.mock('@/components/ui/table.tsx', () => ({
+  Table: 'gui-table',
+  TableBody: 'gui-table-body',
+  TableCell: 'gui-table-cell',
+  TableHead: 'gui-table-head',
+  TableHeader: 'gui-table-header',
+  TableRow: 'gui-table-row',
 }))
 
 vi.mock('lucide-react', () => ({
-  Blocks: 'gui-blocks-icon',
+  HeartHandshake: 'gui-heart-handshake-icon',
 }))
 
 vi.mock(
@@ -43,6 +48,23 @@ vi.mock(
     EmptyState: 'gui-empty-state',
   }),
 )
+
+vi.mock(
+  '@/components/explorer-grid/selected-item/tabs-dependencies/table-utilities.tsx',
+  async () => {
+    const actual = await import(
+      '@/components/explorer-grid/selected-item/tabs-dependencies/table-utilities.tsx'
+    )
+    return {
+      ...actual,
+      SortingHeader: 'gui-sorting-header',
+    }
+  },
+)
+
+vi.mock('@/components/ui/data-badge.tsx', () => ({
+  DataBadge: 'gui-data-badge',
+}))
 
 expect.addSnapshotSerializer({
   serialize: v => html(v),
@@ -55,22 +77,20 @@ afterEach(() => {
   cleanup()
 })
 
-const mockDuplicatedDeps = {
-  next: {
-    count: 2,
-    versions: ['12.0.0', '12.1.0'],
+const mockDepFunding = {
+  darcyclake: {
+    type: 'github',
+    url: 'https://www.github.com/darcyclarke',
+    count: 4,
   },
-  react: {
-    count: 3,
-    versions: ['17.0.2', '18.0.0', '18.1.0'],
+  ruyadorno: {
+    type: 'github',
+    url: 'https://www.github.com/ruyadorno',
+    count: 4,
   },
-  lodash: {
-    count: 1,
-    versions: ['4.17.21'],
-  },
-} satisfies DuplicatedDeps
+} satisfies DepFunding
 
-test('DuplicatesTabButton renders correctly', () => {
+test('FundingTabButton renders correctly', () => {
   vi.mocked(useSelectedItemStore).mockImplementation(selector =>
     selector({
       selectedItem: SELECTED_ITEM,
@@ -96,22 +116,22 @@ test('DuplicatesTabButton renders correctly', () => {
       setDepLicenses: vi.fn(),
       depWarnings: undefined,
       setDepWarnings: vi.fn(),
+      depFunding: undefined,
+      setDepFunding: vi.fn(),
       duplicatedDeps: undefined,
       setDuplicatedDeps: vi.fn(),
-      depFunding: undefined,
-      setDepFunding: vi.fn(),
     }),
   )
 
   const Container = () => {
-    return <DuplicatesTabButton />
+    return <FundingTabButton />
   }
 
   const { container } = render(<Container />)
   expect(container.innerHTML).toMatchSnapshot()
 })
 
-test('DuplicatesTabButton renders with a count', () => {
+test('FundingTabButton renders with a count', () => {
   vi.mocked(useSelectedItemStore).mockImplementation(selector =>
     selector({
       selectedItem: SELECTED_ITEM,
@@ -137,63 +157,22 @@ test('DuplicatesTabButton renders with a count', () => {
       setDepLicenses: vi.fn(),
       depWarnings: undefined,
       setDepWarnings: vi.fn(),
-      duplicatedDeps: mockDuplicatedDeps,
-      setDuplicatedDeps: vi.fn(),
-      depFunding: undefined,
+      depFunding: mockDepFunding,
       setDepFunding: vi.fn(),
-    }),
-  )
-
-  const Container = () => {
-    return <DuplicatesTabButton />
-  }
-
-  const { container } = render(<Container />)
-  expect(container.innerHTML).toMatchSnapshot()
-})
-
-test('DuplicatesTabContent renders with an empty state', () => {
-  vi.mocked(useSelectedItemStore).mockImplementation(selector =>
-    selector({
-      selectedItem: SELECTED_ITEM,
-      activeTab: 'dependencies',
-      setActiveTab: vi.fn(),
-      manifest: null,
-      rawManifest: null,
-      packageScore: undefined,
-      insights: undefined,
-      author: undefined,
-      favicon: undefined,
-      publisher: undefined,
-      publisherAvatar: undefined,
-      versions: undefined,
-      greaterVersions: undefined,
-      depCount: undefined,
-      setDepCount: vi.fn(),
-      scannedDeps: undefined,
-      setScannedDeps: vi.fn(),
-      depsAverageScore: undefined,
-      setDepsAverageScore: vi.fn(),
-      depLicenses: undefined,
-      setDepLicenses: vi.fn(),
-      depWarnings: undefined,
-      setDepWarnings: vi.fn(),
       duplicatedDeps: undefined,
       setDuplicatedDeps: vi.fn(),
-      depFunding: undefined,
-      setDepFunding: vi.fn(),
     }),
   )
 
   const Container = () => {
-    return <DuplicatesTabContent />
+    return <FundingTabButton />
   }
 
   const { container } = render(<Container />)
   expect(container.innerHTML).toMatchSnapshot()
 })
 
-test('DuplicatesTabContent renders with duplicated deps', () => {
+test('FundingTabContent renders with an empty state ', () => {
   vi.mocked(useSelectedItemStore).mockImplementation(selector =>
     selector({
       selectedItem: SELECTED_ITEM,
@@ -219,15 +198,56 @@ test('DuplicatesTabContent renders with duplicated deps', () => {
       setDepLicenses: vi.fn(),
       depWarnings: undefined,
       setDepWarnings: vi.fn(),
-      duplicatedDeps: mockDuplicatedDeps,
-      setDuplicatedDeps: vi.fn(),
       depFunding: undefined,
       setDepFunding: vi.fn(),
+      duplicatedDeps: undefined,
+      setDuplicatedDeps: vi.fn(),
     }),
   )
 
   const Container = () => {
-    return <DuplicatesTabContent />
+    return <FundingTabContent />
+  }
+
+  const { container } = render(<Container />)
+  expect(container.innerHTML).toMatchSnapshot()
+})
+
+test('FundingTabContent renders with an funding', () => {
+  vi.mocked(useSelectedItemStore).mockImplementation(selector =>
+    selector({
+      selectedItem: SELECTED_ITEM,
+      activeTab: 'dependencies',
+      setActiveTab: vi.fn(),
+      manifest: null,
+      rawManifest: null,
+      packageScore: undefined,
+      insights: undefined,
+      author: undefined,
+      favicon: undefined,
+      publisher: undefined,
+      publisherAvatar: undefined,
+      versions: undefined,
+      greaterVersions: undefined,
+      depCount: undefined,
+      setDepCount: vi.fn(),
+      scannedDeps: undefined,
+      setScannedDeps: vi.fn(),
+      depsAverageScore: undefined,
+      setDepsAverageScore: vi.fn(),
+      depLicenses: undefined,
+      setDepLicenses: vi.fn(),
+      depWarnings: undefined,
+      setDepWarnings: vi.fn(),
+      depFunding: mockDepFunding,
+      setDepFunding: vi.fn(),
+      duplicatedDeps: undefined,
+      setDuplicatedDeps: vi.fn(),
+    }),
+  )
+
+  const Container = () => {
+    return <FundingTabContent />
   }
 
   const { container } = render(<Container />)

--- a/src/gui/test/components/explorer-grid/selected-item/tabs-dependencies/tabs-insights.tsx
+++ b/src/gui/test/components/explorer-grid/selected-item/tabs-dependencies/tabs-insights.tsx
@@ -164,6 +164,8 @@ test('InsightsTabButton renders with insight count', () => {
       setDepWarnings: vi.fn(),
       duplicatedDeps: undefined,
       setDuplicatedDeps: vi.fn(),
+      depFunding: undefined,
+      setDepFunding: vi.fn(),
     }),
   )
 
@@ -203,6 +205,8 @@ test('InsightsTabContent renders with an empty state', () => {
       setDepWarnings: vi.fn(),
       duplicatedDeps: undefined,
       setDuplicatedDeps: vi.fn(),
+      depFunding: undefined,
+      setDepFunding: vi.fn(),
     }),
   )
 
@@ -242,6 +246,8 @@ test('InsightsTabContent renders with insights', () => {
       setDepWarnings: vi.fn(),
       duplicatedDeps: undefined,
       setDuplicatedDeps: vi.fn(),
+      depFunding: undefined,
+      setDepFunding: vi.fn(),
     }),
   )
 
@@ -281,6 +287,8 @@ test('InsightsTabContent renders with a warning for unscanned deps', () => {
       setDepWarnings: vi.fn(),
       duplicatedDeps: undefined,
       setDuplicatedDeps: vi.fn(),
+      depFunding: undefined,
+      setDepFunding: vi.fn(),
     }),
   )
 

--- a/src/gui/test/components/explorer-grid/selected-item/tabs-dependencies/tabs-licenses.tsx
+++ b/src/gui/test/components/explorer-grid/selected-item/tabs-dependencies/tabs-licenses.tsx
@@ -177,6 +177,8 @@ test('LicensesTabButton renders default', () => {
       setDepWarnings: vi.fn(),
       duplicatedDeps: undefined,
       setDuplicatedDeps: vi.fn(),
+      depFunding: undefined,
+      setDepFunding: vi.fn(),
     }),
   )
 
@@ -216,6 +218,8 @@ test('LicensesTabButton renders with license count', () => {
       setDepWarnings: vi.fn(),
       duplicatedDeps: undefined,
       setDuplicatedDeps: vi.fn(),
+      depFunding: undefined,
+      setDepFunding: vi.fn(),
     }),
   )
 
@@ -255,6 +259,8 @@ test('LicensesTabContent renders with an empty state', () => {
       setDepWarnings: vi.fn(),
       duplicatedDeps: undefined,
       setDuplicatedDeps: vi.fn(),
+      depFunding: undefined,
+      setDepFunding: vi.fn(),
     }),
   )
 
@@ -294,6 +300,8 @@ test('LicensesTabContent renders with licenses', () => {
       setDepWarnings: vi.fn(),
       duplicatedDeps: undefined,
       setDuplicatedDeps: vi.fn(),
+      depFunding: undefined,
+      setDepFunding: vi.fn(),
     }),
   )
 

--- a/src/gui/test/components/explorer-grid/selected-item/tabs-insight.tsx
+++ b/src/gui/test/components/explorer-grid/selected-item/tabs-insight.tsx
@@ -136,6 +136,8 @@ test('InsightTabContent renders an empty state', () => {
     setDepWarnings: vi.fn(),
     duplicatedDeps: undefined,
     setDuplicatedDeps: vi.fn(),
+    depFunding: undefined,
+    setDepFunding: vi.fn(),
   } satisfies SelectedItemStore
 
   vi.mocked(useSelectedItemStore).mockImplementation(selector =>
@@ -171,6 +173,8 @@ test('InsightTabContent renders with insights', () => {
     setDepWarnings: vi.fn(),
     duplicatedDeps: undefined,
     setDuplicatedDeps: vi.fn(),
+    depFunding: undefined,
+    setDepFunding: vi.fn(),
   } satisfies SelectedItemStore
 
   vi.mocked(useSelectedItemStore).mockImplementation(selector =>
@@ -207,6 +211,8 @@ test('InsightTabContent renders with no insights but a package score', () => {
     setDepWarnings: vi.fn(),
     duplicatedDeps: undefined,
     setDuplicatedDeps: vi.fn(),
+    depFunding: undefined,
+    setDepFunding: vi.fn(),
   } satisfies SelectedItemStore
 
   vi.mocked(useSelectedItemStore).mockImplementation(selector =>
@@ -242,6 +248,8 @@ test('InsightTabButton renders default', () => {
     setDepWarnings: vi.fn(),
     duplicatedDeps: undefined,
     setDuplicatedDeps: vi.fn(),
+    depFunding: undefined,
+    setDepFunding: vi.fn(),
   } satisfies SelectedItemStore
 
   vi.mocked(useSelectedItemStore).mockImplementation(selector =>

--- a/src/gui/test/components/explorer-grid/selected-item/tabs-manifest.tsx
+++ b/src/gui/test/components/explorer-grid/selected-item/tabs-manifest.tsx
@@ -94,6 +94,8 @@ test('TabsManifestButton renders default', () => {
     setDepWarnings: vi.fn(),
     duplicatedDeps: undefined,
     setDuplicatedDeps: vi.fn(),
+    depFunding: undefined,
+    setDepFunding: vi.fn(),
   } satisfies SelectedItemStore
 
   vi.mocked(useSelectedItemStore).mockImplementation(selector =>
@@ -129,6 +131,8 @@ test('TabsManifestContent renders an empty state', () => {
     setDepWarnings: vi.fn(),
     duplicatedDeps: undefined,
     setDuplicatedDeps: vi.fn(),
+    depFunding: undefined,
+    setDepFunding: vi.fn(),
   } satisfies SelectedItemStore
 
   vi.mocked(useSelectedItemStore).mockImplementation(selector =>
@@ -164,6 +168,8 @@ test('TabsManifestContent renders with a manifest', () => {
     setDepWarnings: vi.fn(),
     duplicatedDeps: undefined,
     setDuplicatedDeps: vi.fn(),
+    depFunding: undefined,
+    setDepFunding: vi.fn(),
   } satisfies SelectedItemStore
 
   vi.mocked(useSelectedItemStore).mockImplementation(selector =>

--- a/src/gui/test/components/explorer-grid/selected-item/tabs-overview.tsx
+++ b/src/gui/test/components/explorer-grid/selected-item/tabs-overview.tsx
@@ -121,6 +121,8 @@ test('OverviewTabButton renders default', () => {
     setDepWarnings: vi.fn(),
     duplicatedDeps: undefined,
     setDuplicatedDeps: vi.fn(),
+    depFunding: undefined,
+    setDepFunding: vi.fn(),
   } satisfies SelectedItemStore
 
   vi.mocked(useSelectedItemStore).mockImplementation(selector =>
@@ -157,6 +159,8 @@ test('OverviewTabContent renders default', () => {
     setDepWarnings: vi.fn(),
     duplicatedDeps: undefined,
     setDuplicatedDeps: vi.fn(),
+    depFunding: undefined,
+    setDepFunding: vi.fn(),
   } satisfies SelectedItemStore
 
   vi.mocked(useSelectedItemStore).mockImplementation(selector =>
@@ -195,6 +199,8 @@ test('OverviewTabContent renders with content', () => {
     setDepWarnings: vi.fn(),
     duplicatedDeps: undefined,
     setDuplicatedDeps: vi.fn(),
+    depFunding: undefined,
+    setDepFunding: vi.fn(),
   } satisfies SelectedItemStore
 
   vi.mocked(useSelectedItemStore).mockImplementation(selector =>
@@ -257,6 +263,8 @@ test('OverviewTabContent renders with an aside and content', () => {
     setDepWarnings: vi.fn(),
     duplicatedDeps: undefined,
     setDuplicatedDeps: vi.fn(),
+    depFunding: undefined,
+    setDepFunding: vi.fn(),
   } satisfies SelectedItemStore
 
   vi.mocked(useSelectedItemStore).mockImplementation(selector =>

--- a/src/gui/test/components/explorer-grid/selected-item/tabs-versions.tsx
+++ b/src/gui/test/components/explorer-grid/selected-item/tabs-versions.tsx
@@ -168,6 +168,8 @@ test('VersionsTabButton renders default', () => {
     setDepWarnings: vi.fn(),
     duplicatedDeps: undefined,
     setDuplicatedDeps: vi.fn(),
+    depFunding: undefined,
+    setDepFunding: vi.fn(),
   } satisfies SelectedItemStore
 
   vi.mocked(useSelectedItemStore).mockImplementation(selector =>
@@ -201,6 +203,8 @@ test('VersionsTabContent renders with versions', () => {
     setDepWarnings: vi.fn(),
     duplicatedDeps: undefined,
     setDuplicatedDeps: vi.fn(),
+    depFunding: undefined,
+    setDepFunding: vi.fn(),
   } satisfies SelectedItemStore
 
   vi.mocked(useSelectedItemStore).mockImplementation(selector =>
@@ -234,6 +238,8 @@ test('VersionsTabContent renders an empty state', () => {
     setDepWarnings: vi.fn(),
     duplicatedDeps: undefined,
     setDuplicatedDeps: vi.fn(),
+    depFunding: undefined,
+    setDepFunding: vi.fn(),
   } satisfies SelectedItemStore
 
   vi.mocked(useSelectedItemStore).mockImplementation(selector =>
@@ -267,6 +273,8 @@ test('VersionsTabContent filters versions', () => {
     setDepWarnings: vi.fn(),
     duplicatedDeps: undefined,
     setDuplicatedDeps: vi.fn(),
+    depFunding: undefined,
+    setDepFunding: vi.fn(),
   } satisfies SelectedItemStore
 
   vi.mocked(useSelectedItemStore).mockImplementation(selector =>
@@ -306,6 +314,8 @@ test('VersionsTabContent toggles pre-releases', () => {
     setDepWarnings: vi.fn(),
     duplicatedDeps: undefined,
     setDuplicatedDeps: vi.fn(),
+    depFunding: undefined,
+    setDepFunding: vi.fn(),
   } satisfies SelectedItemStore
 
   vi.mocked(useSelectedItemStore).mockImplementation(selector =>
@@ -345,6 +355,8 @@ test('VersionsTabContent filters pre-releases', () => {
     setDepWarnings: vi.fn(),
     duplicatedDeps: undefined,
     setDuplicatedDeps: vi.fn(),
+    depFunding: undefined,
+    setDepFunding: vi.fn(),
   } satisfies SelectedItemStore
 
   vi.mocked(useSelectedItemStore).mockImplementation(selector =>
@@ -388,6 +400,8 @@ test('VersionsTabContent filters newer versions', () => {
     setDepWarnings: vi.fn(),
     duplicatedDeps: undefined,
     setDuplicatedDeps: vi.fn(),
+    depFunding: undefined,
+    setDepFunding: vi.fn(),
   } satisfies SelectedItemStore
 
   vi.mocked(useSelectedItemStore).mockImplementation(selector =>
@@ -431,6 +445,8 @@ test('VersionsTabContent handles missing manifest version', () => {
     setDepWarnings: vi.fn(),
     duplicatedDeps: undefined,
     setDuplicatedDeps: vi.fn(),
+    depFunding: undefined,
+    setDepFunding: vi.fn(),
   } satisfies SelectedItemStore
 
   vi.mocked(useSelectedItemStore).mockImplementation(selector =>


### PR DESCRIPTION
<img width="736" alt="Screenshot 2025-06-24 at 13 13 29" src="https://github.com/user-attachments/assets/8467ae75-0085-4c17-862c-1127d804869e" />

This PR adds another new subtab inside of `tabs-dependencies` for funding information.

It allows you to see:
- The total packages looking for funding
- The count of the unique funding urls
- To query the dependencies for the funding attribute