### PR TITLE
gui: feat breadcrumb navigation

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1060,6 +1060,9 @@ importers:
       '@vltpkg/dep-id':
         specifier: workspace:*
         version: link:../dep-id
+      '@vltpkg/dss-breadcrumb':
+        specifier: workspace:*
+        version: link:../dss-breadcrumb
       '@vltpkg/graph':
         specifier: workspace:*
         version: link:../graph

--- a/src/gui/package.json
+++ b/src/gui/package.json
@@ -25,6 +25,7 @@
     "@radix-ui/react-tooltip": "^1.2.7",
     "@tanstack/react-table": "^8.21.3",
     "@vltpkg/dep-id": "workspace:*",
+    "@vltpkg/dss-breadcrumb": "workspace:*",
     "@vltpkg/graph": "workspace:*",
     "@vltpkg/query": "workspace:*",
     "@vltpkg/security-archive": "workspace:*",

--- a/src/gui/src/components/explorer-grid/index.tsx
+++ b/src/gui/src/components/explorer-grid/index.tsx
@@ -2,6 +2,9 @@ import { Results } from '@/components/explorer-grid/results/index.tsx'
 import { SelectedItem } from '@/components/explorer-grid/selected-item/index.tsx'
 import { useGraphStore } from '@/state/index.ts'
 import { Spec } from '@vltpkg/spec/browser'
