### PR TITLE
server: load data from hidden lockfile

### DIFF
--- a/src/server/src/graph-data.ts
+++ b/src/server/src/graph-data.ts
@@ -52,6 +52,8 @@ const getGraphData = async (
     ...options,
     mainManifest,
     loadManifests: true,
+    skipHiddenLockfile: false,
+    skipLoadingNodesOnModifiersChange: false,
   })
   const importers = [...graph.importers]
   const securityArchive = await SecurityArchive.start({

--- a/src/server/test/graph-data.ts
+++ b/src/server/test/graph-data.ts
@@ -64,6 +64,23 @@ t.test('graph data for vlt project', async t => {
             }),
           },
         },
+        '.vlt-lock.json': JSON.stringify({
+          options: {},
+          nodes: {
+            [abbrevDepID]: [
+              0,
+              'abbrev',
+              null,
+              null,
+              `./node_modules/.vlt/${abbrevDepID}`,
+              { name: 'abbrev', version: '1.2.3' },
+            ],
+          },
+          edges: {
+            [`${rootDepID} abbrev`]: `prod * ${abbrevDepID}`,
+            [`${abbrevDepID} abbrev`]: `prod * ${abbrevDepID}`,
+          },
+        }),
       },
     },
   })


### PR DESCRIPTION
The GUI server now always load data from the hidden lockfile instead of loading from traversing the `node_modules` folder. This ensures it has access to the `ManifestRegistry` object that is returned from the registry which contains additional data such as `dist` and a complete set of `contributors` which is normalized from the `maintainers` data.

Refs: https://github.com/vltpkg/vltpkg/pull/977
Refs: https://github.com/vltpkg/vltpkg/pull/947