### PR TITLE
gui: update `side-item` alises

### DIFF
--- a/src/gui/src/components/explorer-grid/side-item.tsx
+++ b/src/gui/src/components/explorer-grid/side-item.tsx
@@ -105,7 +105,16 @@ export const SideItem = forwardRef<HTMLDivElement, SideItemOptions>(
           )}
         />
         <ContextMenu>
-          <ContextMenuTrigger>
+          <ContextMenuTrigger className="group/side-item relative">
+            {item.stacked && (
+              <>
+                <div className="duration-250 absolute inset-x-2 top-1 z-[9] h-full rounded-lg border-[1px] bg-card transition-colors group-hover/side-item:border-muted group-hover/side-item:bg-card-accent/50" />
+                {item.size > 2 && (
+                  <div className="duration-250 absolute inset-x-3 top-2 z-[8] h-full rounded-lg border-[1px] bg-card transition-colors group-hover/side-item:border-muted group-hover/side-item:bg-card-accent/30" />
+                )}
+              </>
+            )}
+
             <Card
               role="article"
               className={cn(
@@ -115,18 +124,15 @@ export const SideItem = forwardRef<HTMLDivElement, SideItemOptions>(
               )}
               onClick={onSelect}>
               <CardHeader className="relative flex w-full max-w-full flex-row items-baseline gap-3 px-3 py-2">
-                {!isWorkspace && (
-                  <SideItemSpec
-                    spec={item.spec}
-                    itemSize={item.size}
-                  />
-                )}
+                {!isWorkspace && <SideItemSpec spec={item.spec} />}
                 <TooltipProvider>
                   <Tooltip delayDuration={150}>
                     <TooltipTrigger className="w-full max-w-full cursor-default items-baseline justify-between overflow-hidden truncate text-left text-sm font-medium">
                       {itemName}
                     </TooltipTrigger>
-                    <TooltipContent>{itemName}</TooltipContent>
+                    <TooltipContent align="start">
+                      {itemName}
+                    </TooltipContent>
                   </Tooltip>
                 </TooltipProvider>
                 {!item.id.startsWith('uninstalled-dep:') && (
@@ -135,7 +141,10 @@ export const SideItem = forwardRef<HTMLDivElement, SideItemOptions>(
                   </span>
                 )}
 
-                <SideItemBadges labels={item.labels} />
+                <SideItemBadges
+                  labels={item.labels}
+                  itemSize={item.size}
+                />
               </CardHeader>
             </Card>
           </ContextMenuTrigger>
@@ -155,27 +164,42 @@ export const SideItem = forwardRef<HTMLDivElement, SideItemOptions>(
 
 const SideItemBadges = ({
   labels,
+  itemSize,
 }: {
   labels: SideItemOptions['item']['labels']
+  itemSize: SideItemOptions['item']['size']
 }) => {
-  if (!labels) return null
+  if (!labels && (itemSize === 0 || !itemSize)) return null
+
   return (
-    <div className="absolute -bottom-3 right-2.5">
-      {labels.map((label, idx) => (
-        <RelationBadge key={`${label}-${idx}`} relation={label}>
-          {label}
-        </RelationBadge>
-      ))}
+    <div className="absolute inset-x-0 -bottom-3 px-2.5">
+      <div className="relative flex w-full items-center justify-end">
+        {itemSize > 1 && (
+          <div className="relative flex h-[19px] w-fit cursor-default items-center justify-center rounded-full border-[1px] border-gray-500 bg-gray-200 px-2 dark:border-gray-500 dark:bg-gray-950">
+            <span className="text-xs font-medium text-gray-600 dark:text-gray-400">
+              {itemSize - 1} more
+            </span>
+          </div>
+        )}
+
+        {labels && labels.length > 0 && (
+          <div className="flex flex-wrap items-center gap-1">
+            {labels.map((label, idx) => (
+              <RelationBadge key={`${label}-${idx}`} relation={label}>
+                {label}
+              </RelationBadge>
+            ))}
+          </div>
+        )}
+      </div>
     </div>
   )
 }
 
 const SideItemSpec = ({
   spec,
-  itemSize,
 }: {
   spec: SideItemOptions['item']['spec']
-  itemSize: SideItemOptions['item']['size']
 }) => {
   if (!spec?.bareSpec) return null
 
@@ -194,11 +218,6 @@ const SideItemSpec = ({
           : spec.bareSpec
         }
       />
-      {itemSize > 1 && (
-        <span className="text-xs font-medium text-muted-foreground">
-          and {itemSize - 1} more.
-        </span>
-      )}
     </div>
   )
 }

--- a/src/gui/src/components/explorer-grid/side-item.tsx
+++ b/src/gui/src/components/explorer-grid/side-item.tsx
@@ -106,15 +106,6 @@ export const SideItem = forwardRef<HTMLDivElement, SideItemOptions>(
         />
         <ContextMenu>
           <ContextMenuTrigger className="group/side-item relative">
-            {item.stacked && (
-              <>
-                <div className="duration-250 absolute inset-x-2 top-1 z-[9] h-full rounded-lg border-[1px] bg-card transition-colors group-hover/side-item:border-muted group-hover/side-item:bg-card-accent/50" />
-                {item.size > 2 && (
-                  <div className="duration-250 absolute inset-x-3 top-2 z-[8] h-full rounded-lg border-[1px] bg-card transition-colors group-hover/side-item:border-muted group-hover/side-item:bg-card-accent/30" />
-                )}
-              </>
-            )}
-
             <Card
               role="article"
               className={cn(
@@ -156,6 +147,14 @@ export const SideItem = forwardRef<HTMLDivElement, SideItemOptions>(
               Remove dependency
             </ContextMenuItem>
           </ContextMenuContent>
+          {item.stacked && (
+            <>
+              <div className="duration-250 absolute inset-x-1 top-[0.2rem] z-[9] h-full rounded-lg border-[1px] bg-card transition-colors group-hover/side-item:border-muted group-hover/side-item:bg-card-accent/50" />
+              {item.size > 2 && (
+                <div className="duration-250 absolute inset-x-2 top-[0.4rem] z-[8] h-full rounded-lg border-[1px] bg-card transition-colors group-hover/side-item:border-muted group-hover/side-item:bg-card-accent/30" />
+              )}
+            </>
+          )}
         </ContextMenu>
       </div>
     )

--- a/src/gui/src/main.css
+++ b/src/gui/src/main.css
@@ -46,8 +46,8 @@
   :root {
     --background: 0 0% 98%;
     --foreground: 0 0% 3.9%;
-    --card: 0 0% 100%;
-    --card-accent: 0 0% 98%;
+    --card: 0 0% 99%;
+    --card-accent: 0 0% 100%;
     --card-foreground: 0 0% 3.9%;
     --popover: 0 0% 100%;
     --popover-foreground: 0 0% 3.9%;

--- a/src/gui/test/components/explorer-grid/__snapshots__/side-item.tsx.snap
+++ b/src/gui/test/components/explorer-grid/__snapshots__/side-item.tsx.snap
@@ -8,7 +8,10 @@ exports[`SideItem clicks on a workspace item change the query 1`] = `
     class="pointer-events-none absolute w-[var(--column-gap-x)] h-[calc(100%+var(--column-gap-y))] -top-[calc(100%-1.25px-var(--column-gap-y)/5)] -left-[calc(var(--column-gap-x)/2)] border-l-[1px] border-b-[1px] rounded-bl-md border-muted group-[&amp;:first-of-type]:rounded-none group-[&amp;:first-of-type]:h-[1px] group-[&amp;:first-of-type]:w-[var(--column-gap-x)] group-[&amp;:first-of-type]:-left-4 group-[&amp;:first-of-type]:border-l-[0px] group-[&amp;:first-of-type]:inset-y-0 group-[&amp;:first-of-type]:my-auto group-[&amp;:nth-child(n+3)]:h-[calc(100%+(var(--column-gap-y)*2))] group-[&amp;:nth-child(n+3)]:-top-[calc(100%+var(--column-gap-y)/1.5)] group-has-[.parent]:left-[calc(100%)] group-has-[.parent]:border-l-[0px] group-has-[.parent]:w-[var(--column-gap-x)] group-has-[.parent]:h-[1px] group-has-[.parent]:top-[50%] group-has-[.parent]:rounded-none hidden"
   >
   </div>
-  <span data-state="closed">
+  <span
+    data-state="closed"
+    class="group/side-item relative"
+  >
     <gui-card
       role="article"
       classname="group relative z-[10] cursor-default transition-colors hover:border-muted hover:bg-card-accent"
@@ -23,10 +26,14 @@ exports[`SideItem clicks on a workspace item change the query 1`] = `
         <span class="ml-auto font-courier text-sm font-normal text-muted-foreground">
           v1.0.0
         </span>
-        <div class="absolute -bottom-3 right-2.5">
-          <gui-relation-badge relation="prod">
-            prod
-          </gui-relation-badge>
+        <div class="absolute inset-x-0 -bottom-3 px-2.5">
+          <div class="relative flex w-full items-center justify-end">
+            <div class="flex flex-wrap items-center gap-1">
+              <gui-relation-badge relation="prod">
+                prod
+              </gui-relation-badge>
+            </div>
+          </div>
         </div>
       </gui-card-header>
     </gui-card>
@@ -44,7 +51,10 @@ exports[`SideItem render as aliased dependency 1`] = `
       class="pointer-events-none absolute w-[var(--column-gap-x)] h-[calc(100%+var(--column-gap-y))] -top-[calc(100%-1.25px-var(--column-gap-y)/5)] -left-[calc(var(--column-gap-x)/2)] border-l-[1px] border-b-[1px] rounded-bl-md border-muted group-[&amp;:first-of-type]:rounded-none group-[&amp;:first-of-type]:h-[1px] group-[&amp;:first-of-type]:w-[var(--column-gap-x)] group-[&amp;:first-of-type]:-left-4 group-[&amp;:first-of-type]:border-l-[0px] group-[&amp;:first-of-type]:inset-y-0 group-[&amp;:first-of-type]:my-auto group-[&amp;:nth-child(n+3)]:h-[calc(100%+(var(--column-gap-y)*2))] group-[&amp;:nth-child(n+3)]:-top-[calc(100%+var(--column-gap-y)/1.5)] group-has-[.parent]:left-[calc(100%)] group-has-[.parent]:border-l-[0px] group-has-[.parent]:w-[var(--column-gap-x)] group-has-[.parent]:h-[1px] group-has-[.parent]:top-[50%] group-has-[.parent]:rounded-none"
     >
     </div>
-    <span data-state="closed">
+    <span
+      data-state="closed"
+      class="group/side-item relative"
+    >
       <gui-card
         role="article"
         classname="group relative z-[10] cursor-default transition-colors hover:border-muted hover:bg-card-accent"
@@ -67,10 +77,14 @@ exports[`SideItem render as aliased dependency 1`] = `
           <span class="ml-auto font-courier text-sm font-normal text-muted-foreground">
             v1.0.0
           </span>
-          <div class="absolute -bottom-3 right-2.5">
-            <gui-relation-badge relation="prod">
-              prod
-            </gui-relation-badge>
+          <div class="absolute inset-x-0 -bottom-3 px-2.5">
+            <div class="relative flex w-full items-center justify-end">
+              <div class="flex flex-wrap items-center gap-1">
+                <gui-relation-badge relation="prod">
+                  prod
+                </gui-relation-badge>
+              </div>
+            </div>
           </div>
         </gui-card-header>
       </gui-card>
@@ -89,7 +103,10 @@ exports[`SideItem render as dependency 1`] = `
       class="pointer-events-none absolute w-[var(--column-gap-x)] h-[calc(100%+var(--column-gap-y))] -top-[calc(100%-1.25px-var(--column-gap-y)/5)] -left-[calc(var(--column-gap-x)/2)] border-l-[1px] border-b-[1px] rounded-bl-md border-muted group-[&amp;:first-of-type]:rounded-none group-[&amp;:first-of-type]:h-[1px] group-[&amp;:first-of-type]:w-[var(--column-gap-x)] group-[&amp;:first-of-type]:-left-4 group-[&amp;:first-of-type]:border-l-[0px] group-[&amp;:first-of-type]:inset-y-0 group-[&amp;:first-of-type]:my-auto group-[&amp;:nth-child(n+3)]:h-[calc(100%+(var(--column-gap-y)*2))] group-[&amp;:nth-child(n+3)]:-top-[calc(100%+var(--column-gap-y)/1.5)] group-has-[.parent]:left-[calc(100%)] group-has-[.parent]:border-l-[0px] group-has-[.parent]:w-[var(--column-gap-x)] group-has-[.parent]:h-[1px] group-has-[.parent]:top-[50%] group-has-[.parent]:rounded-none"
     >
     </div>
-    <span data-state="closed">
+    <span
+      data-state="closed"
+      class="group/side-item relative"
+    >
       <gui-card
         role="article"
         classname="group relative z-[10] cursor-default transition-colors hover:border-muted hover:bg-card-accent"
@@ -112,10 +129,14 @@ exports[`SideItem render as dependency 1`] = `
           <span class="ml-auto font-courier text-sm font-normal text-muted-foreground">
             v1.0.0
           </span>
-          <div class="absolute -bottom-3 right-2.5">
-            <gui-relation-badge relation="peer">
-              peer
-            </gui-relation-badge>
+          <div class="absolute inset-x-0 -bottom-3 px-2.5">
+            <div class="relative flex w-full items-center justify-end">
+              <div class="flex flex-wrap items-center gap-1">
+                <gui-relation-badge relation="peer">
+                  peer
+                </gui-relation-badge>
+              </div>
+            </div>
           </div>
         </gui-card-header>
       </gui-card>
@@ -134,7 +155,10 @@ exports[`SideItem render as dependency with long name 1`] = `
       class="pointer-events-none absolute w-[var(--column-gap-x)] h-[calc(100%+var(--column-gap-y))] -top-[calc(100%-1.25px-var(--column-gap-y)/5)] -left-[calc(var(--column-gap-x)/2)] border-l-[1px] border-b-[1px] rounded-bl-md border-muted group-[&amp;:first-of-type]:rounded-none group-[&amp;:first-of-type]:h-[1px] group-[&amp;:first-of-type]:w-[var(--column-gap-x)] group-[&amp;:first-of-type]:-left-4 group-[&amp;:first-of-type]:border-l-[0px] group-[&amp;:first-of-type]:inset-y-0 group-[&amp;:first-of-type]:my-auto group-[&amp;:nth-child(n+3)]:h-[calc(100%+(var(--column-gap-y)*2))] group-[&amp;:nth-child(n+3)]:-top-[calc(100%+var(--column-gap-y)/1.5)] group-has-[.parent]:left-[calc(100%)] group-has-[.parent]:border-l-[0px] group-has-[.parent]:w-[var(--column-gap-x)] group-has-[.parent]:h-[1px] group-has-[.parent]:top-[50%] group-has-[.parent]:rounded-none"
     >
     </div>
-    <span data-state="closed">
+    <span
+      data-state="closed"
+      class="group/side-item relative"
+    >
       <gui-card
         role="article"
         classname="group relative z-[10] cursor-default transition-colors hover:border-muted hover:bg-card-accent"
@@ -157,10 +181,14 @@ exports[`SideItem render as dependency with long name 1`] = `
           <span class="ml-auto font-courier text-sm font-normal text-muted-foreground">
             v1.0.0
           </span>
-          <div class="absolute -bottom-3 right-2.5">
-            <gui-relation-badge relation="peer">
-              peer
-            </gui-relation-badge>
+          <div class="absolute inset-x-0 -bottom-3 px-2.5">
+            <div class="relative flex w-full items-center justify-end">
+              <div class="flex flex-wrap items-center gap-1">
+                <gui-relation-badge relation="peer">
+                  peer
+                </gui-relation-badge>
+              </div>
+            </div>
           </div>
         </gui-card-header>
       </gui-card>
@@ -179,7 +207,10 @@ exports[`SideItem render as dependent 1`] = `
       class="pointer-events-none absolute w-[var(--column-gap-x)] h-[calc(100%+var(--column-gap-y))] -top-[calc(100%-1.25px-var(--column-gap-y)/5)] -left-[calc(var(--column-gap-x)/2)] border-l-[1px] border-b-[1px] rounded-bl-md border-muted group-[&amp;:first-of-type]:rounded-none group-[&amp;:first-of-type]:h-[1px] group-[&amp;:first-of-type]:w-[var(--column-gap-x)] group-[&amp;:first-of-type]:-left-4 group-[&amp;:first-of-type]:border-l-[0px] group-[&amp;:first-of-type]:inset-y-0 group-[&amp;:first-of-type]:my-auto group-[&amp;:nth-child(n+3)]:h-[calc(100%+(var(--column-gap-y)*2))] group-[&amp;:nth-child(n+3)]:-top-[calc(100%+var(--column-gap-y)/1.5)] group-has-[.parent]:left-[calc(100%)] group-has-[.parent]:border-l-[0px] group-has-[.parent]:w-[var(--column-gap-x)] group-has-[.parent]:h-[1px] group-has-[.parent]:top-[50%] group-has-[.parent]:rounded-none hidden"
     >
     </div>
-    <span data-state="closed">
+    <span
+      data-state="closed"
+      class="group/side-item relative"
+    >
       <gui-card
         role="article"
         classname="group relative z-[10] cursor-default transition-colors hover:border-muted hover:bg-card-accent"
@@ -202,10 +233,14 @@ exports[`SideItem render as dependent 1`] = `
           <span class="ml-auto font-courier text-sm font-normal text-muted-foreground">
             v1.0.0
           </span>
-          <div class="absolute -bottom-3 right-2.5">
-            <gui-relation-badge relation="prod">
-              prod
-            </gui-relation-badge>
+          <div class="absolute inset-x-0 -bottom-3 px-2.5">
+            <div class="relative flex w-full items-center justify-end">
+              <div class="flex flex-wrap items-center gap-1">
+                <gui-relation-badge relation="prod">
+                  prod
+                </gui-relation-badge>
+              </div>
+            </div>
           </div>
         </gui-card-header>
       </gui-card>
@@ -224,7 +259,10 @@ exports[`SideItem render as git dependency 1`] = `
       class="pointer-events-none absolute w-[var(--column-gap-x)] h-[calc(100%+var(--column-gap-y))] -top-[calc(100%-1.25px-var(--column-gap-y)/5)] -left-[calc(var(--column-gap-x)/2)] border-l-[1px] border-b-[1px] rounded-bl-md border-muted group-[&amp;:first-of-type]:rounded-none group-[&amp;:first-of-type]:h-[1px] group-[&amp;:first-of-type]:w-[var(--column-gap-x)] group-[&amp;:first-of-type]:-left-4 group-[&amp;:first-of-type]:border-l-[0px] group-[&amp;:first-of-type]:inset-y-0 group-[&amp;:first-of-type]:my-auto group-[&amp;:nth-child(n+3)]:h-[calc(100%+(var(--column-gap-y)*2))] group-[&amp;:nth-child(n+3)]:-top-[calc(100%+var(--column-gap-y)/1.5)] group-has-[.parent]:left-[calc(100%)] group-has-[.parent]:border-l-[0px] group-has-[.parent]:w-[var(--column-gap-x)] group-has-[.parent]:h-[1px] group-has-[.parent]:top-[50%] group-has-[.parent]:rounded-none"
     >
     </div>
-    <span data-state="closed">
+    <span
+      data-state="closed"
+      class="group/side-item relative"
+    >
       <gui-card
         role="article"
         classname="group relative z-[10] cursor-default transition-colors hover:border-muted hover:bg-card-accent"
@@ -247,10 +285,14 @@ exports[`SideItem render as git dependency 1`] = `
           <span class="ml-auto font-courier text-sm font-normal text-muted-foreground">
             v1.0.0
           </span>
-          <div class="absolute -bottom-3 right-2.5">
-            <gui-relation-badge relation="prod">
-              prod
-            </gui-relation-badge>
+          <div class="absolute inset-x-0 -bottom-3 px-2.5">
+            <div class="relative flex w-full items-center justify-end">
+              <div class="flex flex-wrap items-center gap-1">
+                <gui-relation-badge relation="prod">
+                  prod
+                </gui-relation-badge>
+              </div>
+            </div>
           </div>
         </gui-card-header>
       </gui-card>
@@ -269,7 +311,14 @@ exports[`SideItem render as multi-stacked dependent 1`] = `
       class="pointer-events-none absolute w-[var(--column-gap-x)] h-[calc(100%+var(--column-gap-y))] -top-[calc(100%-1.25px-var(--column-gap-y)/5)] -left-[calc(var(--column-gap-x)/2)] border-l-[1px] border-b-[1px] rounded-bl-md border-muted group-[&amp;:first-of-type]:rounded-none group-[&amp;:first-of-type]:h-[1px] group-[&amp;:first-of-type]:w-[var(--column-gap-x)] group-[&amp;:first-of-type]:-left-4 group-[&amp;:first-of-type]:border-l-[0px] group-[&amp;:first-of-type]:inset-y-0 group-[&amp;:first-of-type]:my-auto group-[&amp;:nth-child(n+3)]:h-[calc(100%+(var(--column-gap-y)*2))] group-[&amp;:nth-child(n+3)]:-top-[calc(100%+var(--column-gap-y)/1.5)] group-has-[.parent]:left-[calc(100%)] group-has-[.parent]:border-l-[0px] group-has-[.parent]:w-[var(--column-gap-x)] group-has-[.parent]:h-[1px] group-has-[.parent]:top-[50%] group-has-[.parent]:rounded-none hidden"
     >
     </div>
-    <span data-state="closed">
+    <span
+      data-state="closed"
+      class="group/side-item relative"
+    >
+      <div class="duration-250 absolute inset-x-2 top-1 z-[9] h-full rounded-lg border-[1px] bg-card transition-colors group-hover/side-item:border-muted group-hover/side-item:bg-card-accent/50">
+      </div>
+      <div class="duration-250 absolute inset-x-3 top-2 z-[8] h-full rounded-lg border-[1px] bg-card transition-colors group-hover/side-item:border-muted group-hover/side-item:bg-card-accent/30">
+      </div>
       <gui-card
         role="article"
         classname="group relative z-[10] cursor-default transition-colors hover:border-muted hover:bg-card-accent"
@@ -282,9 +331,6 @@ exports[`SideItem render as multi-stacked dependent 1`] = `
               content="^1.0.0"
             >
             </gui-data-badge>
-            <span class="text-xs font-medium text-muted-foreground">
-              and 4 more.
-            </span>
           </div>
           <button
             data-state="closed"
@@ -295,10 +341,19 @@ exports[`SideItem render as multi-stacked dependent 1`] = `
           <span class="ml-auto font-courier text-sm font-normal text-muted-foreground">
             v1.0.0
           </span>
-          <div class="absolute -bottom-3 right-2.5">
-            <gui-relation-badge relation="prod">
-              prod
-            </gui-relation-badge>
+          <div class="absolute inset-x-0 -bottom-3 px-2.5">
+            <div class="relative flex w-full items-center justify-end">
+              <div class="relative flex h-[19px] w-fit cursor-default items-center justify-center rounded-full border-[1px] border-gray-500 bg-gray-200 px-2 dark:border-gray-500 dark:bg-gray-950">
+                <span class="text-xs font-medium text-gray-600 dark:text-gray-400">
+                  4 more
+                </span>
+              </div>
+              <div class="flex flex-wrap items-center gap-1">
+                <gui-relation-badge relation="prod">
+                  prod
+                </gui-relation-badge>
+              </div>
+            </div>
           </div>
         </gui-card-header>
       </gui-card>
@@ -317,7 +372,10 @@ exports[`SideItem render as parent 1`] = `
       class="pointer-events-none absolute w-[var(--column-gap-x)] h-[calc(100%+var(--column-gap-y))] -top-[calc(100%-1.25px-var(--column-gap-y)/5)] -left-[calc(var(--column-gap-x)/2)] border-l-[1px] border-b-[1px] rounded-bl-md border-muted group-[&amp;:first-of-type]:rounded-none group-[&amp;:first-of-type]:h-[1px] group-[&amp;:first-of-type]:w-[var(--column-gap-x)] group-[&amp;:first-of-type]:-left-4 group-[&amp;:first-of-type]:border-l-[0px] group-[&amp;:first-of-type]:inset-y-0 group-[&amp;:first-of-type]:my-auto group-[&amp;:nth-child(n+3)]:h-[calc(100%+(var(--column-gap-y)*2))] group-[&amp;:nth-child(n+3)]:-top-[calc(100%+var(--column-gap-y)/1.5)] group-has-[.parent]:left-[calc(100%)] group-has-[.parent]:border-l-[0px] group-has-[.parent]:w-[var(--column-gap-x)] group-has-[.parent]:h-[1px] group-has-[.parent]:top-[50%] group-has-[.parent]:rounded-none hidden"
     >
     </div>
-    <span data-state="closed">
+    <span
+      data-state="closed"
+      class="group/side-item relative"
+    >
       <gui-card
         role="article"
         classname="group relative z-[10] cursor-default transition-colors border-muted hover:border-muted hover:bg-card-accent"
@@ -340,10 +398,14 @@ exports[`SideItem render as parent 1`] = `
           <span class="ml-auto font-courier text-sm font-normal text-muted-foreground">
             v1.0.0
           </span>
-          <div class="absolute -bottom-3 right-2.5">
-            <gui-relation-badge relation="prod">
-              prod
-            </gui-relation-badge>
+          <div class="absolute inset-x-0 -bottom-3 px-2.5">
+            <div class="relative flex w-full items-center justify-end">
+              <div class="flex flex-wrap items-center gap-1">
+                <gui-relation-badge relation="prod">
+                  prod
+                </gui-relation-badge>
+              </div>
+            </div>
           </div>
         </gui-card-header>
       </gui-card>
@@ -362,7 +424,12 @@ exports[`SideItem render as two-stacked dependent 1`] = `
       class="pointer-events-none absolute w-[var(--column-gap-x)] h-[calc(100%+var(--column-gap-y))] -top-[calc(100%-1.25px-var(--column-gap-y)/5)] -left-[calc(var(--column-gap-x)/2)] border-l-[1px] border-b-[1px] rounded-bl-md border-muted group-[&amp;:first-of-type]:rounded-none group-[&amp;:first-of-type]:h-[1px] group-[&amp;:first-of-type]:w-[var(--column-gap-x)] group-[&amp;:first-of-type]:-left-4 group-[&amp;:first-of-type]:border-l-[0px] group-[&amp;:first-of-type]:inset-y-0 group-[&amp;:first-of-type]:my-auto group-[&amp;:nth-child(n+3)]:h-[calc(100%+(var(--column-gap-y)*2))] group-[&amp;:nth-child(n+3)]:-top-[calc(100%+var(--column-gap-y)/1.5)] group-has-[.parent]:left-[calc(100%)] group-has-[.parent]:border-l-[0px] group-has-[.parent]:w-[var(--column-gap-x)] group-has-[.parent]:h-[1px] group-has-[.parent]:top-[50%] group-has-[.parent]:rounded-none hidden"
     >
     </div>
-    <span data-state="closed">
+    <span
+      data-state="closed"
+      class="group/side-item relative"
+    >
+      <div class="duration-250 absolute inset-x-2 top-1 z-[9] h-full rounded-lg border-[1px] bg-card transition-colors group-hover/side-item:border-muted group-hover/side-item:bg-card-accent/50">
+      </div>
       <gui-card
         role="article"
         classname="group relative z-[10] cursor-default transition-colors hover:border-muted hover:bg-card-accent"
@@ -375,9 +442,6 @@ exports[`SideItem render as two-stacked dependent 1`] = `
               content="^1.0.0"
             >
             </gui-data-badge>
-            <span class="text-xs font-medium text-muted-foreground">
-              and 1 more.
-            </span>
           </div>
           <button
             data-state="closed"
@@ -388,10 +452,19 @@ exports[`SideItem render as two-stacked dependent 1`] = `
           <span class="ml-auto font-courier text-sm font-normal text-muted-foreground">
             v1.0.0
           </span>
-          <div class="absolute -bottom-3 right-2.5">
-            <gui-relation-badge relation="prod">
-              prod
-            </gui-relation-badge>
+          <div class="absolute inset-x-0 -bottom-3 px-2.5">
+            <div class="relative flex w-full items-center justify-end">
+              <div class="relative flex h-[19px] w-fit cursor-default items-center justify-center rounded-full border-[1px] border-gray-500 bg-gray-200 px-2 dark:border-gray-500 dark:bg-gray-950">
+                <span class="text-xs font-medium text-gray-600 dark:text-gray-400">
+                  1 more
+                </span>
+              </div>
+              <div class="flex flex-wrap items-center gap-1">
+                <gui-relation-badge relation="prod">
+                  prod
+                </gui-relation-badge>
+              </div>
+            </div>
           </div>
         </gui-card-header>
       </gui-card>
@@ -410,7 +483,10 @@ exports[`SideItem render as workspace item 1`] = `
       class="pointer-events-none absolute w-[var(--column-gap-x)] h-[calc(100%+var(--column-gap-y))] -top-[calc(100%-1.25px-var(--column-gap-y)/5)] -left-[calc(var(--column-gap-x)/2)] border-l-[1px] border-b-[1px] rounded-bl-md border-muted group-[&amp;:first-of-type]:rounded-none group-[&amp;:first-of-type]:h-[1px] group-[&amp;:first-of-type]:w-[var(--column-gap-x)] group-[&amp;:first-of-type]:-left-4 group-[&amp;:first-of-type]:border-l-[0px] group-[&amp;:first-of-type]:inset-y-0 group-[&amp;:first-of-type]:my-auto group-[&amp;:nth-child(n+3)]:h-[calc(100%+(var(--column-gap-y)*2))] group-[&amp;:nth-child(n+3)]:-top-[calc(100%+var(--column-gap-y)/1.5)] group-has-[.parent]:left-[calc(100%)] group-has-[.parent]:border-l-[0px] group-has-[.parent]:w-[var(--column-gap-x)] group-has-[.parent]:h-[1px] group-has-[.parent]:top-[50%] group-has-[.parent]:rounded-none hidden"
     >
     </div>
-    <span data-state="closed">
+    <span
+      data-state="closed"
+      class="group/side-item relative"
+    >
       <gui-card
         role="article"
         classname="group relative z-[10] cursor-default transition-colors hover:border-muted hover:bg-card-accent"
@@ -425,10 +501,14 @@ exports[`SideItem render as workspace item 1`] = `
           <span class="ml-auto font-courier text-sm font-normal text-muted-foreground">
             v1.0.0
           </span>
-          <div class="absolute -bottom-3 right-2.5">
-            <gui-relation-badge relation="prod">
-              prod
-            </gui-relation-badge>
+          <div class="absolute inset-x-0 -bottom-3 px-2.5">
+            <div class="relative flex w-full items-center justify-end">
+              <div class="flex flex-wrap items-center gap-1">
+                <gui-relation-badge relation="prod">
+                  prod
+                </gui-relation-badge>
+              </div>
+            </div>
           </div>
         </gui-card-header>
       </gui-card>

--- a/src/gui/test/components/explorer-grid/__snapshots__/side-item.tsx.snap
+++ b/src/gui/test/components/explorer-grid/__snapshots__/side-item.tsx.snap
@@ -315,10 +315,6 @@ exports[`SideItem render as multi-stacked dependent 1`] = `
       data-state="closed"
       class="group/side-item relative"
     >
-      <div class="duration-250 absolute inset-x-2 top-1 z-[9] h-full rounded-lg border-[1px] bg-card transition-colors group-hover/side-item:border-muted group-hover/side-item:bg-card-accent/50">
-      </div>
-      <div class="duration-250 absolute inset-x-3 top-2 z-[8] h-full rounded-lg border-[1px] bg-card transition-colors group-hover/side-item:border-muted group-hover/side-item:bg-card-accent/30">
-      </div>
       <gui-card
         role="article"
         classname="group relative z-[10] cursor-default transition-colors hover:border-muted hover:bg-card-accent"
@@ -358,6 +354,10 @@ exports[`SideItem render as multi-stacked dependent 1`] = `
         </gui-card-header>
       </gui-card>
     </span>
+    <div class="duration-250 absolute inset-x-1 top-[0.2rem] z-[9] h-full rounded-lg border-[1px] bg-card transition-colors group-hover/side-item:border-muted group-hover/side-item:bg-card-accent/50">
+    </div>
+    <div class="duration-250 absolute inset-x-2 top-[0.4rem] z-[8] h-full rounded-lg border-[1px] bg-card transition-colors group-hover/side-item:border-muted group-hover/side-item:bg-card-accent/30">
+    </div>
   </div>
 </div>
 
@@ -428,8 +428,6 @@ exports[`SideItem render as two-stacked dependent 1`] = `
       data-state="closed"
       class="group/side-item relative"
     >
-      <div class="duration-250 absolute inset-x-2 top-1 z-[9] h-full rounded-lg border-[1px] bg-card transition-colors group-hover/side-item:border-muted group-hover/side-item:bg-card-accent/50">
-      </div>
       <gui-card
         role="article"
         classname="group relative z-[10] cursor-default transition-colors hover:border-muted hover:bg-card-accent"
@@ -469,6 +467,8 @@ exports[`SideItem render as two-stacked dependent 1`] = `
         </gui-card-header>
       </gui-card>
     </span>
+    <div class="duration-250 absolute inset-x-1 top-[0.2rem] z-[9] h-full rounded-lg border-[1px] bg-card transition-colors group-hover/side-item:border-muted group-hover/side-item:bg-card-accent/50">
+    </div>
   </div>
 </div>
 


### PR DESCRIPTION
### Overview

| Before | After |
|---|---|
| <img width="355" height="61" alt="Screenshot 2025-07-11 at 11 56 56" src="https://github.com/user-attachments/assets/80f09df2-eac2-4dce-993c-359132e6af01" /> | <img width="355" height="61" alt="Screenshot 2025-07-11 at 11 48 29" src="https://github.com/user-attachments/assets/d7d64b01-2ef6-4799-a27e-321b282a98a7" /> |

This PR re-implements the 'stacked' look for items that contain more than one entry and relocates the 'x and more.' to a badge within `<SideItemBadges />`
