### PR TITLE
graph: fix updating package.json

### DIFF
--- a/src/graph/src/reify/update-importers-package-json.ts
+++ b/src/graph/src/reify/update-importers-package-json.ts
@@ -142,7 +142,7 @@ const addOrRemoveDeps = (
         node.version,
       )
       dependencies[name] = saveValue
-      manifestChanged = saveValue !== existing
+      manifestChanged = manifestChanged || saveValue !== existing
     }
   }
   return manifestChanged ? manifest : undefined

--- a/src/graph/tap-snapshots/test/reify/update-importers-package-json.ts.test.cjs
+++ b/src/graph/tap-snapshots/test/reify/update-importers-package-json.ts.test.cjs
@@ -74,6 +74,19 @@ Array [
 ]
 `
 
+exports[`test/reify/update-importers-package-json.ts > TAP > updatePackageJson > multiple dependencies with mixed changes > should save manifest with mixed dependency changes 1`] = `
+Array [
+  Object {
+    "dependencies": Object {
+      "last-dep": "^2.0.0",
+      "new-dep": "^1.0.0",
+    },
+    "name": "root-with-deps",
+    "version": "1.0.0",
+  },
+]
+`
+
 exports[`test/reify/update-importers-package-json.ts > TAP > updatePackageJson > no semver dep > should use provided def in package json save 1`] = `
 Array [
   Object {


### PR DESCRIPTION
Updating `package.json` was not working as expected if a dependency that comes later would be unchanged since the `manifestChanged` state would be overridden by the latest parsed value.

This changeset fixes it by properly keeping the previous internal to `update-importers-package-json.ts` `manifestChanged` state.