### PR TITLE
graph: add edge modifier removal

### DIFF
--- a/src/graph/src/ideal/append-nodes.ts
+++ b/src/graph/src/ideal/append-nodes.ts
@@ -103,6 +103,9 @@ export const appendNodes = async (
         'spec' in activeModifier.modifier
       ) {
         spec = activeModifier.modifier.spec
+        if (spec.bareSpec === '-') {
+          return
+        }
       }
 
       const existingNode = graph.findResolution(


### PR DESCRIPTION
Add support to a `"-"` `bareSpec` definition in the graph modifiers that enables removing a given edge from the graph.

Fixes: https://github.com/vltpkg/statusboard/issues/175