### PR TITLE
cli-sdk: `vlt ls` positional should be names only

### DIFF
--- a/src/cli-sdk/src/commands/list.ts
+++ b/src/cli-sdk/src/commands/list.ts
@@ -16,6 +16,7 @@ import LZString from 'lz-string'
 import { Query } from '@vltpkg/query'
 import { SecurityArchive } from '@vltpkg/security-archive'
 import type { DepID } from '@vltpkg/dep-id'
+import { error } from '@vltpkg/error-cause'
 import { commandUsage } from '../config/usage.ts'
 import type { CommandFn, CommandUsage } from '../index.ts'
 import { startGUI } from '../start-gui.ts'
@@ -26,15 +27,12 @@ export const usage: CommandUsage = () =>
     command: 'ls',
     usage: [
       '',
-      '[query | specs] [--view=human | json | mermaid | gui]',
+      '[package-names...] [--view=human | json | mermaid | gui]',
     ],
-    description: `List installed dependencies matching given package names or resulting
-      packages from matching a given Dependency Selector Syntax query if one
-      is provided.
+    description: `List installed dependencies matching given package names.
 
-      The vlt Dependency Selector Syntax is a CSS-like query language that
-      allows you to filter installed dependencies using a variety of metadata
-      in the form of CSS-like attributes, pseudo selectors & combinators.
+      Package names provided as positional arguments will be used to filter
+      the results to show only dependencies with those names.
 
       Defaults to listing direct dependencies of a project and any configured
       workspace.`,
@@ -43,19 +41,8 @@ export const usage: CommandUsage = () =>
         description:
           'List direct dependencies of the current project / workspace',
       },
-      '"*"': {
-        description:
-          'List all dependencies for the current project / workspace',
-      },
       'foo bar baz': {
         description: `List all dependencies named 'foo', 'bar', or 'baz'`,
-      },
-      [`'[name="@scoped/package"] > *'`]: {
-        description:
-          'Lists direct dependencies of a specific package',
-      },
-      [`'*:workspace > *:peer'`]: {
-        description: 'List all peer dependencies of all workspaces',
       },
     },
     options: {
@@ -97,9 +84,23 @@ export const command: CommandFn<ListResult> = async conf => {
     loadManifests: true,
   })
 
+  // Validate positional arguments - only allow package names, not direct queries
+  for (const arg of conf.positionals) {
+    if (!/^[@\w-]/.test(arg)) {
+      throw error(
+        `Direct queries are not supported as positional arguments. Use package names only.`,
+        {
+          code: 'EUSAGE',
+          cause: `Argument '${arg}' appears to be a query syntax. Only package names are allowed as positional arguments.`,
+        },
+      )
+    }
+  }
+
   const queryString = conf.positionals
-    .map(k => (/^[@\w-]/.test(k) ? `#${k.replace(/\//, '\\/')}` : k))
+    .map(k => `#${k.replace(/\//, '\\/')}`)
     .join(', ')
