### PR TITLE
types: add manifest.version normalization

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2071,6 +2071,9 @@ importers:
       '@vltpkg/error-cause':
         specifier: workspace:*
         version: link:../error-cause
+      '@vltpkg/semver':
+        specifier: workspace:*
+        version: link:../semver
     devDependencies:
       '@eslint/js':
         specifier: 'catalog:'

--- a/src/graph/src/actual/load.ts
+++ b/src/graph/src/actual/load.ts
@@ -287,9 +287,6 @@ const parseDir = (
           h, // uses spec from hydrated id
           {
             name,
-            ...(h.registrySpec ?
-              { version: h.registrySpec } // adds version if available
-            : null),
           },
           depId,
           queryModifier,

--- a/src/graph/src/node.ts
+++ b/src/graph/src/node.ts
@@ -247,9 +247,6 @@ export class Node implements NodeLike {
 
     this.#name = name || this.manifest?.name
     this.version = version || this.manifest?.version
-    if (this.version?.startsWith('v')) {
-      this.version = this.version.slice(1)
-    }
   }
 
   /**

--- a/src/types/package.json
+++ b/src/types/package.json
@@ -19,7 +19,8 @@
     }
   },
   "dependencies": {
-    "@vltpkg/error-cause": "workspace:*"
+    "@vltpkg/error-cause": "workspace:*",
+    "@vltpkg/semver": "workspace:*"
   },
   "devDependencies": {
     "@eslint/js": "catalog:",

--- a/src/types/src/index.ts
+++ b/src/types/src/index.ts
@@ -1,4 +1,5 @@
 import { error } from '@vltpkg/error-cause'
+import { Version } from '@vltpkg/semver'
 
 /** anything that can be encoded in JSON */
 export type JSONField =
@@ -135,6 +136,20 @@ export const normalizeFunding = (
   const fundingArray = Array.isArray(funding) ? funding : [funding]
   const sources = fundingArray.map(normalizeItem)
   return sources
+}
+
+/**
+ * Normalize the version field in a manifest.
+ */
+export const normalizeVersion = (
+  manifest: Manifest | ManifestRegistry,
+): Manifest | ManifestRegistry => {
+  if (!manifest.version) {
+    return manifest
+  }
+  const version = Version.parse(manifest.version)
+  manifest.version = version.toString()
+  return manifest
 }
 
 /* Parse a string or object into a normalized contributor */
@@ -545,6 +560,8 @@ export const asManifest = (
 export const normalizeManifest = (
   manifest: Manifest | ManifestRegistry,
 ): Manifest => {
+  manifest = normalizeVersion(manifest)
+
   // checks for properties with specific normalization helper methods,
   // if there's nothing to normalize then we just return the original manifest
   if (


### PR DESCRIPTION
Adds a normalization step to `manifest.version` values, properly parsing
semver values and asserting they're valid.