### PR TITLE
dep-id: dry the dep-id module

### DIFF
--- a/src/dep-id/src/index.ts
+++ b/src/dep-id/src/index.ts
@@ -1,171 +1,22 @@
 import { error } from '@vltpkg/error-cause'
 import { Spec } from '@vltpkg/spec'
+import { splitDepID } from './browser.ts'
 import type { SpecOptions } from '@vltpkg/spec'
-import type { Manifest } from '@vltpkg/types'
+import type { DepID, DepIDTuple } from './browser.ts'
 
-export const delimiter: Delimiter = '·'
-export type Delimiter = '·'
-
-/**
- * Dependency IDs are a URI-encoded set of strings, separated
- * by the {@link Delimiter} character (`'·'`).
- *
- * The first entry is always the specifier type. The rest depend on the
- * type. `git`, `registry`, and `workspace` entries have 3 fields, the rest
- * have 2.
- *
- * - `registry`: `'registry·<registry>·name@specifier'`
- *   The `<registry>` portion can be a known named registry name, or a
- *   url to a registry. If empty, it is the default registry. Examples:
- *   - `··some-package@2.0.1`
- *   - `·npm·whatever@1.2.3`
- *   - `·http%3A%2F%2Fvlt.sh%2F·x@1.2.3`
- * - `git`: `'git·<git remote>·<git selector>'`. For example:
- *   - `git·github:user/project·branchname`
- *   - `git·git%2Bssh%3A%2F%2Fuser%40host%3Aproject.git·semver:1.x`
- * - `workspace`: `'workspace·<path>'`. For example:
- *   - `workspace·src/mything`
- * - `remote`: `'remote·<url>'`
- * - `file`: `'file·<path>'`
- *
- * Lastly, the final portion can contain arbitrary string data, and is
- * used to store peer dep resolutions to maintain the peerDep contract.
- */
-export type DepID =
-  | `${'' | 'git'}${Delimiter}${string}${Delimiter}${string}${Delimiter}${string}`
-  | `${'' | 'git'}${Delimiter}${string}${Delimiter}${string}`
-  | `${'file' | 'remote' | 'workspace'}${Delimiter}${string}${Delimiter}${string}`
-  | `${'file' | 'remote' | 'workspace'}${Delimiter}${string}`
+// Here we re-export the browser-specific parts of the implementation
+// we disable the eslint rules for import/export since we are intentionally
+// re-exporting the `hydrate` and `hydrateTuple` functions to make sure they
+// use the Node.js-specific `Spec.parse` method that relies on internal node
+// modules like `util` and `path` that are not isomorphic.
+// eslint-disable-next-line import/export
+export * from './browser.ts'
 
 /**
- * A {@link DepID}, split apart and URI-decoded
+ * Turn a {@link DepID} into a {@link Spec} object using
+ * the Node.js-specific `Spec.parse` method.
  */
-export type DepIDTuple =
-  | [
-      type: 'git',
-      gitRemote: string,
-      gitSelector: string,
-      extra?: string,
-    ]
-  | [
-      type: 'registry',
-      registry: string,
-      registrySpec: string,
-      extra?: string,
-    ]
-  | [type: 'file', path: string, extra?: string]
-  | [type: 'remote', url: string, extra?: string]
-  | [type: 'workspace', workspace: string, extra?: string]
-
-const depIDRegExp = new RegExp(
-  `^((git)?${delimiter}[^${delimiter}]*${delimiter}[^${delimiter}]*(${
-    delimiter
-  }[^${delimiter}]*)?$` +
-    `|` +
-    `^(file|remote|workspace)${delimiter}[^${
-      delimiter
-    }]*)(${delimiter}[^${delimiter}]*)?$`,
-)
-
-export const isDepID = (str: unknown): str is DepID =>
-  typeof str === 'string' && depIDRegExp.test(str)
-
-export const asDepID = (str: string): DepID => {
-  if (!isDepID(str)) {
-    throw error('Expected dep id', {
-      found: str,
-    })
-  }
-  return str
-}
-
-/**
- * turn a {@link DepIDTuple} into a {@link DepID}
- */
-export const joinDepIDTuple = (list: DepIDTuple): DepID => {
-  const [type, first, second, extra] = list
-  const f = encode(first)
-  switch (type) {
-    case 'registry':
-      return `${delimiter}${f}${delimiter}${encode(second)}${extra ? `${delimiter}${encode(extra)}` : ''}`
-    case 'git':
-      return `${type}${delimiter}${f}${delimiter}${encode(second)}${extra ? `${delimiter}${encode(extra)}` : ''}`
-    default:
-      return `${type}${delimiter}${f}${second ? `${delimiter}${encode(second)}` : ''}`
-  }
-}
-
-// allow @, but otherwise, escape everything urls do
-const encode = (s?: string) =>
-  s ?
-    encodeURIComponent(s)
-      .replaceAll('%40', '@')
-      .replaceAll('%2f', '§')
-      .replaceAll('%2F', '§')
-  : s
-
-const decode = (s?: string) =>
-  s ?
-    decodeURIComponent(
-      s.replaceAll('@', '%40').replaceAll('§', '%2F'),
-    )
-  : s
-
-/**
- * turn a {@link DepID} into a {@link DepIDTuple}
- */
-export const splitDepID = (id: string): DepIDTuple => {
-  const [type, first = '', second, extra] = id
-    .replaceAll('§', '/')
-    .split(delimiter, 4)
-  const f = decodeURIComponent(first)
-  switch (type) {
-    case 'git':
-    case '': {
-      if (second === undefined) {
-        throw error(`invalid ${type} id`, { found: id })
-      }
-      const t: DepIDTuple = [
-        type || 'registry',
-        f,
-        decodeURIComponent(second),
-        decode(extra),
-      ]
-      return t
-    }
-    case 'file':
-    case 'remote':
-    case 'workspace': {
-      const t: DepIDTuple = [type, f, decode(second)]
-      return t
-    }
-    default: {
-      throw error('invalid DepID type', {
-        found: type,
-        validOptions: ['git', 'file', 'workspace', 'remote', ''],
-      })
-    }
-  }
-}
-
-/**
- * Retrieves the base {@link DepID} for a given depID,
- * ignoring any extra information that may be present.
- */
-export const baseDepID = (id: string): DepID => {
-  const [type, first, second] = splitDepID(id)
-  switch (type) {
-    case 'git':
-    case 'registry':
-      return joinDepIDTuple([type, first, second])
-    default:
-      return joinDepIDTuple([type, first])
-  }
-}
-
-/**
- * Turn a {@link DepID} into a {@link Spec} object
- */
+// eslint-disable-next-line import/export
 export const hydrate = (
   id: DepID,
   name?: string,
@@ -173,8 +24,10 @@ export const hydrate = (
 ): Spec => hydrateTuple(splitDepID(id), name, options)
 
 /**
- * Turn a {@link DepIDTuple} into a {@link Spec} object
+ * Turn a {@link DepIDTuple} into a {@link Spec} object using
+ * the Node.js-specific `Spec.parse` method.
  */
+// eslint-disable-next-line import/export
 export const hydrateTuple = (
   tuple: DepIDTuple,
   name?: string,
@@ -262,111 +115,3 @@ export const hydrateTuple = (
     }
   }
 }
