### PR TITLE
cli-sdk: add `--scope` to `pkg`, `ls`, `query`

### DIFF
--- a/src/cli-sdk/tap-snapshots/test/commands/list.ts.test.cjs
+++ b/src/cli-sdk/tap-snapshots/test/commands/list.ts.test.cjs
@@ -15,6 +15,22 @@ exports[`test/commands/list.ts > TAP > list > colors > should use colors when se
 [0m
 `
 
+exports[`test/commands/list.ts > TAP > list > default query string selection logic > should select the correct workspace based on default query logic 1`] = `
+a
+
+`
+
+exports[`test/commands/list.ts > TAP > list > scope with a transitive dependency > should handle scope with a transitive dependency 1`] = `
+foo
+└── bar@1.0.0
+
+`
+
+exports[`test/commands/list.ts > TAP > list > scope with workspaces > should handle scope with workspaces correctly 1`] = `
+workspace-a
+
+`
+
 exports[`test/commands/list.ts > TAP > list > should have usage 1`] = `
 Usage:
   vlt ls
@@ -343,6 +359,82 @@ exports[`test/commands/list.ts > TAP > list > should list pkgs in json format 1`
     "overridden": false
   }
 ]
+`
+
+exports[`test/commands/list.ts > TAP > list > workspaces > should add all scope nodes as importers 1`] = `
+[
+  {
+    "name": "my-project",
+    "to": {
+      "id": "file·.",
+      "name": "my-project",
+      "version": "1.0.0",
+      "location": ".",
+      "importer": true,
+      "manifest": {
+        "name": "my-project",
+        "version": "1.0.0"
+      },
+      "projectRoot": "{ROOT}",
+      "dev": false,
+      "optional": false,
+      "confused": false,
+      "insights": {
+        "scanned": false
+      }
+    },
+    "overridden": false
+  },
+  {
+    "name": "b",
+    "to": {
+      "id": "workspace·packages§b",
+      "name": "b",
+      "version": "1.0.0",
+      "location": "./packages/b",
+      "importer": true,
+      "manifest": {
+        "name": "b",
+        "version": "1.0.0"
+      },
+      "projectRoot": "{ROOT}",
+      "dev": false,
+      "optional": false,
+      "confused": false,
+      "insights": {
+        "scanned": false
+      }
+    },
+    "overridden": false
+  },
+  {
+    "name": "a",
+    "to": {
+      "id": "workspace·packages§a",
+      "name": "a",
+      "version": "1.0.0",
+      "location": "./packages/a",
+      "importer": true,
+      "manifest": {
+        "name": "a",
+        "version": "1.0.0"
+      },
+      "projectRoot": "{ROOT}",
+      "dev": false,
+      "optional": false,
+      "confused": false,
+      "insights": {
+        "scanned": false
+      }
+    },
+    "overridden": false
+  }
+]
+`
+
+exports[`test/commands/list.ts > TAP > list > workspaces > should add scope nodes as importers 1`] = `
+a
+
 `
 
 exports[`test/commands/list.ts > TAP > list > workspaces > should list single workspace 1`] = `

--- a/src/cli-sdk/tap-snapshots/test/commands/query.ts.test.cjs
+++ b/src/cli-sdk/tap-snapshots/test/commands/query.ts.test.cjs
@@ -15,6 +15,11 @@ exports[`test/commands/query.ts > TAP > query > colors > should use colors when 
 [0m
 `
 
+exports[`test/commands/query.ts > TAP > query > default query string selection logic > should select the correct workspace based on default query logic 1`] = `
+a
+
+`
+
 exports[`test/commands/query.ts > TAP > query > expect-results option > should return items when expect-results check passes 1`] = `
 my-project
 ├── foo@1.0.0
@@ -22,6 +27,17 @@ my-project
 │ └─┬ baz (custom:baz@1.0.0)
 │   └── foo@1.0.0
 └── missing@^1.0.0 (missing)
+
+`
+
+exports[`test/commands/query.ts > TAP > query > scope with a transitive dependency > should handle scope with a transitive dependency 1`] = `
+foo
+└── bar@1.0.0
+
+`
+
+exports[`test/commands/query.ts > TAP > query > scope with workspaces > should handle scope with workspaces correctly 1`] = `
+workspace-a
 
 `
 
@@ -244,6 +260,82 @@ exports[`test/commands/query.ts > TAP > query > should list pkgs in json format 
     "overridden": false
   }
 ]
