### PR TITLE
gui: fix punctuation

### DIFF
--- a/src/gui/src/components/explorer-grid/selected-item/tabs-dependencies/index.tsx
+++ b/src/gui/src/components/explorer-grid/selected-item/tabs-dependencies/index.tsx
@@ -84,7 +84,7 @@ export const DependenciesTabContent = () => {
         </>
       : <EmptyState
           icon={Blocks}
-          message="This package has no installed dependencies"
+          message="This package has no installed dependencies."
         />
       }
     </TabsContent>

--- a/src/gui/src/components/explorer-grid/selected-item/tabs-dependencies/tabs-duplicates.tsx
+++ b/src/gui/src/components/explorer-grid/selected-item/tabs-dependencies/tabs-duplicates.tsx
@@ -98,7 +98,7 @@ export const DuplicatesTabContent = () => {
         </div>
       : <EmptyState
           icon={Blocks}
-          message="No duplicated dependencies found"
+          message="No duplicated dependencies found."
         />
       }
     </TabsContent>

--- a/src/gui/src/components/explorer-grid/selected-item/tabs-dependencies/tabs-funding.tsx
+++ b/src/gui/src/components/explorer-grid/selected-item/tabs-dependencies/tabs-funding.tsx
@@ -247,7 +247,7 @@ export const FundingTabContent = () => {
         </div>
       : <EmptyState
           icon={HeartHandshake}
-          message="No dependencies are looking for funding"
+          message="No dependencies are looking for funding."
         />
       }
     </TabsContent>

--- a/src/gui/src/components/explorer-grid/selected-item/tabs-dependencies/tabs-insights.tsx
+++ b/src/gui/src/components/explorer-grid/selected-item/tabs-dependencies/tabs-insights.tsx
@@ -364,7 +364,7 @@ export const InsightsTabContent = () => {
         </div>
       : <EmptyState
           icon={ShieldX}
-          message="No insights were available"
+          message="No insights were available."
         />
       }
     </TabsContent>

--- a/src/gui/src/components/explorer-grid/selected-item/tabs-dependencies/tabs-licenses.tsx
+++ b/src/gui/src/components/explorer-grid/selected-item/tabs-dependencies/tabs-licenses.tsx
@@ -353,7 +353,7 @@ export const LicensesTabContent = () => {
         </div>
       : <EmptyState
           icon={Scale}
-          message="No license data was found"
+          message="No license data was found."
         />
       }
     </TabsContent>

