### PR TITLE
cli-sdk: add pkg cwd support

### DIFF
--- a/src/cli-sdk/src/commands/pkg.ts
+++ b/src/cli-sdk/src/commands/pkg.ts
@@ -77,7 +77,7 @@ export const command: CommandFn = async conf => {
   }
 
   const pkg = conf.options.packageJson
-  const mani = pkg.read(conf.projectRoot)
+  const mani = pkg.read(pkg.find() ?? conf.projectRoot)
 
   switch (sub) {
     case 'get':
@@ -151,7 +151,8 @@ const set = (
     )
   }, mani)
 
-  pkg.write(conf.projectRoot, res)
+  /* c8 ignore next */
+  pkg.write(pkg.find() ?? conf.projectRoot, res)
 }
 
 const rm = (
@@ -169,5 +170,6 @@ const rm = (
     return acc
   }, mani)
 
-  pkg.write(conf.projectRoot, res)
+  /* c8 ignore next */
+  pkg.write(pkg.find() ?? conf.projectRoot, res)
 }

--- a/src/package-json/src/index.ts
+++ b/src/package-json/src/index.ts
@@ -17,26 +17,6 @@ const exists = (path: string): boolean => {
   }
 }
 
-/**
- * Walks up the directory tree from the current working directory
- * and returns the path to the first `package.json` file found.
- * Returns undefined if no package.json is found.
- */
-export const find = (
-  cwd: string = process.cwd(),
-  home: string = homedir(),
-): string | undefined => {
-  for (const dir of walkUp(cwd)) {
-    // don't look in home directory
-    if (dir === home) break
-
-    const packageJsonPath = resolve(dir, 'package.json')
-    if (exists(packageJsonPath)) {
-      return packageJsonPath
-    }
-  }
-}
-
 export class PackageJson {
   /**
    * cache of `package.json` loads
@@ -63,7 +43,10 @@ export class PackageJson {
       return cachedPackageJson
     }
 
-    const filename = resolve(dir, 'package.json')
+    const filename =
+      dir.endsWith('package.json') ?
+        resolve(dir)
+      : resolve(dir, 'package.json')
 
     const fail = (err: ErrorCauseOptions) =>
       error('Could not read package.json file', err, this.read)
@@ -91,7 +74,10 @@ export class PackageJson {
   }
 
   write(dir: string, manifest: Manifest, indent?: number): void {
-    const filename = resolve(dir, 'package.json')
+    const filename =
+      dir.endsWith('package.json') ?
+        resolve(dir)
+      : resolve(dir, 'package.json')
     this.fix(manifest)
 
     try {
@@ -140,6 +126,26 @@ export class PackageJson {
             a.localeCompare(b, 'en'),
           ),
         )
+      }
+    }
+  }
+
+  /**
+   * Walks up the directory tree from the current working directory
+   * and returns the path to the first `package.json` file found.
+   * Returns undefined if no package.json is found.
+   */
+  find(
+    cwd: string = process.cwd(),
+    home: string = homedir(),
+  ): string | undefined {
+    for (const dir of walkUp(cwd)) {
+      // don't look in home directory
+      if (dir === home) break
+
+      const packageJsonPath = resolve(dir, 'package.json')
+      if (exists(packageJsonPath)) {
+        return packageJsonPath
       }
     }
   }

--- a/src/package-json/tap-snapshots/test/index.ts.test.cjs
+++ b/src/package-json/tap-snapshots/test/index.ts.test.cjs
@@ -43,3 +43,11 @@ exports[`test/index.ts > TAP > successfully writes a valid package.json file > m
 }
 
 `
+
+exports[`test/index.ts > TAP > writes to a package.json filepath > manifest should be read with original indent 1`] = `
+{
+        "name": "my-project",
+        "version": "1.0.1"
+}
+
+`


### PR DESCRIPTION
Add support to `vlt pkg` command to operate on the current working directory, primarily to support the usage of workspaces but also handles any folders that have a `package.json` in it.