### PR TITLE
cli-sdk: add target option to `query` and `ls`

### DIFF
--- a/src/cli-sdk/src/config/definition.ts
+++ b/src/cli-sdk/src/config/definition.ts
@@ -420,6 +420,11 @@ export const definition = j
       description:
         'Set to filter the scope of an operation using a DSS Query.',
     },
+    target: {
+      short: 't',
+      description:
+        'Set to select packages using a DSS Query selector.',
+    },
   })
 
   .flag({

--- a/src/cli-sdk/tap-snapshots/test/commands/list.ts.test.cjs
+++ b/src/cli-sdk/tap-snapshots/test/commands/list.ts.test.cjs
@@ -5,6 +5,91 @@
  * Make sure to inspect the output below.  Do not ignore changes!
  */
 'use strict'
+exports[`test/commands/list.ts > TAP > list > --target option > should accept attribute selector 1`] = `
+my-project
+└── bar@1.0.0
+
+`
+
+exports[`test/commands/list.ts > TAP > list > --target option > should accept combinator selectors 1`] = `
+my-project
+├── @foo/bazz@1.0.0
+└── bar@1.0.0
+
+`
+
+exports[`test/commands/list.ts > TAP > list > --target option > should accept ID selector 1`] = `
+my-project
+└── bar@1.0.0
+
+`
+
+exports[`test/commands/list.ts > TAP > list > --target option > should accept pseudo-element selectors 1`] = `
+my-project
+├── @foo/bazz@1.0.0
+└── bar@1.0.0
+
+`
+
+exports[`test/commands/list.ts > TAP > list > --target option > should accept wildcard selector 1`] = `
+my-project
+├── @foo/bazz@1.0.0
+├─┬ bar@1.0.0
+│ └─┬ baz (custom:baz@1.0.0)
+│   └── @foo/bazz@1.0.0
+└── missing@^1.0.0 (missing)
+
+`
+
+exports[`test/commands/list.ts > TAP > list > --target option > should handle complex query string 1`] = `
+my-project
+├── @foo/bazz@1.0.0
+└── bar@1.0.0
+
+`
+
+exports[`test/commands/list.ts > TAP > list > --target option > should use --target over positional arguments 1`] = `
+my-project
+├── @foo/bazz@1.0.0
+├─┬ bar@1.0.0
+│ └─┬ baz (custom:baz@1.0.0)
+│   └── @foo/bazz@1.0.0
+└── missing@^1.0.0 (missing)
+
+`
+
+exports[`test/commands/list.ts > TAP > list > --target option > should work with json output 1`] = `
+[
+  {
+    "name": "my-project",
+    "to": {
+      "id": "file·.",
+      "name": "my-project",
+      "version": "1.0.0",
+      "location": ".",
+      "importer": true,
+      "manifest": {
+        "name": "my-project",
+        "version": "1.0.0",
+        "dependencies": {
+          "@foo/bazz": "^1.0.0",
+          "bar": "^1.0.0",
+          "missing": "^1.0.0"
+        }
+      },
+      "projectRoot": "{ROOT}",
+      "dev": false,
+      "optional": false,
+      "confused": false,
+      "insights": {
+        "scanned": false
+      }
+    },
+    "overridden": false
+  }
+]
+`
+
 exports[`test/commands/list.ts > TAP > list > colors > should use colors when set in human readable format 1`] = `
 [0mmy-project
 ├── @foo/bazz@1.0.0
@@ -47,11 +132,19 @@ exports[`test/commands/list.ts > TAP > list > should have usage 1`] = `
 Usage:
   vlt ls
   vlt ls [package-names...] [--view=human | json | mermaid | gui]
+  vlt ls [--scope=<query>] [--target=<query>] [--view=human | json | mermaid |
+  gui]
 
-List installed dependencies matching given package names.
+List installed dependencies matching given package names or query selectors.
 
 Package names provided as positional arguments will be used to filter the
 results to show only dependencies with those names.
+
+The --scope and --target options accepts DSS query selectors to filter packages.
+Using --scope, you can specify which packages to treat as the top-level items in
+the output graph. The --target option allows you to filter what dependencies to
+include in the output. Using both options allows you to render subgraphs of the
+dependency graph.
 
 Defaults to listing direct dependencies of a project and any configured
 workspace.
@@ -66,7 +159,30 @@ workspace.
 
     ​vlt ls foo bar baz
 
+    Defines a direct dependency as the output top-level scope
+
+    ​vlt ls --scope=":root > #dependency-name"
+
+    List all dependencies using a query selector
+
+    ​vlt ls --target="*"
+
+    List all peer dependencies of all workspaces
+
+    ​vlt ls --target=":workspace > *:peer"
+
   Options
+
+    scope
+      Query selector to select top-level packages using the DSS query language
+      syntax.
+
+      ​--scope=<query>
+
+    target
+      Query selector to filter packages using the DSS query language syntax.
+
+      ​--target=<query>
 
     view
       Output format. Defaults to human-readable or json if no tty.

--- a/src/cli-sdk/tap-snapshots/test/commands/query.ts.test.cjs
+++ b/src/cli-sdk/tap-snapshots/test/commands/query.ts.test.cjs
@@ -5,6 +5,97 @@
  * Make sure to inspect the output below.  Do not ignore changes!
  */
 'use strict'
+exports[`test/commands/query.ts > TAP > query > --target option > should accept attribute selector 1`] = `
+my-project
+├── foo@1.0.0
+└─┬ bar@1.0.0
+  └─┬ baz (custom:baz@1.0.0)
+    └── foo@1.0.0
+
+`
+
+exports[`test/commands/query.ts > TAP > query > --target option > should accept combinator selectors 1`] = `
+my-project
+├── foo@1.0.0
+└── bar@1.0.0
+
+`
+
+exports[`test/commands/query.ts > TAP > query > --target option > should accept ID selector 1`] = `
+my-project
+├── foo@1.0.0
+└─┬ bar@1.0.0
+  └─┬ baz (custom:baz@1.0.0)
+    └── foo@1.0.0
+
+`
+
+exports[`test/commands/query.ts > TAP > query > --target option > should accept pseudo-element selectors 1`] = `
+my-project
+├── foo@1.0.0
+└── bar@1.0.0
+
+`
+
+exports[`test/commands/query.ts > TAP > query > --target option > should accept wildcard selector 1`] = `
+my-project
+├── foo@1.0.0
+├─┬ bar@1.0.0
+│ └─┬ baz (custom:baz@1.0.0)
+│   └── foo@1.0.0
+└── missing@^1.0.0 (missing)
+
+`
+
+exports[`test/commands/query.ts > TAP > query > --target option > should handle complex query string 1`] = `
+my-project
+├── foo@1.0.0
+└── bar@1.0.0
+
+`
+
+exports[`test/commands/query.ts > TAP > query > --target option > should use --target over positional arguments 1`] = `
+my-project
+├── foo@1.0.0
+├─┬ bar@1.0.0
+│ └─┬ baz (custom:baz@1.0.0)
+│   └── foo@1.0.0
+└── missing@^1.0.0 (missing)
+
+`
+
+exports[`test/commands/query.ts > TAP > query > --target option > should work with json output 1`] = `
+[
+  {
+    "name": "my-project",
+    "to": {
+      "id": "file·.",
+      "name": "my-project",
+      "version": "1.0.0",
+      "location": ".",
+      "importer": true,
+      "manifest": {
+        "name": "my-project",
+        "version": "1.0.0",
+        "dependencies": {
+          "foo": "^1.0.0",
+          "bar": "^1.0.0",
+          "missing": "^1.0.0"
+        }
+      },
+      "projectRoot": "{ROOT}",
+      "dev": false,
+      "optional": false,
+      "confused": false,
+      "insights": {
+        "scanned": false
+      }
+    },
+    "overridden": false
+  }
+]
+`
+
 exports[`test/commands/query.ts > TAP > query > colors > should use colors when set in human readable format 1`] = `
 [0mmy-project
 ├── foo@1.0.0
@@ -46,12 +137,22 @@ Usage:
   vlt query
   vlt query <query> --view=<human | json | mermaid | gui>
   vlt query <query> --expect-results=<comparison string>
+  vlt query --target=<query> --view=<human | json | mermaid | gui>
 
 List installed dependencies matching the provided query.
 
 The vlt Dependency Selector Syntax is a CSS-like query language that allows you
 to filter installed dependencies using a variety of metadata in the form of
 CSS-like attributes, pseudo selectors & combinators.
+
+The --scope and --target options accepts DSS query selectors to filter packages.
+Using --scope, you can specify which packages to treat as the top-level items in
+the output graph. The --target option can be used as an alternative to
+positional arguments, it allows you to filter what dependencies to include in
+the output. Using both options allows you to render subgraphs of the dependency
+graph.
+
+Defaults to listing all dependencies of the project root and workspaces.
 
   Examples
 
@@ -75,6 +176,18 @@ CSS-like attributes, pseudo selectors & combinators.
 
     ​vlt query '*:license(copyleft) --expect-results=0'
 
+    Defines a direct dependency as the output top-level scope
+
+    ​vlt query --scope=":root > #dependency-name"
+
+    Query all dependencies using the target option
+
+    ​vlt query '--target="*"'
+
+    Query all peer dependencies of workspaces using target option
+
+    ​vlt query '--target=":workspace > *:peer"'
+
   Options
 
     expect-results
@@ -84,6 +197,17 @@ CSS-like attributes, pseudo selectors & combinators.
       followed by a numeric value to be compared.
 
       ​--expect-results=[number | string]
+
+    scope
+      Query selector to select top-level packages using the DSS query language
+      syntax.
+
+      ​--scope=<query>
+
+    target
+      Query selector to filter packages using DSS syntax.
+
+      ​--target=<query>
 
     view
       Output format. Defaults to human-readable or json if no tty.

--- a/src/cli-sdk/tap-snapshots/test/config/definition.ts.test.cjs
+++ b/src/cli-sdk/tap-snapshots/test/config/definition.ts.test.cjs
@@ -378,6 +378,11 @@ Object {
     "description": "Default \`dist-tag\` to install or publish",
     "type": "string",
   },
+  "target": Object {
+    "description": "Set to select packages using a DSS Query selector.",
+    "short": "t",
+    "type": "string",
+  },
   "version": Object {
     "description": "Print the version",
     "short": "v",
@@ -476,6 +481,7 @@ Array [
   "--script-shell=<program>",
   "--stale-while-revalidate-factor=<n>",
   "--tag=<tag>",
+  "--target=<target>",
   "--version",
   "--view=<output>",
   "--workspace=<ws>",
@@ -526,6 +532,7 @@ Array [
   "script-shell",
   "stale-while-revalidate-factor",
   "tag",
+  "target",
   "version",
   "view",
   "workspace",

--- a/src/cli-sdk/tap-snapshots/test/index.ts.test.cjs
+++ b/src/cli-sdk/tap-snapshots/test/index.ts.test.cjs
@@ -74,6 +74,7 @@ Unknown option '--unknown'. To specify a positional argument starting with a '-'
     --script-shell=<program>
     --stale-while-revalidate-factor=<n>
     --tag=<tag>
+    --target=<target>
     --version
     --view=<output>
     --workspace=<ws>
@@ -127,6 +128,7 @@ Unknown config option: asdf
     script-shell
     stale-while-revalidate-factor
     tag
+    target
     version
     view
     workspace

--- a/src/cli-sdk/test/commands/list.ts
+++ b/src/cli-sdk/test/commands/list.ts
@@ -134,6 +134,7 @@ const runCommand = async (
     positionals?: string[]
     values: Partial<LoadedConfig['values']> & {
       view: Exclude<LoadedConfig['values']['view'], 'inspect'>
+      target?: string
     }
   },
   cmd = Command,
@@ -692,6 +693,83 @@ t.test('list', async t => {
         options,
       }),
       'should accept package name starting with numbers',
+    )
+  })
+
+  // Test --target option functionality
+  await t.test('--target option', async t => {
+    t.matchSnapshot(
+      await runCommand({
+        positionals: [],
+        values: { view: 'human', target: '*' },
+        options,
+      }),
+      'should accept wildcard selector',
+    )
+
+    t.matchSnapshot(
+      await runCommand({
+        positionals: [],
+        values: { view: 'human', target: '#bar' },
+        options,
+      }),
+      'should accept ID selector',
+    )
+
+    t.matchSnapshot(
+      await runCommand({
+        positionals: [],
+        values: { view: 'human', target: '[name="bar"]' },
+        options,
+      }),
+      'should accept attribute selector',
+    )
+
+    t.matchSnapshot(
+      await runCommand({
+        positionals: [],
+        values: { view: 'human', target: ':project > *' },
+        options,
+      }),
+      'should accept combinator selectors',
+    )
+
+    t.matchSnapshot(
+      await runCommand({
+        positionals: [],
+        values: { view: 'human', target: ':root > :prod' },
+        options,
+      }),
+      'should accept pseudo-element selectors',
+    )
+
+    t.matchSnapshot(
+      await runCommand({
+        positionals: [],
+        values: { view: 'json', target: ':project' },
+        options,
+      }),
+      'should work with json output',
+    )
+
+    // Test that --target takes precedence over positional arguments
+    t.matchSnapshot(
+      await runCommand({
+        positionals: ['foo'],
+        values: { view: 'human', target: '*' },
+        options,
+      }),
+      'should use --target over positional arguments',
+    )
+
+    // Test complex queries
+    t.matchSnapshot(
+      await runCommand({
+        positionals: [],
+        values: { view: 'human', target: ':project, :project > *' },
+        options,
+      }),
+      'should handle complex query string',
     )
   })
 })

--- a/src/cli-sdk/test/commands/query.ts
+++ b/src/cli-sdk/test/commands/query.ts
@@ -134,6 +134,7 @@ const runCommand = async (
     positionals?: string[]
     values: Partial<LoadedConfig['values']> & {
       view: Exclude<LoadedConfig['values']['view'], 'inspect'>
+      target?: string
     }
   },
   cmd = Command,
@@ -695,6 +696,83 @@ t.test('query', async t => {
     t.matchSnapshot(
       result,
       'should handle scope with a transitive dependency',
+    )
+  })
+
+  // Test --target option functionality
+  await t.test('--target option', async t => {
+    t.matchSnapshot(
+      await runCommand({
+        positionals: [],
+        values: { view: 'human', target: '*' },
+        options,
+      }),
+      'should accept wildcard selector',
+    )
+
+    t.matchSnapshot(
+      await runCommand({
+        positionals: [],
+        values: { view: 'human', target: '#foo' },
+        options,
+      }),
+      'should accept ID selector',
+    )
+
+    t.matchSnapshot(
+      await runCommand({
+        positionals: [],
+        values: { view: 'human', target: '[name="foo"]' },
+        options,
+      }),
+      'should accept attribute selector',
+    )
+
+    t.matchSnapshot(
+      await runCommand({
+        positionals: [],
+        values: { view: 'human', target: ':project > *' },
+        options,
+      }),
+      'should accept combinator selectors',
+    )
+
+    t.matchSnapshot(
+      await runCommand({
+        positionals: [],
+        values: { view: 'human', target: ':root > :prod' },
+        options,
+      }),
+      'should accept pseudo-element selectors',
+    )
+
+    t.matchSnapshot(
+      await runCommand({
+        positionals: [],
+        values: { view: 'json', target: ':project' },
+        options,
+      }),
+      'should work with json output',
+    )
+
+    // Test that --target takes precedence over positional arguments
+    t.matchSnapshot(
+      await runCommand({
+        positionals: ['#bar'],
+        values: { view: 'human', target: '*' },
+        options,
+      }),
+      'should use --target over positional arguments',
+    )
+
+    // Test complex queries
+    t.matchSnapshot(
+      await runCommand({
+        positionals: [],
+        values: { view: 'human', target: ':project, :project > *' },
+        options,
+      }),
+      'should handle complex query string',
     )
   })
 })


### PR DESCRIPTION
Adds a `--target` option to the `vlt query` and `vlt ls` commands, combined with `--scope`, the `--target` option allows for retrieving and rendering a sub graph that starts at scope and contains the elements defined in the target query.

Refs: https://github.com/vltpkg/vltpkg/issues/963