### PR TITLE
types: fix version normalization

### DIFF
--- a/src/types/src/index.ts
+++ b/src/types/src/index.ts
@@ -144,8 +144,13 @@ export const normalizeFunding = (
 export const normalizeVersion = (
   manifest: Manifest | ManifestRegistry,
 ): Manifest | ManifestRegistry => {
-  if (!manifest.version) {
+  if (!Object.hasOwn(manifest, 'version')) {
     return manifest
+  }
+  if (!manifest.version) {
+    throw error('version is empty', {
+      manifest,
+    })
   }
   const version = Version.parse(manifest.version)
   manifest.version = version.toString()

--- a/src/types/test/index.ts
+++ b/src/types/test/index.ts
@@ -539,17 +539,49 @@ t.test('normalizeVersion', t => {
     t.end()
   })
 
-  t.test('returns same manifest when version is undefined', t => {
-    const manifest = { name: 'test', version: undefined }
-    const result = normalizeVersion(manifest)
-    t.equal(result, manifest, 'should return same object reference')
+  t.test('throws when version is 0', t => {
+    const manifest = {
+      name: 'test',
+      version: 0,
+    } as unknown as Manifest
+    t.throws(
+      () => normalizeVersion(manifest),
+      /version is empty/,
+      'should throw error for invalid version',
+    )
     t.end()
   })
 
-  t.test('returns same manifest when version is empty string', t => {
+  t.test('throws when version is RegExp', t => {
+    const manifest = {
+      name: 'test',
+      version: /0/,
+    } as unknown as Manifest
+    t.throws(
+      () => normalizeVersion(manifest),
+      /version.replace is not a function/,
+      'should throw error for invalid type',
+    )
+    t.end()
+  })
+
+  t.test('throws when version is undefined', t => {
+    const manifest = { name: 'test', version: undefined }
+    t.throws(
+      () => normalizeVersion(manifest),
+      /version is empty/,
+      'should throw error for empty version',
+    )
+    t.end()
+  })
+
+  t.test('throws when version is empty string', t => {
     const manifest = { name: 'test', version: '' }
-    const result = normalizeVersion(manifest)
-    t.equal(result, manifest, 'should return same object reference')
+    t.throws(
+      () => normalizeVersion(manifest),
+      /version is empty/,
+      'should throw error for empty version',
+    )
     t.end()
   })
 


### PR DESCRIPTION
`normalizeVersion` should not accept empty values as `manifest.version`