### PR TITLE
gui: fix search result root nav

### DIFF
--- a/src/gui/src/components/explorer-grid/results/result-item.tsx
+++ b/src/gui/src/components/explorer-grid/results/result-item.tsx
@@ -17,21 +17,12 @@ import {
   scoreColors,
 } from '@/components/explorer-grid/selected-item/insight-score-helper.ts'
 import { LICENSE_TYPES } from '@/lib/constants/index.ts'
+import { updateResultItem } from '@/lib/update-result-item.ts'
 import { cn } from '@/lib/utils.ts'
 
-import type { MouseEvent } from 'react'
-import type {
-  GridItemData,
-  GridItemOptions,
-} from '@/components/explorer-grid/types.ts'
+import type { GridItemOptions } from '@/components/explorer-grid/types.ts'
 import type { ProgressCircleVariant } from '@/components/ui/progress-circle.tsx'
 import type { Insights } from '@vltpkg/query'
-
-export type ResultItemClickOptions = {
-  item: GridItemData
-  query: string
-  updateQuery: (query: string) => void
-}
 
 const PackageOverallScore = ({
   className,
@@ -64,45 +55,6 @@ const PackageOverallScore = ({
   )
 }
 
-const onResultItemClick =
-  ({ item, query, updateQuery }: ResultItemClickOptions) =>
-  (e: MouseEvent) => {
-    e.preventDefault()
-    if (!item.to) return
-    let newQuery = ''
-    const appendToQuery = (s: string) => {
-      const q = query.trim()
-      return q === s ? q : `${q}${s}`
-    }
-    if (item.stacked) {
-      newQuery = appendToQuery(item.to.name ? `#${item.to.name}` : '')
-    } else {
-      let suffix = ''
-      if (!item.sameItems) {
-        suffix = item.to.name ? `#${item.to.name}` : ''
-      }
-      if (item.to.importer && !item.from) {
-        newQuery = `:project#${item.to.name}`
-      } else if (item.from) {
-        // use version on the parent node if there are multiple nodes in the graph with the same name
-        const useVersion =
-          [...item.from.graph.nodes.values()].filter(
-            n => n.name === item.from?.name,
-          ).length > 1
-        const fromName = `#${item.from.name}`
-        const fromVersion =
-          useVersion && item.from.version ?
-            `:v(${item.from.version})`
-          : ''
-        newQuery = `${fromName}${fromVersion} > ${appendToQuery(suffix)}`
-      } else {
-        newQuery = appendToQuery(suffix)
-      }
-    }
-    updateQuery(newQuery)
-    return undefined
-  }
-
 export const ResultItem = ({ item }: GridItemOptions) => {
   const updateQuery = useGraphStore(state => state.updateQuery)
   const query = useGraphStore(state => state.query)
@@ -122,7 +74,7 @@ export const ResultItem = ({ item }: GridItemOptions) => {
       <Card
         renderAsLink
         className="duration-250 relative cursor-default transition-colors group-hover:border-neutral-400 dark:group-hover:border-neutral-600"
-        onClick={onResultItemClick({ item, query, updateQuery })}>
+        onClick={updateResultItem({ item, query, updateQuery })}>
         <CardHeader className="relative flex w-full max-w-full flex-wrap items-baseline justify-between gap-3 px-3 py-2 md:flex-row">
           <div className="flex flex-col flex-wrap items-baseline gap-3 md:flex-row">
             {item.version && (

--- a/src/gui/src/lib/update-result-item.ts
+++ b/src/gui/src/lib/update-result-item.ts
@@ -1,0 +1,72 @@
+import type React from 'react'
+import type {GridItemData} from '@/components/explorer-grid/types.ts';
+
+/**
+ * Options for updating a result item.
+ */
+export type UpdateResultItemOptions = {
+  /**
+   * The item data to update.
+   */
+  item: GridItemData
+  /**
+   * The current query string.
+   */
+  query: string
+  /**
+   * The zustand-store query update function.
+   */
+  updateQuery: (query: string) => void
+}
+
+/**
+ * Updates the query based on a given result item.
+ */
+export const updateResultItem =
+  ({ item, query, updateQuery }: UpdateResultItemOptions) =>
+  (e: React.MouseEvent | MouseEvent) => {
+    e.preventDefault()
+    if (!item.to) return
+    let newQuery = ''
+    const appendToQuery = (s: string) => {
+      const q = query.trim()
+      return q === s ? q : `${q}${s}`
+    }
+    if (item.stacked) {
+      newQuery = appendToQuery(item.to.name ? `#${item.to.name}` : '')
+    } else {
+      let suffix = ''
+      if (!item.sameItems) {
+        suffix = item.to.name ? `#${item.to.name}` : ''
+      }
+      if (item.to.importer && !item.from) {
+        newQuery = `:project#${item.to.name}`
+      } else if (item.from) {
+        // use version on the parent node if there are multiple nodes in the graph with the same name
+        const useVersion =
+          [...item.from.graph.nodes.values()].filter(
+            n => n.name === item.from?.name,
+          ).length > 1
+        const fromName = `#${item.from.name}`
+        const fromVersion =
+          useVersion && item.from.version ?
+            `:v(${item.from.version})`
+          : ''
+        if (query.startsWith(':root')) {
+          const queryParts = query.split(' ')
+          queryParts.splice(
+            queryParts.length - 1,
+            0,
+            `${fromName}${fromVersion} >`,
+          )
+          newQuery = queryParts.join(' ')
+        } else {
+          newQuery = `${fromName}${fromVersion} > ${appendToQuery(suffix)}`
+        }
+      } else {
+        newQuery = appendToQuery(suffix)
+      }
+    }
+    updateQuery(newQuery)
+    return undefined
+  }

--- a/src/gui/src/lib/update-result-item.ts
+++ b/src/gui/src/lib/update-result-item.ts
@@ -1,5 +1,5 @@
 import type React from 'react'
-import type {GridItemData} from '@/components/explorer-grid/types.ts';
+import type { GridItemData } from '@/components/explorer-grid/types.ts'
 
 /**
  * Options for updating a result item.

--- a/src/gui/test/lib/update-result-item.test.ts
+++ b/src/gui/test/lib/update-result-item.test.ts
@@ -1,0 +1,765 @@
+import { describe, it, expect, vi } from 'vitest'
+import { updateResultItem } from '@/lib/update-result-item.ts'
+import type { GridItemData } from '@/components/explorer-grid/types.ts'
+import type { QueryResponseNode } from '@vltpkg/query'
+import { joinDepIDTuple } from '@vltpkg/dep-id'
+
+// Helper function to create a mock QueryResponseNode
+const createMockNode = (
+  name: string,
+  version: string,
+  importer = false,
+  id?: string,
+): QueryResponseNode =>
+  ({
+    name,
+    version,
+    importer,
+    id: id || joinDepIDTuple(['registry', '', `${name}@${version}`]),
+    graph: {
+      nodes: new Map([
+        [
+          joinDepIDTuple(['registry', '', `${name}@${version}`]),
+          { name, version },
+        ],
+      ]),
+    } as any,
+    edgesIn: new Set(),
+    edgesOut: new Map(),
+    insights: {
+      scanned: false,
+    },
+    toJSON: () => ({}) as any,
+  }) as QueryResponseNode
+
+// Helper function to create a mock QueryResponseNode with multiple versions
+const createNodeWithMultipleVersions = (
+  name: string,
+  version: string,
+  otherVersions: string[],
+): QueryResponseNode => {
+  const nodes = new Map()
+  nodes.set(joinDepIDTuple(['registry', '', `${name}@${version}`]), {
+    name,
+    version,
+  })
+  otherVersions.forEach(v => {
+    nodes.set(joinDepIDTuple(['registry', '', `${name}@${v}`]), {
+      name,
+      version: v,
+    })
+  })
+
+  return {
+    name,
+    version,
+    id: joinDepIDTuple(['registry', '', `${name}@${version}`]),
+    graph: { nodes } as any,
+    edgesIn: new Set(),
+    edgesOut: new Map(),
+    insights: {
+      scanned: false,
+    },
+    toJSON: () => ({}) as any,
+  } as QueryResponseNode
+}
+
+// Helper function to create GridItemData
+const createGridItemData = (
+  overrides: Partial<GridItemData> = {},
+): GridItemData => ({
+  id: 'test-id',
+  title: 'Test Item',
+  version: '1.0.0',
+  size: 1,
+  stacked: false,
+  name: 'test-package',
+  ...overrides,
+})
+
+describe('updateResultItem', () => {
+  describe('early return cases', () => {
+    it('should return early when item.to is missing', () => {
+      const mockUpdateQuery = vi.fn()
+      const mockEvent = {
+        preventDefault: vi.fn(),
+      } as unknown as MouseEvent
+
+      const item = createGridItemData({
+        to: undefined,
+      })
+
+      const handler = updateResultItem({
+        item,
+        query: 'test query',
+        updateQuery: mockUpdateQuery,
+      })
+
+      const result = handler(mockEvent)
+
+      expect(mockEvent.preventDefault).toHaveBeenCalled()
+      expect(mockUpdateQuery).not.toHaveBeenCalled()
+      expect(result).toBeUndefined()
+    })
+  })
+
+  describe('stacked items', () => {
+    it('should handle stacked item with name', () => {
+      const mockUpdateQuery = vi.fn()
+      const mockEvent = {
+        preventDefault: vi.fn(),
+      } as unknown as MouseEvent
+
+      const item = createGridItemData({
+        stacked: true,
+        to: createMockNode('stacked-package', '1.0.0'),
+      })
+
+      const handler = updateResultItem({
+        item,
+        query: '',
+        updateQuery: mockUpdateQuery,
+      })
+
+      handler(mockEvent)
+
+      expect(mockEvent.preventDefault).toHaveBeenCalled()
+      expect(mockUpdateQuery).toHaveBeenCalledWith('#stacked-package')
+    })
+
+    it('should handle stacked item without name', () => {
+      const mockUpdateQuery = vi.fn()
+      const mockEvent = {
+        preventDefault: vi.fn(),
+      } as unknown as MouseEvent
+
+      const item = createGridItemData({
+        stacked: true,
+        to: createMockNode('', '1.0.0'),
+      })
+
+      const handler = updateResultItem({
+        item,
+        query: '',
+        updateQuery: mockUpdateQuery,
+      })
+
+      handler(mockEvent)
+
+      expect(mockEvent.preventDefault).toHaveBeenCalled()
+      expect(mockUpdateQuery).toHaveBeenCalledWith('')
+    })
+
+    it('should append to existing query for stacked item', () => {
+      const mockUpdateQuery = vi.fn()
+      const mockEvent = {
+        preventDefault: vi.fn(),
+      } as unknown as MouseEvent
+
+      const item = createGridItemData({
+        stacked: true,
+        to: createMockNode('stacked-package', '1.0.0'),
+      })
+
+      const handler = updateResultItem({
+        item,
+        query: 'existing query',
+        updateQuery: mockUpdateQuery,
+      })
+
+      handler(mockEvent)
+
+      expect(mockEvent.preventDefault).toHaveBeenCalled()
+      expect(mockUpdateQuery).toHaveBeenCalledWith(
+        'existing query#stacked-package',
+      )
+    })
+
+    it('should not duplicate query for stacked item', () => {
+      const mockUpdateQuery = vi.fn()
+      const mockEvent = {
+        preventDefault: vi.fn(),
+      } as unknown as MouseEvent
+
+      const item = createGridItemData({
+        stacked: true,
+        to: createMockNode('stacked-package', '1.0.0'),
+      })
+
+      const handler = updateResultItem({
+        item,
+        query: '#stacked-package',
+        updateQuery: mockUpdateQuery,
+      })
+
+      handler(mockEvent)
+
+      expect(mockEvent.preventDefault).toHaveBeenCalled()
+      expect(mockUpdateQuery).toHaveBeenCalledWith('#stacked-package')
+    })
+  })
+
+  describe('importer items (project root)', () => {
+    it('should handle importer with name', () => {
+      const mockUpdateQuery = vi.fn()
+      const mockEvent = {
+        preventDefault: vi.fn(),
+      } as unknown as MouseEvent
+
+      const item = createGridItemData({
+        to: createMockNode('project-name', '1.0.0', true),
+        from: undefined,
+      })
+
+      const handler = updateResultItem({
+        item,
+        query: '',
+        updateQuery: mockUpdateQuery,
+      })
+
+      handler(mockEvent)
+
+      expect(mockEvent.preventDefault).toHaveBeenCalled()
+      expect(mockUpdateQuery).toHaveBeenCalledWith(
+        ':project#project-name',
+      )
+    })
+
+    it('should handle importer without name', () => {
+      const mockUpdateQuery = vi.fn()
+      const mockEvent = {
+        preventDefault: vi.fn(),
+      } as unknown as MouseEvent
+
+      const item = createGridItemData({
+        to: createMockNode('', '1.0.0', true),
+        from: undefined,
+      })
+
+      const handler = updateResultItem({
+        item,
+        query: '',
+        updateQuery: mockUpdateQuery,
+      })
+
+      handler(mockEvent)
+
+      expect(mockEvent.preventDefault).toHaveBeenCalled()
+      expect(mockUpdateQuery).toHaveBeenCalledWith(':project#')
+    })
+  })
+
+  describe('items with from node', () => {
+    it('should handle item with from node and single version', () => {
+      const mockUpdateQuery = vi.fn()
+      const mockEvent = {
+        preventDefault: vi.fn(),
+      } as unknown as MouseEvent
+
+      const fromNode = createMockNode('parent-package', '2.0.0')
+      const toNode = createMockNode('child-package', '1.0.0')
+
+      const item = createGridItemData({
+        from: fromNode,
+        to: toNode,
+        sameItems: false,
+      })
+
+      const handler = updateResultItem({
+        item,
+        query: '',
+        updateQuery: mockUpdateQuery,
+      })
+
+      handler(mockEvent)
+
+      expect(mockEvent.preventDefault).toHaveBeenCalled()
+      expect(mockUpdateQuery).toHaveBeenCalledWith(
+        '#parent-package > #child-package',
+      )
+    })
+
+    it('should handle item with from node and multiple versions (include version)', () => {
+      const mockUpdateQuery = vi.fn()
+      const mockEvent = {
+        preventDefault: vi.fn(),
+      } as unknown as MouseEvent
+
+      const fromNode = createNodeWithMultipleVersions(
+        'parent-package',
+        '2.0.0',
+        ['1.0.0', '3.0.0'],
+      )
+      const toNode = createMockNode('child-package', '1.0.0')
+
+      const item = createGridItemData({
+        from: fromNode,
+        to: toNode,
+        sameItems: false,
+      })
+
+      const handler = updateResultItem({
+        item,
+        query: '',
+        updateQuery: mockUpdateQuery,
+      })
+
+      handler(mockEvent)
+
+      expect(mockEvent.preventDefault).toHaveBeenCalled()
+      expect(mockUpdateQuery).toHaveBeenCalledWith(
+        '#parent-package:v(2.0.0) > #child-package',
+      )
+    })
+
+    it('should handle item with from node but no from version', () => {
+      const mockUpdateQuery = vi.fn()
+      const mockEvent = {
+        preventDefault: vi.fn(),
+      } as unknown as MouseEvent
+
+      const fromNode = createNodeWithMultipleVersions(
+        'parent-package',
+        '2.0.0',
+        ['1.0.0', '3.0.0'],
+      )
+      fromNode.version = undefined as any
+      const toNode = createMockNode('child-package', '1.0.0')
+
+      const item = createGridItemData({
+        from: fromNode,
+        to: toNode,
+        sameItems: false,
+      })
+
+      const handler = updateResultItem({
+        item,
+        query: '',
+        updateQuery: mockUpdateQuery,
+      })
+
+      handler(mockEvent)
+
+      expect(mockEvent.preventDefault).toHaveBeenCalled()
+      expect(mockUpdateQuery).toHaveBeenCalledWith(
+        '#parent-package > #child-package',
+      )
+    })
+
+    it('should handle :root query modification', () => {
+      const mockUpdateQuery = vi.fn()
+      const mockEvent = {
+        preventDefault: vi.fn(),
+      } as unknown as MouseEvent
+
+      const fromNode = createMockNode('parent-package', '2.0.0')
+      const toNode = createMockNode('child-package', '1.0.0')
+
+      const item = createGridItemData({
+        from: fromNode,
+        to: toNode,
+        sameItems: false,
+      })
+
+      const handler = updateResultItem({
+        item,
+        query: ':root some-other-query',
+        updateQuery: mockUpdateQuery,
+      })
+
+      handler(mockEvent)
+
+      expect(mockEvent.preventDefault).toHaveBeenCalled()
+      expect(mockUpdateQuery).toHaveBeenCalledWith(
+        ':root #parent-package > some-other-query',
+      )
+    })
+
+    it('should handle :root query modification with version', () => {
+      const mockUpdateQuery = vi.fn()
+      const mockEvent = {
+        preventDefault: vi.fn(),
+      } as unknown as MouseEvent
+
+      const fromNode = createNodeWithMultipleVersions(
+        'parent-package',
+        '2.0.0',
+        ['1.0.0'],
+      )
+      const toNode = createMockNode('child-package', '1.0.0')
+
+      const item = createGridItemData({
+        from: fromNode,
+        to: toNode,
+        sameItems: false,
+      })
+
+      const handler = updateResultItem({
+        item,
+        query: ':root existing-query final-part',
+        updateQuery: mockUpdateQuery,
+      })
+
+      handler(mockEvent)
+
+      expect(mockEvent.preventDefault).toHaveBeenCalled()
+      expect(mockUpdateQuery).toHaveBeenCalledWith(
+        ':root existing-query #parent-package:v(2.0.0) > final-part',
+      )
+    })
+
+    it('should handle sameItems true (no suffix)', () => {
+      const mockUpdateQuery = vi.fn()
+      const mockEvent = {
+        preventDefault: vi.fn(),
+      } as unknown as MouseEvent
+
+      const fromNode = createMockNode('parent-package', '2.0.0')
+      const toNode = createMockNode('child-package', '1.0.0')
+
+      const item = createGridItemData({
+        from: fromNode,
+        to: toNode,
+        sameItems: true,
+      })
+
+      const handler = updateResultItem({
+        item,
+        query: '',
+        updateQuery: mockUpdateQuery,
+      })
+
+      handler(mockEvent)
+
+      expect(mockEvent.preventDefault).toHaveBeenCalled()
+      expect(mockUpdateQuery).toHaveBeenCalledWith(
+        '#parent-package > ',
+      )
+    })
+  })
+
+  describe('default cases (no from, no importer, not stacked)', () => {
+    it('should handle simple case with name', () => {
+      const mockUpdateQuery = vi.fn()
+      const mockEvent = {
+        preventDefault: vi.fn(),
+      } as unknown as MouseEvent
+
+      const item = createGridItemData({
+        to: createMockNode('simple-package', '1.0.0'),
+        from: undefined,
+        sameItems: false,
+      })
+
+      const handler = updateResultItem({
+        item,
+        query: '',
+        updateQuery: mockUpdateQuery,
+      })
+
+      handler(mockEvent)
+
+      expect(mockEvent.preventDefault).toHaveBeenCalled()
+      expect(mockUpdateQuery).toHaveBeenCalledWith('#simple-package')
+    })
+
+    it('should handle simple case without name', () => {
+      const mockUpdateQuery = vi.fn()
+      const mockEvent = {
+        preventDefault: vi.fn(),
+      } as unknown as MouseEvent
+
+      const item = createGridItemData({
+        to: createMockNode('', '1.0.0'),
+        from: undefined,
+        sameItems: false,
+      })
+
+      const handler = updateResultItem({
+        item,
+        query: '',
+        updateQuery: mockUpdateQuery,
+      })
+
+      handler(mockEvent)
+
+      expect(mockEvent.preventDefault).toHaveBeenCalled()
+      expect(mockUpdateQuery).toHaveBeenCalledWith('')
+    })
+
+    it('should handle sameItems true (no suffix)', () => {
+      const mockUpdateQuery = vi.fn()
+      const mockEvent = {
+        preventDefault: vi.fn(),
+      } as unknown as MouseEvent
+
+      const item = createGridItemData({
+        to: createMockNode('simple-package', '1.0.0'),
+        from: undefined,
+        sameItems: true,
+      })
+
+      const handler = updateResultItem({
+        item,
+        query: '',
+        updateQuery: mockUpdateQuery,
+      })
+
+      handler(mockEvent)
+
+      expect(mockEvent.preventDefault).toHaveBeenCalled()
+      expect(mockUpdateQuery).toHaveBeenCalledWith('')
+    })
+
+    it('should append to existing query', () => {
+      const mockUpdateQuery = vi.fn()
+      const mockEvent = {
+        preventDefault: vi.fn(),
+      } as unknown as MouseEvent
+
+      const item = createGridItemData({
+        to: createMockNode('simple-package', '1.0.0'),
+        from: undefined,
+        sameItems: false,
+      })
+
+      const handler = updateResultItem({
+        item,
+        query: 'existing query',
+        updateQuery: mockUpdateQuery,
+      })
+
+      handler(mockEvent)
+
+      expect(mockEvent.preventDefault).toHaveBeenCalled()
+      expect(mockUpdateQuery).toHaveBeenCalledWith(
+        'existing query#simple-package',
+      )
+    })
+
+    it('should not duplicate query', () => {
+      const mockUpdateQuery = vi.fn()
+      const mockEvent = {
+        preventDefault: vi.fn(),
+      } as unknown as MouseEvent
+
+      const item = createGridItemData({
+        to: createMockNode('simple-package', '1.0.0'),
+        from: undefined,
+        sameItems: false,
+      })
+
+      const handler = updateResultItem({
+        item,
+        query: '#simple-package',
+        updateQuery: mockUpdateQuery,
+      })
+
+      handler(mockEvent)
+
+      expect(mockEvent.preventDefault).toHaveBeenCalled()
+      expect(mockUpdateQuery).toHaveBeenCalledWith('#simple-package')
+    })
+  })
+
+  describe('edge cases and complex scenarios', () => {
+    it('should handle whitespace in query', () => {
+      const mockUpdateQuery = vi.fn()
+      const mockEvent = {
+        preventDefault: vi.fn(),
+      } as unknown as MouseEvent
+
+      const item = createGridItemData({
+        to: createMockNode('package', '1.0.0'),
+        from: undefined,
+        sameItems: false,
+      })
+
+      const handler = updateResultItem({
+        item,
+        query: '   trimmed query   ',
+        updateQuery: mockUpdateQuery,
+      })
+
+      handler(mockEvent)
+
+      expect(mockEvent.preventDefault).toHaveBeenCalled()
+      expect(mockUpdateQuery).toHaveBeenCalledWith(
+        'trimmed query#package',
+      )
+    })
+
+    it('should handle empty query with whitespace', () => {
+      const mockUpdateQuery = vi.fn()
+      const mockEvent = {
+        preventDefault: vi.fn(),
+      } as unknown as MouseEvent
+
+      const item = createGridItemData({
+        to: createMockNode('package', '1.0.0'),
+        from: undefined,
+        sameItems: false,
+      })
+
+      const handler = updateResultItem({
+        item,
+        query: '   ',
+        updateQuery: mockUpdateQuery,
+      })
+
+      handler(mockEvent)
+
+      expect(mockEvent.preventDefault).toHaveBeenCalled()
+      expect(mockUpdateQuery).toHaveBeenCalledWith('#package')
+    })
+
+    it('should handle complex :root query with multiple parts', () => {
+      const mockUpdateQuery = vi.fn()
+      const mockEvent = {
+        preventDefault: vi.fn(),
+      } as unknown as MouseEvent
+
+      const fromNode = createMockNode('parent', '1.0.0')
+      const toNode = createMockNode('child', '2.0.0')
+
+      const item = createGridItemData({
+        from: fromNode,
+        to: toNode,
+        sameItems: false,
+      })
+
+      const handler = updateResultItem({
+        item,
+        query: ':root part1 part2 part3 final',
+        updateQuery: mockUpdateQuery,
+      })
+
+      handler(mockEvent)
+
+      expect(mockEvent.preventDefault).toHaveBeenCalled()
+      expect(mockUpdateQuery).toHaveBeenCalledWith(
+        ':root part1 part2 part3 #parent > final',
+      )
+    })
+
+    it('should handle from node with no graph', () => {
+      const mockUpdateQuery = vi.fn()
+      const mockEvent = {
+        preventDefault: vi.fn(),
+      } as unknown as MouseEvent
+
+      const fromNode = {
+        name: 'parent',
+        version: '1.0.0',
+        graph: { nodes: new Map() },
+        edgesIn: new Set(),
+        edgesOut: new Map(),
+        insights: {
+          scanned: false,
+        },
+        toJSON: () => ({}) as any,
+      } as QueryResponseNode
+      const toNode = createMockNode('child', '2.0.0')
+
+      const item = createGridItemData({
+        from: fromNode,
+        to: toNode,
+        sameItems: false,
+      })
+
+      const handler = updateResultItem({
+        item,
+        query: '',
+        updateQuery: mockUpdateQuery,
+      })
+
+      handler(mockEvent)
+
+      expect(mockEvent.preventDefault).toHaveBeenCalled()
+      expect(mockUpdateQuery).toHaveBeenCalledWith('#parent > #child')
+    })
+
+    it('should handle from node with empty name', () => {
+      const mockUpdateQuery = vi.fn()
+      const mockEvent = {
+        preventDefault: vi.fn(),
+      } as unknown as MouseEvent
+
+      const fromNode = createMockNode('', '1.0.0')
+      const toNode = createMockNode('child', '2.0.0')
+
+      const item = createGridItemData({
+        from: fromNode,
+        to: toNode,
+        sameItems: false,
+      })
+
+      const handler = updateResultItem({
+        item,
+        query: '',
+        updateQuery: mockUpdateQuery,
+      })
+
+      handler(mockEvent)
+
+      expect(mockEvent.preventDefault).toHaveBeenCalled()
+      expect(mockUpdateQuery).toHaveBeenCalledWith('# > #child')
+    })
+
+    it('should handle multiple scenarios combined', () => {
+      const mockUpdateQuery = vi.fn()
+      const mockEvent = {
+        preventDefault: vi.fn(),
+      } as unknown as MouseEvent
+
+      // Test case: from node with multiple versions, complex query, and specific naming
+      const fromNode = createNodeWithMultipleVersions(
+        'my-parent-pkg',
+        '3.1.4',
+        ['1.0.0', '2.0.0', '3.0.0'],
+      )
+      const toNode = createMockNode('@scoped/child-pkg', '1.2.3')
+
+      const item = createGridItemData({
+        from: fromNode,
+        to: toNode,
+        sameItems: false,
+      })
+
+      const handler = updateResultItem({
+        item,
+        query: ':root existing complex query with spaces',
+        updateQuery: mockUpdateQuery,
+      })
+
+      handler(mockEvent)
+
+      expect(mockEvent.preventDefault).toHaveBeenCalled()
+      expect(mockUpdateQuery).toHaveBeenCalledWith(
+        ':root existing complex query with #my-parent-pkg:v(3.1.4) > spaces',
+      )
+    })
+  })
+
+  describe('return value', () => {
+    it('should always return undefined', () => {
+      const mockUpdateQuery = vi.fn()
+      const mockEvent = {
+        preventDefault: vi.fn(),
+      } as unknown as MouseEvent
+
+      const item = createGridItemData({
+        to: createMockNode('package', '1.0.0'),
+      })
+
+      const handler = updateResultItem({
+        item,
+        query: 'test',
+        updateQuery: mockUpdateQuery,
+      })
+
+      const result = handler(mockEvent)
+      expect(result).toBeUndefined()
+    })
+  })
+})


### PR DESCRIPTION
Fix clicking on search results when the current query starts from a `:root` reference.