+import { stringifyNode } from '@vltpkg/graph/browser'
+import { getBreadcrumbs } from '@/components/navigation/crumb-nav.tsx'
+
 import type {
   QueryResponseEdge,
   QueryResponseNode,
@@ -10,8 +13,8 @@ import type {
   EdgeLoose,
   GridItemData,
 } from '@/components/explorer-grid/types.ts'
+import type { State } from '@/state/types.ts'
 import type { DepID } from '@vltpkg/dep-id'
-import { stringifyNode } from '@vltpkg/graph/browser'
 
 export type ExplorerOptions = {
   projectRoot?: string
@@ -20,6 +23,7 @@ export type ExplorerOptions = {
 const getItemsData = (
   edges: QueryResponseEdge[],
   nodes: QueryResponseNode[],
+  query: State['query'],
 ) => {
   const items: GridItemData[] = []
   const seenEdges = new Map<DepID, Set<EdgeLoose>>()
@@ -127,6 +131,7 @@ const getItemsData = (
   if (item && items.length === 1) {
     item.title = item.to?.name || 'Missing package'
     item.version = item.to?.version ? `v${item.to.version}` : ''
+    item.breadcrumbs = getBreadcrumbs(query)
   }
 
   return items.sort((a, b) => a.name.localeCompare(b.name, 'en'))
@@ -135,7 +140,8 @@ const getItemsData = (
 export const ExplorerGrid = () => {
   const edges = useGraphStore(state => state.edges)
   const nodes = useGraphStore(state => state.nodes)
-  const items = getItemsData(edges, nodes)
+  const query = useGraphStore(state => state.query)
+  const items = getItemsData(edges, nodes, query)
   return (
     <div className="h-full w-full grow px-8 pb-8">
       {items.length === 1 && items[0] ?

--- a/src/gui/src/components/explorer-grid/selected-item/item-header.tsx
+++ b/src/gui/src/components/explorer-grid/selected-item/item-header.tsx
@@ -22,8 +22,6 @@ import {
 } from 'lucide-react'
 import { splitDepID } from '@vltpkg/dep-id/browser'
 import { defaultRegistry } from '@vltpkg/spec/browser'
-import type { SpecOptionsFilled } from '@vltpkg/spec/browser'
-import type { GridItemData } from '@/components/explorer-grid/types.ts'
 import {
   getScoreColor,
   scoreColors,
@@ -49,6 +47,10 @@ import {
 import { ProgressCircle } from '@/components/ui/progress-circle.tsx'
 import { toHumanNumber } from '@/utils/human-number.ts'
 import { LICENSE_TYPES } from '@/lib/constants/index.ts'
+import { CrumbNav } from '@/components/navigation/crumb-nav.tsx'
+
+import type { SpecOptionsFilled } from '@vltpkg/spec/browser'
+import type { GridItemData } from '@/components/explorer-grid/types.ts'
 import type { ProgressCircleVariant } from '@/components/ui/progress-circle.tsx'
 import type { LucideIcon } from 'lucide-react'
 
@@ -129,9 +131,12 @@ export const ItemHeader = () => {
       animate={{ opacity: 1 }}
       initial={{ opacity: 0 }}
       className="flex flex-col divide-y-[1px] divide-muted pb-3">
-      <div className="flex w-full justify-between">
-        <PackageImageSpec className="pb-3 pl-6 pt-6" />
-        <PackageOverallScore className="pb-3 pr-6 pt-6" />
+      <div className="flex w-full flex-col">
+        <ItemBreadcrumbs />
+        <div className="flex w-full justify-between">
+          <PackageImageSpec className="pb-3 pl-6 pt-4" />
+          <PackageOverallScore className="pb-3 pr-6 pt-4" />
+        </div>
       </div>
       <div className="flex w-full items-center justify-between px-6 py-2 empty:hidden">
         <Publisher />
@@ -141,6 +146,24 @@ export const ItemHeader = () => {
         <PackageMetadata className="w-full" />
       </div>
     </motion.div>
+  )
+}
+
+const ItemBreadcrumbs = () => {
+  const breadcrumbs = useSelectedItemStore(
+    state => state.selectedItem.breadcrumbs,
+  )
+
+  if (!breadcrumbs) return null
+
+  return (
+    <ScrollArea className="relative w-full overflow-hidden overflow-x-scroll border-b-[1px] border-muted pb-2 pt-2 empty:hidden">
+      <div className="pointer-events-none absolute bottom-0 right-0 top-0 z-[100] h-full w-6 rounded-r-lg bg-gradient-to-l from-card" />
+      <div className="pointer-events-none absolute bottom-0 left-0 top-0 z-[100] h-full w-6 rounded-l-lg bg-gradient-to-r from-card" />
+
+      <CrumbNav className="px-6" breadcrumbs={breadcrumbs} />
+      <ScrollBar className="z-[102]" orientation="horizontal" />
+    </ScrollArea>
   )
 }
 
@@ -324,13 +347,13 @@ const PackageImage = () => {
   )
 
   return (
-    <Avatar className="aspect-square size-[3.75rem]">
+    <Avatar className="aspect-square size-[3.875rem]">
       <AvatarImage
-        className="aspect-square size-[3.75rem] rounded-md border-[1px] bg-secondary object-cover"
+        className="aspect-square size-[3.875rem] rounded-md border-[1px] bg-secondary object-cover"
         src={favicon?.src}
         alt={favicon?.alt ?? 'Package Icon'}
       />
-      <AvatarFallback className="flex aspect-square size-[3.75rem] h-full w-full items-center justify-center rounded-md border-[1px]">
+      <AvatarFallback className="flex aspect-square size-[3.875rem] h-full w-full items-center justify-center rounded-md border-[1px]">
         {selectedItem.to?.mainImporter ?
           <div className="flex h-full w-full items-center justify-center rounded-md bg-muted p-4">
             <Home

--- a/src/gui/src/components/explorer-grid/types.ts
+++ b/src/gui/src/components/explorer-grid/types.ts
@@ -1,4 +1,5 @@
 import type { QueryResponseEdge } from '@vltpkg/query'
+import type { ModifierBreadcrumb } from '@vltpkg/dss-breadcrumb'
 
 /**
  * A looser representation of an edge, it contains optional properties that
@@ -56,6 +57,11 @@ export type GridItemData = EdgeLoose & {
    * A list of labels to be displayed in the Card UI.
    */
   labels?: string[]
+  /**
+   * A list of breadcrumbs leading up to the selected item to be displayed
+   * if available.
+   */
+  breadcrumbs?: ModifierBreadcrumb
 }
 
 /**

--- a/src/gui/src/components/navigation/crumb-nav.tsx
+++ b/src/gui/src/components/navigation/crumb-nav.tsx
@@ -1,0 +1,180 @@
+import React, { useMemo, useState } from 'react'
+import { useGraphStore } from '@/state/index.ts'
+import { QueryToken } from '@/components/query-bar/query-token.tsx'
+import { Query } from '@vltpkg/query'
+import { cn } from '@/lib/utils.ts'
+import { parseBreadcrumb } from '@vltpkg/dss-breadcrumb'
+import { ChevronRight, Ellipsis } from 'lucide-react'
+
+import type { GridItemData } from '@/components/explorer-grid/types.ts'
+import type { ParsedSelectorToken } from '@vltpkg/query'
+import type { State } from '@/state/types'
+
+interface CrumbNavProps {
+  className?: string
+  breadcrumbs: GridItemData['breadcrumbs']
+}
+
+interface CrumbProps {
+  query: string
+  crumbIdx: number
+  crumbLength: number
+}
+
+const MAX_BREADCRUMBS = 5
+const TRUNCATED_TAIL_COUNT = 3
+
+export const getBreadcrumbs = (
+  query: State['query'],
+): GridItemData['breadcrumbs'] | undefined => {
+  try {
+    const breadcrumb = parseBreadcrumb(query)
+
+    if (breadcrumb.single && breadcrumb.first.value === ':root') {
+      return undefined
+    }
+
+    return breadcrumb
+  } catch (_e) {
+    return undefined
+  }
+}
+
+const Crumb = ({ query, crumbIdx, crumbLength }: CrumbProps) => {
+  const parsedTokens = useMemo<ParsedSelectorToken[]>(() => {
+    try {
+      return Query.getQueryTokens(query)
+    } catch (_e) {
+      return []
+    }
+  }, [query])
+
+  return parsedTokens.map((segment, idx) => (
+    <QueryToken
+      className={cn(
+        'px-1.5',
+        crumbIdx !== crumbLength - 1 &&
+          'duration-250 opacity-75 transition-opacity hover:opacity-100',
+      )}
+      variant={segment.type}
+      key={`crumb-${idx}`}>
+      {segment.token}
+    </QueryToken>
+  ))
+}
+
+interface EllipsisButtonProps {
+  onClick: () => void
+  className?: string
+}
+
+const EllipsisButton = ({
+  onClick,
+  className,
+}: EllipsisButtonProps) => (
+  <button
+    onClick={onClick}
+    className={cn(
+      'inline-flex items-center justify-center rounded px-1 py-0.5',
+      'text-muted-foreground opacity-75 transition-opacity hover:opacity-100',
+      'hover:bg-muted/50',
+      className,
+    )}
+    aria-label="Show hidden breadcrumbs">
+    <Ellipsis size={14} />
+  </button>
+)
+
+export const CrumbNav = ({
+  breadcrumbs,
+  className,
+}: CrumbNavProps) => {
+  const updateQuery = useGraphStore(state => state.updateQuery)
+  const [isExpanded, setIsExpanded] = useState(false)
+
+  if (!breadcrumbs) return null
+
+  const parts = [...breadcrumbs]
+  const shouldTruncate = parts.length > MAX_BREADCRUMBS && !isExpanded
+
+  const onCrumbClick = (crumbIndex: number) => {
+    const constructedCrumbPath = parts
+      .slice(0, crumbIndex + 1)
+      .map(i => i.value)
+      .join('>')
+    updateQuery(constructedCrumbPath)
+  }
+
+  const onEllipsisClick = () => {
+    setIsExpanded(!isExpanded)
+  }
+
+  const getVisibleBreadcrumbs = () => {
+    if (!shouldTruncate) {
+      return parts.map((part, index) => ({
+        part,
+        originalIndex: index,
+      }))
+    }
+
+    if (parts.length === 0) return []
+
+    const firstPart = parts[0]
+    if (!firstPart) return []
+
+    const first = [{ part: firstPart, originalIndex: 0 }]
+    const startIndex = Math.max(
+      0,
+      parts.length - TRUNCATED_TAIL_COUNT,
+    )
+    const last = parts.slice(startIndex).map((part, index) => ({
+      part,
+      originalIndex: startIndex + index,
+    }))
+
+    return [...first, ...last]
+  }
+
+  const visibleBreadcrumbs = getVisibleBreadcrumbs()
+
+  return (
+    <nav
+      className={cn('flex flex-row items-center gap-1', className)}>
+      {visibleBreadcrumbs.map(
+        ({ part, originalIndex }, displayIndex) => (
+          <React.Fragment key={`part-${originalIndex}`}>
+            {shouldTruncate && displayIndex === 1 && (
+              <>
+                <ChevronRight
+                  size={14}
+                  strokeWidth={2}
+                  className="text-muted-foreground opacity-75"
+                />
+                <EllipsisButton onClick={onEllipsisClick} />
+              </>
+            )}
+
+            {displayIndex > 0 &&
+              !(shouldTruncate && displayIndex === 1) && (
+                <ChevronRight
+                  size={14}
+                  strokeWidth={2}
+                  className="text-muted-foreground opacity-75"
+                />
+              )}
+
+            <button
+              className="inline-flex"
+              onClick={() => onCrumbClick(originalIndex)}>
+              <Crumb
+                crumbLength={parts.length}
+                crumbIdx={originalIndex}
+                query={part.name ? `#${part.name}` : part.value}
+              />
+            </button>
+          </React.Fragment>
+        ),
+      )}
+    </nav>
+  )
+}

--- a/src/gui/test/components/explorer-grid/selected-item/__snapshots__/item-header.tsx.snap
+++ b/src/gui/test/components/explorer-grid/selected-item/__snapshots__/item-header.tsx.snap
@@ -6,75 +6,77 @@ exports[`ItemHeader renders with a package score 1`] = `
   class="flex flex-col divide-y-[1px] divide-muted pb-3"
   style="opacity: 0;"
 >
-  <div class="flex w-full justify-between">
-    <div class="flex gap-4 overflow-hidden pb-3 pl-6 pt-6">
-      <gui-avatar classname="aspect-square size-[3.75rem]">
-        <gui-avatar-image
-          classname="aspect-square size-[3.75rem] rounded-md border-[1px] bg-secondary object-cover"
-          src="https://example.com/favicon.png"
-          alt="Example Favicon"
-        >
-        </gui-avatar-image>
-        <gui-avatar-fallback classname="flex aspect-square size-[3.75rem] h-full w-full items-center justify-center rounded-md border-[1px]">
-          <div class="h-full w-full rounded-md bg-gradient-to-t from-neutral-200 to-neutral-400 dark:from-neutral-500 dark:to-neutral-800">
-          </div>
-        </gui-avatar-fallback>
-      </gui-avatar>
-      <gui-scroll-area classname="w-full overflow-x-scroll">
-        <div class="flex h-full w-full flex-col justify-between">
-          <div class="flex w-full flex-col gap-0.5">
-            <div class="flex items-center gap-2">
-              <h1 class="w-fit max-w-full cursor-default align-baseline text-lg font-medium">
-                item
-                <span class="ml-2 font-courier text-sm text-muted-foreground">
-                  1.0.0
-                </span>
-              </h1>
-              <gui-tooltip-provider>
-                <gui-tooltip delayduration="150">
-                  <gui-tooltip-trigger classname="flex items-center justify-center">
-                    <div class="cursor-default rounded-sm border-[1px] border-green-600 bg-green-400/30 p-0.5 transition-colors duration-150 hover:bg-green-400/40 dark:border-green-500 dark:bg-green-500/30 dark:hover:bg-green-500/40">
-                      <gui-arrow-big-up-dash-icon
-                        classname="text-green-600 dark:text-green-500"
-                        size="16"
-                      >
-                      </gui-arrow-big-up-dash-icon>
-                    </div>
-                  </gui-tooltip-trigger>
-                  <gui-tooltip-content>
-                    Newer versions available
-                  </gui-tooltip-content>
-                </gui-tooltip>
-              </gui-tooltip-provider>
+  <div class="flex w-full flex-col">
+    <div class="flex w-full justify-between">
+      <div class="flex gap-4 overflow-hidden pb-3 pl-6 pt-4">
+        <gui-avatar classname="aspect-square size-[3.875rem]">
+          <gui-avatar-image
+            classname="aspect-square size-[3.875rem] rounded-md border-[1px] bg-secondary object-cover"
+            src="https://example.com/favicon.png"
+            alt="Example Favicon"
+          >
+          </gui-avatar-image>
+          <gui-avatar-fallback classname="flex aspect-square size-[3.875rem] h-full w-full items-center justify-center rounded-md border-[1px]">
+            <div class="h-full w-full rounded-md bg-gradient-to-t from-neutral-200 to-neutral-400 dark:from-neutral-500 dark:to-neutral-800">
+            </div>
+          </gui-avatar-fallback>
+        </gui-avatar>
+        <gui-scroll-area classname="w-full overflow-x-scroll">
+          <div class="flex h-full w-full flex-col justify-between">
+            <div class="flex w-full flex-col gap-0.5">
+              <div class="flex items-center gap-2">
+                <h1 class="w-fit max-w-full cursor-default align-baseline text-lg font-medium">
+                  item
+                  <span class="ml-2 font-courier text-sm text-muted-foreground">
+                    1.0.0
+                  </span>
+                </h1>
+                <gui-tooltip-provider>
+                  <gui-tooltip delayduration="150">
+                    <gui-tooltip-trigger classname="flex items-center justify-center">
+                      <div class="cursor-default rounded-sm border-[1px] border-green-600 bg-green-400/30 p-0.5 transition-colors duration-150 hover:bg-green-400/40 dark:border-green-500 dark:bg-green-500/30 dark:hover:bg-green-500/40">
+                        <gui-arrow-big-up-dash-icon
+                          classname="text-green-600 dark:text-green-500"
+                          size="16"
+                        >
+                        </gui-arrow-big-up-dash-icon>
+                      </div>
+                    </gui-tooltip-trigger>
+                    <gui-tooltip-content>
+                      Newer versions available
+                    </gui-tooltip-content>
+                  </gui-tooltip>
+                </gui-tooltip-provider>
+              </div>
             </div>
           </div>
-        </div>
-        <gui-scroll-bar orientation="horizontal">
-        </gui-scroll-bar>
-      </gui-scroll-area>
-    </div>
-    <div class="pb-3 pr-6 pt-6">
-      <div class="duration-250 after:duration-250 relative z-[1] flex cursor-default flex-row gap-3 self-start transition-colors after:absolute after:inset-0 after:-left-[0.5rem] after:-top-[0.5rem] after:z-[-1] after:h-[calc(100%+1rem)] after:w-[calc(100%+1rem)] after:rounded-sm after:transition-colors after:content-[''] hover:after:bg-neutral-100 dark:hover:after:bg-neutral-800">
-        <gui-progress-circle
-          value="80"
-          variant="success"
-          strokewidth="5"
-          classname="size-9"
-        >
-          <p
-            class="font-mono text-xs font-medium tabular-nums"
-            style="color: oklch(0.696 0.17 162.48);"
+          <gui-scroll-bar orientation="horizontal">
+          </gui-scroll-bar>
+        </gui-scroll-area>
+      </div>
+      <div class="pb-3 pr-6 pt-4">
+        <div class="duration-250 after:duration-250 relative z-[1] flex cursor-default flex-row gap-3 self-start transition-colors after:absolute after:inset-0 after:-left-[0.5rem] after:-top-[0.5rem] after:z-[-1] after:h-[calc(100%+1rem)] after:w-[calc(100%+1rem)] after:rounded-sm after:transition-colors after:content-[''] hover:after:bg-neutral-100 dark:hover:after:bg-neutral-800">
+          <gui-progress-circle
+            value="80"
+            variant="success"
+            strokewidth="5"
+            classname="size-9"
           >
-            80
-          </p>
-        </gui-progress-circle>
-        <div class="flex flex-col">
-          <p class="text-sm font-semibold text-neutral-600 dark:text-neutral-300">
-            Package Score
-          </p>
-          <p class="font-mono text-xs font-medium tabular-nums text-neutral-400">
-            80/100
-          </p>
+            <p
+              class="font-mono text-xs font-medium tabular-nums"
+              style="color: oklch(0.696 0.17 162.48);"
+            >
+              80
+            </p>
+          </gui-progress-circle>
+          <div class="flex flex-col">
+            <p class="text-sm font-semibold text-neutral-600 dark:text-neutral-300">
+              Package Score
+            </p>
+            <p class="font-mono text-xs font-medium tabular-nums text-neutral-400">
+              80/100
+            </p>
+          </div>
         </div>
       </div>
     </div>
@@ -118,52 +120,54 @@ exports[`ItemHeader renders with a version information 1`] = `
   class="flex flex-col divide-y-[1px] divide-muted pb-3"
   style="opacity: 0;"
 >
-  <div class="flex w-full justify-between">
-    <div class="flex gap-4 overflow-hidden pb-3 pl-6 pt-6">
-      <gui-avatar classname="aspect-square size-[3.75rem]">
-        <gui-avatar-image
-          classname="aspect-square size-[3.75rem] rounded-md border-[1px] bg-secondary object-cover"
-          src="https://example.com/favicon.png"
-          alt="Example Favicon"
-        >
-        </gui-avatar-image>
-        <gui-avatar-fallback classname="flex aspect-square size-[3.75rem] h-full w-full items-center justify-center rounded-md border-[1px]">
-          <div class="h-full w-full rounded-md bg-gradient-to-t from-neutral-200 to-neutral-400 dark:from-neutral-500 dark:to-neutral-800">
-          </div>
-        </gui-avatar-fallback>
-      </gui-avatar>
-      <gui-scroll-area classname="w-full overflow-x-scroll">
-        <div class="flex h-full w-full flex-col justify-between">
-          <div class="flex w-full flex-col gap-0.5">
-            <div class="flex items-center gap-2">
-              <h1 class="w-fit max-w-full cursor-default align-baseline text-lg font-medium">
-                item
-                <span class="ml-2 font-courier text-sm text-muted-foreground">
-                  1.0.0
-                </span>
-              </h1>
-              <gui-tooltip-provider>
-                <gui-tooltip delayduration="150">
-                  <gui-tooltip-trigger classname="flex items-center justify-center">
-                    <div class="cursor-default rounded-sm border-[1px] border-green-600 bg-green-400/30 p-0.5 transition-colors duration-150 hover:bg-green-400/40 dark:border-green-500 dark:bg-green-500/30 dark:hover:bg-green-500/40">
-                      <gui-arrow-big-up-dash-icon
-                        classname="text-green-600 dark:text-green-500"
-                        size="16"
-                      >
-                      </gui-arrow-big-up-dash-icon>
-                    </div>
-                  </gui-tooltip-trigger>
-                  <gui-tooltip-content>
-                    Newer versions available
-                  </gui-tooltip-content>
-                </gui-tooltip>
-              </gui-tooltip-provider>
+  <div class="flex w-full flex-col">
+    <div class="flex w-full justify-between">
+      <div class="flex gap-4 overflow-hidden pb-3 pl-6 pt-4">
+        <gui-avatar classname="aspect-square size-[3.875rem]">
+          <gui-avatar-image
+            classname="aspect-square size-[3.875rem] rounded-md border-[1px] bg-secondary object-cover"
+            src="https://example.com/favicon.png"
+            alt="Example Favicon"
+          >
+          </gui-avatar-image>
+          <gui-avatar-fallback classname="flex aspect-square size-[3.875rem] h-full w-full items-center justify-center rounded-md border-[1px]">
+            <div class="h-full w-full rounded-md bg-gradient-to-t from-neutral-200 to-neutral-400 dark:from-neutral-500 dark:to-neutral-800">
+            </div>
+          </gui-avatar-fallback>
+        </gui-avatar>
+        <gui-scroll-area classname="w-full overflow-x-scroll">
+          <div class="flex h-full w-full flex-col justify-between">
+            <div class="flex w-full flex-col gap-0.5">
+              <div class="flex items-center gap-2">
+                <h1 class="w-fit max-w-full cursor-default align-baseline text-lg font-medium">
+                  item
+                  <span class="ml-2 font-courier text-sm text-muted-foreground">
+                    1.0.0
+                  </span>
+                </h1>
+                <gui-tooltip-provider>
+                  <gui-tooltip delayduration="150">
+                    <gui-tooltip-trigger classname="flex items-center justify-center">
+                      <div class="cursor-default rounded-sm border-[1px] border-green-600 bg-green-400/30 p-0.5 transition-colors duration-150 hover:bg-green-400/40 dark:border-green-500 dark:bg-green-500/30 dark:hover:bg-green-500/40">
+                        <gui-arrow-big-up-dash-icon
+                          classname="text-green-600 dark:text-green-500"
+                          size="16"
+                        >
+                        </gui-arrow-big-up-dash-icon>
+                      </div>
+                    </gui-tooltip-trigger>
+                    <gui-tooltip-content>
+                      Newer versions available
+                    </gui-tooltip-content>
+                  </gui-tooltip>
+                </gui-tooltip-provider>
+              </div>
             </div>
           </div>
-        </div>
-        <gui-scroll-bar orientation="horizontal">
-        </gui-scroll-bar>
-      </gui-scroll-area>
+          <gui-scroll-bar orientation="horizontal">
+          </gui-scroll-bar>
+        </gui-scroll-area>
+      </div>
     </div>
   </div>
   <div class="flex w-full items-center justify-between px-6 py-2 empty:hidden">
@@ -246,58 +250,60 @@ exports[`ItemHeader renders with custom registry item 1`] = `
   class="flex flex-col divide-y-[1px] divide-muted pb-3"
   style="opacity: 0;"
 >
-  <div class="flex w-full justify-between">
-    <div class="flex gap-4 overflow-hidden pb-3 pl-6 pt-6">
-      <gui-avatar classname="aspect-square size-[3.75rem]">
-        <gui-avatar-image
-          classname="aspect-square size-[3.75rem] rounded-md border-[1px] bg-secondary object-cover"
-          src="https://example.com/favicon.png"
-          alt="Example Favicon"
-        >
-        </gui-avatar-image>
-        <gui-avatar-fallback classname="flex aspect-square size-[3.75rem] h-full w-full items-center justify-center rounded-md border-[1px]">
-          <div class="h-full w-full rounded-md bg-gradient-to-t from-neutral-200 to-neutral-400 dark:from-neutral-500 dark:to-neutral-800">
-          </div>
-        </gui-avatar-fallback>
-      </gui-avatar>
-      <gui-scroll-area classname="w-full overflow-x-scroll">
-        <div class="flex h-full w-full flex-col justify-between">
-          <div class="flex w-full flex-col gap-0.5">
-            <div class="flex items-center gap-2">
-              <h1 class="w-fit max-w-full cursor-default align-baseline text-lg font-medium">
-                item
-                <span class="ml-2 font-courier text-sm text-muted-foreground">
-                  1.0.0
-                </span>
-              </h1>
-              <gui-tooltip-provider>
-                <gui-tooltip delayduration="150">
-                  <gui-tooltip-trigger classname="flex items-center justify-center">
-                    <div class="cursor-default rounded-sm border-[1px] border-green-600 bg-green-400/30 p-0.5 transition-colors duration-150 hover:bg-green-400/40 dark:border-green-500 dark:bg-green-500/30 dark:hover:bg-green-500/40">
-                      <gui-arrow-big-up-dash-icon
-                        classname="text-green-600 dark:text-green-500"
-                        size="16"
-                      >
-                      </gui-arrow-big-up-dash-icon>
-                    </div>
-                  </gui-tooltip-trigger>
-                  <gui-tooltip-content>
-                    Newer versions available
-                  </gui-tooltip-content>
-                </gui-tooltip>
-              </gui-tooltip-provider>
+  <div class="flex w-full flex-col">
+    <div class="flex w-full justify-between">
+      <div class="flex gap-4 overflow-hidden pb-3 pl-6 pt-4">
+        <gui-avatar classname="aspect-square size-[3.875rem]">
+          <gui-avatar-image
+            classname="aspect-square size-[3.875rem] rounded-md border-[1px] bg-secondary object-cover"
+            src="https://example.com/favicon.png"
+            alt="Example Favicon"
+          >
+          </gui-avatar-image>
+          <gui-avatar-fallback classname="flex aspect-square size-[3.875rem] h-full w-full items-center justify-center rounded-md border-[1px]">
+            <div class="h-full w-full rounded-md bg-gradient-to-t from-neutral-200 to-neutral-400 dark:from-neutral-500 dark:to-neutral-800">
             </div>
-            <gui-data-badge
-              variant="mono"
-              content="custom:item@1.0.0"
-              tooltip="[object Object]"
-            >
-            </gui-data-badge>
+          </gui-avatar-fallback>
+        </gui-avatar>
+        <gui-scroll-area classname="w-full overflow-x-scroll">
+          <div class="flex h-full w-full flex-col justify-between">
+            <div class="flex w-full flex-col gap-0.5">
+              <div class="flex items-center gap-2">
+                <h1 class="w-fit max-w-full cursor-default align-baseline text-lg font-medium">
+                  item
+                  <span class="ml-2 font-courier text-sm text-muted-foreground">
+                    1.0.0
+                  </span>
+                </h1>
+                <gui-tooltip-provider>
+                  <gui-tooltip delayduration="150">
+                    <gui-tooltip-trigger classname="flex items-center justify-center">
+                      <div class="cursor-default rounded-sm border-[1px] border-green-600 bg-green-400/30 p-0.5 transition-colors duration-150 hover:bg-green-400/40 dark:border-green-500 dark:bg-green-500/30 dark:hover:bg-green-500/40">
+                        <gui-arrow-big-up-dash-icon
+                          classname="text-green-600 dark:text-green-500"
+                          size="16"
+                        >
+                        </gui-arrow-big-up-dash-icon>
+                      </div>
+                    </gui-tooltip-trigger>
+                    <gui-tooltip-content>
+                      Newer versions available
+                    </gui-tooltip-content>
+                  </gui-tooltip>
+                </gui-tooltip-provider>
+              </div>
+              <gui-data-badge
+                variant="mono"
+                content="custom:item@1.0.0"
+                tooltip="[object Object]"
+              >
+              </gui-data-badge>
+            </div>
           </div>
-        </div>
-        <gui-scroll-bar orientation="horizontal">
-        </gui-scroll-bar>
-      </gui-scroll-area>
+          <gui-scroll-bar orientation="horizontal">
+          </gui-scroll-bar>
+        </gui-scroll-area>
+      </div>
     </div>
   </div>
   <div class="flex w-full items-center justify-between px-6 py-2 empty:hidden">
@@ -339,57 +345,59 @@ exports[`ItemHeader renders with default git host item 1`] = `
   class="flex flex-col divide-y-[1px] divide-muted pb-3"
   style="opacity: 0;"
 >
-  <div class="flex w-full justify-between">
-    <div class="flex gap-4 overflow-hidden pb-3 pl-6 pt-6">
-      <gui-avatar classname="aspect-square size-[3.75rem]">
-        <gui-avatar-image
-          classname="aspect-square size-[3.75rem] rounded-md border-[1px] bg-secondary object-cover"
-          src="https://example.com/favicon.png"
-          alt="Example Favicon"
-        >
-        </gui-avatar-image>
-        <gui-avatar-fallback classname="flex aspect-square size-[3.75rem] h-full w-full items-center justify-center rounded-md border-[1px]">
-          <div class="h-full w-full rounded-md bg-gradient-to-t from-neutral-200 to-neutral-400 dark:from-neutral-500 dark:to-neutral-800">
-          </div>
-        </gui-avatar-fallback>
-      </gui-avatar>
-      <gui-scroll-area classname="w-full overflow-x-scroll">
-        <div class="flex h-full w-full flex-col justify-between">
-          <div class="flex w-full flex-col gap-0.5">
-            <div class="flex items-center gap-2">
-              <h1 class="w-fit max-w-full cursor-default align-baseline text-lg font-medium">
-                item
-                <span class="ml-2 font-courier text-sm text-muted-foreground">
-                  1.0.0
-                </span>
-              </h1>
-              <gui-tooltip-provider>
-                <gui-tooltip delayduration="150">
-                  <gui-tooltip-trigger classname="flex items-center justify-center">
-                    <div class="cursor-default rounded-sm border-[1px] border-green-600 bg-green-400/30 p-0.5 transition-colors duration-150 hover:bg-green-400/40 dark:border-green-500 dark:bg-green-500/30 dark:hover:bg-green-500/40">
-                      <gui-arrow-big-up-dash-icon
-                        classname="text-green-600 dark:text-green-500"
-                        size="16"
-                      >
-                      </gui-arrow-big-up-dash-icon>
-                    </div>
-                  </gui-tooltip-trigger>
-                  <gui-tooltip-content>
-                    Newer versions available
-                  </gui-tooltip-content>
-                </gui-tooltip>
-              </gui-tooltip-provider>
+  <div class="flex w-full flex-col">
+    <div class="flex w-full justify-between">
+      <div class="flex gap-4 overflow-hidden pb-3 pl-6 pt-4">
+        <gui-avatar classname="aspect-square size-[3.875rem]">
+          <gui-avatar-image
+            classname="aspect-square size-[3.875rem] rounded-md border-[1px] bg-secondary object-cover"
+            src="https://example.com/favicon.png"
+            alt="Example Favicon"
+          >
+          </gui-avatar-image>
+          <gui-avatar-fallback classname="flex aspect-square size-[3.875rem] h-full w-full items-center justify-center rounded-md border-[1px]">
+            <div class="h-full w-full rounded-md bg-gradient-to-t from-neutral-200 to-neutral-400 dark:from-neutral-500 dark:to-neutral-800">
             </div>
-            <gui-data-badge
-              variant="mono"
-              content="git:github:a/b"
-            >
-            </gui-data-badge>
+          </gui-avatar-fallback>
+        </gui-avatar>
+        <gui-scroll-area classname="w-full overflow-x-scroll">
+          <div class="flex h-full w-full flex-col justify-between">
+            <div class="flex w-full flex-col gap-0.5">
+              <div class="flex items-center gap-2">
+                <h1 class="w-fit max-w-full cursor-default align-baseline text-lg font-medium">
+                  item
+                  <span class="ml-2 font-courier text-sm text-muted-foreground">
+                    1.0.0
+                  </span>
+                </h1>
+                <gui-tooltip-provider>
+                  <gui-tooltip delayduration="150">
+                    <gui-tooltip-trigger classname="flex items-center justify-center">
+                      <div class="cursor-default rounded-sm border-[1px] border-green-600 bg-green-400/30 p-0.5 transition-colors duration-150 hover:bg-green-400/40 dark:border-green-500 dark:bg-green-500/30 dark:hover:bg-green-500/40">
+                        <gui-arrow-big-up-dash-icon
+                          classname="text-green-600 dark:text-green-500"
+                          size="16"
+                        >
+                        </gui-arrow-big-up-dash-icon>
+                      </div>
+                    </gui-tooltip-trigger>
+                    <gui-tooltip-content>
+                      Newer versions available
+                    </gui-tooltip-content>
+                  </gui-tooltip>
+                </gui-tooltip-provider>
+              </div>
+              <gui-data-badge
+                variant="mono"
+                content="git:github:a/b"
+              >
+              </gui-data-badge>
+            </div>
           </div>
-        </div>
-        <gui-scroll-bar orientation="horizontal">
-        </gui-scroll-bar>
-      </gui-scroll-area>
+          <gui-scroll-bar orientation="horizontal">
+          </gui-scroll-bar>
+        </gui-scroll-area>
+      </div>
     </div>
   </div>
   <div class="flex w-full items-center justify-between px-6 py-2 empty:hidden">
@@ -431,52 +439,54 @@ exports[`ItemHeader renders with default item 1`] = `
   class="flex flex-col divide-y-[1px] divide-muted pb-3"
   style="opacity: 0;"
 >
-  <div class="flex w-full justify-between">
-    <div class="flex gap-4 overflow-hidden pb-3 pl-6 pt-6">
-      <gui-avatar classname="aspect-square size-[3.75rem]">
-        <gui-avatar-image
-          classname="aspect-square size-[3.75rem] rounded-md border-[1px] bg-secondary object-cover"
-          src="https://example.com/favicon.png"
-          alt="Example Favicon"
-        >
-        </gui-avatar-image>
-        <gui-avatar-fallback classname="flex aspect-square size-[3.75rem] h-full w-full items-center justify-center rounded-md border-[1px]">
-          <div class="h-full w-full rounded-md bg-gradient-to-t from-neutral-200 to-neutral-400 dark:from-neutral-500 dark:to-neutral-800">
-          </div>
-        </gui-avatar-fallback>
-      </gui-avatar>
-      <gui-scroll-area classname="w-full overflow-x-scroll">
-        <div class="flex h-full w-full flex-col justify-between">
-          <div class="flex w-full flex-col gap-0.5">
-            <div class="flex items-center gap-2">
-              <h1 class="w-fit max-w-full cursor-default align-baseline text-lg font-medium">
-                item
-                <span class="ml-2 font-courier text-sm text-muted-foreground">
-                  1.0.0
-                </span>
-              </h1>
-              <gui-tooltip-provider>
-                <gui-tooltip delayduration="150">
-                  <gui-tooltip-trigger classname="flex items-center justify-center">
-                    <div class="cursor-default rounded-sm border-[1px] border-green-600 bg-green-400/30 p-0.5 transition-colors duration-150 hover:bg-green-400/40 dark:border-green-500 dark:bg-green-500/30 dark:hover:bg-green-500/40">
-                      <gui-arrow-big-up-dash-icon
-                        classname="text-green-600 dark:text-green-500"
-                        size="16"
-                      >
-                      </gui-arrow-big-up-dash-icon>
-                    </div>
-                  </gui-tooltip-trigger>
-                  <gui-tooltip-content>
-                    Newer versions available
-                  </gui-tooltip-content>
-                </gui-tooltip>
-              </gui-tooltip-provider>
+  <div class="flex w-full flex-col">
+    <div class="flex w-full justify-between">
+      <div class="flex gap-4 overflow-hidden pb-3 pl-6 pt-4">
+        <gui-avatar classname="aspect-square size-[3.875rem]">
+          <gui-avatar-image
+            classname="aspect-square size-[3.875rem] rounded-md border-[1px] bg-secondary object-cover"
+            src="https://example.com/favicon.png"
+            alt="Example Favicon"
+          >
+          </gui-avatar-image>
+          <gui-avatar-fallback classname="flex aspect-square size-[3.875rem] h-full w-full items-center justify-center rounded-md border-[1px]">
+            <div class="h-full w-full rounded-md bg-gradient-to-t from-neutral-200 to-neutral-400 dark:from-neutral-500 dark:to-neutral-800">
+            </div>
+          </gui-avatar-fallback>
+        </gui-avatar>
+        <gui-scroll-area classname="w-full overflow-x-scroll">
+          <div class="flex h-full w-full flex-col justify-between">
+            <div class="flex w-full flex-col gap-0.5">
+              <div class="flex items-center gap-2">
+                <h1 class="w-fit max-w-full cursor-default align-baseline text-lg font-medium">
+                  item
+                  <span class="ml-2 font-courier text-sm text-muted-foreground">
+                    1.0.0
+                  </span>
+                </h1>
+                <gui-tooltip-provider>
+                  <gui-tooltip delayduration="150">
+                    <gui-tooltip-trigger classname="flex items-center justify-center">
+                      <div class="cursor-default rounded-sm border-[1px] border-green-600 bg-green-400/30 p-0.5 transition-colors duration-150 hover:bg-green-400/40 dark:border-green-500 dark:bg-green-500/30 dark:hover:bg-green-500/40">
+                        <gui-arrow-big-up-dash-icon
+                          classname="text-green-600 dark:text-green-500"
+                          size="16"
+                        >
+                        </gui-arrow-big-up-dash-icon>
+                      </div>
+                    </gui-tooltip-trigger>
+                    <gui-tooltip-content>
+                      Newer versions available
+                    </gui-tooltip-content>
+                  </gui-tooltip>
+                </gui-tooltip-provider>
+              </div>
             </div>
           </div>
-        </div>
-        <gui-scroll-bar orientation="horizontal">
-        </gui-scroll-bar>
-      </gui-scroll-area>
+          <gui-scroll-bar orientation="horizontal">
+          </gui-scroll-bar>
+        </gui-scroll-area>
+      </div>
     </div>
   </div>
   <div class="flex w-full items-center justify-between px-6 py-2 empty:hidden">
@@ -518,52 +528,54 @@ exports[`ItemHeader renders with insights 1`] = `
   class="flex flex-col divide-y-[1px] divide-muted pb-3"
   style="opacity: 0;"
 >
-  <div class="flex w-full justify-between">
-    <div class="flex gap-4 overflow-hidden pb-3 pl-6 pt-6">
-      <gui-avatar classname="aspect-square size-[3.75rem]">
-        <gui-avatar-image
-          classname="aspect-square size-[3.75rem] rounded-md border-[1px] bg-secondary object-cover"
-          src="https://example.com/favicon.png"
-          alt="Example Favicon"
-        >
-        </gui-avatar-image>
-        <gui-avatar-fallback classname="flex aspect-square size-[3.75rem] h-full w-full items-center justify-center rounded-md border-[1px]">
-          <div class="h-full w-full rounded-md bg-gradient-to-t from-neutral-200 to-neutral-400 dark:from-neutral-500 dark:to-neutral-800">
-          </div>
-        </gui-avatar-fallback>
-      </gui-avatar>
-      <gui-scroll-area classname="w-full overflow-x-scroll">
-        <div class="flex h-full w-full flex-col justify-between">
-          <div class="flex w-full flex-col gap-0.5">
-            <div class="flex items-center gap-2">
-              <h1 class="w-fit max-w-full cursor-default align-baseline text-lg font-medium">
-                item
-                <span class="ml-2 font-courier text-sm text-muted-foreground">
-                  1.0.0
-                </span>
-              </h1>
-              <gui-tooltip-provider>
-                <gui-tooltip delayduration="150">
-                  <gui-tooltip-trigger classname="flex items-center justify-center">
-                    <div class="cursor-default rounded-sm border-[1px] border-green-600 bg-green-400/30 p-0.5 transition-colors duration-150 hover:bg-green-400/40 dark:border-green-500 dark:bg-green-500/30 dark:hover:bg-green-500/40">
-                      <gui-arrow-big-up-dash-icon
-                        classname="text-green-600 dark:text-green-500"
-                        size="16"
-                      >
-                      </gui-arrow-big-up-dash-icon>
-                    </div>
-                  </gui-tooltip-trigger>
-                  <gui-tooltip-content>
-                    Newer versions available
-                  </gui-tooltip-content>
-                </gui-tooltip>
-              </gui-tooltip-provider>
+  <div class="flex w-full flex-col">
+    <div class="flex w-full justify-between">
+      <div class="flex gap-4 overflow-hidden pb-3 pl-6 pt-4">
+        <gui-avatar classname="aspect-square size-[3.875rem]">
+          <gui-avatar-image
+            classname="aspect-square size-[3.875rem] rounded-md border-[1px] bg-secondary object-cover"
+            src="https://example.com/favicon.png"
+            alt="Example Favicon"
+          >
+          </gui-avatar-image>
+          <gui-avatar-fallback classname="flex aspect-square size-[3.875rem] h-full w-full items-center justify-center rounded-md border-[1px]">
+            <div class="h-full w-full rounded-md bg-gradient-to-t from-neutral-200 to-neutral-400 dark:from-neutral-500 dark:to-neutral-800">
+            </div>
+          </gui-avatar-fallback>
+        </gui-avatar>
+        <gui-scroll-area classname="w-full overflow-x-scroll">
+          <div class="flex h-full w-full flex-col justify-between">
+            <div class="flex w-full flex-col gap-0.5">
+              <div class="flex items-center gap-2">
+                <h1 class="w-fit max-w-full cursor-default align-baseline text-lg font-medium">
+                  item
+                  <span class="ml-2 font-courier text-sm text-muted-foreground">
+                    1.0.0
+                  </span>
+                </h1>
+                <gui-tooltip-provider>
+                  <gui-tooltip delayduration="150">
+                    <gui-tooltip-trigger classname="flex items-center justify-center">
+                      <div class="cursor-default rounded-sm border-[1px] border-green-600 bg-green-400/30 p-0.5 transition-colors duration-150 hover:bg-green-400/40 dark:border-green-500 dark:bg-green-500/30 dark:hover:bg-green-500/40">
+                        <gui-arrow-big-up-dash-icon
+                          classname="text-green-600 dark:text-green-500"
+                          size="16"
+                        >
+                        </gui-arrow-big-up-dash-icon>
+                      </div>
+                    </gui-tooltip-trigger>
+                    <gui-tooltip-content>
+                      Newer versions available
+                    </gui-tooltip-content>
+                  </gui-tooltip>
+                </gui-tooltip-provider>
+              </div>
             </div>
           </div>
-        </div>
-        <gui-scroll-bar orientation="horizontal">
-        </gui-scroll-bar>
-      </gui-scroll-area>
+          <gui-scroll-bar orientation="horizontal">
+          </gui-scroll-bar>
+        </gui-scroll-area>
+      </div>
     </div>
   </div>
   <div class="flex w-full items-center justify-between px-6 py-2 empty:hidden">
@@ -605,58 +617,60 @@ exports[`ItemHeader renders with scoped registry item 1`] = `
   class="flex flex-col divide-y-[1px] divide-muted pb-3"
   style="opacity: 0;"
 >
-  <div class="flex w-full justify-between">
-    <div class="flex gap-4 overflow-hidden pb-3 pl-6 pt-6">
-      <gui-avatar classname="aspect-square size-[3.75rem]">
-        <gui-avatar-image
-          classname="aspect-square size-[3.75rem] rounded-md border-[1px] bg-secondary object-cover"
-          src="https://example.com/favicon.png"
-          alt="Example Favicon"
-        >
-        </gui-avatar-image>
-        <gui-avatar-fallback classname="flex aspect-square size-[3.75rem] h-full w-full items-center justify-center rounded-md border-[1px]">
-          <div class="h-full w-full rounded-md bg-gradient-to-t from-neutral-200 to-neutral-400 dark:from-neutral-500 dark:to-neutral-800">
-          </div>
-        </gui-avatar-fallback>
-      </gui-avatar>
-      <gui-scroll-area classname="w-full overflow-x-scroll">
-        <div class="flex h-full w-full flex-col justify-between">
-          <div class="flex w-full flex-col gap-0.5">
-            <div class="flex items-center gap-2">
-              <h1 class="w-fit max-w-full cursor-default align-baseline text-lg font-medium">
-                item
-                <span class="ml-2 font-courier text-sm text-muted-foreground">
-                  1.0.0
-                </span>
-              </h1>
-              <gui-tooltip-provider>
-                <gui-tooltip delayduration="150">
-                  <gui-tooltip-trigger classname="flex items-center justify-center">
-                    <div class="cursor-default rounded-sm border-[1px] border-green-600 bg-green-400/30 p-0.5 transition-colors duration-150 hover:bg-green-400/40 dark:border-green-500 dark:bg-green-500/30 dark:hover:bg-green-500/40">
-                      <gui-arrow-big-up-dash-icon
-                        classname="text-green-600 dark:text-green-500"
-                        size="16"
-                      >
-                      </gui-arrow-big-up-dash-icon>
-                    </div>
-                  </gui-tooltip-trigger>
-                  <gui-tooltip-content>
-                    Newer versions available
-                  </gui-tooltip-content>
-                </gui-tooltip>
-              </gui-tooltip-provider>
+  <div class="flex w-full flex-col">
+    <div class="flex w-full justify-between">
+      <div class="flex gap-4 overflow-hidden pb-3 pl-6 pt-4">
+        <gui-avatar classname="aspect-square size-[3.875rem]">
+          <gui-avatar-image
+            classname="aspect-square size-[3.875rem] rounded-md border-[1px] bg-secondary object-cover"
+            src="https://example.com/favicon.png"
+            alt="Example Favicon"
+          >
+          </gui-avatar-image>
+          <gui-avatar-fallback classname="flex aspect-square size-[3.875rem] h-full w-full items-center justify-center rounded-md border-[1px]">
+            <div class="h-full w-full rounded-md bg-gradient-to-t from-neutral-200 to-neutral-400 dark:from-neutral-500 dark:to-neutral-800">
             </div>
-            <gui-data-badge
-              variant="mono"
-              content="item@1.0.0"
-              tooltip="[object Object]"
-            >
-            </gui-data-badge>
+          </gui-avatar-fallback>
+        </gui-avatar>
+        <gui-scroll-area classname="w-full overflow-x-scroll">
+          <div class="flex h-full w-full flex-col justify-between">
+            <div class="flex w-full flex-col gap-0.5">
+              <div class="flex items-center gap-2">
+                <h1 class="w-fit max-w-full cursor-default align-baseline text-lg font-medium">
+                  item
+                  <span class="ml-2 font-courier text-sm text-muted-foreground">
+                    1.0.0
+                  </span>
+                </h1>
+                <gui-tooltip-provider>
+                  <gui-tooltip delayduration="150">
+                    <gui-tooltip-trigger classname="flex items-center justify-center">
+                      <div class="cursor-default rounded-sm border-[1px] border-green-600 bg-green-400/30 p-0.5 transition-colors duration-150 hover:bg-green-400/40 dark:border-green-500 dark:bg-green-500/30 dark:hover:bg-green-500/40">
+                        <gui-arrow-big-up-dash-icon
+                          classname="text-green-600 dark:text-green-500"
+                          size="16"
+                        >
+                        </gui-arrow-big-up-dash-icon>
+                      </div>
+                    </gui-tooltip-trigger>
+                    <gui-tooltip-content>
+                      Newer versions available
+                    </gui-tooltip-content>
+                  </gui-tooltip>
+                </gui-tooltip-provider>
+              </div>
+              <gui-data-badge
+                variant="mono"
+                content="item@1.0.0"
+                tooltip="[object Object]"
+              >
+              </gui-data-badge>
+            </div>
           </div>
-        </div>
-        <gui-scroll-bar orientation="horizontal">
-        </gui-scroll-bar>
-      </gui-scroll-area>
+          <gui-scroll-bar orientation="horizontal">
+          </gui-scroll-bar>
+        </gui-scroll-area>
+      </div>
     </div>
   </div>
   <div class="flex w-full items-center justify-between px-6 py-2 empty:hidden">

--- a/src/gui/test/components/explorer-grid/selected-item/item-header.tsx
+++ b/src/gui/test/components/explorer-grid/selected-item/item-header.tsx
@@ -3,7 +3,6 @@ import { cleanup, render } from '@testing-library/react'
 import html from 'diffable-html'
 import { useGraphStore as useStore } from '@/state/index.ts'
 import { ItemHeader } from '@/components/explorer-grid/selected-item/item-header.tsx'
-import type { SelectedItemStore } from '@/components/explorer-grid/selected-item/context.tsx'
 import { useSelectedItemStore } from '@/components/explorer-grid/selected-item/context.tsx'
 import {
   specOptions,
@@ -13,6 +12,7 @@ import {
   SELECTED_ITEM_DEFAULT_GIT_HOST,
   SELECTED_ITEM_DETAILS,
 } from './__fixtures__/item.ts'
+import type { SelectedItemStore } from '@/components/explorer-grid/selected-item/context.tsx'
 import type { SocketSecurityDetails } from '@/lib/constants/socket.ts'
 import type { PackageScore } from '@vltpkg/security-archive'
 
@@ -88,6 +88,10 @@ vi.mock('@/components/ui/data-badge.tsx', () => ({
 
 vi.mock('@/components/ui/progress-circle.tsx', () => ({
   ProgressCircle: 'gui-progress-circle',
+}))
+
+vi.mock('@/components/navigation/crumb-nav.tsx', () => ({
+  CrumbNav: 'gui-crumb-nav',
 }))
 
 expect.addSnapshotSerializer({

--- a/src/gui/test/components/navigation/__snapshots__/crumb-nav.tsx.snap
+++ b/src/gui/test/components/navigation/__snapshots__/crumb-nav.tsx.snap
@@ -1,0 +1,529 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`CrumbNav component > does not truncate when 5 or fewer breadcrumbs 1`] = `
+
+<nav class="flex flex-row items-center gap-1">
+  <button class="inline-flex">
+    <gui-query-token
+      classname="px-1.5 duration-250 opacity-75 transition-opacity hover:opacity-100"
+      variant="pseudo"
+    >
+      :root
+    </gui-query-token>
+  </button>
+  <gui-chevron-right-icon
+    size="14"
+    strokewidth="2"
+    classname="text-muted-foreground opacity-75"
+  >
+  </gui-chevron-right-icon>
+  <button class="inline-flex">
+    <gui-query-token
+      classname="px-1.5 duration-250 opacity-75 transition-opacity hover:opacity-100"
+      variant="id"
+    >
+      #a
+    </gui-query-token>
+  </button>
+  <gui-chevron-right-icon
+    size="14"
+    strokewidth="2"
+    classname="text-muted-foreground opacity-75"
+  >
+  </gui-chevron-right-icon>
+  <button class="inline-flex">
+    <gui-query-token
+      classname="px-1.5 duration-250 opacity-75 transition-opacity hover:opacity-100"
+      variant="id"
+    >
+      #b
+    </gui-query-token>
+  </button>
+  <gui-chevron-right-icon
+    size="14"
+    strokewidth="2"
+    classname="text-muted-foreground opacity-75"
+  >
+  </gui-chevron-right-icon>
+  <button class="inline-flex">
+    <gui-query-token
+      classname="px-1.5 duration-250 opacity-75 transition-opacity hover:opacity-100"
+      variant="id"
+    >
+      #c
+    </gui-query-token>
+  </button>
+  <gui-chevron-right-icon
+    size="14"
+    strokewidth="2"
+    classname="text-muted-foreground opacity-75"
+  >
+  </gui-chevron-right-icon>
+  <button class="inline-flex">
+    <gui-query-token
+      classname="px-1.5"
+      variant="id"
+    >
+      #d
+    </gui-query-token>
+  </button>
+</nav>
+
+`;
+
+exports[`CrumbNav component > expands breadcrumbs when ellipsis button is clicked 1`] = `
+
+<nav class="flex flex-row items-center gap-1">
+  <button class="inline-flex">
+    <gui-query-token
+      classname="px-1.5 duration-250 opacity-75 transition-opacity hover:opacity-100"
+      variant="pseudo"
+    >
+      :root
+    </gui-query-token>
+  </button>
+  <gui-chevron-right-icon
+    size="14"
+    strokewidth="2"
+    classname="text-muted-foreground opacity-75"
+  >
+  </gui-chevron-right-icon>
+  <button class="inline-flex">
+    <gui-query-token
+      classname="px-1.5 duration-250 opacity-75 transition-opacity hover:opacity-100"
+      variant="id"
+    >
+      #a
+    </gui-query-token>
+  </button>
+  <gui-chevron-right-icon
+    size="14"
+    strokewidth="2"
+    classname="text-muted-foreground opacity-75"
+  >
+  </gui-chevron-right-icon>
+  <button class="inline-flex">
+    <gui-query-token
+      classname="px-1.5 duration-250 opacity-75 transition-opacity hover:opacity-100"
+      variant="id"
+    >
+      #b
+    </gui-query-token>
+  </button>
+  <gui-chevron-right-icon
+    size="14"
+    strokewidth="2"
+    classname="text-muted-foreground opacity-75"
+  >
+  </gui-chevron-right-icon>
+  <button class="inline-flex">
+    <gui-query-token
+      classname="px-1.5 duration-250 opacity-75 transition-opacity hover:opacity-100"
+      variant="id"
+    >
+      #c
+    </gui-query-token>
+  </button>
+  <gui-chevron-right-icon
+    size="14"
+    strokewidth="2"
+    classname="text-muted-foreground opacity-75"
+  >
+  </gui-chevron-right-icon>
+  <button class="inline-flex">
+    <gui-query-token
+      classname="px-1.5 duration-250 opacity-75 transition-opacity hover:opacity-100"
+      variant="id"
+    >
+      #d
+    </gui-query-token>
+  </button>
+  <gui-chevron-right-icon
+    size="14"
+    strokewidth="2"
+    classname="text-muted-foreground opacity-75"
+  >
+  </gui-chevron-right-icon>
+  <button class="inline-flex">
+    <gui-query-token
+      classname="px-1.5 duration-250 opacity-75 transition-opacity hover:opacity-100"
+      variant="id"
+    >
+      #e
+    </gui-query-token>
+  </button>
+  <gui-chevron-right-icon
+    size="14"
+    strokewidth="2"
+    classname="text-muted-foreground opacity-75"
+  >
+  </gui-chevron-right-icon>
+  <button class="inline-flex">
+    <gui-query-token
+      classname="px-1.5 duration-250 opacity-75 transition-opacity hover:opacity-100"
+      variant="id"
+    >
+      #f
+    </gui-query-token>
+  </button>
+  <gui-chevron-right-icon
+    size="14"
+    strokewidth="2"
+    classname="text-muted-foreground opacity-75"
+  >
+  </gui-chevron-right-icon>
+  <button class="inline-flex">
+    <gui-query-token
+      classname="px-1.5 duration-250 opacity-75 transition-opacity hover:opacity-100"
+      variant="id"
+    >
+      #g
+    </gui-query-token>
+  </button>
+  <gui-chevron-right-icon
+    size="14"
+    strokewidth="2"
+    classname="text-muted-foreground opacity-75"
+  >
+  </gui-chevron-right-icon>
+  <button class="inline-flex">
+    <gui-query-token
+      classname="px-1.5 duration-250 opacity-75 transition-opacity hover:opacity-100"
+      variant="id"
+    >
+      #h
+    </gui-query-token>
+  </button>
+  <gui-chevron-right-icon
+    size="14"
+    strokewidth="2"
+    classname="text-muted-foreground opacity-75"
+  >
+  </gui-chevron-right-icon>
+  <button class="inline-flex">
+    <gui-query-token
+      classname="px-1.5"
+      variant="id"
+    >
+      #i
+    </gui-query-token>
+  </button>
+</nav>
+
+`;
+
+exports[`CrumbNav component > renders breadcrumb with semver selector 1`] = `
+
+<nav class="flex flex-row items-center gap-1">
+  <button class="inline-flex">
+    <gui-query-token
+      classname="px-1.5"
+      variant="id"
+    >
+      #express
+    </gui-query-token>
+  </button>
+</nav>
+
+`;
+
+exports[`CrumbNav component > renders complex breadcrumb path 1`] = `
+
+<nav class="flex flex-row items-center gap-1">
+  <button class="inline-flex">
+    <gui-query-token
+      classname="px-1.5 duration-250 opacity-75 transition-opacity hover:opacity-100"
+      variant="pseudo"
+    >
+      :project
+    </gui-query-token>
+  </button>
+  <gui-chevron-right-icon
+    size="14"
+    strokewidth="2"
+    classname="text-muted-foreground opacity-75"
+  >
+  </gui-chevron-right-icon>
+  <button class="inline-flex">
+    <gui-query-token
+      classname="px-1.5 duration-250 opacity-75 transition-opacity hover:opacity-100"
+      variant="id"
+    >
+      #express
+    </gui-query-token>
+  </button>
+  <gui-chevron-right-icon
+    size="14"
+    strokewidth="2"
+    classname="text-muted-foreground opacity-75"
+  >
+  </gui-chevron-right-icon>
+  <button class="inline-flex">
+    <gui-query-token
+      classname="px-1.5 duration-250 opacity-75 transition-opacity hover:opacity-100"
+      variant="id"
+    >
+      #lodash
+    </gui-query-token>
+  </button>
+  <gui-chevron-right-icon
+    size="14"
+    strokewidth="2"
+    classname="text-muted-foreground opacity-75"
+  >
+  </gui-chevron-right-icon>
+  <button class="inline-flex">
+    <gui-query-token
+      classname="px-1.5"
+      variant="id"
+    >
+      #underscore
+    </gui-query-token>
+  </button>
+</nav>
+
+`;
+
+exports[`CrumbNav component > renders multiple breadcrumb items with separators 1`] = `
+
+<nav class="flex flex-row items-center gap-1">
+  <button class="inline-flex">
+    <gui-query-token
+      classname="px-1.5 duration-250 opacity-75 transition-opacity hover:opacity-100"
+      variant="pseudo"
+    >
+      :root
+    </gui-query-token>
+  </button>
+  <gui-chevron-right-icon
+    size="14"
+    strokewidth="2"
+    classname="text-muted-foreground opacity-75"
+  >
+  </gui-chevron-right-icon>
+  <button class="inline-flex">
+    <gui-query-token
+      classname="px-1.5 duration-250 opacity-75 transition-opacity hover:opacity-100"
+      variant="id"
+    >
+      #express
+    </gui-query-token>
+  </button>
+  <gui-chevron-right-icon
+    size="14"
+    strokewidth="2"
+    classname="text-muted-foreground opacity-75"
+  >
+  </gui-chevron-right-icon>
+  <button class="inline-flex">
+    <gui-query-token
+      classname="px-1.5"
+      variant="id"
+    >
+      #lodash
+    </gui-query-token>
+  </button>
+</nav>
+
+`;
+
+exports[`CrumbNav component > renders single breadcrumb item 1`] = `
+
+<nav class="flex flex-row items-center gap-1">
+  <button class="inline-flex">
+    <gui-query-token
+      classname="px-1.5"
+      variant="id"
+    >
+      #express
+    </gui-query-token>
+  </button>
+</nav>
+
+`;
+
+exports[`CrumbNav component > renders truncated breadcrumbs when more than 5 items 1`] = `
+
+<nav class="flex flex-row items-center gap-1">
+  <button class="inline-flex">
+    <gui-query-token
+      classname="px-1.5 duration-250 opacity-75 transition-opacity hover:opacity-100"
+      variant="pseudo"
+    >
+      :root
+    </gui-query-token>
+  </button>
+  <gui-chevron-right-icon
+    size="14"
+    strokewidth="2"
+    classname="text-muted-foreground opacity-75"
+  >
+  </gui-chevron-right-icon>
+  <button
+    class="inline-flex items-center justify-center rounded px-1 py-0.5 text-muted-foreground opacity-75 transition-opacity hover:opacity-100 hover:bg-muted/50"
+    aria-label="Show hidden breadcrumbs"
+  >
+    <gui-ellipsis-icon size="14">
+    </gui-ellipsis-icon>
+  </button>
+  <button class="inline-flex">
+    <gui-query-token
+      classname="px-1.5 duration-250 opacity-75 transition-opacity hover:opacity-100"
+      variant="id"
+    >
+      #g
+    </gui-query-token>
+  </button>
+  <gui-chevron-right-icon
+    size="14"
+    strokewidth="2"
+    classname="text-muted-foreground opacity-75"
+  >
+  </gui-chevron-right-icon>
+  <button class="inline-flex">
+    <gui-query-token
+      classname="px-1.5 duration-250 opacity-75 transition-opacity hover:opacity-100"
+      variant="id"
+    >
+      #h
+    </gui-query-token>
+  </button>
+  <gui-chevron-right-icon
+    size="14"
+    strokewidth="2"
+    classname="text-muted-foreground opacity-75"
+  >
+  </gui-chevron-right-icon>
+  <button class="inline-flex">
+    <gui-query-token
+      classname="px-1.5"
+      variant="id"
+    >
+      #i
+    </gui-query-token>
+  </button>
+</nav>
+
+`;
+
+exports[`CrumbNav component > renders with custom className 1`] = `
+
+<nav class="flex flex-row items-center gap-1 custom-nav-class">
+  <button class="inline-flex">
+    <gui-query-token
+      classname="px-1.5 duration-250 opacity-75 transition-opacity hover:opacity-100"
+      variant="id"
+    >
+      #express
+    </gui-query-token>
+  </button>
+  <gui-chevron-right-icon
+    size="14"
+    strokewidth="2"
+    classname="text-muted-foreground opacity-75"
+  >
+  </gui-chevron-right-icon>
+  <button class="inline-flex">
+    <gui-query-token
+      classname="px-1.5"
+      variant="id"
+    >
+      #lodash
+    </gui-query-token>
+  </button>
+</nav>
+
+`;
+
+exports[`CrumbNav component > renders workspace breadcrumb 1`] = `
+
+<nav class="flex flex-row items-center gap-1">
+  <button class="inline-flex">
+    <gui-query-token
+      classname="px-1.5 duration-250 opacity-75 transition-opacity hover:opacity-100"
+      variant="pseudo"
+    >
+      :workspace
+    </gui-query-token>
+  </button>
+  <gui-chevron-right-icon
+    size="14"
+    strokewidth="2"
+    classname="text-muted-foreground opacity-75"
+  >
+  </gui-chevron-right-icon>
+  <button class="inline-flex">
+    <gui-query-token
+      classname="px-1.5"
+      variant="id"
+    >
+      #utils
+    </gui-query-token>
+  </button>
+</nav>
+
+`;
+
+exports[`CrumbNav component > shows ellipsis button in truncated view 1`] = `
+
+<nav class="flex flex-row items-center gap-1">
+  <button class="inline-flex">
+    <gui-query-token
+      classname="px-1.5 duration-250 opacity-75 transition-opacity hover:opacity-100"
+      variant="pseudo"
+    >
+      :root
+    </gui-query-token>
+  </button>
+  <gui-chevron-right-icon
+    size="14"
+    strokewidth="2"
+    classname="text-muted-foreground opacity-75"
+  >
+  </gui-chevron-right-icon>
+  <button
+    class="inline-flex items-center justify-center rounded px-1 py-0.5 text-muted-foreground opacity-75 transition-opacity hover:opacity-100 hover:bg-muted/50"
+    aria-label="Show hidden breadcrumbs"
+  >
+    <gui-ellipsis-icon size="14">
+    </gui-ellipsis-icon>
+  </button>
+  <button class="inline-flex">
+    <gui-query-token
+      classname="px-1.5 duration-250 opacity-75 transition-opacity hover:opacity-100"
+      variant="id"
+    >
+      #g
+    </gui-query-token>
+  </button>
+  <gui-chevron-right-icon
+    size="14"
+    strokewidth="2"
+    classname="text-muted-foreground opacity-75"
+  >
+  </gui-chevron-right-icon>
+  <button class="inline-flex">
+    <gui-query-token
+      classname="px-1.5 duration-250 opacity-75 transition-opacity hover:opacity-100"
+      variant="id"
+    >
+      #h
+    </gui-query-token>
+  </button>
+  <gui-chevron-right-icon
+    size="14"
+    strokewidth="2"
+    classname="text-muted-foreground opacity-75"
+  >
+  </gui-chevron-right-icon>
+  <button class="inline-flex">
+    <gui-query-token
+      classname="px-1.5"
+      variant="id"
+    >
+      #i
+    </gui-query-token>
+  </button>
+</nav>
+
+`;

--- a/src/gui/test/components/navigation/crumb-nav.tsx
+++ b/src/gui/test/components/navigation/crumb-nav.tsx
@@ -1,0 +1,253 @@
+import { vi, test, expect, afterEach, describe } from 'vitest'
+import { render, cleanup, fireEvent } from '@testing-library/react'
+import html from 'diffable-html'
+import { useGraphStore as useStore } from '@/state/index.ts'
+import {
+  getBreadcrumbs,
+  CrumbNav,
+} from '@/components/navigation/crumb-nav.tsx'
+
+vi.mock('@/components/query-bar/query-token.tsx', () => ({
+  QueryToken: 'gui-query-token',
+}))
+
+vi.mock('lucide-react', () => ({
+  ChevronRight: 'gui-chevron-right-icon',
+  Ellipsis: 'gui-ellipsis-icon',
+}))
+
+expect.addSnapshotSerializer({
+  serialize: v => html(v),
+  test: () => true,
+})
+
+afterEach(() => {
+  const CleanUp = () => (useStore(state => state.reset)(), '')
+  render(<CleanUp />)
+  cleanup()
+})
+
+describe('CrumbNav component', () => {
+  test('does not render without breadcrumbs', () => {
+    const Container = () => {
+      return <CrumbNav breadcrumbs={undefined} />
+    }
+
+    const { container } = render(<Container />)
+    expect(container.innerHTML).toBe('')
+  })
+
+  test('renders single breadcrumb item', () => {
+    const breadcrumbs = getBreadcrumbs('#express')
+
+    const Container = () => {
+      return <CrumbNav breadcrumbs={breadcrumbs} />
+    }
+
+    const { container } = render(<Container />)
+    expect(container.innerHTML).toMatchSnapshot()
+  })
+
+  test('renders multiple breadcrumb items with separators', () => {
+    const breadcrumbs = getBreadcrumbs(':root > #express > #lodash')
+
+    const Container = () => {
+      return <CrumbNav breadcrumbs={breadcrumbs} />
+    }
+
+    const { container } = render(<Container />)
+    expect(container.innerHTML).toMatchSnapshot()
+  })
+
+  test('renders breadcrumb with semver selector', () => {
+    const breadcrumbs = getBreadcrumbs('#express:semver(^4.0.0)')
+
+    const Container = () => {
+      return <CrumbNav breadcrumbs={breadcrumbs} />
+    }
+
+    const { container } = render(<Container />)
+    expect(container.innerHTML).toMatchSnapshot()
+  })
+
+  test('renders complex breadcrumb path', () => {
+    const breadcrumbs = getBreadcrumbs(
+      ':project > #express:v(4) > #lodash > #underscore',
+    )
+
+    const Container = () => {
+      return <CrumbNav breadcrumbs={breadcrumbs} />
+    }
+
+    const { container } = render(<Container />)
+    expect(container.innerHTML).toMatchSnapshot()
+  })
+
+  test('renders workspace breadcrumb', () => {
+    const breadcrumbs = getBreadcrumbs(':workspace > #utils')
+
+    const Container = () => {
+      return <CrumbNav breadcrumbs={breadcrumbs} />
+    }
+
+    const { container } = render(<Container />)
+    expect(container.innerHTML).toMatchSnapshot()
+  })
+
+  test('renders with custom className', () => {
+    const breadcrumbs = getBreadcrumbs('#express > #lodash')
+
+    const Container = () => {
+      return (
+        <CrumbNav
+          breadcrumbs={breadcrumbs}
+          className="custom-nav-class"
+        />
+      )
+    }
+
+    const { container } = render(<Container />)
+    expect(container.innerHTML).toMatchSnapshot()
+  })
+
+  test('renders truncated breadcrumbs when more than 5 items', () => {
+    // Create a long breadcrumb path with 10 items
+    const longQuery =
+      ':root > #a > #b > #c > #d > #e > #f > #g > #h > #i'
+    const breadcrumbs = getBreadcrumbs(longQuery)
+
+    const Container = () => {
+      return <CrumbNav breadcrumbs={breadcrumbs} />
+    }
+
+    const { container } = render(<Container />)
+    expect(container.innerHTML).toMatchSnapshot()
+  })
+
+  test('shows ellipsis button in truncated view', () => {
+    const longQuery =
+      ':root > #a > #b > #c > #d > #e > #f > #g > #h > #i'
+    const breadcrumbs = getBreadcrumbs(longQuery)
+
+    const Container = () => {
+      return <CrumbNav breadcrumbs={breadcrumbs} />
+    }
+
+    const { container, getByLabelText } = render(<Container />)
+
+    // Should show ellipsis button
+    const ellipsisButton = getByLabelText('Show hidden breadcrumbs')
+    expect(ellipsisButton).toBeDefined()
+    expect(container.innerHTML).toMatchSnapshot()
+  })
+
+  test('expands breadcrumbs when ellipsis button is clicked', () => {
+    const longQuery =
+      ':root > #a > #b > #c > #d > #e > #f > #g > #h > #i'
+    const breadcrumbs = getBreadcrumbs(longQuery)
+
+    const Container = () => {
+      return <CrumbNav breadcrumbs={breadcrumbs} />
+    }
+
+    const { container, getByLabelText } = render(<Container />)
+
+    // Click ellipsis button to expand
+    const ellipsisButton = getByLabelText('Show hidden breadcrumbs')
+    fireEvent.click(ellipsisButton)
+
+    expect(container.innerHTML).toMatchSnapshot()
+  })
+
+  test('does not truncate when 5 or fewer breadcrumbs', () => {
+    // Create exactly 5 breadcrumbs
+    const mediumQuery = ':root > #a > #b > #c > #d'
+    const breadcrumbs = getBreadcrumbs(mediumQuery)
+
+    const Container = () => {
+      return <CrumbNav breadcrumbs={breadcrumbs} />
+    }
+
+    const { container, queryByLabelText } = render(<Container />)
+
+    // Should not show ellipsis button
+    const ellipsisButton = queryByLabelText('Show hidden breadcrumbs')
+    expect(ellipsisButton).toBeNull()
+    expect(container.innerHTML).toMatchSnapshot()
+  })
+
+  test('handles undefined breadcrumbs gracefully', () => {
+    const Container = () => {
+      return <CrumbNav breadcrumbs={undefined} />
+    }
+
+    const { container } = render(<Container />)
+    expect(container.innerHTML).toBe('')
+  })
+})
+
+describe('getBreadcrumbs function', () => {
+  test('returns undefined for root query', () => {
+    const breadcrumbs = getBreadcrumbs(':root')
+    expect(breadcrumbs).toBeUndefined()
+  })
+
+  test('returns breadcrumb for simple id selector', () => {
+    const breadcrumbs = getBreadcrumbs('#express')
+    expect(breadcrumbs).toBeDefined()
+    expect(breadcrumbs?.single).toBe(true)
+    expect(breadcrumbs?.first.value).toBe('#express')
+    expect(breadcrumbs?.first.type).toBe('id')
+  })
+
+  test('returns breadcrumb for complex query', () => {
+    const breadcrumbs = getBreadcrumbs(':root > #express > #lodash')
+    expect(breadcrumbs).toBeDefined()
+    expect(breadcrumbs?.single).toBe(false)
+    expect(breadcrumbs?.first.value).toBe(':root')
+    expect(breadcrumbs?.last.value).toBe('#lodash')
+  })
+
+  test('returns breadcrumb for semver query', () => {
+    const breadcrumbs = getBreadcrumbs('#express:semver(^4.0.0)')
+    expect(breadcrumbs).toBeDefined()
+    expect(breadcrumbs?.single).toBe(true)
+    expect(breadcrumbs?.first.value).toBe('#express:semver(^4.0.0)')
+    expect(breadcrumbs?.first.type).toBe('id')
+  })
+
+  test('returns undefined for invalid query', () => {
+    const breadcrumbs = getBreadcrumbs('[invalid-selector]')
+    expect(breadcrumbs).toBeUndefined()
+  })
+
+  test('returns breadcrumb for workspace selector', () => {
+    const breadcrumbs = getBreadcrumbs(':workspace')
+    expect(breadcrumbs).toBeDefined()
+    expect(breadcrumbs?.single).toBe(true)
+    expect(breadcrumbs?.first.value).toBe(':workspace')
+    expect(breadcrumbs?.first.type).toBe('pseudo')
+    expect(breadcrumbs?.first.importer).toBe(true)
+  })
+
+  test('returns breadcrumb for project selector', () => {
+    const breadcrumbs = getBreadcrumbs(':project')
+    expect(breadcrumbs).toBeDefined()
+    expect(breadcrumbs?.single).toBe(true)
+    expect(breadcrumbs?.first.value).toBe(':project')
+    expect(breadcrumbs?.first.type).toBe('pseudo')
+    expect(breadcrumbs?.first.importer).toBe(true)
+  })
+
+  test('returns breadcrumb for long query', () => {
+    const longQuery =
+      ':root > #a > #b > #c > #d > #e > #f > #g > #h > #i'
+    const breadcrumbs = getBreadcrumbs(longQuery)
+    expect(breadcrumbs).toBeDefined()
+    expect(breadcrumbs?.single).toBe(false)
+
+    // Count breadcrumbs
+    const count = breadcrumbs ? [...breadcrumbs].length : 0
+    expect(count).toBe(10)
+  })
+})


### PR DESCRIPTION
<img width="704" alt="Screenshot 2025-07-02 at 13 39 45" src="https://github.com/user-attachments/assets/5ae4de72-8c6d-478a-aed5-23b1e26a85f0" />

### Overview
This PR introduces a new way of navigating the selected item's ancestry by adding a `crumb-nav` component. The `crumb-nav` is placed into the selected item's `item-header` and utilizes `@vltpkg/dss-breadcrumb` to parse the breadcrumbs from the current query in the `state` to render the trail.
This allows quick navigation to the parent items, making a nice quality of life improvement

### Changelog
- **feat: creates `crumb-nav` to navigate selected item ancestry**
- **feat: integrates `crumb-nav` into the `item-header`**
