### PR TITLE
cli-sdk: always load security insights info

### DIFF
--- a/src/cli-sdk/src/commands/list.ts
+++ b/src/cli-sdk/src/commands/list.ts
@@ -100,15 +100,10 @@ export const command: CommandFn<ListResult> = async conf => {
   const queryString = conf.positionals
     .map(k => `#${k.replace(/\//, '\\/')}`)
     .join(', ')
-  /* c8 ignore start - TODO: may be removed when --target is added */
-  const securityArchive =
-    Query.hasSecuritySelectors(queryString) ?
-      await SecurityArchive.start({
-        graph,
-        specOptions: conf.options,
-      })
-    : undefined
-  /* c8 ignore stop */
+  const securityArchive = await SecurityArchive.start({
+    graph,
+    specOptions: conf.options,
+  })
   const query = new Query({
     graph,
     specOptions: conf.options,

--- a/src/cli-sdk/src/commands/query.ts
+++ b/src/cli-sdk/src/commands/query.ts
@@ -121,13 +121,10 @@ export const command: CommandFn<QueryResult> = async conf => {
 
   const defaultQueryString = '*'
   const queryString = conf.positionals[0]
-  const securityArchive =
-    queryString && Query.hasSecuritySelectors(queryString) ?
-      await SecurityArchive.start({
-        graph,
-        specOptions: conf.options,
-      })
-    : undefined
+  const securityArchive = await SecurityArchive.start({
+    graph,
+    specOptions: conf.options,
+  })
   const query = new Query({
     graph,
     specOptions: conf.options,

--- a/src/cli-sdk/test/commands/list.ts
+++ b/src/cli-sdk/test/commands/list.ts
@@ -113,6 +113,7 @@ const mockList = async (
           async start() {
             return {
               ok: false,
+              get: () => undefined,
             }
           },
         },

--- a/src/cli-sdk/test/commands/query.ts
+++ b/src/cli-sdk/test/commands/query.ts
@@ -113,6 +113,7 @@ const mockQuery = async (
           async start() {
             return {
               ok: false,
+              get: () => undefined,
             }
           },
         },
@@ -194,17 +195,6 @@ t.test('query', async t => {
       options,
     }),
     'should list mermaid in json format',
-  )
-
-  await t.rejects(
-    Command.command({
-      positionals: ['*:malware'],
-      values: { view: 'human' },
-      options,
-      get: () => undefined,
-    } as unknown as LoadedConfig),
-    /Failed to parse :malware selector/,
-    'should fail to run with no security archive',
   )
 
   await t.test('expect-results option', async t => {


### PR DESCRIPTION
Removes the check that avoids loading security insights based on whether security insight selectors were used in the query provided to either `vlt query` or `vlt ls`.

By removing that extra check, security insights data is now always loaded and available on insights when using `--view=json` output.

Fixes: https://github.com/vltpkg/vltpkg/issues/788