+`
+
+exports[`test/commands/query.ts > TAP > query > workspaces > should add all scope nodes as importers 1`] = `
+[
+  {
+    "name": "my-project",
+    "to": {
+      "id": "file·.",
+      "name": "my-project",
+      "version": "1.0.0",
+      "location": ".",
+      "importer": true,
+      "manifest": {
+        "name": "my-project",
+        "version": "1.0.0"
+      },
+      "projectRoot": "{ROOT}",
+      "dev": false,
+      "optional": false,
+      "confused": false,
+      "insights": {
+        "scanned": false
+      }
+    },
+    "overridden": false
+  },
+  {
+    "name": "b",
+    "to": {
+      "id": "workspace·packages§b",
+      "name": "b",
+      "version": "1.0.0",
+      "location": "./packages/b",
+      "importer": true,
+      "manifest": {
+        "name": "b",
+        "version": "1.0.0"
+      },
+      "projectRoot": "{ROOT}",
+      "dev": false,
+      "optional": false,
+      "confused": false,
+      "insights": {
+        "scanned": false
+      }
+    },
+    "overridden": false
+  },
+  {
+    "name": "a",
+    "to": {
+      "id": "workspace·packages§a",
+      "name": "a",
+      "version": "1.0.0",
+      "location": "./packages/a",
+      "importer": true,
+      "manifest": {
+        "name": "a",
+        "version": "1.0.0"
+      },
+      "projectRoot": "{ROOT}",
+      "dev": false,
+      "optional": false,
+      "confused": false,
+      "insights": {
+        "scanned": false
+      }
+    },
+    "overridden": false
+  }
+]
+`
+
+exports[`test/commands/query.ts > TAP > query > workspaces > should add scope nodes as importers 1`] = `
+a
+
 `
 
 exports[`test/commands/query.ts > TAP > query > workspaces > should list single workspace 1`] = `

--- a/src/cli-sdk/test/commands/pkg.ts
+++ b/src/cli-sdk/test/commands/pkg.ts
@@ -13,6 +13,13 @@ const kIndent = Symbol.for('indent')
 const readPackageJson = (dir: string) =>
   readFileSync(join(dir, 'package.json'), 'utf8')
 
+// Helper to create a config with get method for tests
+const makeTestConfig = (config: any): LoadedConfig =>
+  ({
+    ...config,
+    get: (key: string) => config.values?.[key],
+  }) as unknown as LoadedConfig
+
 setupEnv(t)
 
 t.matchSnapshot(Command.usage().usage(), 'usage')
@@ -22,11 +29,11 @@ t.test('basic', async t => {
     'vlt.json': JSON.stringify({ workspaces: [] }),
     'package.json': JSON.stringify({}),
   })
