### PR TITLE
gui: bugfix `tabs-versions` tooltip collisions

### DIFF
--- a/src/gui/src/components/explorer-grid/selected-item/tabs-versions.tsx
+++ b/src/gui/src/components/explorer-grid/selected-item/tabs-versions.tsx
@@ -29,6 +29,7 @@ import {
   Tooltip,
   TooltipTrigger,
   TooltipContent,
+  TooltipPortal,
 } from '@/components/ui/tooltip.tsx'
 import { Button } from '@/components/ui/button.tsx'
 import { formatDownloadSize } from '@/utils/format-download-size.ts'
@@ -324,12 +325,14 @@ const VersionItem = memo(
                       addSuffix: true,
                     })}
                   </TooltipTrigger>
-                  <TooltipContent>
-                    {format(
-                      publishedDate,
-                      'MMMM do, yyyy | HH:mm:ss',
-                    )}
-                  </TooltipContent>
+                  <TooltipPortal>
+                    <TooltipContent>
+                      {format(
+                        publishedDate,
+                        'MMMM do, yyyy | HH:mm:ss',
+                      )}
+                    </TooltipContent>
+                  </TooltipPortal>
                 </Tooltip>
               </TooltipProvider>
             </>
@@ -369,9 +372,11 @@ const VersionItem = memo(
                     {publishedAuthor?.name}
                   </p>
                 </TooltipTrigger>
-                <TooltipContent>
-                  {publishedAuthor?.name}
-                </TooltipContent>
+                <TooltipPortal>
+                  <TooltipContent>
+                    {publishedAuthor?.name}
+                  </TooltipContent>
+                </TooltipPortal>
               </Tooltip>
             </TooltipProvider>
           </div>
@@ -445,9 +450,11 @@ const DownloadGraph = () => {
                     <CircleHelp strokeWidth={2} size={16} />
                   </span>
                 </TooltipTrigger>
-                <TooltipContent className="font-normal">
-                  Downloads across all package versions
-                </TooltipContent>
+                <TooltipPortal>
+                  <TooltipContent className="font-normal">
+                    Downloads across all package versions
+                  </TooltipContent>
+                </TooltipPortal>
               </Tooltip>
             </h3>
           </TooltipProvider>

--- a/src/gui/test/components/explorer-grid/selected-item/__snapshots__/tabs-versions.tsx.snap
+++ b/src/gui/test/components/explorer-grid/selected-item/__snapshots__/tabs-versions.tsx.snap
@@ -41,9 +41,11 @@ exports[`VersionsTabContent filters newer versions 1`] = `
                     </gui-circle-help-icon>
                   </span>
                 </gui-tooltip-trigger>
-                <gui-tooltip-content classname="font-normal">
-                  Downloads across all package versions
-                </gui-tooltip-content>
+                <gui-tooltip-portal>
+                  <gui-tooltip-content classname="font-normal">
+                    Downloads across all package versions
+                  </gui-tooltip-content>
+                </gui-tooltip-portal>
               </gui-tooltip>
             </h3>
           </gui-tooltip-provider>
@@ -222,9 +224,11 @@ exports[`VersionsTabContent filters pre-releases 1`] = `
                     </gui-circle-help-icon>
                   </span>
                 </gui-tooltip-trigger>
-                <gui-tooltip-content classname="font-normal">
-                  Downloads across all package versions
-                </gui-tooltip-content>
+                <gui-tooltip-portal>
+                  <gui-tooltip-content classname="font-normal">
+                    Downloads across all package versions
+                  </gui-tooltip-content>
+                </gui-tooltip-portal>
               </gui-tooltip>
             </h3>
           </gui-tooltip-provider>

--- a/src/gui/test/components/explorer-grid/selected-item/tabs-versions.tsx
+++ b/src/gui/test/components/explorer-grid/selected-item/tabs-versions.tsx
@@ -98,6 +98,7 @@ vi.mock('@/components/ui/tooltip.tsx', () => ({
   TooltipTrigger: 'gui-tooltip-trigger',
   TooltipContent: 'gui-tooltip-content',
   TooltipProvider: 'gui-tooltip-provider',
+  TooltipPortal: 'gui-tooltip-portal',
 }))
 
 vi.mock('@/components/ui/dropdown-menu.tsx', () => ({


### PR DESCRIPTION
Closes #1023

- wraps the `TooltipContent` with a `TooltipPortal`