-
-// Strip out the default registry, there's no need to store that
-const omitDefReg = (s?: string): string =>
-  (
-    !s ||
-    s === 'https://registry.npmjs.org' ||
-    s === 'https://registry.npmjs.org/'
-  ) ?
-    ''
-  : s
-
-/**
- * Get the {@link DepIDTuple} for a given {@link Spec} and {@link Manifest}.
- * The Manifest is used to get the name and version, if possible. If not found
- * in the manifest, registry ID types will use the name or bareSpec from the
- * specifier, so at least there's something to use later.
- */
-export const getTuple = (
-  spec: Spec,
-  mani: Manifest,
-  extra?: string,
-): DepIDTuple => {
-  const f = spec.final
-  switch (f.type) {
-    case 'registry': {
-      // try to shorten to a known name if we can.
-      const reg = omitDefReg(f.registry)
-      if (!f.namedRegistry && reg) {
-        for (const [alias, host] of Object.entries(
-          spec.options.registries,
-        )) {
-          if (reg === host) {
-            f.namedRegistry = alias
-            break
-          }
-        }
-      }
-      const version =
-        mani.version ?
-          mani.version.startsWith('v') ?
-            mani.version.slice(1)
-          : mani.version
-        : f.bareSpec
-      return [
-        f.type,
-        f.namedRegistry ?? reg,
-        `${isPackageNameConfused(spec, mani.name) ? spec.name : (mani.name ?? f.name)}@${version}`,
-        extra,
-      ]
-    }
-    case 'git': {
-      const {
-        namedGitHost,
-        namedGitHostPath,
-        gitRemote,
-        gitSelector = '',
-      } = f
-      if (!gitRemote)
-        throw error('no host on git specifier', { spec })
-      if (namedGitHost) {
-        if (!namedGitHostPath) {
-          throw error('named git host without path portion', {
-            spec,
-          })
-        }
-        return [
-          f.type,
-          `${namedGitHost}:${namedGitHostPath}`,
-          gitSelector,
-          extra,
-        ]
-      } else {
-        return [f.type, gitRemote, gitSelector, extra]
-      }
-    }
-    case 'remote': {
-      const { remoteURL } = f
-      if (!remoteURL)
-        throw error('no URL on remote specifier', { spec })
-      return [f.type, remoteURL, extra]
-    }
-    case 'file':
-    case 'workspace':
-      throw error('Path-based dep ids are not supported', { spec })
-  }
-}
-
-/**
- * Checks for a potentially manifest-confused package name.
- * Returns `true` if the package name is confused, `false` otherwise.
- */
-export const isPackageNameConfused = (spec?: Spec, name?: string) =>
-  !!spec?.name && // a nameless spec can't be checked
-  !spec.subspec && // it's not an aliased package or using a custom protocol
-  spec.type === 'registry' && // the defined spec is of type registry
-  spec.name !== name // its name is not the same as the defined spec name
-
-/**
- * Get the {@link DepID} for a given {@link Spec} and {@link Manifest}. The
- * Manifest is used to get the name and version, if possible. If not found in
- * the manifest, registry ID types will use the name or bareSpec from the
- * specifier, so at least there's something to use later.
- */
-export const getId = (
-  spec: Spec,
-  mani: Manifest,
-  extra?: string,
-): DepID => joinDepIDTuple(getTuple(spec, mani, extra))


### PR DESCRIPTION
At some point we duplicated all the implementation in the `@vltpkg/dep-id` module to provide an isomorphic `/browser` variation that does not rely on node internals.

This has been a liability since the node-specific implementation kept evolving without updating the isomorphic implementation in `./browser.ts`.

This refactors it to make sure there's proper reusability while only redefining the specific methods that rely on the node internals: `hydrate` and `hydrateTuple`.