--- a/src/gui/src/components/explorer-grid/selected-item/tabs-overview.tsx
+++ b/src/gui/src/components/explorer-grid/selected-item/tabs-overview.tsx
@@ -323,7 +323,7 @@ const EmptyState = () => {
           />
         </div>
         <p className="w-2/3 text-pretty text-sm text-muted-foreground">
-          We couldn't find a description for this project
+          We couldn't find a description for this project.
         </p>
       </div>
     </div>

--- a/src/gui/src/components/explorer-grid/selected-item/tabs-versions.tsx
+++ b/src/gui/src/components/explorer-grid/selected-item/tabs-versions.tsx
@@ -270,7 +270,7 @@ const VersionItem = memo(
             tooltip={{ content: version }}
             classNames={{
               wrapperClassName:
-                'w-fit max-w-none break-all xl:w-fit xl:max-w-[5.5rem]',
+                'w-fit max-w-none xl:w-fit xl:max-w-[5.5rem]',
               contentClassName: 'truncate pt-0.5',
             }}
             content={version}
@@ -388,7 +388,7 @@ const EmptyState = ({ message }: { message: string }) => (
           strokeWidth={1.25}
         />
       </div>
-      <div className="flex w-2/3 flex-col items-center justify-center gap-1 break-all text-center">
+      <div className="flex w-2/3 flex-col items-center justify-center gap-1 text-center">
         <p className="w-full text-pretty text-sm text-muted-foreground">
           {message}
         </p>
@@ -624,7 +624,7 @@ export const VersionsTabContent = () => {
   return (
     <TabsContent value="versions">
       {isEmpty ?
-        <EmptyState message="There is no versioning information about this package yet" />
+        <EmptyState message="There is no versioning information about this package yet." />
       : <section className="flex flex-col px-6 py-4">
           <DownloadGraph />
 
@@ -729,7 +729,7 @@ export const VersionsTabContent = () => {
 
           {!hasSearchResults && searchTerm.trim() ?
             <EmptyState
-              message={`No versions found matching "${searchTerm}"`}
+              message={`No versions found matching "${searchTerm}".`}
             />
           : <div>
               {filteredVersions.length > 0 && (

--- a/src/gui/src/components/explorer-grid/side-item.tsx
+++ b/src/gui/src/components/explorer-grid/side-item.tsx
@@ -191,7 +191,7 @@ const SideItemSpec = ({
         variant="mono"
         classNames={{
           wrapperClassName:
-            'inline-flex min-w-[10ch] max-w-[20ch] break-all h-[1.375rem]',
+            'inline-flex min-w-[10ch] max-w-[20ch] h-[1.375rem]',
           contentClassName: 'truncate pt-0.5',
         }}
         content={

--- a/src/gui/test/components/explorer-grid/selected-item/__snapshots__/tabs-overview.tsx.snap
+++ b/src/gui/test/components/explorer-grid/selected-item/__snapshots__/tabs-overview.tsx.snap
@@ -39,7 +39,7 @@ exports[`OverviewTabContent renders default 1`] = `
           </gui-rectangle-horizontal-icon>
         </div>
         <p class="w-2/3 text-pretty text-sm text-muted-foreground">
-          We couldn't find a description for this project
+          We couldn't find a description for this project.
         </p>
       </div>
     </div>
@@ -75,7 +75,7 @@ exports[`OverviewTabContent renders with an aside and content 1`] = `
           </gui-rectangle-horizontal-icon>
         </div>
         <p class="w-2/3 text-pretty text-sm text-muted-foreground">
-          We couldn't find a description for this project
+          We couldn't find a description for this project.
         </p>
       </div>
     </div>

--- a/src/gui/test/components/explorer-grid/selected-item/__snapshots__/tabs-versions.tsx.snap
+++ b/src/gui/test/components/explorer-grid/selected-item/__snapshots__/tabs-versions.tsx.snap
@@ -624,9 +624,9 @@ exports[`VersionsTabContent renders an empty state 1`] = `
         >
         </gui-history-icon>
       </div>
-      <div class="flex w-2/3 flex-col items-center justify-center gap-1 break-all text-center">
+      <div class="flex w-2/3 flex-col items-center justify-center gap-1 text-center">
         <p class="w-full text-pretty text-sm text-muted-foreground">
-          There is no versioning information about this package yet
+          There is no versioning information about this package yet.
         </p>
       </div>
     </div>

--- a/src/gui/test/components/explorer-grid/selected-item/tabs-dependencies/__snapshots__/tabs-duplicates.tsx.snap
+++ b/src/gui/test/components/explorer-grid/selected-item/tabs-dependencies/__snapshots__/tabs-duplicates.tsx.snap
@@ -33,7 +33,7 @@ exports[`DuplicatesTabContent renders with an empty state 1`] = `
 <gui-tabs-content value="duplicates">
   <gui-empty-state
     icon="gui-blocks-icon"
-    message="No duplicated dependencies found"
+    message="No duplicated dependencies found."
   >
   </gui-empty-state>
 </gui-tabs-content>

--- a/src/gui/test/components/explorer-grid/selected-item/tabs-dependencies/__snapshots__/tabs-funding.tsx.snap
+++ b/src/gui/test/components/explorer-grid/selected-item/tabs-dependencies/__snapshots__/tabs-funding.tsx.snap
@@ -35,7 +35,7 @@ exports[`FundingTabContent renders with an empty state  1`] = `
 <gui-tabs-content value="funding">
   <gui-empty-state
     icon="gui-heart-handshake-icon"
-    message="No dependencies are looking for funding"
+    message="No dependencies are looking for funding."
   >
   </gui-empty-state>
 </gui-tabs-content>

--- a/src/gui/test/components/explorer-grid/selected-item/tabs-dependencies/__snapshots__/tabs-insights.tsx.snap
+++ b/src/gui/test/components/explorer-grid/selected-item/tabs-dependencies/__snapshots__/tabs-insights.tsx.snap
@@ -250,7 +250,7 @@ exports[`InsightsTabContent renders with an empty state 1`] = `
 <gui-tabs-content value="insights">
   <gui-empty-state
     icon="gui-shield-x-icon"
-    message="No insights were available"
+    message="No insights were available."
   >
   </gui-empty-state>
 </gui-tabs-content>

--- a/src/gui/test/components/explorer-grid/selected-item/tabs-dependencies/__snapshots__/tabs-licenses.tsx.snap
+++ b/src/gui/test/components/explorer-grid/selected-item/tabs-dependencies/__snapshots__/tabs-licenses.tsx.snap
@@ -33,7 +33,7 @@ exports[`LicensesTabContent renders with an empty state 1`] = `
 <gui-tabs-content value="licenses">
   <gui-empty-state
     icon="gui-scale-icon"
-    message="No license data was found"
+    message="No license data was found."
   >
   </gui-empty-state>
 </gui-tabs-content>


### PR DESCRIPTION
Fixes ponctuation in all empty states and also fixes a bug with wrapping half words in a line break due to usage of break-all.