### PR TITLE
cli-sdk: add init workspace support

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -501,6 +501,9 @@ importers:
       lz-string:
         specifier: 'catalog:'
         version: 1.5.0
+      minimatch:
+        specifier: 'catalog:'
+        version: 10.0.1
       package-json-from-dist:
         specifier: 'catalog:'
         version: 1.0.1

--- a/src/cli-sdk/package.json
+++ b/src/cli-sdk/package.json
@@ -49,6 +49,7 @@
     "ink-spinner": "^5.0.0",
     "jackspeak": "^4.1.1",
     "lz-string": "catalog:",
+    "minimatch": "catalog:",
     "package-json-from-dist": "catalog:",
     "path-scurry": "catalog:",
     "pretty-bytes": "^6.1.1",

--- a/src/cli-sdk/src/commands/init.ts
+++ b/src/cli-sdk/src/commands/init.ts
@@ -1,7 +1,12 @@
-import { commandUsage } from '../config/usage.ts'
-import type { CommandFn, CommandUsage } from '../index.ts'
+import { mkdirSync } from 'node:fs'
+import { relative, resolve } from 'node:path'
+import { minimatch } from 'minimatch'
 import { init } from '@vltpkg/init'
+import { load, save } from '@vltpkg/vlt-json'
+import { assertWSConfig, asWSConfig } from '@vltpkg/workspaces'
+import { commandUsage } from '../config/usage.ts'
 import type { InitFileResults } from '@vltpkg/init'
+import type { CommandFn, CommandUsage } from '../index.ts'
 import type { Views } from '../view.ts'
 
 export const usage: CommandUsage = () =>
@@ -11,22 +16,115 @@ export const usage: CommandUsage = () =>
     description: `Create a new package.json file in the current directory.`,
   })
 
+// TODO: colorize the JSON if config.options.color
 export const views = {
-  human: (results, _options, _config) => {
+  human: (results: InitFileResults | InitFileResults[]) => {
     const output: string[] = []
-    // TODO: colorize the JSON if config.options.color
-    for (const [type, { path, data }] of Object.entries(results)) {
-      output.push(`Wrote ${type} to ${path}:
+    // if results is an array, it means multiple workspaces were initialized
+    if (Array.isArray(results)) {
+      for (const result of results) {
+        for (const [type, { path }] of Object.entries(result)) {
+          output.push(`Wrote ${type} to ${path}:`)
+        }
+      }
+    } else {
+      // otherwise, it's a single result
+      for (const [type, { path, data }] of Object.entries(results)) {
+        output.push(`Wrote ${type} to ${path}:
 
-${JSON.stringify(data, null, 2)}
-`)
+${JSON.stringify(data, null, 2)}`)
+      }
     }
-    output.push(`Modify/add properties using \`vlt pkg\`. For example:
+    output.push(`\nModify/add properties using \`vlt pkg\`. For example:
 
   vlt pkg set "description=My new project"`)
     return output.join('\n')
   },
 } as const satisfies Views<InitFileResults>
 