+  /* c8 ignore start - TODO: may be removed when --target is added */
   const securityArchive =
     Query.hasSecuritySelectors(queryString) ?
       await SecurityArchive.start({
@@ -107,6 +108,7 @@ export const command: CommandFn<ListResult> = async conf => {
         specOptions: conf.options,
       })
     : undefined
+  /* c8 ignore stop */
   const query = new Query({
     graph,
     specOptions: conf.options,

--- a/src/cli-sdk/tap-snapshots/test/commands/list.ts.test.cjs
+++ b/src/cli-sdk/tap-snapshots/test/commands/list.ts.test.cjs
@@ -6,12 +6,9 @@
  */
 'use strict'
 exports[`test/commands/list.ts > TAP > list > colors > should use colors when set in human readable format 1`] = `
-[0m[33mmy-project[39m
-├── [33m@foo/bazz@1.0.0[39m
-├─┬ [33mbar@1.0.0[39m
-│ └─┬ [33mbaz (custom:baz@1.0.0)[39m
-│   └── [33m@foo/bazz@1.0.0[39m
-└── [33mmissing@^1.0.0[39m [31m(missing)[39m
+[0mmy-project
+├── @foo/bazz@1.0.0
+└── bar@1.0.0
 [0m
 `
 
@@ -20,9 +17,24 @@ a
 
 `
 
+exports[`test/commands/list.ts > TAP > list > package names as positionals > should accept package name starting with numbers 1`] = `
+
+`
+
+exports[`test/commands/list.ts > TAP > list > package names as positionals > should accept package name with dashes 1`] = `
+
+`
+
+exports[`test/commands/list.ts > TAP > list > package names as positionals > should accept scoped package name 1`] = `
+
+`
+
+exports[`test/commands/list.ts > TAP > list > package names as positionals > should accept simple package name 1`] = `
+
+`
+
 exports[`test/commands/list.ts > TAP > list > scope with a transitive dependency > should handle scope with a transitive dependency 1`] = `
 foo
-└── bar@1.0.0
 
 `
 
@@ -34,14 +46,12 @@ workspace-a
 exports[`test/commands/list.ts > TAP > list > should have usage 1`] = `
 Usage:
   vlt ls
-  vlt ls [query | specs] [--view=human | json | mermaid | gui]
+  vlt ls [package-names...] [--view=human | json | mermaid | gui]
 
-List installed dependencies matching given package names or resulting packages
-from matching a given Dependency Selector Syntax query if one is provided.
+List installed dependencies matching given package names.
 
-The vlt Dependency Selector Syntax is a CSS-like query language that allows you
-to filter installed dependencies using a variety of metadata in the form of
-CSS-like attributes, pseudo selectors & combinators.
+Package names provided as positional arguments will be used to filter the
+results to show only dependencies with those names.
 
 Defaults to listing direct dependencies of a project and any configured
 workspace.
@@ -52,21 +62,9 @@ workspace.
 
     ​vlt ls
 
-    List all dependencies for the current project / workspace
-
-    ​vlt ls "*"
-
     List all dependencies named 'foo', 'bar', or 'baz'
 
     ​vlt ls foo bar baz
-
-    Lists direct dependencies of a specific package
-
-    ​vlt ls '[name="@scoped/package"] > *'
-
-    List all peer dependencies of all workspaces
-
-    ​vlt ls '*:workspace > *:peer'
 
   Options
 
@@ -86,176 +84,6 @@ my-project
 
 `
 
-exports[`test/commands/list.ts > TAP > list > should list all pkgs in human readable format 1`] = `
-my-project
-├── @foo/bazz@1.0.0
-├─┬ bar@1.0.0
-│ └─┬ baz (custom:baz@1.0.0)
-│   └── @foo/bazz@1.0.0
-└── missing@^1.0.0 (missing)
-
-`
-
-exports[`test/commands/list.ts > TAP > list > should list all pkgs in json format 1`] = `
-[
-  {
-    "name": "my-project",
-    "to": {
-      "id": "file·.",
-      "name": "my-project",
-      "version": "1.0.0",
-      "location": ".",
-      "importer": true,
-      "manifest": {
-        "name": "my-project",
-        "version": "1.0.0",
-        "dependencies": {
-          "@foo/bazz": "^1.0.0",
-          "bar": "^1.0.0",
-          "missing": "^1.0.0"
-        }
-      },
-      "projectRoot": "{ROOT}",
-      "dev": false,
-      "optional": false,
-      "confused": false,
-      "insights": {
-        "scanned": false
-      }
-    },
-    "overridden": false
-  },
-  {
-    "name": "@foo/bazz",
-    "fromID": "file·.",
-    "spec": "@foo/bazz@^1.0.0",
-    "type": "prod",
-    "to": {
-      "id": "··@foo§bazz@1.0.0",
-      "name": "@foo/bazz",
-      "version": "1.0.0",
-      "location": "./node_modules/.vlt/··@foo§bazz@1.0.0/node_modules/@foo/bazz",
-      "importer": false,
-      "manifest": {
-        "name": "@foo/bazz",
-        "version": "1.0.0"
-      },
-      "projectRoot": "{ROOT}",
-      "dev": false,
-      "optional": false,
-      "confused": false,
-      "insights": {
-        "scanned": false
-      }
-    },
-    "overridden": false
-  },
-  {
-    "name": "bar",
-    "fromID": "file·.",
-    "spec": "bar@^1.0.0",
-    "type": "prod",
-    "to": {
-      "id": "··bar@1.0.0",
-      "name": "bar",
-      "version": "1.0.0",
-      "location": "./node_modules/.vlt/··bar@1.0.0/node_modules/bar",
-      "importer": false,
-      "manifest": {
-        "name": "bar",
-        "version": "1.0.0",
-        "dependencies": {
-          "baz": "^1.0.0"
-        }
-      },
-      "projectRoot": "{ROOT}",
-      "dev": false,
-      "optional": false,
-      "confused": false,
-      "insights": {
-        "scanned": false
-      }
-    },
-    "overridden": false
-  },
-  {
-    "name": "baz",
-    "fromID": "··bar@1.0.0",
-    "spec": "baz@custom:baz@^1.0.0",
-    "type": "prod",
-    "to": {
-      "id": "·custom·baz@1.0.0",
-      "name": "baz",
-      "version": "1.0.0",
-      "location": "./node_modules/.vlt/·custom·baz@1.0.0/node_modules/baz",
-      "importer": false,
-      "manifest": {
-        "name": "baz",
-        "version": "1.0.0",
-        "dist": {
-          "tarball": "https://registry.vlt.sh/baz"
-        }
-      },
-      "projectRoot": "{ROOT}",
-      "dev": false,
-      "optional": false,
-      "confused": false,
-      "insights": {
-        "scanned": false
-      }
-    },
-    "overridden": false
-  },
-  {
-    "name": "missing",
-    "fromID": "file·.",
-    "spec": "missing@^1.0.0",
-    "type": "prod",
-    "overridden": false
-  },
-  {
-    "name": "@foo/bazz",
-    "fromID": "·custom·baz@1.0.0",
-    "spec": "@foo/bazz@^1.0.0",
-    "type": "prod",
-    "to": {
-      "id": "··@foo§bazz@1.0.0",
-      "name": "@foo/bazz",
-      "version": "1.0.0",
-      "location": "./node_modules/.vlt/··@foo§bazz@1.0.0/node_modules/@foo/bazz",
-      "importer": false,
-      "manifest": {
-        "name": "@foo/bazz",
-        "version": "1.0.0"
-      },
-      "projectRoot": "{ROOT}",
-      "dev": false,
-      "optional": false,
-      "confused": false,
-      "insights": {
-        "scanned": false
-      }
-    },
-    "overridden": false
-  }
-]
-`
-
-exports[`test/commands/list.ts > TAP > list > should list all pkgs in mermaid format 1`] = `
-flowchart TD
-a("root:my-project")
-a("root:my-project") -->|"#64;foo/bazz#64;^1.0.0"| b("npm:#64;foo/bazz#64;1.0.0")
-b("npm:#64;foo/bazz#64;1.0.0")
-a("root:my-project") -->|"bar#64;^1.0.0"| c("npm:bar#64;1.0.0")
-c("npm:bar#64;1.0.0")
-c("npm:bar#64;1.0.0") -->|"baz#64;custom:baz#64;^1.0.0"| d("custom:baz#64;1.0.0")
-d("custom:baz#64;1.0.0")
-d("custom:baz#64;1.0.0") -->|"#64;foo/bazz#64;^1.0.0"| b("npm:#64;foo/bazz#64;1.0.0")
-
-a("root:my-project") -->|"missing#64;^1.0.0"| missing-0(Missing)
-
-`
-
 exports[`test/commands/list.ts > TAP > list > should list mermaid in json format 1`] = `
 flowchart TD
 a("root:my-project")
@@ -270,6 +98,13 @@ d("custom:baz#64;1.0.0") -->|"#64;foo/bazz#64;^1.0.0"| b("npm:#64;foo/bazz#64;1.
 `
 
 exports[`test/commands/list.ts > TAP > list > should list pkgs in human readable format 1`] = `
+my-project
+├── @foo/bazz@1.0.0
+└── bar@1.0.0
+
+`
+
+exports[`test/commands/list.ts > TAP > list > should list pkgs in human readable format 2`] = `
 my-project
 ├── @foo/bazz@1.0.0
 └── bar@1.0.0
@@ -359,6 +194,104 @@ exports[`test/commands/list.ts > TAP > list > should list pkgs in json format 1`
     "overridden": false
   }
 ]
+`
+
+exports[`test/commands/list.ts > TAP > list > should list pkgs in json format 2`] = `
+[
+  {
+    "name": "my-project",
+    "to": {
+      "id": "file·.",
+      "name": "my-project",
+      "version": "1.0.0",
+      "location": ".",
+      "importer": true,
+      "manifest": {
+        "name": "my-project",
+        "version": "1.0.0",
+        "dependencies": {
+          "@foo/bazz": "^1.0.0",
+          "bar": "^1.0.0",
+          "missing": "^1.0.0"
+        }
+      },
+      "projectRoot": "{ROOT}",
+      "dev": false,
+      "optional": false,
+      "confused": false,
+      "insights": {
+        "scanned": false
+      }
+    },
+    "overridden": false
+  },
+  {
+    "name": "@foo/bazz",
+    "fromID": "file·.",
+    "spec": "@foo/bazz@^1.0.0",
+    "type": "prod",
+    "to": {
+      "id": "··@foo§bazz@1.0.0",
+      "name": "@foo/bazz",
+      "version": "1.0.0",
+      "location": "./node_modules/.vlt/··@foo§bazz@1.0.0/node_modules/@foo/bazz",
+      "importer": false,
+      "manifest": {
+        "name": "@foo/bazz",
+        "version": "1.0.0"
+      },
+      "projectRoot": "{ROOT}",
+      "dev": false,
+      "optional": false,
+      "confused": false,
+      "insights": {
+        "scanned": false
+      }
+    },
+    "overridden": false
+  },
+  {
+    "name": "bar",
+    "fromID": "file·.",
+    "spec": "bar@^1.0.0",
+    "type": "prod",
+    "to": {
+      "id": "··bar@1.0.0",
+      "name": "bar",
+      "version": "1.0.0",
+      "location": "./node_modules/.vlt/··bar@1.0.0/node_modules/bar",
+      "importer": false,
+      "manifest": {
+        "name": "bar",
+        "version": "1.0.0",
+        "dependencies": {
+          "baz": "^1.0.0"
+        }
+      },
+      "projectRoot": "{ROOT}",
+      "dev": false,
+      "optional": false,
+      "confused": false,
+      "insights": {
+        "scanned": false
+      }
+    },
+    "overridden": false
+  }
+]
+`
+
+exports[`test/commands/list.ts > TAP > list > should list pkgs in mermaid format 1`] = `
+flowchart TD
+a("root:my-project")
+a("root:my-project") -->|"#64;foo/bazz#64;^1.0.0"| b("npm:#64;foo/bazz#64;1.0.0")
+b("npm:#64;foo/bazz#64;1.0.0")
+a("root:my-project") -->|"bar#64;^1.0.0"| c("npm:bar#64;1.0.0")
+c("npm:bar#64;1.0.0")
+c("npm:bar#64;1.0.0") -->|"baz#64;custom:baz#64;^1.0.0"| d("custom:baz#64;1.0.0")
+d("custom:baz#64;1.0.0")
+d("custom:baz#64;1.0.0") -->|"#64;foo/bazz#64;^1.0.0"| b("npm:#64;foo/bazz#64;1.0.0")
+
 `
 
 exports[`test/commands/list.ts > TAP > list > workspaces > should add all scope nodes as importers 1`] = `


### PR DESCRIPTION
`vlt ls` should no longer support query parameters as positional arguments, which are now reserved to package names only.

Fixes: https://github.com/vltpkg/vltpkg/issues/967