### PR TITLE
gui: fix breadcrumb links

### DIFF
--- a/src/gui/src/components/navigation/crumb-nav.tsx
+++ b/src/gui/src/components/navigation/crumb-nav.tsx
@@ -101,7 +101,7 @@ export const CrumbNav = ({
     const constructedCrumbPath = parts
       .slice(0, crumbIndex + 1)
       .map(i => i.value)
-      .join('>')
+      .join(' > ')
     updateQuery(constructedCrumbPath)
   }
 


### PR DESCRIPTION
The more complex navigation logic such as found in:
- src/gui/src/lib/update-dependents-item.ts
- src/gui/src/lib/update-result-item.ts

Assume that direct dependency queries are split using spaces in between the direct dependency comparator, e.g: ` > `

This PR modifies it so that clicking on the parent and / or dependent items still work as expected after clicking in a breadcrumb item.