### PR TITLE
gui: fix create query tooltip

### DIFF
--- a/src/gui/src/components/queries/create-query.tsx
+++ b/src/gui/src/components/queries/create-query.tsx
@@ -18,6 +18,7 @@ import {
   TooltipProvider,
   TooltipTrigger,
   TooltipContent,
+  TooltipPortal,
 } from '@/components/ui/tooltip.tsx'
 import { ChevronsUpDown, CircleHelp } from 'lucide-react'
 import { cn } from '@/lib/utils.ts'
@@ -132,10 +133,12 @@ export const CreateQuery = ({
                     size={18}
                   />
                 </TooltipTrigger>
-                <TooltipContent>
-                  Set directory to 'Global' to reuse across all
-                  projects.
-                </TooltipContent>
+                <TooltipPortal>
+                  <TooltipContent>
+                    Set directory to 'Global' to reuse across all
+                    projects.
+                  </TooltipContent>
+                </TooltipPortal>
               </Tooltip>
             </TooltipProvider>
             <DirectorySelect

--- a/src/gui/test/components/queries/__snapshots__/create-query.tsx.snap
+++ b/src/gui/test/components/queries/__snapshots__/create-query.tsx.snap
@@ -47,9 +47,11 @@ exports[`create-query > should render correctly 1`] = `
               >
               </gui-circle-help-icon>
             </gui-tooltip-trigger>
-            <gui-tooltip-content>
-              Set directory to 'Global' to reuse across all projects.
-            </gui-tooltip-content>
+            <gui-tooltip-portal>
+              <gui-tooltip-content>
+                Set directory to 'Global' to reuse across all projects.
+              </gui-tooltip-content>
+            </gui-tooltip-portal>
           </gui-tooltip>
         </gui-tooltip-provider>
         <gui-directory-select directory>

--- a/src/gui/test/components/queries/create-query.tsx
+++ b/src/gui/test/components/queries/create-query.tsx
@@ -36,6 +36,7 @@ vi.mock('@/components/ui/tooltip.tsx', () => ({
   TooltipContent: 'gui-tooltip-content',
   TooltipProvider: 'gui-tooltip-provider',
   TooltipTrigger: 'gui-tooltip-trigger',
+  TooltipPortal: 'gui-tooltip-portal',
 }))
 
 vi.mock('lucide-react', () => ({


### PR DESCRIPTION
The query tooltip for the saved category color was being cropped by the top level background.

<img width="281" alt="Screenshot 2025-06-24 at 9 33 54 PM" src="https://github.com/user-attachments/assets/c4498151-ea74-451b-a80c-80d8f5b5d3ff" />
