### PR TITLE
gui: dashboard card design update

### DIFF
--- a/src/gui/src/components/dashboard-grid/dashboard-item.tsx
+++ b/src/gui/src/components/dashboard-grid/dashboard-item.tsx
@@ -1,0 +1,89 @@
+import { CardTitle } from '@/components/ui/card.tsx'
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@/components/ui/tooltip.tsx'
+import { getIconSet } from '@/utils/dashboard-tools.tsx'
+import { format } from 'date-fns'
+
+import type { MouseEvent } from 'react'
+import type { DashboardDataProject } from '@/state/types.ts'
+
+export interface DashboardItemOptions {
+  item: DashboardDataProject
+  onItemClick: (selectedProject: DashboardDataProject) => void
+}
+
+const iconClassnames =
+  'text-muted-foreground fill-muted-foreground transition-colors duration-250 size-6'
+
+export const DashboardItem = ({
+  item,
+  onItemClick,
+}: DashboardItemOptions) => {
+  const { packageManager: PackageManager, runtime: RunTime } =
+    getIconSet(item.tools)
+
+  const onDashboardItemClick = (e: MouseEvent) => {
+    e.preventDefault()
+    onItemClick(item)
+  }
+
+  return (
+    <div
+      role="link"
+      className="group/card duration-250 group relative w-full cursor-default grid-rows-3 gap-3 rounded-lg border-[1px] bg-card transition-colors hover:border-muted hover:bg-card-accent"
+      onClick={onDashboardItemClick}>
+      <div className="flex justify-end px-3 py-3">
+        {item.mtime && (
+          <TooltipProvider delayDuration={150}>
+            <Tooltip>
+              <TooltipTrigger className="cursor-default text-xxs text-muted-foreground">
+                {format(
+                  new Date(item.mtime).toJSON(),
+                  'LLLL do, yyyy',
+                )}
+              </TooltipTrigger>
+              <TooltipContent side="top" align="start">
+                <p className="">
+                  {format(
+                    new Date(item.mtime).toJSON(),
+                    'LLLL do, yyyy - HH:mm:ss',
+                  )}
+                </p>
+              </TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
+        )}
+      </div>
+
+      <div className="flex min-h-14 items-center px-3">
+        <CardTitle className="text-md font-medium">
+          {item.name}
+        </CardTitle>
+      </div>
+
+      <div className="duration-250 flex w-full gap-2 border-t-[1px] px-3 py-1.5 transition-colors group-hover/card:border-muted">
+        <TooltipProvider delayDuration={150}>
+          <Tooltip>
+            <TooltipTrigger className="grow cursor-default truncate text-left text-xs text-muted-foreground">
+              {item.readablePath}
+            </TooltipTrigger>
+            <TooltipContent side="top" align="start">
+              {item.readablePath}
+            </TooltipContent>
+          </Tooltip>
+        </TooltipProvider>
+
+        <div className="flex gap-1">
+          {PackageManager && (
+            <PackageManager className={iconClassnames} />
+          )}
+          {RunTime && <RunTime className={iconClassnames} />}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/gui/src/components/dashboard-grid/index.tsx
+++ b/src/gui/src/components/dashboard-grid/index.tsx
@@ -1,92 +1,14 @@
 import { motion, AnimatePresence } from 'framer-motion'
 import { useNavigate } from 'react-router'
 import { useState } from 'react'
-import { CardTitle } from '@/components/ui/card.tsx'
 import { useGraphStore } from '@/state/index.ts'
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger,
-} from '@/components/ui/tooltip.tsx'
 import { DashboardTable } from '@/components/dashboard-grid/dashboard-table.tsx'
-import { getIconSet } from '@/utils/dashboard-tools.tsx'
-import { format } from 'date-fns'
 import { requestRouteTransition } from '@/lib/request-route-transition.ts'
 import { LoadingSpinner } from '@/components/ui/loading-spinner.tsx'
 import { useDashboardStore } from '@/state/dashboard.ts'
+import { DashboardItem } from '@/components/dashboard-grid/dashboard-item.tsx'
 
-import type { MouseEvent } from 'react'
 import type { DashboardDataProject } from '@/state/types.ts'
-
-export type DashboardItemOptions = {
-  item: DashboardDataProject
-  onItemClick: (selectedProject: DashboardDataProject) => void
-}
-
-export const DashboardItem = ({
-  item,
-  onItemClick,
-}: DashboardItemOptions) => {
-  const { packageManager: PackageManger, runtime: RunTime } =
-    getIconSet(item.tools)
-
-  const onDashboardItemClick = (e: MouseEvent) => {
-    e.preventDefault()
-    onItemClick(item)
-  }
-
-  return (
-    <div
-      role="link"
-      className="group relative w-full cursor-default"
-      onClick={onDashboardItemClick}>
-      {/* top */}
-      <div className="relative flex h-24 items-center overflow-hidden rounded-t-lg border-x-[1px] border-t-[1px] border-muted bg-card transition-colors group-hover:bg-card-accent">
-        <div className="flex px-3 py-2">
-          <CardTitle className="text-md z-[1] font-medium">
-            {item.name}
-          </CardTitle>
-        </div>
-        <div className="absolute right-0 top-0 z-[1] flex flex-row rounded-sm px-3 py-2 backdrop-blur-[1px]">
-          {item.mtime && (
-            <p className="z-[1] text-[0.7rem] text-muted-foreground">
-              {format(new Date(item.mtime).toJSON(), 'LLLL do, yyyy')}
-            </p>
-          )}
-        </div>
-
-        {/* icons */}
-        <div className="absolute -inset-4 -right-2 flex flex-row items-center justify-end gap-2 bg-clip-content">
-          {PackageManger && (
-            <PackageManger
-              size={120}
-              className="stroke-0 text-neutral-200/80 dark:text-neutral-800/40"
-            />
-          )}
-          {RunTime && (
-            <RunTime
-              size={120}
-              className="stroke-0 text-neutral-200/80 dark:text-neutral-800/40"
-            />
-          )}
-        </div>
-      </div>
-
-      {/* footer */}
-      <div className="flex w-full items-center rounded-b-lg border-[1px] border-muted bg-card px-3 py-3 transition-colors group-hover:bg-card-accent">
-        <TooltipProvider>
-          <Tooltip>
-            <TooltipTrigger className="truncate text-left text-xs text-muted-foreground">
-              {item.readablePath}
-            </TooltipTrigger>
-            <TooltipContent>{item.readablePath}</TooltipContent>
-          </Tooltip>
-        </TooltipProvider>
-      </div>
-    </div>
-  )
-}
 
 export const DashboardGrid = () => {
   const navigate = useNavigate()
@@ -142,7 +64,7 @@ export const DashboardGrid = () => {
 
   return (
     <div className="flex h-full flex-col px-8 py-4">
-      <AnimatePresence mode="wait">
+      <AnimatePresence initial={false} mode="wait">
         {currentView === 'table' ?
           <motion.div
             key={currentView}

--- a/src/gui/test/components/dashboard-grid/__snapshots__/dashboard-item.tsx.snap
+++ b/src/gui/test/components/dashboard-grid/__snapshots__/dashboard-item.tsx.snap
@@ -1,0 +1,54 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`dashboard-item renders correctly 1`] = `
+
+<div
+  role="link"
+  class="group/card duration-250 group relative w-full cursor-default grid-rows-3 gap-3 rounded-lg border-[1px] bg-card transition-colors hover:border-muted hover:bg-card-accent"
+>
+  <div class="flex justify-end px-3 py-3">
+    <gui-tooltip-provider delayduration="150">
+      <gui-tooltip>
+        <gui-tooltip-trigger classname="cursor-default text-xxs text-muted-foreground">
+          November 1st, 2024
+        </gui-tooltip-trigger>
+        <gui-tooltip-content
+          side="top"
+          align="start"
+        >
+          <p class>
+            November 1st, 2024
+          </p>
+        </gui-tooltip-content>
+      </gui-tooltip>
+    </gui-tooltip-provider>
+  </div>
+  <div class="flex min-h-14 items-center px-3">
+    <gui-card-title classname="text-md font-medium">
+      project-foo
+    </gui-card-title>
+  </div>
+  <div class="duration-250 flex w-full gap-2 border-t-[1px] px-3 py-1.5 transition-colors group-hover/card:border-muted">
+    <gui-tooltip-provider delayduration="150">
+      <gui-tooltip>
+        <gui-tooltip-trigger classname="grow cursor-default truncate text-left text-xs text-muted-foreground">
+          ~/project-foo
+        </gui-tooltip-trigger>
+        <gui-tooltip-content
+          side="top"
+          align="start"
+        >
+          ~/project-foo
+        </gui-tooltip-content>
+      </gui-tooltip>
+    </gui-tooltip-provider>
+    <div class="flex gap-1">
+      <gui-package-manager-vlt-icon classname="text-muted-foreground fill-muted-foreground transition-colors duration-250 size-6">
+      </gui-package-manager-vlt-icon>
+      <gui-runtime-node-icon classname="text-muted-foreground fill-muted-foreground transition-colors duration-250 size-6">
+      </gui-runtime-node-icon>
+    </div>
+  </div>
+</div>
+
+`;

--- a/src/gui/test/components/dashboard-grid/__snapshots__/index.tsx.snap
+++ b/src/gui/test/components/dashboard-grid/__snapshots__/index.tsx.snap
@@ -6,7 +6,7 @@ exports[`dashboard-grid render default 1`] = `
   <div class="flex h-full flex-col px-8 py-4">
     <div
       class="flex w-full max-w-8xl flex-col"
-      style="opacity: 0; transform: translateY(-5px);"
+      style="opacity: 1; transform: none;"
     >
       <p class="mb-4 text-sm font-semibold">
         Projects
@@ -28,7 +28,7 @@ exports[`dashboard-grid with results 1`] = `
   <div class="flex h-full flex-col px-8 py-4">
     <div
       class="flex w-full max-w-8xl flex-col"
-      style="opacity: 0; transform: translateY(-5px);"
+      style="opacity: 1; transform: none;"
     >
       <p class="mb-4 text-sm font-semibold">
         Projects

--- a/src/gui/test/components/dashboard-grid/dashboard-item.tsx
+++ b/src/gui/test/components/dashboard-grid/dashboard-item.tsx
@@ -1,0 +1,92 @@
+import { vi, test, expect, afterEach } from 'vitest'
+import { cleanup, render } from '@testing-library/react'
+import html from 'diffable-html'
+import { useGraphStore as useStore } from '@/state/index.ts'
+import { DashboardItem } from '@/components/dashboard-grid/dashboard-item.tsx'
+import type {
+  DashboardTools,
+  DashboardDataProject,
+} from '@/state/types.ts'
+
+vi.mock('react-router', () => ({
+  useNavigate: vi.fn(),
+  NavLink: 'gui-nav-link',
+}))
+
+vi.mock('@/utils/dashboard-tools.tsx', () => ({
+  getIconSet: vi.fn((tools: DashboardTools[]) => {
+    const mockRuntimes: Partial<Record<DashboardTools, string>> = {
+      node: 'gui-runtime-node-icon',
+      deno: 'gui-runtime-deno-icon',
+      js: 'gui-runtime-js-icon',
+      bun: 'gui-runtime-bun-icon',
+    }
+
+    const mockPackageManagers: Partial<
+      Record<DashboardTools, string>
+    > = {
+      npm: 'gui-package-manager-npm-icon',
+      pnpm: 'gui-package-manager-pnpm-icon',
+      yarn: 'gui-package-manager-yarn-icon',
+      vlt: 'gui-package-manager-vlt-icon',
+    }
+
+    const runtimeKey = tools.find(tool => mockRuntimes[tool] ?? null)
+    const packageManagerKey = tools.find(
+      tool => mockPackageManagers[tool] ?? null,
+    )
+
+    return {
+      runtime: runtimeKey ? mockRuntimes[runtimeKey] : null,
+      packageManager:
+        packageManagerKey ?
+          mockPackageManagers[packageManagerKey]
+        : null,
+    }
+  }),
+}))
+
+vi.mock('@/components/ui/card.tsx', () => ({
+  CardTitle: 'gui-card-title',
+}))
+
+vi.mock('@/components/ui/tooltip.tsx', () => ({
+  Tooltip: 'gui-tooltip',
+  TooltipContent: 'gui-tooltip-content',
+  TooltipProvider: 'gui-tooltip-provider',
+  TooltipTrigger: 'gui-tooltip-trigger',
+}))
+
+vi.mock('date-fns', () => ({
+  format: () => 'November 1st, 2024',
+}))
+
+expect.addSnapshotSerializer({
+  serialize: v => html(v),
+  test: () => true,
+})
+
+afterEach(() => {
+  const CleanUp = () => (useStore(state => state.reset)(), '')
+  render(<CleanUp />)
+  cleanup()
+})
+
+test('dashboard-item renders correctly', () => {
+  const mockItem: DashboardDataProject = {
+    name: 'project-foo',
+    readablePath: '~/project-foo',
+    path: '/home/user/project-foo',
+    manifest: { name: 'project-foo', version: '1.0.0' },
+    tools: ['node', 'vlt'],
+    mtime: 1730498483044,
+  }
+  const mockOnClick = vi.fn()
+
+  const Container = () => {
+    return <DashboardItem item={mockItem} onItemClick={mockOnClick} />
+  }
+
+  const { container } = render(<Container />)
+  expect(container.innerHTML).toMatchSnapshot()
+})

--- a/src/gui/test/components/dashboard-grid/index.tsx
+++ b/src/gui/test/components/dashboard-grid/index.tsx
@@ -42,23 +42,43 @@ vi.mock('@/utils/dashboard-tools.tsx', () => ({
   }),
 }))
 
-vi.mock('@/components/ui/card.tsx', () => ({
-  CardTitle: 'gui-card-title',
+vi.mock('@/components/ui/button.tsx', () => ({
+  Button: 'gui-button',
 }))
 
-vi.mock('@/components/ui/tooltip.tsx', () => ({
-  Tooltip: 'gui-tooltip',
-  TooltipContent: 'gui-tooltip-content',
-  TooltipProvider: 'gui-tooltip-provider',
-  TooltipTrigger: 'gui-tooltip-trigger',
+vi.mock('@/components/ui/filter-search.tsx', () => ({
+  FilterSearch: 'gui-filter-search',
+}))
+
+vi.mock('@/components/data-table/table-filter-search.tsx', () => ({
+  TableFilterSearch: 'gui-dashboard-table-filter-search',
+}))
+
+vi.mock('@/components/data-table/table-view-dropdown.tsx', () => ({
+  TableViewDropdown: 'gui-dashboard-table-view-dropdown',
 }))
 
 vi.mock('@/components/dashboard-grid/dasboard-table.tsx', () => ({
   DashboardTable: 'gui-dashboard-table',
 }))
 
-vi.mock('date-fns', () => ({
-  format: () => 'November 1st, 2024 | 06:01 PM',
+vi.mock('@/components/sort-dropdown.tsx', () => ({
+  SortDropdown: 'gui-sort-dropdown',
+}))
+
+vi.mock(
+  '@/components/dashboard-grid/dashboard-view-toggle.tsx',
+  () => ({
+    DashboardViewToggle: 'gui-dashboard-view-toggle',
+  }),
+)
+
+vi.mock('lucide-react', () => ({
+  Plus: 'gui-plus-icon',
+}))
+
+vi.mock('@/components/dashboard-grid/dashboard-item.tsx', () => ({
+  DashboardItem: 'gui-dashboard-item',
 }))
 
 expect.addSnapshotSerializer({


### PR DESCRIPTION
<img width="333" alt="Screenshot 2025-07-07 at 09 54 16" src="https://github.com/user-attachments/assets/893467d3-360f-4fba-9ee8-b2fb7bdb1177" />

### Overview

This PR simplifies the `dashboard-item` card design. It moves the `dashboard-item` into a separate file and updates the icon position and style of the cards.

Closes #868 

### Changelog
- **feat: moves `dashboard-item` into its own component**
- **feat: simplifies dashbaord card design**
