### PR TITLE
chore: note on how to merge the release pr

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -153,7 +153,7 @@ release PR should be:
 
 1. Marked as ready for review
 1. Approved
-1. Merged
+1. Merged (Make sure to use "Rebase and merge")
 
 #### Release PR
 


### PR DESCRIPTION
I noticed we have a mention to merging the release PR using the rebase option in the PR itself in the form of the `gh` scripts to run:

```
gh pr merge -R vltpkg/vltpkg --rebase release
```

But I would like to also have a mention in the CONTRIBUTING file so that if I'm approving / merging the release PR from the GitHub web UI there's also a note on using the rebase option to keep it consistent.