### PR TITLE
cli-sdk: rename option query to scope

### DIFF
--- a/src/cli-sdk/src/config/definition.ts
+++ b/src/cli-sdk/src/config/definition.ts
@@ -413,9 +413,10 @@ export const definition = j
   })
 
   .opt({
-    query: {
-      short: 'q',
-      description: `Set to filter the results of an operation by a query.`,
+    scope: {
+      short: 's',
+      description:
+        'Set to filter the scope of an operation using a DSS Query.',
     },
   })
 

--- a/src/cli-sdk/src/exec-command.ts
+++ b/src/cli-sdk/src/exec-command.ts
@@ -124,8 +124,8 @@ export class ExecCommand<B extends RunnerBG, F extends RunnerFG> {
   async run(): Promise<ExecResult> {
     const { conf } = this
 
-    const queryString = conf.get('query')
-    // query takes precedence over workspaces or groups
+    const queryString = conf.get('scope')
+    // scope takes precedence over workspaces or groups
     if (queryString) {
       const graph = actual.load({
         ...conf.options,

--- a/src/cli-sdk/tap-snapshots/test/config/definition.ts.test.cjs
+++ b/src/cli-sdk/tap-snapshots/test/config/definition.ts.test.cjs
@@ -252,11 +252,6 @@ Object {
     "hint": "p",
     "type": "string",
   },
-  "query": Object {
-    "description": "Set to filter the results of an operation by a query.",
-    "short": "q",
-    "type": "string",
-  },
   "recursive": Object {
     "description": String(
       Run an operation across multiple workspaces.
@@ -313,6 +308,11 @@ Object {
     "description": "Save installed packages into dependencies specifically. This is useful if a package already exists in devDependencies or optionalDependencies, but you want to move it to be a non-optional production dependency.",
     "short": "P",
     "type": "boolean",
+  },
+  "scope": Object {
+    "description": "Set to filter the scope of an operation using a DSS Query.",
+    "short": "s",
+    "type": "string",
   },
   "scope-registries": Object {
     "description": String(
@@ -441,7 +441,6 @@ Array [
   "--node-version=<version>",
   "--os=<os>",
   "--package=<p>",
-  "--query=<query>",
   "--recursive",
   "--registries=<name=url>",
   "--registry=<url>",
@@ -449,6 +448,7 @@ Array [
   "--save-optional",
   "--save-peer",
   "--save-prod",
+  "--scope=<scope>",
   "--scope-registries=<@scope=url>",
   "--script-shell=<program>",
   "--stale-while-revalidate-factor=<n>",
@@ -488,7 +488,6 @@ Array [
   "node-version",
   "os",
   "package",
-  "query",
   "recursive",
   "registries",
   "registry",
@@ -496,6 +495,7 @@ Array [
   "save-optional",
   "save-peer",
   "save-prod",
+  "scope",
   "scope-registries",
   "script-shell",
   "stale-while-revalidate-factor",

--- a/src/cli-sdk/tap-snapshots/test/index.ts.test.cjs
+++ b/src/cli-sdk/tap-snapshots/test/index.ts.test.cjs
@@ -59,7 +59,6 @@ Unknown option '--unknown'. To specify a positional argument starting with a '-'
     --node-version=<version>
     --os=<os>
     --package=<p>
-    --query=<query>
     --recursive
     --registries=<name=url>
     --registry=<url>
@@ -67,6 +66,7 @@ Unknown option '--unknown'. To specify a positional argument starting with a '-'
     --save-optional
     --save-peer
     --save-prod
+    --scope=<scope>
     --scope-registries=<@scope=url>
     --script-shell=<program>
     --stale-while-revalidate-factor=<n>
@@ -109,7 +109,6 @@ Unknown config option: asdf
     node-version
     os
     package
-    query
     recursive
     registries
     registry
@@ -117,6 +116,7 @@ Unknown config option: asdf
     save-optional
     save-peer
     save-prod
+    scope
     scope-registries
     script-shell
     stale-while-revalidate-factor

--- a/src/cli-sdk/test/commands/run.ts
+++ b/src/cli-sdk/test/commands/run.ts
@@ -165,9 +165,9 @@ t.test('run script across several workspaces', async t => {
     await runTest(t, { args: ['-w', 'src/a', '-w', 'src/b'] })
   })
 
-  t.test('with query', async t => {
+  t.test('with scope', async t => {
     await runTest(t, {
-      args: ['--query', ':workspace#a, :workspace#b'],
+      args: ['--scope', ':workspace#a, :workspace#b'],
     })
   })
 })
@@ -220,8 +220,8 @@ t.test('run script across no workspaces', async t => {
     await runTest(t, { args: ['-w', 'src/c'] })
   })
 
-  t.test('with query', async t => {
-    await runTest(t, { args: ['--query', ':workspace#c'] })
+  t.test('with scope', async t => {
+    await runTest(t, { args: ['--scope', ':workspace#c'] })
   })
 })
 


### PR DESCRIPTION
As part of making queries a first-class citizen of the client we're normalizing the options names to use `--scope` for options that will operate at the importer level, setting what scope operations should run on and a new `--target` option will eventually be introduced to handle operations that will be selecting or targetting nodes and edges deep in the graph structure.

This change also clears up some of the weirdness / confusion brought up in the original implementation at:
da15cd0fb93b53519e8cee8e78cc82da0a53ad58