### PR TITLE
gui: fix sidebar parent item render

### DIFF
--- a/src/gui/src/components/explorer-grid/selected-item/index.tsx
+++ b/src/gui/src/components/explorer-grid/selected-item/index.tsx
@@ -19,6 +19,7 @@ const getParent = (
   const title = edge?.name ? `${edge.name}${edgeVersion}` : ''
   return {
     ...edge,
+    spec: undefined,
     id: node.id,
     name: node.name || '',
     title,


### PR DESCRIPTION
The parent sidebar item should not display any spec value.

### Before

<img width="1214" alt="Screenshot 2025-06-24 at 9 17 57 PM" src="https://github.com/user-attachments/assets/e1ea7d4a-f991-4fa6-a8a1-f05983e76674" />

### After

<img width="1215" alt="Screenshot 2025-06-24 at 9 16 57 PM" src="https://github.com/user-attachments/assets/50fe78c9-fe90-4159-8b4a-46d4cbcd9bf0" />
