### PR TITLE
graph: add overridden notice to human output

### DIFF
--- a/src/graph/src/visualization/human-readable-output.ts
+++ b/src/graph/src/visualization/human-readable-output.ts
@@ -186,6 +186,9 @@ export function humanReadableOutput(
         nextItem.name =
           nextItem.node?.confused ?
             `${nextItem.edge?.name} ${red('(confused)')}`
+          : nextItem.edge?.spec.overridden ?
+            /* c8 ignore next */
+            `${nextItem.edge.name}@${nextItem.node?.version || nextItem.edge.spec.bareSpec} ${yellow('(overridden)')}`
           : nextItem.node?.name && nextItem.edge?.name !== nodeName ?
             `${nextItem.edge?.name} (${toName})`
           : `${nextItem.edge?.name}@${nextItem.node?.version || nextItem.edge?.spec.bareSpec}`

--- a/src/graph/tap-snapshots/test/visualization/human-readable-output.ts.test.cjs
+++ b/src/graph/tap-snapshots/test/visualization/human-readable-output.ts.test.cjs
@@ -102,6 +102,18 @@ file·.
 
 `
 
+exports[`test/visualization/human-readable-output.ts > TAP > overridden package > colors > should use colors for overridden package 1`] = `
+[0mmy-project
+└── foo@2.0.0 [33m(overridden)[39m
+[0m
+`
+
+exports[`test/visualization/human-readable-output.ts > TAP > overridden package > should print overridden package 1`] = `
+my-project
+└── foo@2.0.0 (overridden)
+
+`
+
 exports[`test/visualization/human-readable-output.ts > TAP > versionless package > should skip printing version number 1`] = `
 my-project
 └── a@^1.0.0

--- a/src/graph/test/visualization/human-readable-output.ts
+++ b/src/graph/test/visualization/human-readable-output.ts
@@ -444,3 +444,60 @@ t.test('missing optional', async t => {
     )
   })
 })
+
+t.test('overridden package', async t => {
+  const projectRoot = t.testdir({ 'vlt.json': '{}' })
+  t.chdir(projectRoot)
+  unload('project')
+  const graph = new Graph({
+    projectRoot,
+    ...configData,
+    mainManifest: {
+      name: 'my-project',
+      version: '1.0.0',
+      dependencies: {
+        foo: '^1.0.0',
+      },
+    },
+  })
+  const fooSpec = Spec.parse('foo', '^1.0.0')
+  // Mark the spec as overridden
+  fooSpec.overridden = true
+  const foo = graph.placePackage(
+    graph.mainImporter,
+    'prod',
+    fooSpec,
+    {
+      name: 'foo',
+      version: '2.0.0',
+    },
+  )
+  t.ok(foo)
+  t.matchSnapshot(
+    humanReadableOutput(
+      {
+        edges: [...graph.edges],
+        highlightSelection: false,
+        importers: graph.importers,
+        nodes: [...graph.nodes.values()],
+      },
+      {},
+    ),
+    'should print overridden package',
+  )
+
+  t.test('colors', async t => {
+    t.matchSnapshot(
+      humanReadableOutput(
+        {
+          edges: [...graph.edges],
+          highlightSelection: false,
+          importers: graph.importers,
+          nodes: [...graph.nodes.values()],
+        },
+        { colors: true },
+      ),
+      'should use colors for overridden package',
+    )
+  })
+})


### PR DESCRIPTION
Added a `(overridden)` mark / notice to the human readable output for packages / edges that have been overridden by a graph modifier.

Refs: https://github.com/vltpkg/statusboard/issues/64