### PR TITLE
gui: change dep type colors

### DIFF
--- a/src/gui/src/components/explorer-grid/label-helper.ts
+++ b/src/gui/src/components/explorer-grid/label-helper.ts
@@ -2,27 +2,27 @@ export const labelClassNamesMap = new Map<string | undefined, string>(
   [
     [
       undefined,
-      'bg-gray-100 border-[1px] border-neutral-900 text-neutral-900 hover:bg-gray-100/80',
+      'border-[1px] border-neutral-900  bg-gray-100 text-neutral-900 hover:bg-gray-100/80',
     ],
     [
       'prod',
-      'bg-cyan-500/25 text-cyan-600 border-[1px] border-cyan-600 dark:border-cyan-500 hover:bg-cyan-500/40 dark:bg-cyan-500/30 dark:text-cyan-500 dark:hover:bg-cyan-500/40',
+      'border-transparent bg-cyan-100 text-neutral-900 hover:bg-cyan-100/80',
     ],
     [
       'dev',
-      'bg-fuchsia-500/20 border-[1px] dark:border-fuchsia-400 border-fuchsia-500 text-fuchsia-500 hover:bg-fuchsia-400/30 dark:bg-fuchsia-500/30 dark:text-fuchsia-400 dark:hover:bg-fuchsia-500/40',
+      'border-[1px] dark:border-fuchsia-600 border-fuchsia-500 bg-fuchsia-100 dark:bg-fuchsia-300 text-neutral-900 dark:text-fuchsia-900 hover:bg-fuchsia-100/80',
     ],
     [
       'optional',
-      'bg-orange-500/20 border-[1px] border-orange-500 dark:border-orange-400 text-orange-500 hover:bg-orange-400/30 dark:bg-orange-500/30 dark:text-orange-400 dark:hover:bg-orange-500/40',
+      'border-[1px] border-orange-500 dark:border-orange-400 bg-orange-100 text-neutral-900 dark:text-orange-900 hover:bg-orange-100/80',
     ],
     [
       'peer',
-      'bg-lime-500/25 border-[1px] border-lime-600 dark:border-lime-400 text-lime-600 hover:bg-lime-400/40 dark:bg-lime-500/30 dark:text-lime-400 dark:hover:bg-lime-500/40',
+      'border-[1px] border-lime-600 dark:border-lime-700 bg-lime-100 dark:bg-lime-300 text-neutral-900 dark:text-lime-900 hover:bg-lime-100/80',
     ],
     [
       'peerOptional',
-      'bg-yellow-500/25 border-[1px] border-yellow-600 dark:border-yellow-400 text-yellow-600 hover:bg-yellow-400/40 dark:bg-yellow-500/30 dark:text-yellow-400 dark:hover:bg-yellow-500/40',
+      'border-[1px] border-yellow-600 dark:border-yellow-400  bg-yellow-100 text-neutral-900 dark:text-yellow-900 hover:bg-yellow-100/80',
     ],
     [
       'workspace',

--- a/src/gui/src/components/ui/badge.tsx
+++ b/src/gui/src/components/ui/badge.tsx
@@ -4,7 +4,7 @@ import type { VariantProps } from 'class-variance-authority'
 import { cn } from '@/lib/utils.ts'
 
 const badgeVariants = cva(
-  'inline-flex items-center rounded-full border border-muted px-2.5 py-0.5 text-xs font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2',
+  'inline-flex items-center rounded-full border border-muted px-2.5 text-xs font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2',
   {
     variants: {
       variant: {

--- a/src/gui/test/components/explorer-grid/__snapshots__/side-item.tsx.snap
+++ b/src/gui/test/components/explorer-grid/__snapshots__/side-item.tsx.snap
@@ -24,7 +24,7 @@ exports[`SideItem clicks on a workspace item change the query 1`] = `
           v1.0.0
         </span>
         <div class="absolute -bottom-3 right-2.5">
-          <gui-badge classname="bg-cyan-500/25 border-[1px] border-cyan-600 dark:border-cyan-500 hover:bg-cyan-500/40 dark:bg-cyan-500/30 dark:text-cyan-500 dark:hover:bg-cyan-500/40 h-[18px] rounded-full text-xxs font-normal">
+          <gui-badge classname="border-transparent bg-cyan-100 hover:bg-cyan-100/80 h-[18px] rounded-full text-xxs font-normal">
             prod
           </gui-badge>
         </div>
@@ -68,7 +68,7 @@ exports[`SideItem render as aliased dependency 1`] = `
             v1.0.0
           </span>
           <div class="absolute -bottom-3 right-2.5">
-            <gui-badge classname="bg-cyan-500/25 border-[1px] border-cyan-600 dark:border-cyan-500 hover:bg-cyan-500/40 dark:bg-cyan-500/30 dark:text-cyan-500 dark:hover:bg-cyan-500/40 h-[18px] rounded-full text-xxs font-normal">
+            <gui-badge classname="border-transparent bg-cyan-100 hover:bg-cyan-100/80 h-[18px] rounded-full text-xxs font-normal">
               prod
             </gui-badge>
           </div>
@@ -113,7 +113,7 @@ exports[`SideItem render as dependency 1`] = `
             v1.0.0
           </span>
           <div class="absolute -bottom-3 right-2.5">
-            <gui-badge classname="bg-lime-500/25 border-[1px] border-lime-600 dark:border-lime-400 hover:bg-lime-400/40 dark:bg-lime-500/30 dark:text-lime-400 dark:hover:bg-lime-500/40 h-[18px] rounded-full text-xxs font-normal">
+            <gui-badge classname="border-[1px] border-lime-600 dark:border-lime-700 bg-lime-100 dark:bg-lime-300 dark:text-lime-900 hover:bg-lime-100/80 h-[18px] rounded-full text-xxs font-normal">
               peer
             </gui-badge>
           </div>
@@ -158,7 +158,7 @@ exports[`SideItem render as dependency with long name 1`] = `
             v1.0.0
           </span>
           <div class="absolute -bottom-3 right-2.5">
-            <gui-badge classname="bg-lime-500/25 border-[1px] border-lime-600 dark:border-lime-400 hover:bg-lime-400/40 dark:bg-lime-500/30 dark:text-lime-400 dark:hover:bg-lime-500/40 h-[18px] rounded-full text-xxs font-normal">
+            <gui-badge classname="border-[1px] border-lime-600 dark:border-lime-700 bg-lime-100 dark:bg-lime-300 dark:text-lime-900 hover:bg-lime-100/80 h-[18px] rounded-full text-xxs font-normal">
               peer
             </gui-badge>
           </div>
@@ -203,7 +203,7 @@ exports[`SideItem render as dependent 1`] = `
             v1.0.0
           </span>
           <div class="absolute -bottom-3 right-2.5">
-            <gui-badge classname="bg-cyan-500/25 border-[1px] border-cyan-600 dark:border-cyan-500 hover:bg-cyan-500/40 dark:bg-cyan-500/30 dark:text-cyan-500 dark:hover:bg-cyan-500/40 h-[18px] rounded-full text-xxs font-normal">
+            <gui-badge classname="border-transparent bg-cyan-100 hover:bg-cyan-100/80 h-[18px] rounded-full text-xxs font-normal">
               prod
             </gui-badge>
           </div>
@@ -248,7 +248,7 @@ exports[`SideItem render as git dependency 1`] = `
             v1.0.0
           </span>
           <div class="absolute -bottom-3 right-2.5">
-            <gui-badge classname="bg-cyan-500/25 border-[1px] border-cyan-600 dark:border-cyan-500 hover:bg-cyan-500/40 dark:bg-cyan-500/30 dark:text-cyan-500 dark:hover:bg-cyan-500/40 h-[18px] rounded-full text-xxs font-normal">
+            <gui-badge classname="border-transparent bg-cyan-100 hover:bg-cyan-100/80 h-[18px] rounded-full text-xxs font-normal">
               prod
             </gui-badge>
           </div>
@@ -296,7 +296,7 @@ exports[`SideItem render as multi-stacked dependent 1`] = `
             v1.0.0
           </span>
           <div class="absolute -bottom-3 right-2.5">
-            <gui-badge classname="bg-cyan-500/25 border-[1px] border-cyan-600 dark:border-cyan-500 hover:bg-cyan-500/40 dark:bg-cyan-500/30 dark:text-cyan-500 dark:hover:bg-cyan-500/40 h-[18px] rounded-full text-xxs font-normal">
+            <gui-badge classname="border-transparent bg-cyan-100 hover:bg-cyan-100/80 h-[18px] rounded-full text-xxs font-normal">
               prod
             </gui-badge>
           </div>
@@ -341,7 +341,7 @@ exports[`SideItem render as parent 1`] = `
             v1.0.0
           </span>
           <div class="absolute -bottom-3 right-2.5">
-            <gui-badge classname="bg-cyan-500/25 border-[1px] border-cyan-600 dark:border-cyan-500 hover:bg-cyan-500/40 dark:bg-cyan-500/30 dark:text-cyan-500 dark:hover:bg-cyan-500/40 h-[18px] rounded-full text-xxs font-normal">
+            <gui-badge classname="border-transparent bg-cyan-100 hover:bg-cyan-100/80 h-[18px] rounded-full text-xxs font-normal">
               prod
             </gui-badge>
           </div>
@@ -389,7 +389,7 @@ exports[`SideItem render as two-stacked dependent 1`] = `
             v1.0.0
           </span>
           <div class="absolute -bottom-3 right-2.5">
-            <gui-badge classname="bg-cyan-500/25 border-[1px] border-cyan-600 dark:border-cyan-500 hover:bg-cyan-500/40 dark:bg-cyan-500/30 dark:text-cyan-500 dark:hover:bg-cyan-500/40 h-[18px] rounded-full text-xxs font-normal">
+            <gui-badge classname="border-transparent bg-cyan-100 hover:bg-cyan-100/80 h-[18px] rounded-full text-xxs font-normal">
               prod
             </gui-badge>
           </div>
@@ -426,7 +426,7 @@ exports[`SideItem render as workspace item 1`] = `
             v1.0.0
           </span>
           <div class="absolute -bottom-3 right-2.5">
-            <gui-badge classname="bg-cyan-500/25 border-[1px] border-cyan-600 dark:border-cyan-500 hover:bg-cyan-500/40 dark:bg-cyan-500/30 dark:text-cyan-500 dark:hover:bg-cyan-500/40 h-[18px] rounded-full text-xxs font-normal">
+            <gui-badge classname="border-transparent bg-cyan-100 hover:bg-cyan-100/80 h-[18px] rounded-full text-xxs font-normal">
               prod
             </gui-badge>
           </div>

--- a/src/gui/test/components/explorer-grid/dependency-sidebar/__snapshots__/filter.tsx.snap
+++ b/src/gui/test/components/explorer-grid/dependency-sidebar/__snapshots__/filter.tsx.snap
@@ -62,7 +62,7 @@ exports[`filter-button renders default 1`] = `
                     classname="gap-2"
                     tabindex="1"
                   >
-                    <div class="size-2 rounded-full bg-cyan-500/25 text-cyan-600 border-[1px] border-cyan-600 dark:border-cyan-500 hover:bg-cyan-500/40 dark:bg-cyan-500/30 dark:text-cyan-500 dark:hover:bg-cyan-500/40">
+                    <div class="size-2 rounded-full border-transparent bg-cyan-100 text-neutral-900 hover:bg-cyan-100/80">
                     </div>
                     prod
                   </gui-dropdown-menu-item>
@@ -70,7 +70,7 @@ exports[`filter-button renders default 1`] = `
                     classname="gap-2"
                     tabindex="2"
                   >
-                    <div class="size-2 rounded-full bg-fuchsia-500/20 border-[1px] dark:border-fuchsia-400 border-fuchsia-500 text-fuchsia-500 hover:bg-fuchsia-400/30 dark:bg-fuchsia-500/30 dark:text-fuchsia-400 dark:hover:bg-fuchsia-500/40">
+                    <div class="size-2 rounded-full border-[1px] dark:border-fuchsia-600 border-fuchsia-500 bg-fuchsia-100 dark:bg-fuchsia-300 text-neutral-900 dark:text-fuchsia-900 hover:bg-fuchsia-100/80">
                     </div>
                     dev
                   </gui-dropdown-menu-item>
@@ -78,7 +78,7 @@ exports[`filter-button renders default 1`] = `
                     classname="gap-2"
                     tabindex="3"
                   >
-                    <div class="size-2 rounded-full bg-lime-500/25 border-[1px] border-lime-600 dark:border-lime-400 text-lime-600 hover:bg-lime-400/40 dark:bg-lime-500/30 dark:text-lime-400 dark:hover:bg-lime-500/40">
+                    <div class="size-2 rounded-full border-[1px] border-lime-600 dark:border-lime-700 bg-lime-100 dark:bg-lime-300 text-neutral-900 dark:text-lime-900 hover:bg-lime-100/80">
                     </div>
                     peer
                   </gui-dropdown-menu-item>
@@ -86,7 +86,7 @@ exports[`filter-button renders default 1`] = `
                     classname="gap-2"
                     tabindex="4"
                   >
-                    <div class="size-2 rounded-full bg-orange-500/20 border-[1px] border-orange-500 dark:border-orange-400 text-orange-500 hover:bg-orange-400/30 dark:bg-orange-500/30 dark:text-orange-400 dark:hover:bg-orange-500/40">
+                    <div class="size-2 rounded-full border-[1px] border-orange-500 dark:border-orange-400 bg-orange-100 text-neutral-900 dark:text-orange-900 hover:bg-orange-100/80">
                     </div>
                     optional
                   </gui-dropdown-menu-item>
@@ -94,7 +94,7 @@ exports[`filter-button renders default 1`] = `
                     classname="gap-2"
                     tabindex="5"
                   >
-                    <div class="size-2 rounded-full bg-yellow-500/25 border-[1px] border-yellow-600 dark:border-yellow-400 text-yellow-600 hover:bg-yellow-400/40 dark:bg-yellow-500/30 dark:text-yellow-400 dark:hover:bg-yellow-500/40">
+                    <div class="size-2 rounded-full border-[1px] border-yellow-600 dark:border-yellow-400 bg-yellow-100 text-neutral-900 dark:text-yellow-900 hover:bg-yellow-100/80">
                     </div>
                     peerOptional
                   </gui-dropdown-menu-item>
@@ -123,7 +123,7 @@ exports[`filter-list renders with filters 1`] = `
   >
     <gui-badge
       variant="default"
-      classname="cursor-default bg-cyan-500/25 text-cyan-600 border-[1px] border-cyan-600 dark:border-cyan-500 hover:bg-cyan-500/40 dark:bg-cyan-500/30 dark:text-cyan-500 dark:hover:bg-cyan-500/40"
+      classname="cursor-default border-transparent bg-cyan-100 text-neutral-900 hover:bg-cyan-100/80"
     >
       prod
     </gui-badge>
@@ -135,7 +135,7 @@ exports[`filter-list renders with filters 1`] = `
   >
     <gui-badge
       variant="default"
-      classname="cursor-default bg-fuchsia-500/20 border-[1px] dark:border-fuchsia-400 border-fuchsia-500 text-fuchsia-500 hover:bg-fuchsia-400/30 dark:bg-fuchsia-500/30 dark:text-fuchsia-400 dark:hover:bg-fuchsia-500/40"
+      classname="cursor-default border-[1px] dark:border-fuchsia-600 border-fuchsia-500 bg-fuchsia-100 dark:bg-fuchsia-300 text-neutral-900 dark:text-fuchsia-900 hover:bg-fuchsia-100/80"
     >
       dev
     </gui-badge>
@@ -147,7 +147,7 @@ exports[`filter-list renders with filters 1`] = `
   >
     <gui-badge
       variant="default"
-      classname="cursor-default bg-lime-500/25 border-[1px] border-lime-600 dark:border-lime-400 text-lime-600 hover:bg-lime-400/40 dark:bg-lime-500/30 dark:text-lime-400 dark:hover:bg-lime-500/40"
+      classname="cursor-default border-[1px] border-lime-600 dark:border-lime-700 bg-lime-100 dark:bg-lime-300 text-neutral-900 dark:text-lime-900 hover:bg-lime-100/80"
     >
       peer
     </gui-badge>

--- a/src/gui/test/components/explorer-grid/results/__snapshots__/result-item.tsx.snap
+++ b/src/gui/test/components/explorer-grid/results/__snapshots__/result-item.tsx.snap
@@ -61,7 +61,7 @@ exports[`ResultItem render stacked many 1`] = `
         </div>
         <div class="absolute -bottom-3.5 right-2.5 flex gap-2">
           <div>
-            <div class="inline-flex items-center px-2.5 py-0.5 text-xs transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 bg-lime-500/25 border-[1px] border-lime-600 dark:border-lime-400 hover:bg-lime-400/40 dark:bg-lime-500/30 dark:text-lime-400 dark:hover:bg-lime-500/40 h-[18px] rounded-full font-normal text-inherit">
+            <div class="inline-flex items-center px-2.5 text-xs transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 border-[1px] border-lime-600 dark:border-lime-700 bg-lime-100 dark:bg-lime-300 dark:text-lime-900 hover:bg-lime-100/80 h-[18px] rounded-full font-normal text-inherit">
               peer
             </div>
           </div>
@@ -104,7 +104,7 @@ exports[`ResultItem render stacked two 1`] = `
         </div>
         <div class="absolute -bottom-3.5 right-2.5 flex gap-2">
           <div>
-            <div class="inline-flex items-center px-2.5 py-0.5 text-xs transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 bg-fuchsia-500/20 border-[1px] dark:border-fuchsia-400 border-fuchsia-500 hover:bg-fuchsia-400/30 dark:bg-fuchsia-500/30 dark:text-fuchsia-400 dark:hover:bg-fuchsia-500/40 h-[18px] rounded-full font-normal text-inherit">
+            <div class="inline-flex items-center px-2.5 text-xs transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 border-[1px] dark:border-fuchsia-600 border-fuchsia-500 bg-fuchsia-100 dark:bg-fuchsia-300 dark:text-fuchsia-900 hover:bg-fuchsia-100/80 h-[18px] rounded-full font-normal text-inherit">
               dev
             </div>
           </div>
@@ -145,7 +145,7 @@ exports[`ResultItem render with item 1`] = `
         </div>
         <div class="absolute -bottom-3.5 right-2.5 flex gap-2">
           <div>
-            <div class="inline-flex items-center px-2.5 py-0.5 text-xs transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 bg-cyan-500/25 border-[1px] border-cyan-600 dark:border-cyan-500 hover:bg-cyan-500/40 dark:bg-cyan-500/30 dark:text-cyan-500 dark:hover:bg-cyan-500/40 h-[18px] rounded-full font-normal text-inherit">
+            <div class="inline-flex items-center border px-2.5 text-xs transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 border-transparent bg-cyan-100 hover:bg-cyan-100/80 h-[18px] rounded-full font-normal text-inherit">
               prod
             </div>
           </div>
@@ -198,7 +198,7 @@ exports[`ResultItem render with type 1`] = `
         </div>
         <div class="absolute -bottom-3.5 right-2.5 flex gap-2">
           <div>
-            <div class="inline-flex items-center px-2.5 py-0.5 text-xs transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 bg-cyan-500/25 border-[1px] border-cyan-600 dark:border-cyan-500 hover:bg-cyan-500/40 dark:bg-cyan-500/30 dark:text-cyan-500 dark:hover:bg-cyan-500/40 h-[18px] rounded-full font-normal text-inherit">
+            <div class="inline-flex items-center border px-2.5 text-xs transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 border-transparent bg-cyan-100 hover:bg-cyan-100/80 h-[18px] rounded-full font-normal text-inherit">
               prod
             </div>
           </div>

--- a/src/gui/test/components/ui/__snapshots__/badge.tsx.snap
+++ b/src/gui/test/components/ui/__snapshots__/badge.tsx.snap
@@ -3,7 +3,7 @@
 exports[`badge render custom class 1`] = `
 
 <div>
-  <div class="inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 border-transparent bg-primary text-primary-foreground hover:bg-primary/80 custom-class">
+  <div class="inline-flex items-center rounded-full border px-2.5 text-xs font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 border-transparent bg-primary text-primary-foreground hover:bg-primary/80 custom-class">
   </div>
 </div>
 
@@ -12,7 +12,7 @@ exports[`badge render custom class 1`] = `
 exports[`badge render default 1`] = `
 
 <div>
-  <div class="inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 border-transparent bg-primary text-primary-foreground hover:bg-primary/80">
+  <div class="inline-flex items-center rounded-full border px-2.5 text-xs font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 border-transparent bg-primary text-primary-foreground hover:bg-primary/80">
   </div>
 </div>
 
@@ -21,7 +21,7 @@ exports[`badge render default 1`] = `
 exports[`badge render destructive 1`] = `
 
 <div>
-  <div class="inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 border-transparent bg-destructive text-destructive-foreground hover:bg-destructive/80">
+  <div class="inline-flex items-center rounded-full border px-2.5 text-xs font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 border-transparent bg-destructive text-destructive-foreground hover:bg-destructive/80">
   </div>
 </div>
 
@@ -30,7 +30,7 @@ exports[`badge render destructive 1`] = `
 exports[`badge render outline 1`] = `
 
 <div>
-  <div class="inline-flex items-center rounded-full border border-muted px-2.5 py-0.5 text-xs font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 text-foreground bg-background">
+  <div class="inline-flex items-center rounded-full border border-muted px-2.5 text-xs font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 text-foreground bg-background">
   </div>
 </div>
 
@@ -39,7 +39,7 @@ exports[`badge render outline 1`] = `
 exports[`badge render secondary 1`] = `
 
 <div>
-  <div class="inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 border-transparent bg-secondary text-secondary-foreground hover:bg-secondary/80">
+  <div class="inline-flex items-center rounded-full border px-2.5 text-xs font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 border-transparent bg-secondary text-secondary-foreground hover:bg-secondary/80">
   </div>
 </div>
 


### PR DESCRIPTION
Removes the transparent backgrounds in the dependency type colors.

<img width="1527" alt="Screenshot 2025-06-24 at 10 30 59 PM" src="https://github.com/user-attachments/assets/c7a15532-045a-4f77-94cb-286c83719645" />