-export const command: CommandFn<InitFileResults> = async () =>
-  await init({ cwd: process.cwd() })
+export const command: CommandFn<
+  InitFileResults | InitFileResults[]
+> = async conf => {
+  if (conf.values.workspace?.length) {
+    const workspacesConfig = load('workspaces', assertWSConfig)
+    const parsedWSConfig = asWSConfig(workspacesConfig ?? {})
+    const results: InitFileResults[] = []
+    const addToConfig: string[] = []
+
+    // create a new package.json file for every workspace
+    // defined as cli --workspace options
+    for (const workspace of conf.values.workspace) {
+      // cwd is the resolved location of the workspace
+      const cwd = resolve(conf.options.projectRoot, workspace)
+
+      // create the folder in case it's missing
+      mkdirSync(cwd, { recursive: true })
+
+      // run the initialization script and collect results
+      results.push(await init({ cwd }))
+
+      // Check if this workspace path is covered by existing workspace patterns
+      const isMatched = Object.values(parsedWSConfig).some(
+        (patterns: string[]) => {
+          return patterns.some(pattern =>
+            minimatch(workspace, pattern),
+          )
+        },
+      )
+
+      // When a workspace is not matched we track it for insertion later
+      if (!isMatched) {
+        addToConfig.push(
+          relative(conf.options.projectRoot, cwd).replace(/\\/g, '/'),
+        )
+      }
+    }
+
+    // if there are workspaces that were not matched by existing
+    // patterns, we add them to the workspaces config
+    if (addToConfig.length > 0) {
+      let workspaces = workspacesConfig
+      // if the original workspaces config is a string, we'll need
+      // to convert it to an array in order to append the recently
+      // added workspaces
+      if (typeof workspacesConfig === 'string') {
+        workspaces = [workspacesConfig, ...addToConfig]
+      } else if (Array.isArray(workspacesConfig)) {
+        // if the original workspaces config is an array, we simply
+        // append the missing items to it
+        workspaces = [...workspacesConfig, ...addToConfig]
+      } else {
+        // otherwise we assume it's an Record<string, string[]> object
+        // and we'll add the new workspaces to the `packages` keys
+        workspaces = (workspacesConfig ?? {}) as Record<
+          string,
+          string[]
+        >
+        // if the `packages` key is not being used
+        if (!workspaces.packages) {
+          workspaces.packages = addToConfig
+        } else {
+          // if the `packages` key is defined as a string, we
+          // convert it to an array to append the new items
+          if (typeof workspaces.packages === 'string') {
+            workspaces.packages = [
+              workspaces.packages,
+              ...addToConfig,
+            ]
+          } else {
+            // if it is, we simply append the new workspaces
+            workspaces.packages = [
+              ...workspaces.packages,
+              ...addToConfig,
+            ]
+          }
+        }
+      }
+      // finally, we add the new workspaces to the config file
+      save('workspaces', workspaces)
+    }
+    return results
+  }
+
+  return init({ cwd: process.cwd() })
+}

