### PR TITLE
graph: fix overridden pkg human output name

### DIFF
--- a/src/graph/src/visualization/human-readable-output.ts
+++ b/src/graph/src/visualization/human-readable-output.ts
@@ -183,14 +183,15 @@ export function humanReadableOutput(
           : nodeName
         const nextChar = isLast ? 'last-child' : 'middle-child'
 
+        const aliasedPackage =
+          nextItem.node?.name && nextItem.edge?.name !== nodeName
         nextItem.name =
           nextItem.node?.confused ?
             `${nextItem.edge?.name} ${red('(confused)')}`
           : nextItem.edge?.spec.overridden ?
             /* c8 ignore next */
-            `${nextItem.edge.name}@${nextItem.node?.version || nextItem.edge.spec.bareSpec} ${yellow('(overridden)')}`
-          : nextItem.node?.name && nextItem.edge?.name !== nodeName ?
-            `${nextItem.edge?.name} (${toName})`
+            `${nextItem.edge.name}@${nextItem.node?.version || nextItem.edge.spec.bareSpec}${aliasedPackage ? ` (${toName})` : ''} ${yellow('(overridden)')}`
+          : aliasedPackage ? `${nextItem.edge?.name} (${toName})`
           : `${nextItem.edge?.name}@${nextItem.node?.version || nextItem.edge?.spec.bareSpec}`
         nextItem.padding =
           parent.prefix.length ?

--- a/src/graph/tap-snapshots/test/visualization/human-readable-output.ts.test.cjs
+++ b/src/graph/tap-snapshots/test/visualization/human-readable-output.ts.test.cjs
@@ -102,6 +102,18 @@ file·.
 
 `
 
+exports[`test/visualization/human-readable-output.ts > TAP > overridden aliased package > colors > should use colors for overridden aliased package 1`] = `
+[0mmy-project
+└── a@2.0.0 (npm:@myscope/foo@2.0.0) [33m(overridden)[39m
+[0m
+`
+
+exports[`test/visualization/human-readable-output.ts > TAP > overridden aliased package > should print overridden aliased package with toName 1`] = `
+my-project
+└── a@2.0.0 (npm:@myscope/foo@2.0.0) (overridden)
+
+`
+
 exports[`test/visualization/human-readable-output.ts > TAP > overridden package > colors > should use colors for overridden package 1`] = `
 [0mmy-project
 └── foo@2.0.0 [33m(overridden)[39m

--- a/src/graph/test/visualization/human-readable-output.ts
+++ b/src/graph/test/visualization/human-readable-output.ts
@@ -501,3 +501,60 @@ t.test('overridden package', async t => {
     )
   })
 })
+
+t.test('overridden aliased package', async t => {
+  const projectRoot = t.testdir({ 'vlt.json': '{}' })
+  t.chdir(projectRoot)
+  unload('project')
+  const graph = new Graph({
+    projectRoot,
+    ...configData,
+    mainManifest: {
+      name: 'my-project',
+      version: '1.0.0',
+      dependencies: {
+        a: 'npm:@myscope/foo@^1.0.0',
+      },
+    },
+  })
+  const aliasedSpec = Spec.parse('a', 'npm:@myscope/foo@^1.0.0')
+  // Mark the spec as overridden
+  aliasedSpec.overridden = true
+  const foo = graph.placePackage(
+    graph.mainImporter,
+    'prod',
+    aliasedSpec,
+    {
+      name: '@myscope/foo',
+      version: '2.0.0',
+    },
+  )
+  t.ok(foo)
+  t.matchSnapshot(
+    humanReadableOutput(
+      {
+        edges: [...graph.edges],
+        highlightSelection: false,
+        importers: graph.importers,
+        nodes: [...graph.nodes.values()],
+      },
+      {},
+    ),
+    'should print overridden aliased package with toName',
+  )
+
+  t.test('colors', async t => {
+    t.matchSnapshot(
+      humanReadableOutput(
+        {
+          edges: [...graph.edges],
+          highlightSelection: false,
+          importers: graph.importers,
+          nodes: [...graph.nodes.values()],
+        },
+        { colors: true },
+      ),
+      'should use colors for overridden aliased package',
+    )
+  })
+})


### PR DESCRIPTION
Fixes the human output render for overridden packages when they're using aliased versions.