### PR TITLE
gui: fix dependency query

### DIFF
--- a/src/gui/src/components/explorer-grid/selected-item/index.tsx
+++ b/src/gui/src/components/explorer-grid/selected-item/index.tsx
@@ -97,7 +97,6 @@ const getDependencyItems = (
       depIndex: count.currIndex++,
       id: edge.to.id,
       title,
-      name: edge.to.name || '',
       version: edge.to.version || '',
       stacked: false,
       size: 1,
@@ -150,7 +149,7 @@ const getUninstalledDependencyItems = (
 
 const getItemQuery = (item: GridItemData) => {
   if (!item.to) return ''
-  const name = item.to.name ? `#${item.to.name}` : ''
+  const name = item.name ? `#${item.name}` : ''
   return name.trim()
 }
 


### PR DESCRIPTION
When clicking on a sidebar dependency item, the query should use the edge name instead of node in order to support aliased packages.


https://github.com/user-attachments/assets/f2e7980e-8aea-4be5-80ba-1ff728bb0595
