### PR TITLE
package-json: add find method

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1377,6 +1377,9 @@ importers:
       polite-json:
         specifier: 'catalog:'
         version: 5.0.0
+      walk-up-path:
+        specifier: 'catalog:'
+        version: 4.0.0
     devDependencies:
       '@eslint/js':
         specifier: 'catalog:'

--- a/src/package-json/package.json
+++ b/src/package-json/package.json
@@ -21,7 +21,8 @@
   "dependencies": {
     "@vltpkg/error-cause": "workspace:*",
     "@vltpkg/types": "workspace:*",
-    "polite-json": "catalog:"
+    "polite-json": "catalog:",
+    "walk-up-path": "catalog:"
   },
   "devDependencies": {
     "@eslint/js": "catalog:",


### PR DESCRIPTION
Add a `find` method to `@vltpkg/package-json` that walks up the directory structure and returns the full path to the first found `package.json` file, returns `undefined` if a `package.json` can't be found and never looks at the home directory level or above.