### PR TITLE
gui: fix graph modifier navigation

### DIFF
--- a/src/gui/src/components/explorer-grid/index.tsx
+++ b/src/gui/src/components/explorer-grid/index.tsx
@@ -59,13 +59,13 @@ const getItemsData = (
 
   for (const edge of allEdges) {
     if (sameItems && !edge.from && allEdges.length > 1) continue
-    const _id = edge.to?.id
+    const id_ = edge.to?.id
     const titleVersion =
       edge.spec?.bareSpec ? `@${edge.spec.bareSpec}` : ''
     const title =
       edge.from ? `${edge.name}${titleVersion}` : edge.name
     // will not stack missing packages
-    if (!_id) {
+    if (!id_) {
       items.push({
         ...edge,
         id: `${edge.from?.id}${title}`,
@@ -79,7 +79,7 @@ const getItemsData = (
       continue
     }
     // retrieve the target node base depID
-    const id = baseDepID(_id)
+    const id = baseDepID(id_)
     // items resolving to the same package will be stacked
     const item = seenItems.get(id)
     if (item && stackable) {

--- a/src/gui/src/components/explorer-grid/index.tsx
+++ b/src/gui/src/components/explorer-grid/index.tsx
@@ -1,3 +1,4 @@
+import { baseDepID } from '@vltpkg/dep-id/browser'
 import { Results } from '@/components/explorer-grid/results/index.tsx'
 import { SelectedItem } from '@/components/explorer-grid/selected-item/index.tsx'
 import { useGraphStore } from '@/state/index.ts'
@@ -48,20 +49,23 @@ const getItemsData = (
   }
 
   const ids = new Set<string | undefined>(
-    allEdges.map(edge => edge.to?.id),
+    allEdges.map(edge =>
+      edge.to?.id ? baseDepID(edge.to.id) : undefined,
+    ),
   )
+  ids.delete(undefined)
   const stackable = ids.size > 1
   const sameItems = ids.size === 1
 
   for (const edge of allEdges) {
     if (sameItems && !edge.from && allEdges.length > 1) continue
-    const id = edge.to?.id
+    const _id = edge.to?.id
     const titleVersion =
       edge.spec?.bareSpec ? `@${edge.spec.bareSpec}` : ''
     const title =
       edge.from ? `${edge.name}${titleVersion}` : edge.name
     // will not stack missing packages
-    if (!id) {
+    if (!_id) {
       items.push({
         ...edge,
         id: `${edge.from?.id}${title}`,
@@ -74,6 +78,8 @@ const getItemsData = (
       })
       continue
     }
+    // retrieve the target node base depID
+    const id = baseDepID(_id)
     // items resolving to the same package will be stacked
     const item = seenItems.get(id)
     if (item && stackable) {

--- a/src/gui/src/components/explorer-grid/selected-item/index.tsx
+++ b/src/gui/src/components/explorer-grid/selected-item/index.tsx
@@ -1,3 +1,4 @@
+import { baseDepID } from '@vltpkg/dep-id/browser'
 import { longDependencyTypes, shorten } from '@vltpkg/graph/browser'
 import { Spec } from '@vltpkg/spec/browser'
 import { useGraphStore } from '@/state/index.ts'
@@ -9,6 +10,7 @@ import { updateDependentsItem } from '@/lib/update-dependents-item.ts'
 
 import type { GridItemData } from '@/components/explorer-grid/types.ts'
 import type { QueryResponseNode } from '@vltpkg/query'
+import type { DepID } from '@vltpkg/dep-id/browser'
 
 const getParent = (
   edge?: GridItemData,
@@ -57,19 +59,22 @@ const getWorkspaceItems = (item?: GridItemData): GridItemData[] => {
   return items
 }
 
-const getDependentItems = (
+export const getDependentItems = (
   node?: QueryResponseNode,
   parent?: QueryResponseNode,
 ) => {
+  const seenIds = new Set<DepID>()
   const items: GridItemData[] = []
   if (!node) return items
   for (const edge of Array.from(node.edgesIn)) {
-    if (edge.from === parent) continue
+    const id = baseDepID(edge.from.id)
+    if (edge.from === parent || seenIds.has(id)) continue
+    seenIds.add(id)
     const title = `${edge.name}@${edge.spec.bareSpec}`
 
     items.push({
       ...edge,
-      id: edge.from.id,
+      id,
       title,
       version: edge.from.version || '',
       name: edge.from.name || '',

--- a/src/gui/test/components/explorer-grid/selected-item/__snapshots__/index.tsx.snap
+++ b/src/gui/test/components/explorer-grid/selected-item/__snapshots__/index.tsx.snap
@@ -25,3 +25,84 @@ exports[`SelectedItem renders default 1`] = `
 </div>
 
 `;
+
+exports[`getDependentItems 1`] = `
+
+[
+  {
+    name: 'dependent',
+    type: 'prod',
+    spec: @vltpkg/spec.Spec dependent@^1.0.0,
+    from: {
+      id: '··dependent@1.0.0',
+      name: 'dependent',
+      version: '1.0.0',
+      edgesIn: Set(0) {}
+    },
+    id: '··dependent@1.0.0',
+    title: 'dependent@^1.0.0',
+    version: '1.0.0',
+    stacked: false,
+    size: 0,
+    labels: undefined
+  },
+  {
+    name: 'foo',
+    type: 'dev',
+    spec: @vltpkg/spec.Spec foo@^1.0.0,
+    from: {
+      id: '··foo@1.0.0',
+      name: 'foo',
+      version: '1.0.0',
+      edgesIn: Set(2) {
+        {
+          name: 'foo',
+          type: 'dev',
+          spec: @vltpkg/spec.Spec foo@^1.0.0,
+          from: {
+            id: 'file·.',
+            name: 'root',
+            version: '1.0.0',
+            edgesIn: Set(0) {}
+          }
+        },
+        {
+          name: 'foo',
+          type: 'dev',
+          spec: @vltpkg/spec.Spec foo@^1.0.0,
+          from: {
+            id: 'workspace·a',
+            name: 'a',
+            version: '1.0.0',
+            edgesIn: Set(0) {}
+          }
+        }
+      }
+    },
+    id: '··foo@1.0.0',
+    title: 'foo@^1.0.0',
+    version: '1.0.0',
+    stacked: true,
+    size: 2,
+    labels: undefined
+  },
+  {
+    name: 'bar',
+    type: 'prod',
+    spec: @vltpkg/spec.Spec bar@^1.0.0,
+    from: {
+      id: '··bar@1.0.0',
+      name: 'bar',
+      version: '1.0.0',
+      edgesIn: Set(0) {}
+    },
+    id: '··bar@1.0.0',
+    title: 'bar@^1.0.0',
+    version: '1.0.0',
+    stacked: false,
+    size: 0,
+    labels: undefined
+  }
+]
+
+`;

--- a/src/gui/test/components/explorer-grid/selected-item/index.tsx
+++ b/src/gui/test/components/explorer-grid/selected-item/index.tsx
@@ -1,9 +1,16 @@
+import { inspect } from 'node:util'
 import { test, expect, vi, beforeEach, afterEach } from 'vitest'
 import { cleanup, render } from '@testing-library/react'
 import html from 'diffable-html'
 import { useGraphStore as useStore } from '@/state/index.ts'
-import { SelectedItem } from '@/components/explorer-grid/selected-item/index.tsx'
+import {
+  SelectedItem,
+  getDependentItems,
+} from '@/components/explorer-grid/selected-item/index.tsx'
+import { joinDepIDTuple } from '@vltpkg/dep-id/browser'
+import { Spec } from '@vltpkg/spec/browser'
 import type { GridItemData } from '@/components/explorer-grid/types'
+import type { QueryResponseNode } from '@vltpkg/query'
 
 vi.mock('@/components/explorer-grid/selected-item/item.tsx', () => ({
   Item: 'gui-selected-item',
@@ -60,4 +67,89 @@ test('SelectedItem renders default', () => {
 
   const { container } = render(<Container />)
   expect(container.innerHTML).toMatchSnapshot()
+})
+
+test('getDependentItems', () => {
+  const mockNode = {
+    id: joinDepIDTuple(['registry', '', 'item@1.0.0']),
+    edgesIn: new Set([
+      {
+        name: 'dependent',
+        type: 'prod',
+        spec: Spec.parse('dependent', '^1.0.0'),
+        from: {
+          id: joinDepIDTuple(['registry', '', 'dependent@1.0.0']),
+          name: 'dependent',
+          version: '1.0.0',
+          edgesIn: new Set(),
+        } as unknown as QueryResponseNode,
+      },
+      {
+        name: 'foo',
+        type: 'dev',
+        spec: Spec.parse('foo', '^1.0.0'),
+        from: {
+          id: joinDepIDTuple(['registry', '', 'foo@1.0.0']),
+          name: 'foo',
+          version: '1.0.0',
+          edgesIn: new Set([
+            {
+              name: 'foo',
+              type: 'dev',
+              spec: Spec.parse('foo', '^1.0.0'),
+              from: {
+                id: joinDepIDTuple(['file', '.']),
+                name: 'root',
+                version: '1.0.0',
+                edgesIn: new Set(),
+              } as unknown as QueryResponseNode,
+            },
+            {
+              name: 'foo',
+              type: 'dev',
+              spec: Spec.parse('foo', '^1.0.0'),
+              from: {
+                id: joinDepIDTuple(['workspace', 'a']),
+                name: 'a',
+                version: '1.0.0',
+                edgesIn: new Set(),
+              } as unknown as QueryResponseNode,
+            },
+          ]),
+        } as unknown as QueryResponseNode,
+      },
+      {
+        name: 'bar',
+        type: 'prod',
+        spec: Spec.parse('bar', '^1.0.0'),
+        from: {
+          id: joinDepIDTuple(['registry', '', 'bar@1.0.0']),
+          name: 'bar',
+          version: '1.0.0',
+          edgesIn: new Set(),
+        } as unknown as QueryResponseNode,
+      },
+      {
+        name: 'bar',
+        type: 'prod',
+        spec: Spec.parse('bar', '^1.0.0'),
+        from: {
+          id: joinDepIDTuple([
+            'registry',
+            '',
+            'bar@1.0.0',
+            '#modifier',
+          ]),
+          name: 'bar',
+          version: '2.0.0',
+          edgesIn: new Set(),
+        } as unknown as QueryResponseNode,
+      },
+    ]),
+    edgesOut: new Set(),
+  } as unknown as QueryResponseNode
+
+  const dependents = getDependentItems(mockNode)
+
+  expect(inspect(dependents, { depth: 10 })).toMatchSnapshot()
 })


### PR DESCRIPTION
Stacking elements and navigating dependents was not working properly when using graph modifiers due to the possibility of finding forked nodes in the graph. This fixes it by properly handling it using the base dep ids instead.