### PR TITLE
gui: avoid 1password in input fields

### DIFF
--- a/src/gui/src/components/explorer-grid/dependency-sidebar/add-dependency.tsx
+++ b/src/gui/src/components/explorer-grid/dependency-sidebar/add-dependency.tsx
@@ -157,6 +157,7 @@ export const AddDependenciesPopover = () => {
             const value = (e.currentTarget as HTMLInputElement).value
             setPackageName(value)
           }}
+          data-1p-ignore
         />
         <Label htmlFor="package-version" className="ml-1 mt-2">
           Version | Spec
@@ -171,6 +172,7 @@ export const AddDependenciesPopover = () => {
             const value = (e.currentTarget as HTMLInputElement).value
             setPackageVersion(value)
           }}
+          data-1p-ignore
         />
         <Label htmlFor="package-type" className="ml-1 mt-2">
           Type

--- a/src/gui/test/components/explorer-grid/dependency-sidebar/__snapshots__/add-dependency.tsx.snap
+++ b/src/gui/test/components/explorer-grid/dependency-sidebar/__snapshots__/add-dependency.tsx.snap
@@ -81,6 +81,7 @@ exports[`add-dependencies-popover render default 1`] = `
     role="input"
     placeholder="Package name"
     value
+    data-1p-ignore="true"
   >
   </gui-input>
   <gui-label
@@ -95,6 +96,7 @@ exports[`add-dependencies-popover render default 1`] = `
     type="text"
     role="input"
     value="latest"
+    data-1p-ignore="true"
   >
   </gui-input>
   <gui-label


### PR DESCRIPTION
The 1password extension icon should not show up in the add dependency input fields.