--- a/src/cli-sdk/src/commands/pkg.ts
+++ b/src/cli-sdk/src/commands/pkg.ts
@@ -12,15 +12,11 @@ import type { Views } from '../view.ts'
 import { views as initViews } from './init.ts'
 
 export const views = {
-  human: (results, options, config) => {
+  human: (results, _options, config) => {
     // `vlt pkg init` is an alias for `vlt init`
     // use the same output handling
     if (config.positionals[0] === 'init') {
-      return initViews.human(
-        results as InitFileResults,
-        options,
-        config,
-      )
+      return initViews.human(results as InitFileResults)
     }
     return results && typeof results === 'object' ?
         Object.fromEntries(

--- a/src/cli-sdk/src/index.ts
+++ b/src/cli-sdk/src/index.ts
@@ -83,6 +83,7 @@ const run = async () => {
   }
 
   if (
+    vlt.command !== 'init' &&
     (vlt.get('workspace') || vlt.get('workspace-group')) &&
     ![...(monorepo?.values() ?? [])].length
   ) {

--- a/src/cli-sdk/tap-snapshots/test/commands/init.ts.test.cjs
+++ b/src/cli-sdk/tap-snapshots/test/commands/init.ts.test.cjs
@@ -27,3 +27,22 @@ vlt init
 Create a new package.json file in the current directory.
 
 `
+
+exports[`test/commands/init.ts > TAP > test command with workspace > should add workspace to vlt.json 1`] = `
+{
+  "workspaces": {
+    "packages": [
+      "packages/a"
+    ]
+  }
+}
+
+`
+
+exports[`test/commands/init.ts > TAP > test command with workspace > should output human readable message 1`] = `
+Wrote manifest to packages/a:
+
+Modify/add properties using \`vlt pkg\`. For example:
+
+  vlt pkg set "description=My new project"
+`

--- a/src/cli-sdk/test/commands/init.ts
+++ b/src/cli-sdk/test/commands/init.ts
@@ -1,8 +1,12 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
 import t from 'tap'
 import type { LoadedConfig } from '../../src/config/index.ts'
-import type { ViewOptions } from '../../src/view.ts'
+import type { InitFileResults } from '@vltpkg/init'
 
 const inited: string[] = []
+const vltJsonData: Record<string, any> = {}
+
 const { usage, command, views } = await t.mockImport<
   typeof import('../../src/commands/init.ts')
 >('../../src/commands/init.ts', {
@@ -14,28 +18,335 @@ const { usage, command, views } = await t.mockImport<
       return ''
     },
   },
+  '@vltpkg/vlt-json': {
+    load: (field: string) => vltJsonData[field],
+    save: (field: string, value: any) => {
+      vltJsonData[field] = value
+    },
+  },
 })
 
 t.matchSnapshot(usage().usageMarkdown())
 
 t.test('test command', async t => {
   t.chdir(t.testdir())
-  await command({} as LoadedConfig)
+  await command({ values: {} } as LoadedConfig)
   t.strictSame(inited, [t.testdirName])
+})
+
+t.test('test command with workspace', async t => {
+  const res: InitFileResults[] = []
+  const { command, views } = await t.mockImport<
+    typeof import('../../src/commands/init.ts')
+  >('../../src/commands/init.ts', {
+    '@vltpkg/init': {
+      init: async ({ cwd }: { cwd: string }) => {
+        res.push({
+          manifest: {
+            path: cwd,
+            data: {
+              name: 'a',
+              version: '1.0.0',
+            },
+          },
+        })
+      },
+      getAuthorFromGitUser() {
+        return ''
+      },
+    },
+  })
+  const dir = t.testdir({
+    'README.md': 'This is a workspace',
+    '.git': {},
+  })
+  t.chdir(dir)
+  inited.length = 0 // reset array
+
+  await command({
+    values: {
+      workspace: ['packages/a'],
+    },
+    options: {
+      projectRoot: dir,
+    },
+  } as unknown as LoadedConfig)
+  t.strictSame(
+    res,
+    [
+      {
+        manifest: {
+          data: { name: 'a', version: '1.0.0' },
+          path: resolve(dir, 'packages/a'),
+        },
+      },
+    ],
+    'should have initial result',
+  )
+  t.matchSnapshot(
+    readFileSync(resolve(dir, 'vlt.json'), 'utf8'),
+    'should add workspace to vlt.json',
+  )
+
+  t.matchSnapshot(
+    views
+      .human(res)
+      .replace(resolve(dir, 'packages/a'), 'packages/a'),
+    'should output human readable message',
+  )
+})
+
+t.test('test command with empty workspace array', async t => {
+  t.chdir(t.testdir())
+  inited.length = 0 // reset array
+  await command({
+    values: {
+      workspace: [],
+    },
+  } as unknown as LoadedConfig)
+  t.strictSame(inited, [t.testdirName])
+})
+
+t.test('test command with undefined workspace', async t => {
+  t.chdir(t.testdir())
+  inited.length = 0 // reset array
+  await command({
+    values: {
+      workspace: undefined,
+    },
+  } as unknown as LoadedConfig)
+  t.strictSame(inited, [t.testdirName])
+})
+
+t.test(
+  'test workspace already matched by existing pattern',
+  async t => {
+    const dir = t.testdir({
+      'README.md': 'This is a workspace',
+      '.git': {},
+    })
+
+    // Set up initial vlt.json data in mock
+    vltJsonData.workspaces = 'packages/*'
+    inited.length = 0 // reset array
+
+    await command({
+      values: {
+        workspace: ['packages/a'],
+      },
+      options: {
+        projectRoot: dir,
+      },
+    } as unknown as LoadedConfig)
+
+    t.strictSame(inited, [resolve(dir, 'packages/a')])
+
+    // vlt.json should remain unchanged since packages/a matches packages/*
+    t.strictSame(vltJsonData.workspaces, 'packages/*')
+  },
+)
+
+t.test(
+  'test string workspace config - add non-matching workspace',
+  async t => {
+    const dir = t.testdir({
+      'README.md': 'This is a workspace',
+      '.git': {},
+    })
+
+    // Set up initial vlt.json data in mock
+    vltJsonData.workspaces = 'packages/*'
+    inited.length = 0 // reset array
+
+    await command({
+      values: {
+        workspace: ['docs/website'],
+      },
+      options: {
+        projectRoot: dir,
+      },
+    } as unknown as LoadedConfig)
+
+    t.strictSame(inited, [resolve(dir, 'docs/website')])
+
+    // vlt.json should be converted to array with new workspace added
+    t.strictSame(vltJsonData.workspaces, [
+      'packages/*',
+      'docs/website',
+    ])
+  },
+)
+
+t.test(
+  'test array workspace config - add non-matching workspace',
+  async t => {
+    const dir = t.testdir({
+      'README.md': 'This is a workspace',
+      '.git': {},
+    })
+
+    // Set up initial vlt.json data in mock
+    vltJsonData.workspaces = ['app/*', 'docs/*']
+    inited.length = 0 // reset array
+
+    await command({
+      values: {
+        workspace: ['packages/a'],
+      },
+      options: {
+        projectRoot: dir,
+      },
+    } as unknown as LoadedConfig)
+
+    t.strictSame(inited, [resolve(dir, 'packages/a')])
+
+    // new workspace should be appended to existing array
+    t.strictSame(vltJsonData.workspaces, [
+      'app/*',
+      'docs/*',
+      'packages/a',
+    ])
+  },
+)
+
+t.test(
+  'test object with packages key (array) - add non-matching workspace',
+  async t => {
+    const dir = t.testdir({
+      'README.md': 'This is a workspace',
+      '.git': {},
+    })
+
+    // Set up initial vlt.json data in mock
+    vltJsonData.workspaces = {
+      packages: ['packages/*'],
+    }
+    inited.length = 0 // reset array
+
+    await command({
+      values: {
+        workspace: ['docs/website'],
+      },
+      options: {
+        projectRoot: dir,
+      },
+    } as unknown as LoadedConfig)
+
+    t.strictSame(inited, [resolve(dir, 'docs/website')])
+
+    // new workspace should be appended to packages array
+    t.strictSame(vltJsonData.workspaces, {
+      packages: ['packages/*', 'docs/website'],
+    })
+  },
+)
+
+t.test(
+  'test object with packages key (string) - convert to array and add workspace',
+  async t => {
+    const dir = t.testdir({
+      'README.md': 'This is a workspace',
+      '.git': {},
+    })
+
+    // Set up initial vlt.json data in mock
+    vltJsonData.workspaces = {
+      packages: 'packages/a',
+    }
+    inited.length = 0 // reset array
+
+    await command({
+      values: {
+        workspace: ['packages/b'],
+      },
+      options: {
+        projectRoot: dir,
+      },
+    } as unknown as LoadedConfig)
+
+    t.strictSame(inited, [resolve(dir, 'packages/b')])
+
+    // packages should be converted to array with new workspace added
+    t.strictSame(vltJsonData.workspaces, {
+      packages: ['packages/a', 'packages/b'],
+    })
+  },
+)
+
+t.test(
+  'test object without packages key - create packages key with new workspace',
+  async t => {
+    const dir = t.testdir({
+      'README.md': 'This is a workspace',
+      '.git': {},
+    })
+
+    // Set up initial vlt.json data in mock
+    vltJsonData.workspaces = {
+      utils: ['utils/*'],
+    }
+    inited.length = 0 // reset array
+
+    await command({
+      values: {
+        workspace: ['docs/website'],
+      },
+      options: {
+        projectRoot: dir,
+      },
+    } as unknown as LoadedConfig)
+
+    t.strictSame(inited, [resolve(dir, 'docs/website')])
+
+    // packages key should be created with new workspace
+    t.strictSame(vltJsonData.workspaces, {
+      utils: ['utils/*'],
+      packages: ['docs/website'],
+    })
+  },
+)
+
+t.test('test multiple workspaces with mixed matching', async t => {
+  const dir = t.testdir({
+    'README.md': 'This is a workspace',
+    '.git': {},
+  })
+
+  // Set up initial vlt.json data in mock
+  vltJsonData.workspaces = ['packages/*', 'apps/*']
+  inited.length = 0 // reset array
+
+  await command({
+    values: {
+      workspace: ['packages/a', 'docs/website', 'apps/web'],
+    },
+    options: {
+      projectRoot: dir,
+    },
+  } as unknown as LoadedConfig)
+
+  t.strictSame(inited, [
+    resolve(dir, 'packages/a'),
+    resolve(dir, 'docs/website'),
+    resolve(dir, 'apps/web'),
+  ])
+
+  // only docs/website should be added since packages/a and apps/web match existing patterns
+  t.strictSame(vltJsonData.workspaces, [
+    'packages/*',
+    'apps/*',
+    'docs/website',
+  ])
 })
 
 t.test('human output', t => {
   t.matchSnapshot(
-    views.human(
-      {
-        manifest: {
-          path: '/some/path',
-          data: { name: 'myproject' },
-        },
+    views.human({
+      manifest: {
+        path: '/some/path',
+        data: { name: 'myproject' },
       },
-      {} as ViewOptions,
-      {} as LoadedConfig,
-    ),
+    }),
   )
   t.end()
 })

--- a/src/cli-sdk/test/config/index.ts
+++ b/src/cli-sdk/test/config/index.ts
@@ -392,22 +392,30 @@ t.test('kv string[] stored as Record<string, string>', async t => {
   })
   t.equal(
     readFileSync(dir + '/vlt.json', 'utf8'),
-    JSON.stringify({
-      config: {
-        registries: { example: 'https://example.com' },
+    JSON.stringify(
+      {
+        config: {
+          registries: { example: 'https://example.com' },
+        },
       },
-    }),
+      null,
+      2,
+    ) + '\n',
   )
   await c.writeConfigFile('project', {
     registries: ['example=https://another.example.com'],
   })
   t.equal(
     readFileSync(dir + '/vlt.json', 'utf8'),
-    JSON.stringify({
-      config: {
-        registries: { example: 'https://another.example.com' },
+    JSON.stringify(
+      {
+        config: {
+          registries: { example: 'https://another.example.com' },
+        },
       },
-    }),
+      null,
+      2,
+    ) + '\n',
   )
 
   await c.writeConfigFile('project', {
@@ -430,25 +438,29 @@ t.test('kv string[] stored as Record<string, string>', async t => {
 
   t.equal(
     readFileSync(dir + '/vlt.json', 'utf8'),
-    JSON.stringify({
-      config: {
-        registries: {
-          example: 'https://another.example.com',
-          bar: 'https://registry.bar',
-        },
-        command: {
-          install: {
-            registries: {
-              example: 'https://install.example.com',
-              foo: 'https://registry.foo',
-            },
-            'git-hosts': {
-              github: 'git+https://github.com/$1/$2',
+    JSON.stringify(
+      {
+        config: {
+          registries: {
+            example: 'https://another.example.com',
+            bar: 'https://registry.bar',
+          },
+          command: {
+            install: {
+              registries: {
+                example: 'https://install.example.com',
+                foo: 'https://registry.foo',
+              },
+              'git-hosts': {
+                github: 'git+https://github.com/$1/$2',
+              },
             },
           },
         },
       },
-    }),
+      null,
+      2,
+    ) + '\n',
   )
 
   clearEnv()
@@ -561,14 +573,22 @@ t.test('delete config values from file', async t => {
     await conf.deleteConfigKeys('project', ['cache', 'registry'])
     t.equal(
       readFileSync(f, 'utf8'),
-      JSON.stringify({
-        config: {
-          color: true,
+      JSON.stringify(
+        {
+          config: {
+            color: true,
+          },
         },
-      }),
+        null,
+        2,
+      ) + '\n',
     )
     await conf.deleteConfigKeys('project', ['color'])
-    t.equal(readFileSync(f, 'utf8'), JSON.stringify({ config: {} }))
+    t.equal(
+      readFileSync(f, 'utf8'),
+      JSON.stringify({ config: {} }, null, 2) + '\n',
+      'deleted color config',
+    )
   })
 
   t.test('delete record field', async t => {
@@ -601,7 +621,11 @@ t.test('delete config values from file', async t => {
       'registries.npm',
       'registries.acme',
     ])
-    t.equal(readFileSync(f, 'utf8'), JSON.stringify({ config: {} }))
+    t.equal(
+      readFileSync(f, 'utf8'),
+      JSON.stringify({ config: {} }, null, 2) + '\n',
+      'deleted named registries',
+    )
   })
 
   t.test('delete record field as array', async t => {
@@ -658,7 +682,11 @@ t.test('delete config values from file', async t => {
       'registries.npm',
       'registries.acme',
     ])
-    t.equal(readFileSync(f, 'utf8'), JSON.stringify({ config: {} }))
+    t.equal(
+      readFileSync(f, 'utf8'),
+      JSON.stringify({ config: {} }, null, 2) + '\n',
+      'deleted all registries',
+    )
   })
 })
 
@@ -681,11 +709,15 @@ t.test('edit config file', async t => {
     t.equal(readFileSync(f, 'utf8'), '{\n  "config": {}\n}\n')
     writeFileSync(
       f,
-      JSON.stringify({
-        config: {
-          registry: 'my happy regas try',
+      JSON.stringify(
+        {
+          config: {
+            registry: 'my happy regas try',
+          },
         },
-      }),
+        null,
+        2,
+      ) + '\n',
     )
   })
   t.equal(editCalled, true)
@@ -696,11 +728,15 @@ t.test('edit config file', async t => {
       editCalled = true
       t.equal(
         readFileSync(f, 'utf8'),
-        JSON.stringify({
-          config: {
-            registry: 'my happy regas try',
+        JSON.stringify(
+          {
+            config: {
+              registry: 'my happy regas try',
+            },
           },
-        }),
+          null,
+          2,
+        ) + '\n',
       )
       writeFileSync(f, '{"config":{"color":true}}')
       throw new Error()
@@ -709,11 +745,15 @@ t.test('edit config file', async t => {
   t.equal(editCalled, true)
   t.equal(
     readFileSync(f, 'utf8'),
-    JSON.stringify({
-      config: {
-        registry: 'my happy regas try',
+    JSON.stringify(
+      {
+        config: {
+          registry: 'my happy regas try',
+        },
       },
-    }),
+      null,
+      2,
+    ) + '\n',
     'edit threw, file reverted',
   )
 

--- a/src/vlt-json/src/index.ts
+++ b/src/vlt-json/src/index.ts
@@ -219,9 +219,23 @@ export const save = (
       },
     )
   }
+
+  // defines a default indentation and newline in case
+  // a user config file has not yet been read before
+  const extraStringifyOptions: {
+    [kIndent]?: number | string
+    [kNewline]?: string
+  } = stringifyOptions[path] ?? {}
+  if (!extraStringifyOptions[kIndent]) {
+    extraStringifyOptions[kIndent] = 2
+  }
+  if (!extraStringifyOptions[kNewline]) {
+    extraStringifyOptions[kNewline] = '\n'
+  }
+
   writeFileSync(
     path,
-    jsonStringify({ ...data, ...stringifyOptions[path] }),
+    jsonStringify({ ...data, ...extraStringifyOptions }),
   )
   delete lstatCache[path]
   mtimes[which] = cachedLstat(path)?.mtime.getTime()

--- a/www/docs/src/content/docs/cli/workspaces.mdx
+++ b/www/docs/src/content/docs/cli/workspaces.mdx
@@ -16,10 +16,23 @@ The `vlt` client supports workspaces defined by glob patterns, and you
 can also define named groups to perform vlt operations on a specific
 subset of your workspaces.
 
-## Defining Workspaces
+## Getting Started
 
-To use monorepo features, create a `vlt.json` file in the root of your
-project with a `workspaces` field.
+It's possible to use the `vlt init` command to create new workspaces
+by using the `--workspace` (or `-w` for short) option, e.g:
+
+```bash
+$ vlt init -w packages/a
+```
+
+This will ensure the folder is created and a `package.json` file is
+added to it, along with adding the required configuration to the
+`vlt.json` file if needed.
+
+### Manually defining Workspaces
+
+If you want to set up new workspaces, it's also possible to use the
+`vlt.json` file in the root of your project with a `workspaces` field.
 
 At its most explicit, the `workspaces` field can be an object with
 `group` names as the keys, and either a single string or an array of


### PR DESCRIPTION
Add the ability to start new workspaces from the cli, so that in a given project folder, the user may run:

    vlt init -w packages/a

This will create the folders if missing, create a new package.json in the location defined and add references to find this new folder in the vlt.json config file.

Fixes: https://github.com/vltpkg/statusboard/issues/164