### PR TITLE
gui: fix result item queries

### DIFF
--- a/src/gui/src/lib/update-result-item.ts
+++ b/src/gui/src/lib/update-result-item.ts
@@ -1,5 +1,7 @@
 import type React from 'react'
 import type { GridItemData } from '@/components/explorer-grid/types.ts'
+import { Query } from '@vltpkg/query'
+import type { ParsedSelectorToken } from '@vltpkg/query'
 
 /**
  * Options for updating a result item.
@@ -20,27 +22,60 @@ export type UpdateResultItemOptions = {
 }
 
 /**
+ * Appends a string to the query if it is not already present.
+ */
+const appendToQuery = (query: string, s: string) => {
+  const q = query.trim()
+  return q === s ? q : `${q}${s}`
+}
+
+/**
+ * Checks if any segment of the query has an importer token.
+ */
+const hasImporterToken = (
+  queryTokens: ParsedSelectorToken[],
+): boolean => {
+  for (const segment of queryTokens) {
+    return (
+      segment.value === ':root' ||
+      segment.value === ':workspace' ||
+      segment.value === ':project'
+    )
+  }
+  return false
+}
+
+/**
  * Updates the query based on a given result item.
  */
 export const updateResultItem =
-  ({ item, query, updateQuery }: UpdateResultItemOptions) =>
+  ({ item, query: q, updateQuery }: UpdateResultItemOptions) =>
   (e: React.MouseEvent | MouseEvent) => {
     e.preventDefault()
     if (!item.to) return
     let newQuery = ''
-    const appendToQuery = (s: string) => {
-      const q = query.trim()
-      return q === s ? q : `${q}${s}`
-    }
+    const query = q.trim()
+    // if it's a stacked item we make sure we select the unique node so that
+    // either we get down to a single item or the user is presented with the
+    // list of same items to refine the selection again
     if (item.stacked) {
-      newQuery = appendToQuery(item.to.name ? `#${item.to.name}` : '')
+      newQuery = appendToQuery(
+        query,
+        `[name="${item.to.name}"]:v(${item.to.version})`,
+      )
     } else {
       let suffix = ''
+      // if it's not a list of the same items then we only attemp to suffix
+      // the query with the regular item name
       if (!item.sameItems) {
-        suffix = item.to.name ? `#${item.to.name}` : ''
+        suffix = item.name ? `#${item.name}` : ''
       }
-      if (item.to.importer && !item.from) {
-        newQuery = `:project#${item.to.name}`
+      // the item is root
+      if (item.to.mainImporter) {
+        newQuery = `:root`
+        // the item is a workspace
+      } else if (item.to.importer) {
+        newQuery = `#${item.to.name}:workspace`
       } else if (item.from) {
         // use version on the parent node if there are multiple nodes in the graph with the same name
         const useVersion =
@@ -52,21 +87,37 @@ export const updateResultItem =
           useVersion && item.from.version ?
             `:v(${item.from.version})`
           : ''
-        if (query.startsWith(':root')) {
-          const queryParts = query.split(' ')
-          queryParts.splice(
-            queryParts.length - 1,
-            0,
-            `${fromName}${fromVersion} >`,
-          )
-          newQuery = queryParts.join(' ')
+        const queryTokens = Query.getQueryTokens(query)
+
+        // direct dependency of the root
+        if (item.from.mainImporter) {
+          newQuery = `:root > #${item.name}`
+          // parent isn't importer but not root, so it's a workspace
+        } else if (item.from.importer) {
+          newQuery = `#${item.from.name}:workspace > #${item.name}`
+          // if the selector has an importer than we append a second part
+          // using :is() to be able to narrow down by providing a parent
+        } else if (hasImporterToken(queryTokens)) {
+          const name = `#${item.name}`
+          const dest =
+            name !== suffix ?
+              `#${appendToQuery(item.name, suffix)}`
+            : name
+          newQuery = `${query}:is(${fromName}${fromVersion} > ${dest})`
         } else {
-          newQuery = `${fromName}${fromVersion} > ${appendToQuery(suffix)}`
+          // by default we preppend the parent item to the query
+          const prefix = `${fromName}${fromVersion}`
+          if (query.startsWith(prefix)) {
+            newQuery = `${appendToQuery(query, suffix)}:v(${item.to.version})`
+          } else {
+            newQuery = `${prefix} > ${appendToQuery(query, suffix)}`
+          }
         }
       } else {
-        newQuery = appendToQuery(suffix)
+        newQuery = appendToQuery(query, suffix)
       }
     }
+
     updateQuery(newQuery)
     return undefined
   }

--- a/src/gui/test/components/explorer-grid/results/result-item.tsx
+++ b/src/gui/test/components/explorer-grid/results/result-item.tsx
@@ -136,7 +136,7 @@ describe('ResultItem updates query store value', () => {
 
     assert.deepEqual(
       query,
-      ':root#item',
+      ':root[name="item"]:v(1.0.0)',
       'should append item and version in order to narrow & show stacked items',
     )
   })
@@ -171,7 +171,7 @@ describe('ResultItem updates query store value', () => {
 
     assert.deepEqual(
       query,
-      ':project#my-item',
+      '#my-item:workspace',
       'should prefix with :project followed by the name of the importer',
     )
   })
@@ -211,7 +211,7 @@ describe('ResultItem updates query store value', () => {
 
     assert.deepEqual(
       query,
-      '#parent > :root',
+      ':root:is(#parent > #item)',
       'should prefix the parent name and version',
     )
   })


### PR DESCRIPTION
Fixes a variety of broken cases when clicking on the result item view elements.

Also update the unit tests in order to prune any scenario that would not match the expected data structure of real graph items and add a few additional tests to check for missing scenarios.