### PR TITLE
graph: init package.json on install

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -909,6 +909,9 @@ importers:
       '@vltpkg/fast-split':
         specifier: workspace:*
         version: link:../fast-split
+      '@vltpkg/init':
+        specifier: workspace:*
+        version: link:../init
       '@vltpkg/output':
         specifier: workspace:*
         version: link:../output

--- a/src/graph/package.json
+++ b/src/graph/package.json
@@ -25,6 +25,7 @@
     "@vltpkg/dss-breadcrumb": "workspace:*",
     "@vltpkg/error-cause": "workspace:*",
     "@vltpkg/fast-split": "workspace:*",
+    "@vltpkg/init": "workspace:*",
     "@vltpkg/output": "workspace:*",
     "@vltpkg/package-info": "workspace:*",
     "@vltpkg/package-json": "workspace:*",

--- a/src/graph/src/install.ts
+++ b/src/graph/src/install.ts
@@ -1,10 +1,13 @@
-import type { PackageInfoClient } from '@vltpkg/package-info'
-import type { LoadOptions } from './actual/load.ts'
 import { load as actualLoad } from './actual/load.ts'
-import type { AddImportersDependenciesMap } from './dependencies.ts'
 import { build as idealBuild } from './ideal/build.ts'
 import { reify } from './reify/index.ts'
 import { GraphModifier } from './modifiers.ts'
+import { init } from '@vltpkg/init'
+import { asError } from '@vltpkg/types'
+import type { Manifest } from '@vltpkg/types'
+import type { PackageInfoClient } from '@vltpkg/package-info'
+import type { LoadOptions } from './actual/load.ts'
+import type { AddImportersDependenciesMap } from './dependencies.ts'
 
 export type InstallOptions = LoadOptions & {
   packageInfo: PackageInfoClient
@@ -14,7 +17,19 @@ export const install = async (
   options: InstallOptions,
   add?: AddImportersDependenciesMap,
 ) => {
-  const mainManifest = options.packageJson.read(options.projectRoot)
+  let mainManifest: Manifest | undefined = undefined
+  try {
+    mainManifest = options.packageJson.read(options.projectRoot)
+  } catch (err) {
+    if (asError(err).message === 'Could not read package.json file') {
+      await init({ cwd: options.projectRoot })
+      mainManifest = options.packageJson.read(options.projectRoot, {
+        reload: true,
+      })
+    } else {
+      throw err
+    }
+  }
   const modifiers = GraphModifier.maybeLoad(options)
 
   const graph = await idealBuild({

--- a/src/graph/tap-snapshots/test/install.ts.test.cjs
+++ b/src/graph/tap-snapshots/test/install.ts.test.cjs
@@ -20,3 +20,21 @@ actual.load
 reify
 
 `
+
+exports[`test/install.ts > TAP > install with no package.json file in cwd > should create a graph with the new dependency 1`] = `
+[
+  Node {
+    id: 'file·.',
+    location: '.',
+    importer: true,
+    edgesOut: [
+      Edge spec(abbrev@2.0.0) -prod-> to: Node {
+        id: '··abbrev@2.0.0',
+        location: './node_modules/.vlt/··abbrev@2.0.0/node_modules/abbrev',
+        resolved: 'https://registry.npmjs.org/abbrev/-/abbrev-2.0.0.tgz',
+        integrity: 'sha512-6/mh1E2u2YgEsCHdY0Yx5oW+61gZU+1vXaoiHHrpKeuRNNgFvS+/jrwHiQhB5apAf5oB7UB7E19ol2R2LKH8hQ=='
+      }
+    ]
+  }
+]
+`


### PR DESCRIPTION
If there is no `package.json` file in the parsed project root, we proceed to `init` a new `package.json` before running install.