### PR TITLE
gui: update contributor list

### DIFF
--- a/src/gui/src/components/explorer-grid/selected-item/context.tsx
+++ b/src/gui/src/components/explorer-grid/selected-item/context.tsx
@@ -32,6 +32,7 @@ export type Tab =
   | 'versions'
   | 'json'
   | 'dependencies'
+  | 'contributors'
 
 export type SubTabDependencies =
   | 'insights'

--- a/src/gui/src/components/explorer-grid/selected-item/tabs-contributors.tsx
+++ b/src/gui/src/components/explorer-grid/selected-item/tabs-contributors.tsx
@@ -1,7 +1,12 @@
 import { TabsContent } from '@/components/ui/tabs.tsx'
 import { Link, useParams } from 'react-router'
 import { Button } from '@/components/ui/button.tsx'
-import { ArrowRight, UsersRound, CircleHelp } from 'lucide-react'
+import {
+  ArrowLeft,
+  ArrowRight,
+  UsersRound,
+  CircleHelp,
+} from 'lucide-react'
 import {
   Avatar,
   AvatarImage,
@@ -17,6 +22,7 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from '@/components/ui/tooltip.tsx'
+import { useGraphStore } from '@/state/index.ts'
 
 import type { Tab } from '@/components/explorer-grid/selected-item/context.tsx'
 import type { Contributor } from '@/lib/external-info.ts'
@@ -85,8 +91,16 @@ const Contributor = ({
   contributor: Contributor
   size?: ContributorAvatarProps['size']
 }) => {
+  const updateQuery = useGraphStore(state => state.updateQuery)
+
+  const handleQueryContributor = (email: Contributor['email']) =>
+    updateQuery(`:attr(contributors, [email=${email}])`)
+
   return (
-    <div className="flex cursor-default gap-2">
+    <div
+      role="button"
+      onClick={() => handleQueryContributor(email)}
+      className="duration-250 flex cursor-default gap-2 bg-transparent px-6 py-2 transition-colors hover:bg-neutral-100 dark:hover:bg-neutral-800">
       <ContributorAvatar size={size} avatar={avatar} />
       <div className="flex flex-col justify-center text-sm text-foreground">
         <p className="font-medium text-neutral-900 dark:text-neutral-200">
@@ -149,6 +163,11 @@ export const ContributorTabContent = () => {
   const contributors = useSelectedItemStore(
     state => state.contributors,
   )
+  const setActiveTab = useSelectedItemStore(
+    state => state.setActiveTab,
+  )
+
+  const handleBackToOverview = () => setActiveTab('overview')
 
   if (!contributors || contributors.length <= 0)
     return (
@@ -160,11 +179,21 @@ export const ContributorTabContent = () => {
 
   return (
     <TabsContent value="contributors">
-      <section className="flex flex-col gap-4 px-6 py-4">
-        <ContributorHelp
-          triggerContent={`${contributors.length} contributors`}
-        />
-        <div className="flex flex-col gap-4">
+      <section className="flex flex-col gap-4 py-4">
+        <div className="flex items-center gap-3 px-6">
+          <Button
+            onClick={() => handleBackToOverview()}
+            className="inline-flex h-fit w-fit items-center gap-1.5 rounded-md border-[1px] border-muted bg-transparent px-3 py-1 text-foreground hover:bg-neutral-100 dark:hover:bg-neutral-900">
+            <ArrowLeft />
+            <span>Back</span>
+          </Button>
+
+          <ContributorHelp
+            triggerContent={`${contributors.length} contributors`}
+          />
+        </div>
+
+        <div className="flex flex-col gap-2">
           {contributors.map((contributor, idx) => (
             <Contributor
               size="rg"

--- a/src/gui/src/components/explorer-grid/selected-item/tabs-contributors.tsx
+++ b/src/gui/src/components/explorer-grid/selected-item/tabs-contributors.tsx
@@ -1,0 +1,179 @@
+import { TabsContent } from '@/components/ui/tabs.tsx'
+import { Link, useParams } from 'react-router'
+import { Button } from '@/components/ui/button.tsx'
+import { ArrowRight, UsersRound, CircleHelp } from 'lucide-react'
+import {
+  Avatar,
+  AvatarImage,
+  AvatarFallback,
+} from '@radix-ui/react-avatar'
+import { useSelectedItemStore } from '@/components/explorer-grid/selected-item/context.tsx'
+import { cn } from '@/lib/utils.ts'
+import { EmptyState } from '@/components/explorer-grid/selected-item/tabs-dependencies/empty-state.tsx'
+import {
+  Tooltip,
+  TooltipPortal,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@/components/ui/tooltip.tsx'
+
+import type { Tab } from '@/components/explorer-grid/selected-item/context.tsx'
+import type { Contributor } from '@/lib/external-info.ts'
+
+interface ContributorAvatarProps {
+  avatar: Contributor['avatar']
+  size?: 'sm' | 'rg'
+}
+
+const ContributorHelp = ({
+  triggerContent,
+}: {
+  triggerContent: string
+}) => {
+  return (
+    <TooltipProvider>
+      <Tooltip delayDuration={150}>
+        <TooltipTrigger className="inline-flex w-fit cursor-default items-center gap-1 text-sm font-medium capitalize text-muted-foreground">
+          {triggerContent}
+          <span>
+            <CircleHelp size={16} />
+          </span>
+        </TooltipTrigger>
+        <TooltipPortal>
+          <TooltipContent>
+            Contributors are aggregated from metadata on this artifact
+          </TooltipContent>
+        </TooltipPortal>
+      </Tooltip>
+    </TooltipProvider>
+  )
+}
+
+const ContributorAvatar = ({
+  avatar,
+  size = 'sm',
+}: ContributorAvatarProps) => {
+  const avatarSize = size === 'sm' ? 'size-6' : 'size-9'
+
+  return (
+    <Avatar className={cn(avatarSize)}>
+      {avatar && (
+        <AvatarImage
+          className={cn(
+            'rounded-full outline outline-[1px] outline-neutral-200 dark:outline-neutral-700',
+            avatarSize,
+          )}
+          src={avatar}
+        />
+      )}
+      <AvatarFallback
+        className={cn(
+          'flex aspect-square items-center justify-center',
+          avatarSize,
+        )}>
+        <div className="h-full w-full rounded-full bg-gradient-to-t from-neutral-200 to-neutral-400 dark:from-neutral-500 dark:to-neutral-800" />
+      </AvatarFallback>
+    </Avatar>
+  )
+}
+
+const Contributor = ({
+  contributor: { avatar, name, email },
+  size = 'sm',
+}: {
+  contributor: Contributor
+  size?: ContributorAvatarProps['size']
+}) => {
+  return (
+    <div className="flex cursor-default gap-2">
+      <ContributorAvatar size={size} avatar={avatar} />
+      <div className="flex flex-col justify-center text-sm text-foreground">
+        <p className="font-medium text-neutral-900 dark:text-neutral-200">
+          {name}
+        </p>
+        {email && (
+          <p className="text-xs text-muted-foreground">{email}</p>
+        )}
+      </div>
+    </div>
+  )
+}
+
+export const ContributorList = () => {
+  const { query } = useParams<{ query: string; tab: Tab }>()
+  const contributors = useSelectedItemStore(
+    state => state.contributors,
+  )
+
+  if (!contributors || contributors.length === 0) return null
+
+  return (
+    <div className="flex cursor-default flex-col gap-2 px-6 pb-4">
+      <ContributorHelp triggerContent="Contributors" />
+      <div className="flex items-center gap-2">
+        <div className="flex flex-wrap items-center -space-x-2">
+          {contributors.slice(0, 6).map((contributor, idx) => (
+            <ContributorAvatar
+              key={`contributor-avatar-${idx}`}
+              avatar={contributor.avatar}
+            />
+          ))}
+          {contributors.length > 6 && (
+            <div className="flex size-6 items-center justify-center rounded-full bg-background p-0.5 outline outline-[1px] outline-neutral-200 dark:outline-neutral-700">
+              <span className="font-mono text-xxs font-medium tabular-nums text-muted-foreground">
+                {contributors.length > 99 ?
+                  '99+'
+                : `+${contributors.length - 6}`}
+              </span>
+            </div>
+          )}
+        </div>
+        <Button
+          className="duration-250 font-muted-foreground h-fit rounded-full border-[1px] border-neutral-200 bg-neutral-100 px-3 py-1.5 text-sm font-normal text-foreground transition-colors hover:border-muted-foreground/20 hover:bg-muted-foreground/15 hover:text-foreground dark:border-[#313131] dark:bg-neutral-800 dark:hover:bg-neutral-700/70"
+          variant="default"
+          asChild>
+          <Link to={`/explore/${query}/contributors`}>
+            See all contributors
+            <span>
+              <ArrowRight size={14} />
+            </span>
+          </Link>
+        </Button>
+      </div>
+    </div>
+  )
+}
+
+export const ContributorTabContent = () => {
+  const contributors = useSelectedItemStore(
+    state => state.contributors,
+  )
+
+  if (!contributors || contributors.length <= 0)
+    return (
+      <EmptyState
+        icon={UsersRound}
+        message="We couldn't find any contributors for this project"
+      />
+    )
+
+  return (
+    <TabsContent value="contributors">
+      <section className="flex flex-col gap-4 px-6 py-4">
+        <ContributorHelp
+          triggerContent={`${contributors.length} contributors`}
+        />
+        <div className="flex flex-col gap-4">
+          {contributors.map((contributor, idx) => (
+            <Contributor
+              size="rg"
+              key={`contributor-${idx}`}
+              contributor={contributor}
+            />
+          ))}
+        </div>
+      </section>
+    </TabsContent>
+  )
+}

--- a/src/gui/src/components/explorer-grid/selected-item/tabs-overview.tsx
+++ b/src/gui/src/components/explorer-grid/selected-item/tabs-overview.tsx
@@ -13,15 +13,10 @@ import {
 } from 'lucide-react'
 import { DataBadge } from '@/components/ui/data-badge.tsx'
 import { Link } from '@/components/ui/link.tsx'
-import {
-  Avatar,
-  AvatarImage,
-  AvatarFallback,
-} from '@radix-ui/react-avatar'
 import { toHumanNumber } from '@/utils/human-number.ts'
 import { Github } from '@/components/icons/index.ts'
 import { getRepositoryUrl } from '@/utils/get-repo-url.ts'
-import type { Contributor } from '@/lib/external-info.ts'
+import { ContributorList } from '@/components/explorer-grid/selected-item/tabs-contributors.tsx'
 
 export const OverviewTabButton = () => {
   return (
@@ -247,60 +242,6 @@ export const OverviewTabContent = () => {
       </div>
       <TabContentAside />
     </TabsContent>
-  )
-}
-
-const Contributor = ({
-  contributor: { name, email, avatar },
-}: {
-  contributor: Contributor
-}) => {
-  return (
-    <div className="flex cursor-default gap-2">
-      <Avatar className="size-9">
-        {avatar && (
-          <AvatarImage
-            className="size-9 rounded-full outline outline-[1px] outline-neutral-200 dark:outline-neutral-700"
-            src={avatar}
-          />
-        )}
-        <AvatarFallback className="flex aspect-square size-9 items-center justify-center">
-          <div className="h-full w-full rounded-full bg-gradient-to-t from-neutral-200 to-neutral-400 dark:from-neutral-500 dark:to-neutral-800" />
-        </AvatarFallback>
-      </Avatar>
-      <div className="flex flex-col justify-center text-sm text-foreground">
-        <p className="font-medium text-neutral-900 dark:text-neutral-200">
-          {name}
-        </p>
-        {email && (
-          <p className="text-xs text-muted-foreground">{email}</p>
-        )}
-      </div>
-    </div>
-  )
-}
-
-const ContributorList = () => {
-  const contributors = useSelectedItemStore(
-    state => state.contributors,
-  )
-
-  if (!contributors?.length) return null
-
-  return (
-    <div className="flex cursor-default flex-col gap-2 px-6 pb-4">
-      <h4 className="text-sm font-medium capitalize text-muted-foreground">
-        Contributors
-      </h4>
-      <div className="flex flex-wrap gap-x-8 gap-y-5">
-        {contributors.map((contributor, idx) => (
-          <Contributor
-            key={`contributor-${idx}`}
-            contributor={contributor}
-          />
-        ))}
-      </div>
-    </div>
   )
 }
 

--- a/src/gui/src/routes.tsx
+++ b/src/gui/src/routes.tsx
@@ -23,6 +23,7 @@ import { TabsJsonContent } from '@/components/explorer-grid/selected-item/tabs-j
 import { InsightTabContent } from '@/components/explorer-grid/selected-item/tabs-insight.tsx'
 import { DependenciesTabContent } from '@/components/explorer-grid/selected-item/tabs-dependencies/index.tsx'
 import { VersionsTabContent } from '@/components/explorer-grid/selected-item/tabs-versions.tsx'
+import { ContributorTabContent } from '@/components/explorer-grid/selected-item/tabs-contributors.tsx'
 
 /** Dependencies SubTabs */
 import { InsightsTabContent } from '@/components/explorer-grid/selected-item/tabs-dependencies/tabs-insights.tsx'
@@ -39,7 +40,7 @@ import { encodeCompressedQuery } from '@/lib/compress-query.ts'
 import type {
   Tab,
   SubTabDependencies,
-} from './components/explorer-grid/selected-item/context'
+} from '@/components/explorer-grid/selected-item/context.tsx'
 
 const TabRouter = () => {
   const { tab } = useParams<{ tab: Tab }>()
@@ -54,6 +55,8 @@ const TabRouter = () => {
       return <InsightTabContent />
     case 'dependencies':
       return <DependenciesTabContent />
+    case 'contributors':
+      return <ContributorTabContent />
     default:
       return <Navigate to="overview" replace />
   }

--- a/src/gui/test/components/explorer-grid/selected-item/__snapshots__/tabs-contributors.tsx.snap
+++ b/src/gui/test/components/explorer-grid/selected-item/__snapshots__/tabs-contributors.tsx.snap
@@ -1,0 +1,306 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`ContributorList renders with less than 6 contributors 1`] = `
+
+<div class="flex cursor-default flex-col gap-2 px-6 pb-4">
+  <gui-tooltip-provider>
+    <gui-tooltip delayduration="150">
+      <gui-tooltip-trigger classname="inline-flex w-fit cursor-default items-center gap-1 text-sm font-medium capitalize text-muted-foreground">
+        Contributors
+        <span>
+          <gui-circle-help-icon size="16">
+          </gui-circle-help-icon>
+        </span>
+      </gui-tooltip-trigger>
+      <gui-tooltip-portal>
+        <gui-tooltip-content>
+          Contributors are aggregated from metadata on this artifact
+        </gui-tooltip-content>
+      </gui-tooltip-portal>
+    </gui-tooltip>
+  </gui-tooltip-provider>
+  <div class="flex items-center gap-2">
+    <div class="flex flex-wrap items-center -space-x-2">
+      <gui-avatar classname="size-6">
+        <gui-avatar-image
+          classname="rounded-full outline outline-[1px] outline-neutral-200 dark:outline-neutral-700 size-6"
+          src="https://acme.com/avatar.png"
+        >
+        </gui-avatar-image>
+        <gui-avatar-fallback classname="flex aspect-square items-center justify-center size-6">
+          <div class="h-full w-full rounded-full bg-gradient-to-t from-neutral-200 to-neutral-400 dark:from-neutral-500 dark:to-neutral-800">
+          </div>
+        </gui-avatar-fallback>
+      </gui-avatar>
+      <gui-avatar classname="size-6">
+        <gui-avatar-image
+          classname="rounded-full outline outline-[1px] outline-neutral-200 dark:outline-neutral-700 size-6"
+          src="https://acme.com/avatar.png"
+        >
+        </gui-avatar-image>
+        <gui-avatar-fallback classname="flex aspect-square items-center justify-center size-6">
+          <div class="h-full w-full rounded-full bg-gradient-to-t from-neutral-200 to-neutral-400 dark:from-neutral-500 dark:to-neutral-800">
+          </div>
+        </gui-avatar-fallback>
+      </gui-avatar>
+      <gui-avatar classname="size-6">
+        <gui-avatar-image
+          classname="rounded-full outline outline-[1px] outline-neutral-200 dark:outline-neutral-700 size-6"
+          src="https://acme.com/avatar.png"
+        >
+        </gui-avatar-image>
+        <gui-avatar-fallback classname="flex aspect-square items-center justify-center size-6">
+          <div class="h-full w-full rounded-full bg-gradient-to-t from-neutral-200 to-neutral-400 dark:from-neutral-500 dark:to-neutral-800">
+          </div>
+        </gui-avatar-fallback>
+      </gui-avatar>
+    </div>
+    <gui-button
+      classname="duration-250 font-muted-foreground h-fit rounded-full border-[1px] border-neutral-200 bg-neutral-100 px-3 py-1.5 text-sm font-normal text-foreground transition-colors hover:border-muted-foreground/20 hover:bg-muted-foreground/15 hover:text-foreground dark:border-[#313131] dark:bg-neutral-800 dark:hover:bg-neutral-700/70"
+      variant="default"
+      aschild="true"
+    >
+      <gui-router-link to="/explore/:root/contributors">
+        See all contributors
+        <span>
+          <gui-arrow-right-icon size="14">
+          </gui-arrow-right-icon>
+        </span>
+      </gui-router-link>
+    </gui-button>
+  </div>
+</div>
+
+`;
+
+exports[`ContributorList renders with more than 6 contributors 1`] = `
+
+<div class="flex cursor-default flex-col gap-2 px-6 pb-4">
+  <gui-tooltip-provider>
+    <gui-tooltip delayduration="150">
+      <gui-tooltip-trigger classname="inline-flex w-fit cursor-default items-center gap-1 text-sm font-medium capitalize text-muted-foreground">
+        Contributors
+        <span>
+          <gui-circle-help-icon size="16">
+          </gui-circle-help-icon>
+        </span>
+      </gui-tooltip-trigger>
+      <gui-tooltip-portal>
+        <gui-tooltip-content>
+          Contributors are aggregated from metadata on this artifact
+        </gui-tooltip-content>
+      </gui-tooltip-portal>
+    </gui-tooltip>
+  </gui-tooltip-provider>
+  <div class="flex items-center gap-2">
+    <div class="flex flex-wrap items-center -space-x-2">
+      <gui-avatar classname="size-6">
+        <gui-avatar-image
+          classname="rounded-full outline outline-[1px] outline-neutral-200 dark:outline-neutral-700 size-6"
+          src="https://acme.com/avatar.png"
+        >
+        </gui-avatar-image>
+        <gui-avatar-fallback classname="flex aspect-square items-center justify-center size-6">
+          <div class="h-full w-full rounded-full bg-gradient-to-t from-neutral-200 to-neutral-400 dark:from-neutral-500 dark:to-neutral-800">
+          </div>
+        </gui-avatar-fallback>
+      </gui-avatar>
+      <gui-avatar classname="size-6">
+        <gui-avatar-image
+          classname="rounded-full outline outline-[1px] outline-neutral-200 dark:outline-neutral-700 size-6"
+          src="https://acme.com/avatar.png"
+        >
+        </gui-avatar-image>
+        <gui-avatar-fallback classname="flex aspect-square items-center justify-center size-6">
+          <div class="h-full w-full rounded-full bg-gradient-to-t from-neutral-200 to-neutral-400 dark:from-neutral-500 dark:to-neutral-800">
+          </div>
+        </gui-avatar-fallback>
+      </gui-avatar>
+      <gui-avatar classname="size-6">
+        <gui-avatar-image
+          classname="rounded-full outline outline-[1px] outline-neutral-200 dark:outline-neutral-700 size-6"
+          src="https://acme.com/avatar.png"
+        >
+        </gui-avatar-image>
+        <gui-avatar-fallback classname="flex aspect-square items-center justify-center size-6">
+          <div class="h-full w-full rounded-full bg-gradient-to-t from-neutral-200 to-neutral-400 dark:from-neutral-500 dark:to-neutral-800">
+          </div>
+        </gui-avatar-fallback>
+      </gui-avatar>
+      <gui-avatar classname="size-6">
+        <gui-avatar-image
+          classname="rounded-full outline outline-[1px] outline-neutral-200 dark:outline-neutral-700 size-6"
+          src="https://acme.com/avatar.png"
+        >
+        </gui-avatar-image>
+        <gui-avatar-fallback classname="flex aspect-square items-center justify-center size-6">
+          <div class="h-full w-full rounded-full bg-gradient-to-t from-neutral-200 to-neutral-400 dark:from-neutral-500 dark:to-neutral-800">
+          </div>
+        </gui-avatar-fallback>
+      </gui-avatar>
+      <gui-avatar classname="size-6">
+        <gui-avatar-image
+          classname="rounded-full outline outline-[1px] outline-neutral-200 dark:outline-neutral-700 size-6"
+          src="https://acme.com/avatar.png"
+        >
+        </gui-avatar-image>
+        <gui-avatar-fallback classname="flex aspect-square items-center justify-center size-6">
+          <div class="h-full w-full rounded-full bg-gradient-to-t from-neutral-200 to-neutral-400 dark:from-neutral-500 dark:to-neutral-800">
+          </div>
+        </gui-avatar-fallback>
+      </gui-avatar>
+      <gui-avatar classname="size-6">
+        <gui-avatar-image
+          classname="rounded-full outline outline-[1px] outline-neutral-200 dark:outline-neutral-700 size-6"
+          src="https://acme.com/avatar.png"
+        >
+        </gui-avatar-image>
+        <gui-avatar-fallback classname="flex aspect-square items-center justify-center size-6">
+          <div class="h-full w-full rounded-full bg-gradient-to-t from-neutral-200 to-neutral-400 dark:from-neutral-500 dark:to-neutral-800">
+          </div>
+        </gui-avatar-fallback>
+      </gui-avatar>
+      <div class="flex size-6 items-center justify-center rounded-full bg-background p-0.5 outline outline-[1px] outline-neutral-200 dark:outline-neutral-700">
+        <span class="font-mono text-xxs font-medium tabular-nums text-muted-foreground">
+          +1
+        </span>
+      </div>
+    </div>
+    <gui-button
+      classname="duration-250 font-muted-foreground h-fit rounded-full border-[1px] border-neutral-200 bg-neutral-100 px-3 py-1.5 text-sm font-normal text-foreground transition-colors hover:border-muted-foreground/20 hover:bg-muted-foreground/15 hover:text-foreground dark:border-[#313131] dark:bg-neutral-800 dark:hover:bg-neutral-700/70"
+      variant="default"
+      aschild="true"
+    >
+      <gui-router-link to="/explore/:root/contributors">
+        See all contributors
+        <span>
+          <gui-arrow-right-icon size="14">
+          </gui-arrow-right-icon>
+        </span>
+      </gui-router-link>
+    </gui-button>
+  </div>
+</div>
+
+`;
+
+exports[`ContributorTabContent renders with contributors 1`] = `
+
+<gui-tabs-content value="contributors">
+  <section class="flex flex-col gap-4 px-6 py-4">
+    <gui-tooltip-provider>
+      <gui-tooltip delayduration="150">
+        <gui-tooltip-trigger classname="inline-flex w-fit cursor-default items-center gap-1 text-sm font-medium capitalize text-muted-foreground">
+          4 contributors
+          <span>
+            <gui-circle-help-icon size="16">
+            </gui-circle-help-icon>
+          </span>
+        </gui-tooltip-trigger>
+        <gui-tooltip-portal>
+          <gui-tooltip-content>
+            Contributors are aggregated from metadata on this artifact
+          </gui-tooltip-content>
+        </gui-tooltip-portal>
+      </gui-tooltip>
+    </gui-tooltip-provider>
+    <div class="flex flex-col gap-4">
+      <div class="flex cursor-default gap-2">
+        <gui-avatar classname="size-9">
+          <gui-avatar-image
+            classname="rounded-full outline outline-[1px] outline-neutral-200 dark:outline-neutral-700 size-9"
+            src="https://acme.com/avatar.png"
+          >
+          </gui-avatar-image>
+          <gui-avatar-fallback classname="flex aspect-square items-center justify-center size-9">
+            <div class="h-full w-full rounded-full bg-gradient-to-t from-neutral-200 to-neutral-400 dark:from-neutral-500 dark:to-neutral-800">
+            </div>
+          </gui-avatar-fallback>
+        </gui-avatar>
+        <div class="flex flex-col justify-center text-sm text-foreground">
+          <p class="font-medium text-neutral-900 dark:text-neutral-200">
+            John Doe
+          </p>
+          <p class="text-xs text-muted-foreground">
+            johndoe@acme.com
+          </p>
+        </div>
+      </div>
+      <div class="flex cursor-default gap-2">
+        <gui-avatar classname="size-9">
+          <gui-avatar-image
+            classname="rounded-full outline outline-[1px] outline-neutral-200 dark:outline-neutral-700 size-9"
+            src="https://acme.com/avatar.png"
+          >
+          </gui-avatar-image>
+          <gui-avatar-fallback classname="flex aspect-square items-center justify-center size-9">
+            <div class="h-full w-full rounded-full bg-gradient-to-t from-neutral-200 to-neutral-400 dark:from-neutral-500 dark:to-neutral-800">
+            </div>
+          </gui-avatar-fallback>
+        </gui-avatar>
+        <div class="flex flex-col justify-center text-sm text-foreground">
+          <p class="font-medium text-neutral-900 dark:text-neutral-200">
+            Jane Doe
+          </p>
+          <p class="text-xs text-muted-foreground">
+            janedoe@acme.com
+          </p>
+        </div>
+      </div>
+      <div class="flex cursor-default gap-2">
+        <gui-avatar classname="size-9">
+          <gui-avatar-image
+            classname="rounded-full outline outline-[1px] outline-neutral-200 dark:outline-neutral-700 size-9"
+            src="https://acme.com/avatar.png"
+          >
+          </gui-avatar-image>
+          <gui-avatar-fallback classname="flex aspect-square items-center justify-center size-9">
+            <div class="h-full w-full rounded-full bg-gradient-to-t from-neutral-200 to-neutral-400 dark:from-neutral-500 dark:to-neutral-800">
+            </div>
+          </gui-avatar-fallback>
+        </gui-avatar>
+        <div class="flex flex-col justify-center text-sm text-foreground">
+          <p class="font-medium text-neutral-900 dark:text-neutral-200">
+            John Smith
+          </p>
+          <p class="text-xs text-muted-foreground">
+            johnsmith@acme.com
+          </p>
+        </div>
+      </div>
+      <div class="flex cursor-default gap-2">
+        <gui-avatar classname="size-9">
+          <gui-avatar-image
+            classname="rounded-full outline outline-[1px] outline-neutral-200 dark:outline-neutral-700 size-9"
+            src="https://acme.com/avatar.png"
+          >
+          </gui-avatar-image>
+          <gui-avatar-fallback classname="flex aspect-square items-center justify-center size-9">
+            <div class="h-full w-full rounded-full bg-gradient-to-t from-neutral-200 to-neutral-400 dark:from-neutral-500 dark:to-neutral-800">
+            </div>
+          </gui-avatar-fallback>
+        </gui-avatar>
+        <div class="flex flex-col justify-center text-sm text-foreground">
+          <p class="font-medium text-neutral-900 dark:text-neutral-200">
+            Sarah Davis
+          </p>
+          <p class="text-xs text-muted-foreground">
+            sarahdavis@acme.com
+          </p>
+        </div>
+      </div>
+    </div>
+  </section>
+</gui-tabs-content>
+
+`;
+
+exports[`ContributorTabContent renders with no contributors 1`] = `
+
+<gui-empty-state
+  icon="gui-users-round-icon"
+  message="We couldn't find any contributors for this project"
+>
+</gui-empty-state>
+
+`;

--- a/src/gui/test/components/explorer-grid/selected-item/__snapshots__/tabs-contributors.tsx.snap
+++ b/src/gui/test/components/explorer-grid/selected-item/__snapshots__/tabs-contributors.tsx.snap
@@ -187,25 +187,37 @@ exports[`ContributorList renders with more than 6 contributors 1`] = `
 exports[`ContributorTabContent renders with contributors 1`] = `
 
 <gui-tabs-content value="contributors">
-  <section class="flex flex-col gap-4 px-6 py-4">
-    <gui-tooltip-provider>
-      <gui-tooltip delayduration="150">
-        <gui-tooltip-trigger classname="inline-flex w-fit cursor-default items-center gap-1 text-sm font-medium capitalize text-muted-foreground">
-          4 contributors
-          <span>
-            <gui-circle-help-icon size="16">
-            </gui-circle-help-icon>
-          </span>
-        </gui-tooltip-trigger>
-        <gui-tooltip-portal>
-          <gui-tooltip-content>
-            Contributors are aggregated from metadata on this artifact
-          </gui-tooltip-content>
-        </gui-tooltip-portal>
-      </gui-tooltip>
-    </gui-tooltip-provider>
-    <div class="flex flex-col gap-4">
-      <div class="flex cursor-default gap-2">
+  <section class="flex flex-col gap-4 py-4">
+    <div class="flex items-center gap-3 px-6">
+      <gui-button classname="inline-flex h-fit w-fit items-center gap-1.5 rounded-md border-[1px] border-muted bg-transparent px-3 py-1 text-foreground hover:bg-neutral-100 dark:hover:bg-neutral-900">
+        <gui-arrow-left-icon>
+        </gui-arrow-left-icon>
+        <span>
+          Back
+        </span>
+      </gui-button>
+      <gui-tooltip-provider>
+        <gui-tooltip delayduration="150">
+          <gui-tooltip-trigger classname="inline-flex w-fit cursor-default items-center gap-1 text-sm font-medium capitalize text-muted-foreground">
+            4 contributors
+            <span>
+              <gui-circle-help-icon size="16">
+              </gui-circle-help-icon>
+            </span>
+          </gui-tooltip-trigger>
+          <gui-tooltip-portal>
+            <gui-tooltip-content>
+              Contributors are aggregated from metadata on this artifact
+            </gui-tooltip-content>
+          </gui-tooltip-portal>
+        </gui-tooltip>
+      </gui-tooltip-provider>
+    </div>
+    <div class="flex flex-col gap-2">
+      <div
+        role="button"
+        class="duration-250 flex cursor-default gap-2 bg-transparent px-6 py-2 transition-colors hover:bg-neutral-100 dark:hover:bg-neutral-800"
+      >
         <gui-avatar classname="size-9">
           <gui-avatar-image
             classname="rounded-full outline outline-[1px] outline-neutral-200 dark:outline-neutral-700 size-9"
@@ -226,7 +238,10 @@ exports[`ContributorTabContent renders with contributors 1`] = `
           </p>
         </div>
       </div>
-      <div class="flex cursor-default gap-2">
+      <div
+        role="button"
+        class="duration-250 flex cursor-default gap-2 bg-transparent px-6 py-2 transition-colors hover:bg-neutral-100 dark:hover:bg-neutral-800"
+      >
         <gui-avatar classname="size-9">
           <gui-avatar-image
             classname="rounded-full outline outline-[1px] outline-neutral-200 dark:outline-neutral-700 size-9"
@@ -247,7 +262,10 @@ exports[`ContributorTabContent renders with contributors 1`] = `
           </p>
         </div>
       </div>
-      <div class="flex cursor-default gap-2">
+      <div
+        role="button"
+        class="duration-250 flex cursor-default gap-2 bg-transparent px-6 py-2 transition-colors hover:bg-neutral-100 dark:hover:bg-neutral-800"
+      >
         <gui-avatar classname="size-9">
           <gui-avatar-image
             classname="rounded-full outline outline-[1px] outline-neutral-200 dark:outline-neutral-700 size-9"
@@ -268,7 +286,10 @@ exports[`ContributorTabContent renders with contributors 1`] = `
           </p>
         </div>
       </div>
-      <div class="flex cursor-default gap-2">
+      <div
+        role="button"
+        class="duration-250 flex cursor-default gap-2 bg-transparent px-6 py-2 transition-colors hover:bg-neutral-100 dark:hover:bg-neutral-800"
+      >
         <gui-avatar classname="size-9">
           <gui-avatar-image
             classname="rounded-full outline outline-[1px] outline-neutral-200 dark:outline-neutral-700 size-9"

--- a/src/gui/test/components/explorer-grid/selected-item/__snapshots__/tabs-overview.tsx.snap
+++ b/src/gui/test/components/explorer-grid/selected-item/__snapshots__/tabs-overview.tsx.snap
@@ -43,6 +43,8 @@ exports[`OverviewTabContent renders default 1`] = `
         </p>
       </div>
     </div>
+    <gui-contributor-list>
+    </gui-contributor-list>
   </div>
 </gui-tabs-content>
 
@@ -79,55 +81,8 @@ exports[`OverviewTabContent renders with an aside and content 1`] = `
         </p>
       </div>
     </div>
-    <div class="flex cursor-default flex-col gap-2 px-6 pb-4">
-      <h4 class="text-sm font-medium capitalize text-muted-foreground">
-        Contributors
-      </h4>
-      <div class="flex flex-wrap gap-x-8 gap-y-5">
-        <div class="flex cursor-default gap-2">
-          <gui-avatar classname="size-9">
-            <gui-avatar-image
-              classname="size-9 rounded-full outline outline-[1px] outline-neutral-200 dark:outline-neutral-700"
-              src="https://acme.com/johndoe"
-            >
-            </gui-avatar-image>
-            <gui-avatar-fallback classname="flex aspect-square size-9 items-center justify-center">
-              <div class="h-full w-full rounded-full bg-gradient-to-t from-neutral-200 to-neutral-400 dark:from-neutral-500 dark:to-neutral-800">
-              </div>
-            </gui-avatar-fallback>
-          </gui-avatar>
-          <div class="flex flex-col justify-center text-sm text-foreground">
-            <p class="font-medium text-neutral-900 dark:text-neutral-200">
-              John Doe
-            </p>
-            <p class="text-xs text-muted-foreground">
-              johndoe@acme.com
-            </p>
-          </div>
-        </div>
-        <div class="flex cursor-default gap-2">
-          <gui-avatar classname="size-9">
-            <gui-avatar-image
-              classname="size-9 rounded-full outline outline-[1px] outline-neutral-200 dark:outline-neutral-700"
-              src="https://acme.com/janedoo"
-            >
-            </gui-avatar-image>
-            <gui-avatar-fallback classname="flex aspect-square size-9 items-center justify-center">
-              <div class="h-full w-full rounded-full bg-gradient-to-t from-neutral-200 to-neutral-400 dark:from-neutral-500 dark:to-neutral-800">
-              </div>
-            </gui-avatar-fallback>
-          </gui-avatar>
-          <div class="flex flex-col justify-center text-sm text-foreground">
-            <p class="font-medium text-neutral-900 dark:text-neutral-200">
-              Jane Doo
-            </p>
-            <p class="text-xs text-muted-foreground">
-              janedoo@acme.com
-            </p>
-          </div>
-        </div>
-      </div>
-    </div>
+    <gui-contributor-list>
+    </gui-contributor-list>
   </div>
   <aside class="order-1 flex cursor-default flex-col gap-4 px-6 py-4 xl:order-2 xl:col-span-4">
     <div class="flex flex-col gap-2">
@@ -276,6 +231,8 @@ This is a custom description
         </gui-markdown>
       </div>
     </div>
+    <gui-contributor-list>
+    </gui-contributor-list>
     <div class="flex grow flex-col justify-end gap-2 px-6 pb-4">
       <h4 class="text-sm font-medium capitalize text-muted-foreground">
         keywords

--- a/src/gui/test/components/explorer-grid/selected-item/tabs-contributors.tsx
+++ b/src/gui/test/components/explorer-grid/selected-item/tabs-contributors.tsx
@@ -39,6 +39,7 @@ vi.mock('@/components/ui/button.tsx', () => ({
 }))
 
 vi.mock('lucide-react', () => ({
+  ArrowLeft: 'gui-arrow-left-icon',
   ArrowRight: 'gui-arrow-right-icon',
   UsersRound: 'gui-users-round-icon',
   CircleHelp: 'gui-circle-help-icon',

--- a/src/gui/test/components/explorer-grid/selected-item/tabs-contributors.tsx
+++ b/src/gui/test/components/explorer-grid/selected-item/tabs-contributors.tsx
@@ -2,42 +2,18 @@ import { test, expect, vi, beforeEach, afterEach } from 'vitest'
 import { cleanup, render } from '@testing-library/react'
 import html from 'diffable-html'
 import { useGraphStore as useStore } from '@/state/index.ts'
-import type { SelectedItemStore } from '@/components/explorer-grid/selected-item/context.tsx'
 import { useSelectedItemStore } from '@/components/explorer-grid/selected-item/context.tsx'
 import {
-  OverviewTabButton,
-  OverviewTabContent,
-} from '@/components/explorer-grid/selected-item/tabs-overview.tsx'
+  ContributorTabContent,
+  ContributorList,
+} from '@/components/explorer-grid/selected-item/tabs-contributors.tsx'
 import {
   SELECTED_ITEM,
   SELECTED_ITEM_DETAILS,
 } from './__fixtures__/item.ts'
-import type { GridItemData } from '@/components/explorer-grid/types.ts'
-import type { DetailsInfo } from '@/lib/external-info.ts'
 
-const ITEM_WITH_DESCRIPTION = {
-  ...SELECTED_ITEM,
-  to: {
-    name: 'item',
-    version: '1.0.0',
-    id: ['registry', 'custom', 'item@1.0.0'],
-    manifest: {
-      description: '## Description\n\nThis is a custom description',
-    },
-    rawManifest: null,
-  },
-} as unknown as GridItemData
-
-const ITEM_DETAILS_WITH_AUTHOR = {
-  ...SELECTED_ITEM_DETAILS,
-  author: {
-    name: 'John Doe',
-    mail: 'johndoe@acme.com',
-    email: 'johndoe@acme.com',
-    url: 'https://acme.com/johndoe',
-    web: 'https://acme.com/johndoe',
-  },
-} as unknown as DetailsInfo
+import type { SelectedItemStore } from '@/components/explorer-grid/selected-item/context.tsx'
+import type { Contributor } from '@/lib/external-info.ts'
 
 vi.mock(
   '@/components/explorer-grid/selected-item/context.tsx',
@@ -48,43 +24,46 @@ vi.mock(
 )
 
 vi.mock('@/components/ui/tabs.tsx', () => ({
-  TabsTrigger: 'gui-tabs-trigger',
   TabsContent: 'gui-tabs-content',
 }))
 
-vi.mock('react-markdown', () => ({
-  default: 'gui-markdown',
+vi.mock('react-router', () => ({
+  Link: 'gui-router-link',
+  useParams: vi.fn().mockReturnValue({
+    query: ':root',
+  }),
+}))
+
+vi.mock('@/components/ui/button.tsx', () => ({
+  Button: 'gui-button',
 }))
 
 vi.mock('lucide-react', () => ({
-  FileText: 'gui-file-text-icon',
-  Globe: 'gui-globe-icon',
-  Bug: 'gui-bug-icon',
-  RectangleHorizontal: 'gui-rectangle-horizontal-icon',
-  Star: 'gui-star-icon',
-  CircleDot: 'gui-circle-dot-icon',
-  GitPullRequest: 'gui-git-pull-request-icon',
-  Link: 'gui-link-icon',
+  ArrowRight: 'gui-arrow-right-icon',
+  UsersRound: 'gui-users-round-icon',
+  CircleHelp: 'gui-circle-help-icon',
 }))
 
-vi.mock('@/components/icons/index.ts', () => ({
-  Github: 'gui-github-icon',
-}))
-
-vi.mock('@/components/ui/data-badge.tsx', () => ({
-  DataBadge: 'gui-data-badge',
-}))
-
-vi.mock('@/components/ui/link.tsx', () => ({
-  Link: 'gui-link',
+vi.mock('@radix-ui/react-avatar', () => ({
+  Avatar: 'gui-avatar',
+  AvatarImage: 'gui-avatar-image',
+  AvatarFallback: 'gui-avatar-fallback',
 }))
 
 vi.mock(
-  '@/components/explorer-grid/selected-item/tabs-contributors.tsx',
+  '@/components/explorer-grid/selected-item/tabs-dependencies/empty-state.tsx',
   () => ({
-    ContributorList: 'gui-contributor-list',
+    EmptyState: 'gui-empty-state',
   }),
 )
+
+vi.mock('@/components/ui/tooltip.jsx', () => ({
+  Tooltip: 'gui-tooltip',
+  TooltipPortal: 'gui-tooltip-portal',
+  TooltipContent: 'gui-tooltip-content',
+  TooltipProvider: 'gui-tooltip-provider',
+  TooltipTrigger: 'gui-tooltip-trigger',
+}))
 
 expect.addSnapshotSerializer({
   serialize: v => html(v),
@@ -101,12 +80,52 @@ afterEach(() => {
   cleanup()
 })
 
-test('OverviewTabButton renders default', () => {
+const mockContributors = [
+  {
+    avatar: 'https://acme.com/avatar.png',
+    name: 'John Doe',
+    email: 'johndoe@acme.com',
+  },
+  {
+    avatar: 'https://acme.com/avatar.png',
+    name: 'Jane Doe',
+    email: 'janedoe@acme.com',
+  },
+  {
+    avatar: 'https://acme.com/avatar.png',
+    name: 'John Smith',
+    email: 'johnsmith@acme.com',
+  },
+  {
+    avatar: 'https://acme.com/avatar.png',
+    name: 'Sarah Davis',
+    email: 'sarahdavis@acme.com',
+  },
+  {
+    avatar: 'https://acme.com/avatar.png',
+    name: 'Laura Brown',
+    email: 'laurabrown@acme.com',
+  },
+  {
+    avatar: 'https://acme.com/avatar.png',
+    name: 'Anna Miller',
+    email: 'annamiller@acme.com',
+  },
+
+  {
+    avatar: 'https://acme.com/avatar.png',
+    name: 'Rachel Wilson',
+    email: 'rachelwilson@acme.com',
+  },
+] satisfies Contributor[]
+
+test('ContributorTabContent renders with contributors', () => {
   const mockState = {
     selectedItem: SELECTED_ITEM,
     ...SELECTED_ITEM_DETAILS,
     manifest: {},
     rawManifest: null,
+    contributors: mockContributors.slice(0, 4),
     insights: undefined,
     activeTab: 'overview' as const,
     activeSubTab: undefined,
@@ -133,20 +152,19 @@ test('OverviewTabButton renders default', () => {
   )
 
   const Container = () => {
-    return <OverviewTabButton />
+    return <ContributorTabContent />
   }
-
   const { container } = render(<Container />)
-
   expect(container.innerHTML).toMatchSnapshot()
 })
 
-test('OverviewTabContent renders default', () => {
+test('ContributorTabContent renders with no contributors', () => {
   const mockState = {
     selectedItem: SELECTED_ITEM,
     ...SELECTED_ITEM_DETAILS,
     manifest: {},
     rawManifest: null,
+    contributors: undefined,
     insights: undefined,
     activeTab: 'overview' as const,
     activeSubTab: undefined,
@@ -173,27 +191,24 @@ test('OverviewTabContent renders default', () => {
   )
 
   const Container = () => {
-    return <OverviewTabContent />
+    return <ContributorTabContent />
   }
-
   const { container } = render(<Container />)
   expect(container.innerHTML).toMatchSnapshot()
 })
 
-test('OverviewTabContent renders with content', () => {
+test('ContributorList renders with less than 6 contributors', () => {
   const mockState = {
-    selectedItem: ITEM_WITH_DESCRIPTION,
-    ...ITEM_DETAILS_WITH_AUTHOR,
+    selectedItem: SELECTED_ITEM,
+    ...SELECTED_ITEM_DETAILS,
+    manifest: {},
+    rawManifest: null,
+    contributors: mockContributors.slice(0, 3),
     insights: undefined,
     activeTab: 'overview' as const,
     activeSubTab: undefined,
     setActiveSubTab: vi.fn(),
     setActiveTab: vi.fn(),
-    rawManifest: null,
-    manifest: {
-      description: '## Description\n\nThis is a custom description',
-      keywords: ['testing', 'vitest'],
-    },
     depCount: undefined,
     setDepCount: vi.fn(),
     scannedDeps: undefined,
@@ -215,51 +230,24 @@ test('OverviewTabContent renders with content', () => {
   )
 
   const Container = () => {
-    return <OverviewTabContent />
+    return <ContributorList />
   }
-
   const { container } = render(<Container />)
   expect(container.innerHTML).toMatchSnapshot()
 })
 
-test('OverviewTabContent renders with an aside and content', () => {
+test('ContributorList renders with more than 6 contributors', () => {
   const mockState = {
-    selectedItem: ITEM_WITH_DESCRIPTION,
-    ...ITEM_DETAILS_WITH_AUTHOR,
+    selectedItem: SELECTED_ITEM,
+    ...SELECTED_ITEM_DETAILS,
+    manifest: {},
+    rawManifest: null,
+    contributors: mockContributors,
     insights: undefined,
     activeTab: 'overview' as const,
     activeSubTab: undefined,
     setActiveSubTab: vi.fn(),
     setActiveTab: vi.fn(),
-    rawManifest: null,
-    contributors: [
-      {
-        name: 'John Doe',
-        email: 'johndoe@acme.com',
-        avatar: 'https://acme.com/johndoe',
-      },
-      {
-        name: 'Jane Doo',
-        email: 'janedoo@acme.com',
-        avatar: 'https://acme.com/janedoo',
-      },
-    ],
-    stargazersCount: 100,
-    openIssueCount: '10',
-    openPullRequestCount: '5',
-    manifest: {
-      homepage: 'https://acme.com',
-      repository: {
-        type: 'git',
-        url: 'github.com/acme/repo.git',
-      },
-      bugs: {
-        url: 'https://acme.com/bugs',
-      },
-      funding: {
-        url: 'https://acme.com/funding',
-      },
-    },
     depCount: undefined,
     setDepCount: vi.fn(),
     scannedDeps: undefined,
@@ -281,9 +269,8 @@ test('OverviewTabContent renders with an aside and content', () => {
   )
 
   const Container = () => {
-    return <OverviewTabContent />
+    return <ContributorList />
   }
-
   const { container } = render(<Container />)
   expect(container.innerHTML).toMatchSnapshot()
 })

--- a/src/gui/test/lib/external-info.ts
+++ b/src/gui/test/lib/external-info.ts
@@ -181,6 +181,37 @@ global.fetch = vi.fn(async url => ({
           ],
         }
       }
+      case 'https://registry.npmjs.org/with-contributors': {
+        return {
+          contributors: [
+            {
+              name: 'Contributor One',
+              email: 'contrib1@example.com',
+            },
+            'Contributor Two <contrib2@example.com>',
+          ],
+          maintainers: [
+            {
+              name: 'Maintainer One',
+              email: 'maintainer1@example.com',
+            },
+          ],
+          versions: {
+            '1.0.0': {
+              version: '1.0.0',
+              dist: {
+                unpackedSize: 1000,
+                integrity: 'sha512-abc123',
+                tarball:
+                  'https://registry.npmjs.org/with-contributors/-/with-contributors-1.0.0.tgz',
+              },
+            },
+          },
+          time: {
+            '1.0.0': '2023-01-01T00:00:00.000Z',
+          },
+        }
+      }
       case 'https://api.github.com/repos/ruyadorno/github-repo-info': {
         return {
           stargazers_count: 100,
@@ -841,6 +872,23 @@ test('fetchDetails with contributors in manifest', async () => {
           'https://gravatar.com/avatar/296b6a91e056b396b44a3035b407e2433bfa8e78a94ecb30635af80576f58810?d=retro',
       },
     ],
+    versions: [
+      {
+        version: '1.0.0',
+        publishedDate: '2023-01-01T00:00:00.000Z',
+        unpackedSize: 1000,
+        integrity: 'sha512-abc123',
+        tarball:
+          'https://registry.npmjs.org/with-contributors/-/with-contributors-1.0.0.tgz',
+        gitHead: undefined,
+        publishedAuthor: {
+          name: undefined,
+          email: undefined,
+          avatar: undefined,
+        },
+      },
+    ],
+    greaterVersions: [],
   })
 })
 

--- a/src/types/src/index.ts
+++ b/src/types/src/index.ts
@@ -328,6 +328,8 @@ export type Packument = {
   modified?: string
   time?: Record<string, string>
   readme?: string
+  contributors?: Person[]
+  maintainers?: Person[]
 }
 
 export type RefType = 'branch' | 'head' | 'other' | 'pull' | 'tag'


### PR DESCRIPTION
### Overview
The previous contributor list in the overview tab was visually distracting and chaotic, this PR resolves this issue by creating a new hidden `tabs-contributors` view within the selected item, that is accessible by clicking 'see all contributors' button, and provides a cleaner and more organized view of contributors.

Additionally, this PR aggregates the `contributors` and `maintainers` not from the `manifest` but from the `packument`


| overview tab | contributor tab |
| --- | --- |
| <img width="600px" alt="Screenshot 2025-06-28 at 03 00 29" src="https://github.com/user-attachments/assets/394bf634-3d94-46c1-88d6-43cd3a2eab14" /> | <img width="500px" alt="Screenshot 2025-06-28 at 03 00 36" src="https://github.com/user-attachments/assets/d363d58f-bf51-4784-9c5b-1615bb579d5c" /> |

### Features
- **feat: creates `tabs-contributors`**
- **removes old contributor components from `tabs-overview`**
- **feat: creates new routes and tab types**