-  const config = {
+  const config = makeTestConfig({
     projectRoot: dir,
     options: { packageJson: new PackageJson() },
     positionals: ['gett'],
-  } as LoadedConfig
+  })
   t.chdir(dir)
   await t.rejects(Command.command(config), {
     cause: {
@@ -84,41 +91,45 @@ t.test('get', async t => {
     'package.json': JSON.stringify(pkg),
   })
 
-  const config = {
+  const config = makeTestConfig({
     projectRoot: dir,
     options: { packageJson: new PackageJson() },
-  }
+  })
   t.chdir(dir)
 
   t.strictSame(
-    await Command.command({
-      ...config,
-      positionals: ['get'],
-    } as LoadedConfig),
+    await Command.command(
+      Object.assign(config, {
+        positionals: ['get'],
+      }) as LoadedConfig,
+    ),
     { ...pkg, [kNewline]: '', [kIndent]: '' },
   )
 
   t.strictSame(
-    await Command.command({
-      ...config,
-      positionals: ['get', 'name'],
-    } as LoadedConfig),
+    await Command.command(
+      Object.assign({}, config, {
+        positionals: ['get', 'name'],
+      }) as LoadedConfig,
+    ),
     'package-name',
   )
 
   t.strictSame(
-    await Command.command({
-      ...config,
-      positionals: ['get', 'nested.keywords[3].obj[1]'],
-    } as LoadedConfig),
+    await Command.command(
+      Object.assign({}, config, {
+        positionals: ['get', 'nested.keywords[3].obj[1]'],
+      }) as LoadedConfig,
+    ),
     'arrays',
   )
 
   await t.rejects(
-    Command.command({
-      ...config,
-      positionals: ['get', 'name', 'version'],
-    } as LoadedConfig),
+    Command.command(
+      Object.assign({}, config, {
+        positionals: ['get', 'name', 'version'],
+      }) as LoadedConfig,
+    ),
     { cause: { code: 'EUSAGE' } },
   )
 })
@@ -138,33 +149,36 @@ t.test('pick', async t => {
     'package.json': JSON.stringify(pkg),
   })
 
-  const config = {
+  const config = makeTestConfig({
     projectRoot: dir,
     options: { packageJson: new PackageJson() },
-  }
+  })
   t.chdir(dir)
 
   t.strictSame(
-    await Command.command({
-      ...config,
-      positionals: ['pick'],
-    } as LoadedConfig),
+    await Command.command(
+      Object.assign({}, config, {
+        positionals: ['pick'],
+      }) as LoadedConfig,
+    ),
     { ...pkg, [kNewline]: '', [kIndent]: '' },
   )
 
   t.strictSame(
-    await Command.command({
-      ...config,
-      positionals: ['pick', 'name'],
-    } as LoadedConfig),
+    await Command.command(
+      Object.assign({}, config, {
+        positionals: ['pick', 'name'],
+      }) as LoadedConfig,
+    ),
     { name: 'package-name' },
   )
 
   t.strictSame(
-    await Command.command({
-      ...config,
-      positionals: ['pick', 'nested.keywords[3].obj[1]'],
-    } as LoadedConfig),
+    await Command.command(
+      Object.assign({}, config, {
+        positionals: ['pick', 'nested.keywords[3].obj[1]'],
+      }) as LoadedConfig,
+    ),
     {
       nested: {
         keywords: [null, null, null, { obj: [null, 'arrays'] }],
@@ -173,10 +187,11 @@ t.test('pick', async t => {
   )
 
   t.strictSame(
-    await Command.command({
-      ...config,
-      positionals: ['pick', 'nested.keywords'],
-    } as LoadedConfig),
+    await Command.command(
+      Object.assign({}, config, {
+        positionals: ['pick', 'nested.keywords'],
+      }) as LoadedConfig,
+    ),
     {
       nested: {
         keywords: ['one', 'two', 'last', { obj: ['more', 'arrays'] }],
@@ -185,10 +200,11 @@ t.test('pick', async t => {
   )
 
   t.strictSame(
-    await Command.command({
-      ...config,
-      positionals: ['pick', 'name', 'version'],
-    } as LoadedConfig),
+    await Command.command(
+      Object.assign({}, config, {
+        positionals: ['pick', 'name', 'version'],
+      }) as LoadedConfig,
+    ),
     {
       name: pkg.name,
       version: pkg.version,
@@ -215,10 +231,11 @@ t.test('pick', async t => {
     t.chdir(join(dir, 'my-project', 'packages', 'a'))
 
     t.strictSame(
-      await Command.command({
-        ...config,
-        positionals: ['get', 'name'],
-      } as LoadedConfig),
+      await Command.command(
+        Object.assign({}, config, {
+          positionals: ['get', 'name'],
+        }) as LoadedConfig,
+      ),
       'workspace-a',
       'should get name from workspace directory',
     )
@@ -233,22 +250,22 @@ t.test('pick', async t => {
           version: '1.0.0',
         }),
       })
-      const config = {
+      const config = makeTestConfig({
         projectRoot: dir,
         options: { packageJson: new PackageJson() },
         positionals: ['get'],
-      } as LoadedConfig
+      })
 
       // mocks the find method to simulate an environment in which
       // no package.json was found but we still have a projectRoot
       config.options.packageJson.find = () => undefined
 
       t.strictSame(
-        await Command.command({
-          // eslint-disable-next-line @typescript-eslint/no-misused-spread
-          ...config,
-          positionals: ['get', 'name'],
-        } as LoadedConfig),
+        await Command.command(
+          Object.assign({}, config, {
+            positionals: ['get', 'name'],
+          }) as LoadedConfig,
+        ),
         'my-project',
         'should default to the project root location',
       )
@@ -268,16 +285,17 @@ t.test('set', async t => {
     'package.json': JSON.stringify(pkg),
   })
 
-  const config = {
+  const config = makeTestConfig({
     projectRoot: dir,
     options: { packageJson: new PackageJson() },
-  }
+  })
   t.chdir(dir)
 
-  await Command.command({
-    ...config,
-    positionals: ['set', 'name=new-package-name'],
-  } as LoadedConfig)
+  await Command.command(
+    Object.assign({}, config, {
+      positionals: ['set', 'name=new-package-name'],
+    }) as LoadedConfig,
+  )
   t.strictSame(JSON.parse(readPackageJson(dir)), {
     name: 'new-package-name',
     version: '1.0.0',
@@ -285,18 +303,20 @@ t.test('set', async t => {
   })
 
   await t.rejects(
-    Command.command({
-      ...config,
-      positionals: ['set'],
-    } as LoadedConfig),
+    Command.command(
+      Object.assign({}, config, {
+        positionals: ['set'],
+      }) as LoadedConfig,
+    ),
     { cause: { code: 'EUSAGE' } },
   )
 
   await t.rejects(
-    Command.command({
-      ...config,
-      positionals: ['set', 'name'],
-    } as LoadedConfig),
+    Command.command(
+      Object.assign({}, config, {
+        positionals: ['set', 'name'],
+      }) as LoadedConfig,
+    ),
     { cause: { code: 'EUSAGE' } },
   )
 
@@ -319,10 +339,11 @@ t.test('set', async t => {
     })
     t.chdir(join(dir, 'my-project', 'packages', 'a'))
 
-    await Command.command({
-      ...config,
-      positionals: ['set', 'foo=bar'],
-    } as LoadedConfig)
+    await Command.command(
+      Object.assign({}, config, {
+        positionals: ['set', 'foo=bar'],
+      }) as LoadedConfig,
+    )
 
     t.strictSame(
       JSON.parse(
@@ -352,21 +373,23 @@ t.test('delete', async t => {
     'package.json': JSON.stringify(pkg),
   })
 
-  const config = {
+  const config = makeTestConfig({
     projectRoot: dir,
     options: { packageJson: new PackageJson() },
-  }
+  })
   t.chdir(dir)
 
-  await Command.command({
-    ...config,
-    positionals: ['rm', 'name'],
-  } as LoadedConfig)
+  await Command.command(
+    Object.assign({}, config, {
+      positionals: ['rm', 'name'],
+    }) as LoadedConfig,
+  )
 
-  await Command.command({
-    ...config,
-    positionals: ['rm', 'nested.keywords[3].obj[0]'],
-  } as LoadedConfig)
+  await Command.command(
+    Object.assign({}, config, {
+      positionals: ['rm', 'nested.keywords[3].obj[0]'],
+    }) as LoadedConfig,
+  )
 
   t.strictSame(JSON.parse(readPackageJson(dir)), {
     version: '1.0.0',
@@ -377,10 +400,11 @@ t.test('delete', async t => {
   })
 
   await t.rejects(
-    Command.command({
-      ...config,
-      positionals: ['rm'],
-    } as LoadedConfig),
+    Command.command(
+      Object.assign({}, config, {
+        positionals: ['rm'],
+      }) as LoadedConfig,
+    ),
     { cause: { code: 'EUSAGE' } },
   )
 
@@ -404,10 +428,11 @@ t.test('delete', async t => {
     })
     t.chdir(join(dir, 'my-project', 'packages', 'a'))
 
-    await Command.command({
-      ...config,
-      positionals: ['rm', 'foo'],
-    } as LoadedConfig)
+    await Command.command(
+      Object.assign({}, config, {
+        positionals: ['rm', 'foo'],
+      }) as LoadedConfig,
+    )
 
     t.strictSame(
       JSON.parse(
@@ -419,6 +444,596 @@ t.test('delete', async t => {
       },
     )
   })
+})
+
+t.test('scope functionality', async t => {
+  const mainManifest = {
+    name: 'my-project',
+    version: '1.0.0',
+  }
+  const dir = t.testdir({
+    'package.json': JSON.stringify(mainManifest),
+    'vlt.json': JSON.stringify({
+      workspaces: { packages: ['./packages/*'] },
+    }),
+    packages: {
+      a: {
+        'package.json': JSON.stringify({
+          name: 'workspace-a',
+          version: '2.0.0',
+          description: 'Workspace A description',
+        }),
+      },
+      b: {
+        'package.json': JSON.stringify({
+          name: 'workspace-b',
+          version: '3.0.0',
+          description: 'Workspace B description',
+        }),
+      },
+    },
+  })
+  t.chdir(dir)
+
+  const mockGraph = {
+    nodes: new Map([
+      [
+        'workspace-a-id',
+        { name: 'workspace-a', location: 'packages/a' },
+      ],
+      [
+        'workspace-b-id',
+        { name: 'workspace-b', location: 'packages/b' },
+      ],
+    ]),
+  }
+
+  const mockQuery = {
+    search: async (_queryString: string) => ({
+      nodes: [
+        {
+          id: 'workspace-a-id',
+          location: 'packages/a',
+          name: 'workspace-a',
+        },
+        {
+          id: 'workspace-b-id',
+          location: 'packages/b',
+          name: 'workspace-b',
+        },
+      ],
+    }),
+  }
+
+  const Command = await t.mockImport<
+    typeof import('../../src/commands/pkg.ts')
+  >('../../src/commands/pkg.ts', {
+    '@vltpkg/graph': {
+      actual: {
+        load: () => mockGraph,
+      },
+      GraphModifier: {
+        maybeLoad: () => undefined,
+      },
+    },
+    '@vltpkg/query': {
+      Query: class {
+        static hasSecuritySelectors() {
+          return false
+        }
+        search = mockQuery.search
+      },
+    },
+    '@vltpkg/security-archive': {
+      SecurityArchive: {
+        start: async () => undefined,
+      },
+    },
+  })
+
+  const config = makeTestConfig({
+    projectRoot: dir,
+    options: {
+      packageJson: new PackageJson(),
+      projectRoot: dir,
+    },
+    values: {
+      scope: ':workspace',
+    },
+  })
+
+  // Test scope get with multiple manifests
+  const getResult = await Command.command(
+    Object.assign({}, config, {
+      positionals: ['get', 'name'],
+    }) as LoadedConfig,
+  )
+
+  t.strictSame(
+    getResult,
+    ['workspace-a', 'workspace-b'],
+    'should get name from multiple manifests via scope',
+  )
+
+  // Test scope pick with multiple manifests
+  const pickResult = await Command.command(
+    Object.assign({}, config, {
+      positionals: ['pick', 'name', 'version'],
+    }) as LoadedConfig,
+  )
+
+  t.strictSame(
+    pickResult,
+    [
+      { name: 'workspace-a', version: '2.0.0' },
+      { name: 'workspace-b', version: '3.0.0' },
+    ],
+    'should pick from multiple manifests via scope',
+  )
+
+  // Test multiple manifests pick with no args (entire manifest)
+  const pickAllResult = await Command.command(
+    Object.assign({}, config, {
+      positionals: ['pick'],
+    }) as LoadedConfig,
+  )
+
+  t.strictSame(
+    Array.isArray(pickAllResult),
+    true,
+    'should return array for multiple manifests pick with no args',
+  )
+  t.strictSame(
+    (pickAllResult as any[])[0].name,
+    'workspace-a',
+    'should return full manifest for first workspace',
+  )
+  t.strictSame(
+    (pickAllResult as any[])[1].name,
+    'workspace-b',
+    'should return full manifest for second workspace',
+  )
+
+  // Test error case with invalid key in multiple manifests scenario
+  const getWithInvalidKeyResult = await Command.command(
+    Object.assign({}, config, {
+      positionals: ['get', ''],
+    }) as LoadedConfig,
+  )
+
+  t.strictSame(
+    getWithInvalidKeyResult,
+    [undefined, undefined],
+    'should handle invalid/empty key in multiple manifests get',
+  )
+
+  // Test error case where key is undefined in multiple manifests get
+  try {
+    await Command.command(
+      Object.assign({}, config, {
+        positionals: ['get'], // No key provided, args[0] will be undefined
+      }) as LoadedConfig,
+    )
+  } catch (_error) {
+    // This should trigger the get() function to call pick() instead, not the error case
+    // Let me try a different approach to trigger the error
+  }
+
+  // Test the exact scenario for lines 208-209: multiple manifests with falsy key
+  const mockConfigWithFalsyKey = Object.assign({}, config, {
+    positionals: ['get', ''], // Empty string key
+  })
+
+  // This will go to the multiple manifests path and check `if (!key)` on line 208-209
+  const getEmptyKeyResult = await Command.command(
+    mockConfigWithFalsyKey as LoadedConfig,
+  )
+
+  t.strictSame(
+    getEmptyKeyResult,
+    [undefined, undefined],
+    'should handle empty key in multiple manifests get scenario',
+  )
+
+  // Test the specific error condition: multiple manifests with null key (to trigger lines 208-209)
+  const mockQuery2 = {
+    search: async (_queryString: string) => ({
+      nodes: [
+        {
+          id: 'workspace-a-id',
+          location: 'packages/a',
+          name: 'workspace-a',
+        },
+        {
+          id: 'workspace-b-id',
+          location: 'packages/b',
+          name: 'workspace-b',
+        },
+      ],
+    }),
+  }
+
+  const Command2 = await t.mockImport<
+    typeof import('../../src/commands/pkg.ts')
+  >('../../src/commands/pkg.ts', {
+    '@vltpkg/graph': {
+      actual: { load: () => mockGraph },
+      GraphModifier: { maybeLoad: () => undefined },
+    },
+    '@vltpkg/query': {
+      Query: class {
+        static hasSecuritySelectors() {
+          return false
+        }
+        search = mockQuery2.search
+      },
+    },
+    '@vltpkg/security-archive': {
+      SecurityArchive: { start: async () => undefined },
+    },
+  })
+
+  // Test error condition with null key in multiple manifests scenario
+  await t.rejects(
+    Command2.command(
+      Object.assign({}, config, {
+        positionals: ['get', null as any],
+      }) as LoadedConfig,
+    ),
+    {
+      cause: { code: 'EUSAGE' },
+    },
+    'should reject with null key in multiple manifests get',
+  )
+
+  // Test multiple manifests get with valid key (lines 201-202)
+  const getMultipleResult = await Command.command(
+    Object.assign({}, config, {
+      positionals: ['get', 'version'],
+    }) as LoadedConfig,
+  )
+
+  t.strictSame(
+    getMultipleResult,
+    ['2.0.0', '3.0.0'],
+    'should get values from multiple manifests',
+  )
+
+  // Test multiple manifests pick with args (lines 220-221)
+  const pickMultipleWithArgsResult = await Command.command(
+    Object.assign({}, config, {
+      positionals: ['pick', 'name'],
+    }) as LoadedConfig,
+  )
+
+  t.strictSame(
+    pickMultipleWithArgsResult,
+    [{ name: 'workspace-a' }, { name: 'workspace-b' }],
+    'should pick values from multiple manifests with args',
+  )
+
+  // Test rm with multiple manifests returning results array (line 301)
+  const rmMultipleResult = await Command.command(
+    Object.assign({}, config, {
+      positionals: ['rm', 'customField'], // This should return the results array
+    }) as LoadedConfig,
+  )
+
+  t.strictSame(
+    Array.isArray(rmMultipleResult),
+    true,
+    'should return results array for multiple manifests rm',
+  )
+
+  // Test scope set with multiple manifests
+  await Command.command(
+    Object.assign({}, config, {
+      positionals: ['set', 'customField=scopedValue'],
+    }) as LoadedConfig,
+  )
+
+  t.strictSame(
+    JSON.parse(readPackageJson(join(dir, 'packages', 'a')))
+      .customField,
+    'scopedValue',
+    'should set value in workspace a via scope',
+  )
+  t.strictSame(
+    JSON.parse(readPackageJson(join(dir, 'packages', 'b')))
+      .customField,
+    'scopedValue',
+    'should set value in workspace b via scope',
+  )
+
+  // Test scope rm with multiple manifests
+  const rmResult = await Command.command(
+    Object.assign({}, config, {
+      positionals: ['rm', 'description'],
+    }) as LoadedConfig,
+  )
+
+  t.strictSame(
+    Array.isArray(rmResult),
+    true,
+    'should return array for multiple manifests rm',
+  )
+
+  t.notOk(
+    JSON.parse(readPackageJson(join(dir, 'packages', 'a')))
+      .description,
+    'should remove description from workspace a via scope',
+  )
+  t.notOk(
+    JSON.parse(readPackageJson(join(dir, 'packages', 'b')))
+      .description,
+    'should remove description from workspace b via scope',
+  )
+})
+
+t.test('scope with no matching workspaces', async t => {
+  const dir = t.testdir({
+    'package.json': JSON.stringify({
+      name: 'test-project',
+      version: '1.0.0',
+    }),
+    'vlt.json': JSON.stringify({
+      workspaces: { packages: ['./packages/*'] },
+    }),
+  })
+  t.chdir(dir)
+
+  const mockQuery = {
+    search: async () => ({ nodes: [] }),
+  }
+
+  const Command = await t.mockImport<
+    typeof import('../../src/commands/pkg.ts')
+  >('../../src/commands/pkg.ts', {
+    '@vltpkg/graph': {
+      actual: {
+        load: () => ({ nodes: new Map() }),
+      },
+      GraphModifier: {
+        maybeLoad: () => undefined,
+      },
+    },
+    '@vltpkg/query': {
+      Query: class {
+        static hasSecuritySelectors() {
+          return false
+        }
+        search = mockQuery.search
+      },
+    },
+    '@vltpkg/security-archive': {
+      SecurityArchive: {
+        start: async () => undefined,
+      },
+    },
+  })
+
+  const config = makeTestConfig({
+    projectRoot: dir,
+    options: {
+      packageJson: new PackageJson(),
+      projectRoot: dir,
+    },
+    values: {
+      scope: ':nonexistent',
+    },
+  })
+
+  await t.rejects(
+    Command.command(
+      Object.assign({}, config, {
+        positionals: ['get', 'name'],
+      }) as LoadedConfig,
+    ),
+    /No matching package found using scope/,
+    'should reject when no workspaces match scope',
+  )
+})
+
+t.test('scope with security selectors', async t => {
+  const dir = t.testdir({
+    'package.json': JSON.stringify({
+      name: 'test-project',
+      version: '1.0.0',
+    }),
+    'vlt.json': JSON.stringify({
+      workspaces: { packages: ['./packages/*'] },
+    }),
+    packages: {
+      a: {
+        'package.json': JSON.stringify({
+          name: 'workspace-a',
+          version: '1.0.0',
+        }),
+      },
+    },
+  })
+  t.chdir(dir)
+
+  const mockSecurityArchive = { ok: true }
+  const mockQuery = {
+    search: async () => ({
+      nodes: [
+        {
+          id: 'workspace-a-id',
+          location: 'packages/a',
+          name: 'workspace-a',
+        },
+      ],
+    }),
+  }
+
+  const Command = await t.mockImport<
+    typeof import('../../src/commands/pkg.ts')
+  >('../../src/commands/pkg.ts', {
+    '@vltpkg/graph': {
+      actual: {
+        load: () => ({ nodes: new Map() }),
+      },
+      GraphModifier: {
+        maybeLoad: () => undefined,
+      },
+    },
+    '@vltpkg/query': {
+      Query: class {
+        static hasSecuritySelectors(query: string) {
+          return query.includes(':malware')
+        }
+        search = mockQuery.search
+      },
+    },
+    '@vltpkg/security-archive': {
+      SecurityArchive: {
+        start: async () => mockSecurityArchive,
+      },
+    },
+  })
+
+  const config = makeTestConfig({
+    projectRoot: dir,
+    options: {
+      packageJson: new PackageJson(),
+      projectRoot: dir,
+    },
+    values: {
+      scope: '*:malware',
+    },
+  })
+
+  const result = await Command.command(
+    Object.assign({}, config, {
+      positionals: ['get', 'name'],
+    }) as LoadedConfig,
+  )
+
+  t.strictSame(
+    result,
+    'workspace-a',
+    'should handle scope with security selectors',
+  )
+})
+
+t.test('alternative command aliases', async t => {
+  const pkg = {
+    name: 'test-package',
+    version: '1.0.0',
+    toRemove: 'should be removed',
+  }
+
+  const dir = t.testdir({
+    'package.json': JSON.stringify(pkg),
+  })
+
+  const config = makeTestConfig({
+    projectRoot: dir,
+    options: { packageJson: new PackageJson() },
+  })
+  t.chdir(dir)
+
+  // Test 'remove' alias
+  await Command.command(
+    Object.assign({}, config, {
+      positionals: ['remove', 'toRemove'],
+    }) as LoadedConfig,
+  )
+
+  t.notOk(
+    JSON.parse(readPackageJson(dir)).toRemove,
+    'should handle "remove" alias',
+  )
+
+  // Add the field back for next test
+  await Command.command(
+    Object.assign({}, config, {
+      positionals: ['set', 'toRemove=should be removed'],
+    }) as LoadedConfig,
+  )
+
+  // Test 'unset' alias
+  await Command.command(
+    Object.assign({}, config, {
+      positionals: ['unset', 'toRemove'],
+    }) as LoadedConfig,
+  )
+
+  t.notOk(
+    JSON.parse(readPackageJson(dir)).toRemove,
+    'should handle "unset" alias',
+  )
+
+  // Add the field back for next test
+  await Command.command(
+    Object.assign({}, config, {
+      positionals: ['set', 'toRemove=should be removed'],
+    }) as LoadedConfig,
+  )
+
+  // Test 'delete' alias
+  await Command.command(
+    Object.assign({}, config, {
+      positionals: ['delete', 'toRemove'],
+    }) as LoadedConfig,
+  )
+
+  t.notOk(
+    JSON.parse(readPackageJson(dir)).toRemove,
+    'should handle "delete" alias',
+  )
+})
+
+t.test('error cases', async t => {
+  const dir = t.testdir({
+    'package.json': JSON.stringify({
+      name: 'test-package',
+      version: '1.0.0',
+    }),
+  })
+
+  const config = makeTestConfig({
+    projectRoot: dir,
+    options: { packageJson: new PackageJson() },
+  })
+  t.chdir(dir)
+
+  // Test get with invalid arguments when manifest is undefined
+  const Command = await t.mockImport<
+    typeof import('../../src/commands/pkg.ts')
+  >('../../src/commands/pkg.ts', {})
+
+  // Mock scenario where firstManifest is undefined
+  const mockConfig = Object.assign({}, config, {
+    options: Object.assign({}, config.options, {
+      packageJson: Object.assign({}, config.options.packageJson, {
+        find: () => dir,
+        read: () => undefined, // This will make firstManifest undefined
+      }),
+    }),
+  })
+
+  await t.rejects(
+    Command.command(
+      Object.assign({}, mockConfig, {
+        positionals: ['get', 'name'],
+      }) as unknown as LoadedConfig,
+    ),
+    /No manifest found/,
+    'should handle undefined manifest in get',
+  )
+
+  // Test pick with undefined manifest
+  await t.rejects(
+    Command.command(
+      Object.assign({}, mockConfig, {
+        positionals: ['pick', 'name'],
+      }) as unknown as LoadedConfig,
+    ),
+    /No manifest found/,
+    'should handle undefined manifest in pick',
+  )
 })
 
 t.test('human output', async t => {
@@ -446,7 +1061,7 @@ t.test('human output', async t => {
         { positionals: ['init'] },
       ),
     )
-    t.strictSame(human({}, { positionals: ['not', 'init'] }), {})
+    t.strictSame(human({}, { positionals: ['not', 'init'] }), '{}')
   })
 
   t.test('get', async t => {
@@ -455,8 +1070,68 @@ t.test('human output', async t => {
         { [Symbol.for('some symbol')]: 1, a: 2 },
         { positionals: ['get'] },
       ),
-      { a: 2 },
+      JSON.stringify({ a: 2 }, null, 2),
     )
-    t.strictSame(human(1, { positionals: ['get'] }), 1)
+    t.strictSame(human(1, { positionals: ['get'] }), '1')
+  })
+
+  // Test json() function for array results
+  t.test('json output for arrays', async t => {
+    const arrayResult = [
+      { manifest: { name: 'pkg1' }, location: '/path1' },
+      { manifest: { name: 'pkg2' }, location: '/path2' },
+    ]
+    t.strictSame(
+      human(arrayResult, { positionals: ['get'] }),
+      JSON.stringify(arrayResult, null, 2),
+      'should handle array results',
+    )
+
+    const stringArray = ['result1', 'result2']
+    t.strictSame(
+      human(stringArray, { positionals: ['get'] }),
+      'result1\nresult2',
+      'should handle string array results',
+    )
+  })
+})
+
+t.test('scope option', async t => {
+  await t.test('scope config is properly read', async t => {
+    const config = makeTestConfig({
+      projectRoot: '/test/dir',
+      options: { packageJson: new PackageJson() },
+      positionals: ['get', 'name'],
+      values: { scope: ':workspace#workspace-a' },
+      get: (key: string) =>
+        key === 'scope' ? ':workspace#workspace-a' : undefined,
+    })
+
+    // Test that get method works with scope
+    t.equal(
+      config.get('scope'),
+      ':workspace#workspace-a',
+      'should read scope from config',
+    )
+    t.equal(
+      (config.get as any)('unknown'),
+      undefined,
+      'should return undefined for unknown keys',
+    )
+  })
+
+  await t.test('scope config handles undefined values', async t => {
+    const config = makeTestConfig({
+      projectRoot: '/test/dir',
+      options: { packageJson: new PackageJson() },
+      positionals: ['get', 'name'],
+      // No values object
+    })
+
+    t.equal(
+      config.get('scope'),
+      undefined,
+      'should return undefined when no values',
+    )
   })
 })

--- a/src/graph/src/node.ts
+++ b/src/graph/src/node.ts
@@ -389,3 +389,20 @@ export class Node implements NodeLike {
     return stringifyNode(this)
   }
 }
+
+export const isNode = (value: unknown): value is Node => {
+  return (
+    typeof value === 'object' &&
+    value != null &&
+    'id' in value &&
+    'manifest' in value &&
+    (value as Node)[Symbol.toStringTag] === '@vltpkg/graph.Node'
+  )
+}
+
+export const asNode = (value: unknown): Node => {
+  if (!isNode(value)) {
+    throw typeError('Expected a node', { found: value })
+  }
+  return value
+}

--- a/src/graph/test/node.ts
+++ b/src/graph/test/node.ts
@@ -4,7 +4,7 @@ import type { SpecOptions } from '@vltpkg/spec'
 import { inspect } from 'node:util'
 import t from 'tap'
 import { Edge } from '../src/edge.ts'
-import { Node } from '../src/node.ts'
+import { asNode, isNode, Node } from '../src/node.ts'
 import type { GraphLike } from '../src/types.ts'
 import { PathScurry } from 'path-scurry'
 
@@ -505,4 +505,55 @@ t.test('rawManifest getter and setter', t => {
   t.strictSame(node.toString(), 'npm:foo@1.0.0')
 
   t.end()
+})
+
+t.test('isNode', async t => {
+  const opts = {
+    ...options,
+    projectRoot: t.testdirName,
+    graph: {} as GraphLike,
+  }
+  const mani = {
+    name: 'test',
+    version: '1.0.0',
+  }
+  const spec = Spec.parse('foo', '^1.0.0')
+  const node = new Node(opts, undefined, mani, spec)
+  t.ok(isNode(node), 'should be ok if object is a valid node')
+  node[Symbol.toStringTag] === 'something else'
+  t.ok(
+    isNode(node),
+    "should not be ok if the object string tag won't match",
+  )
+  t.notOk(
+    isNode({}),
+    'should not be ok if object does not have a valid obj',
+  )
+  t.notOk(
+    isNode(undefined),
+    "should not be ok if it's an undefined value",
+  )
+})
+
+t.test('asNode', async t => {
+  const opts = {
+    ...options,
+    projectRoot: t.testdirName,
+    graph: {} as GraphLike,
+  }
+  const mani = {
+    name: 'test',
+    version: '1.0.0',
+  }
+  const spec = Spec.parse('foo', '^1.0.0')
+  const node = new Node(opts, undefined, mani, spec)
+  t.ok(
+    asNode(node),
+    'should return typed object if a valid dependency shaped obj is found',
+  )
+  t.throws(
+    () => asNode({}),
+    /Expected a node/,
+    'should throw if object is not a node',
+  )
 })


### PR DESCRIPTION
Add support to the `--scope` option to the following commands:
- `vlt pkg`
- `vlt ls`
- `vlt query`

In `vlt pkg` the `scope` option will now allow for retrieving, setting and removing keys from the `package.json` file of any packages found using the provided `scope` query.

In `vlt ls` and `vlt query` using the `scope` option allows for setting arbitrary roots for selecting a sub-graph that can then be visualized in all the supported formats.