### PR TITLE
gui: overview aside metadata aggregation

### DIFF
--- a/src/gui/src/components/explorer-grid/selected-item/aside/aside-bugs.tsx
+++ b/src/gui/src/components/explorer-grid/selected-item/aside/aside-bugs.tsx
@@ -1,0 +1,34 @@
+import { getKnownHostname } from '@/utils/get-known-hostname.ts'
+import { useSelectedItemStore } from '@/components/explorer-grid/selected-item/context.tsx'
+import {
+  AsideHeader,
+  AsideSection,
+  AsideItem,
+} from '@/components/explorer-grid/selected-item/aside/aside.tsx'
+import { useEmptyCheck } from '@/components/explorer-grid/selected-item/aside/use-empty-check.tsx'
+
+export const AsideBugs = () => {
+  const manifest = useSelectedItemStore(state => state.manifest)
+  const manifestBugs = manifest?.bugs
+  const { isBugsEmpty } = useEmptyCheck()
+  const bugs =
+    !Array.isArray(manifestBugs) ? [manifestBugs] : manifestBugs
+
+  if (isBugsEmpty) return null
+
+  return (
+    <AsideSection>
+      <AsideHeader>Bug reports</AsideHeader>
+      {bugs.map((item, idx) => (
+        <AsideItem
+          type={item?.type}
+          key={idx}
+          href={item?.url ?? item?.email}>
+          {item?.url ?
+            (getKnownHostname(item.url) ?? 'Website')
+          : 'Email'}
+        </AsideItem>
+      ))}
+    </AsideSection>
+  )
+}

--- a/src/gui/src/components/explorer-grid/selected-item/aside/aside-funding.tsx
+++ b/src/gui/src/components/explorer-grid/selected-item/aside/aside-funding.tsx
@@ -1,0 +1,32 @@
+import { useSelectedItemStore } from '@/components/explorer-grid/selected-item/context.tsx'
+import { getKnownHostname } from '@/utils/get-known-hostname.ts'
+import {
+  AsideHeader,
+  AsideSection,
+  AsideItem,
+} from '@/components/explorer-grid/selected-item/aside/aside.tsx'
+import { useEmptyCheck } from '@/components/explorer-grid/selected-item/aside/use-empty-check.tsx'
+
+export const AsideFunding = () => {
+  const manifest = useSelectedItemStore(state => state.manifest)
+  const manifestFunding = manifest?.funding
+  const { isFundingEmpty } = useEmptyCheck()
+
+  if (isFundingEmpty) return null
+
+  const funding =
+    !Array.isArray(manifestFunding) ?
+      [manifestFunding]
+    : manifestFunding
+
+  return (
+    <AsideSection>
+      <AsideHeader>Funding</AsideHeader>
+      {funding.map((item, idx) => (
+        <AsideItem key={idx} href={item?.url}>
+          {(item?.url && getKnownHostname(item.url)) || 'Website'}
+        </AsideItem>
+      ))}
+    </AsideSection>
+  )
+}

--- a/src/gui/src/components/explorer-grid/selected-item/aside/aside-metadata.tsx
+++ b/src/gui/src/components/explorer-grid/selected-item/aside/aside-metadata.tsx
@@ -1,0 +1,119 @@
+import {
+  CircleFadingArrowUp,
+  Download,
+  FileLock2,
+  Package,
+} from 'lucide-react'
+import {
+  Node,
+  Npm,
+  Yarn,
+  Pnpm,
+  Deno,
+  Bun,
+} from '@/components/icons/index.ts'
+import { useSelectedItemStore } from '@/components/explorer-grid/selected-item/context.tsx'
+import {
+  AsideHeader,
+  AsideSection,
+  AsideItem,
+} from '@/components/explorer-grid/selected-item/aside/aside.tsx'
+import { useEmptyCheck } from '@/components/explorer-grid/selected-item/aside/use-empty-check.tsx'
+import { isRecord } from '@/utils/typeguards.ts'
+import { formatDownloadSize } from '@/utils/format-download-size.ts'
+
+import type { LucideIcon } from 'lucide-react'
+
+const getEngine = (engine: string): LucideIcon => {
+  switch (engine) {
+    case 'node':
+      return Node
+    case 'npm':
+      return Npm
+    case 'yarn':
+      return Yarn
+    case 'pnpm':
+      return Pnpm
+    case 'deno':
+      return Deno
+    case 'bun':
+      return Bun
+    default:
+      return Node
+  }
+}
+
+export const AsideMetadata = () => {
+  const { isMetadataEmpty } = useEmptyCheck()
+
+  const versions = useSelectedItemStore(state => state.versions)
+  const manifest = useSelectedItemStore(state => state.manifest)
+  const currentVersion = versions?.find(
+    version => version.version === manifest?.version,
+  )
+
+  const tarballUrl = currentVersion?.tarball
+  const integrity = currentVersion?.integrity
+  const unpackedSize = currentVersion?.unpackedSize
+  const type = manifest?.type
+  const engines = manifest?.engines
+
+  if (isMetadataEmpty) return null
+
+  return (
+    <>
+      <AsideSection>
+        <AsideHeader>Metadata</AsideHeader>
+        {unpackedSize && (
+          <AsideItem
+            icon={Download}
+            count={formatDownloadSize(unpackedSize)}
+          />
+        )}
+        {type && (
+          <AsideItem icon={Package}>
+            {manifest.type === 'module' ? 'ESM' : 'CJS'}
+          </AsideItem>
+        )}
+        {integrity && (
+          <AsideItem
+            icon={FileLock2}
+            copyToClipboard={{ copyValue: integrity }}>
+            Integrity Value
+          </AsideItem>
+        )}
+        {tarballUrl && (
+          <AsideItem
+            icon={CircleFadingArrowUp}
+            copyToClipboard={{ copyValue: tarballUrl }}>
+            Tarball URL
+          </AsideItem>
+        )}
+      </AsideSection>
+      {engines && (
+        <AsideSection>
+          <AsideHeader>Engines</AsideHeader>
+          {isRecord(engines) &&
+            Object.entries(engines).map(([engine, version], idx) => (
+              <AsideItem
+                count={version}
+                classNames={{
+                  dataBadge: {
+                    wrapperClassName: 'justify-start',
+                    contentClassName:
+                      'inline-block truncate max-w-fit overflow-hidden',
+                  },
+                }}
+                dataBadgeTooltip={{
+                  content: version,
+                  delayDuration: 150,
+                }}
+                icon={getEngine(engine)}
+                key={`${engine}-${version}-${idx}`}
+              />
+            ))}
+        </AsideSection>
+      )}
+    </>
+  )
+}

--- a/src/gui/src/components/explorer-grid/selected-item/aside/aside-repo.tsx
+++ b/src/gui/src/components/explorer-grid/selected-item/aside/aside-repo.tsx
@@ -1,0 +1,71 @@
+import {
+  Scale,
+  CircleDot,
+  Globe,
+  GitPullRequest,
+  Star,
+} from 'lucide-react'
+import { Github } from '@/components/icons/index.ts'
+import { useSelectedItemStore } from '@/components/explorer-grid/selected-item/context.tsx'
+import { getRepositoryUrl } from '@/utils/get-repo-url.ts'
+import {
+  AsideHeader,
+  AsideSection,
+  AsideItem,
+} from '@/components/explorer-grid/selected-item/aside/aside.tsx'
+import { useEmptyCheck } from '@/components/explorer-grid/selected-item/aside/use-empty-check.tsx'
+import { getKnownHostname } from '@/utils/get-known-hostname.ts'
+
+export const AsideRepo = () => {
+  const { isRepoEmpty } = useEmptyCheck()
+
+  const manifest = useSelectedItemStore(state => state.manifest)
+  const starGazers = useSelectedItemStore(
+    state => state.stargazersCount,
+  )
+  const openIssue = useSelectedItemStore(
+    state => state.openIssueCount,
+  )
+  const openPrs = useSelectedItemStore(
+    state => state.openPullRequestCount,
+  )
+
+  const homepage = manifest?.homepage
+  const repository = manifest?.repository
+  const license = manifest?.license
+
+  const repoUrl = repository && getRepositoryUrl(repository)
+  const repoHost = repoUrl && getKnownHostname(repoUrl)
+
+  if (isRepoEmpty) return null
+
+  return (
+    <AsideSection>
+      <AsideHeader>About</AsideHeader>
+      {homepage && (
+        <AsideItem icon={Globe} href={homepage}>
+          Website
+        </AsideItem>
+      )}
+      {repository && (
+        <AsideItem
+          icon={Github}
+          href={getRepositoryUrl(repository) ?? undefined}>
+          {repoHost ? repoHost : 'Repository'}
+        </AsideItem>
+      )}
+      <AsideItem count={openPrs} icon={GitPullRequest}>
+        Pull Requests
+      </AsideItem>
+      <AsideItem count={openIssue} icon={CircleDot}>
+        Issues
+      </AsideItem>
+      {(starGazers ?? 0) > 0 && (
+        <AsideItem count={String(starGazers)} icon={Star}>
+          Stars
+        </AsideItem>
+      )}
+      {license && <AsideItem icon={Scale}>{license}</AsideItem>}
+    </AsideSection>
+  )
+}

--- a/src/gui/src/components/explorer-grid/selected-item/aside/aside.tsx
+++ b/src/gui/src/components/explorer-grid/selected-item/aside/aside.tsx
@@ -1,0 +1,194 @@
+import { useState } from 'react'
+import { motion, AnimatePresence } from 'framer-motion'
+import { DataBadge } from '@/components/ui/data-badge.tsx'
+import { Link as GuiLink } from '@/components/ui/link.tsx'
+import { Link as LucideLink, Copy, Check } from 'lucide-react'
+import { cn } from '@/lib/utils.ts'
+
+import type { PropsWithChildren } from 'react'
+import type { LucideIcon } from 'lucide-react'
+import type { Variants, Transition } from 'framer-motion'
+import type { DataBadgeProps } from '@/components/ui/data-badge.tsx'
+
+interface AsideProps extends PropsWithChildren {
+  className?: string
+}
+
+const Aside = ({ className, children }: AsideProps) => {
+  return (
+    <aside
+      className={cn(
+        'order-1 flex cursor-default flex-col gap-4 px-6 py-4 xl:order-2 xl:col-span-4',
+        className,
+      )}>
+      {children}
+    </aside>
+  )
+}
+
+const AsideHeader = ({ children, className }: AsideProps) => {
+  return (
+    <h4
+      className={cn(
+        'text-sm font-medium capitalize text-muted-foreground',
+        className,
+      )}>
+      {children}
+    </h4>
+  )
+}
+
+const AsideSection = ({ children, className }: AsideProps) => {
+  return (
+    <div className={cn('flex flex-col gap-2', className)}>
+      {children}
+    </div>
+  )
+}
+
+interface CopyIconProps {
+  icon: LucideIcon
+  copied: boolean
+  hovered: boolean
+}
+
+const CopyIcon = ({ icon: Icon, copied, hovered }: CopyIconProps) => {
+  const transitionMotion: Transition = {
+    ease: 'easeInOut',
+    duration: 0.125,
+  }
+
+  const iconMotion: Variants = {
+    initial: { opacity: 0.05, scale: 0.8 },
+    animate: { opacity: 1, scale: 1 },
+    exit: { opacity: 0.05, scale: 0.8 },
+  }
+
+  return (
+    <span className="inline-flex items-center">
+      <AnimatePresence mode="wait" initial={false}>
+        {!hovered ?
+          <motion.span
+            key="default"
+            variants={iconMotion}
+            initial="initial"
+            animate="animate"
+            exit="exit"
+            className="text-muted-foreground"
+            transition={transitionMotion}>
+            <Icon size={16} />
+          </motion.span>
+        : copied ?
+          <motion.span
+            key="check"
+            variants={iconMotion}
+            initial="initial"
+            animate="animate"
+            exit="exit"
+            className="text-muted-foreground"
+            transition={transitionMotion}>
+            <Check size={16} className="my-auto" />
+          </motion.span>
+        : <motion.span
+            key="copy"
+            variants={iconMotion}
+            initial="initial"
+            animate="animate"
+            exit="exit"
+            className="text-muted-foreground"
+            transition={transitionMotion}>
+            <Copy size={16} className="my-auto" />
+          </motion.span>
+        }
+      </AnimatePresence>
+    </span>
+  )
+}
+
+interface AsideItemProps extends AsideProps {
+  href?: string
+  icon?: LucideIcon
+  count?: string | number
+  type?: 'link' | 'email'
+  copyToClipboard?: {
+    copyValue: string
+  }
+  classNames?: {
+    dataBadge: DataBadgeProps['classNames']
+  }
+  dataBadgeTooltip?: DataBadgeProps['tooltip']
+}
+
+const AsideItem = ({
+  className,
+  classNames,
+  dataBadgeTooltip,
+  children,
+  href,
+  icon: Icon,
+  count,
+  type,
+  copyToClipboard,
+}: AsideItemProps) => {
+  const [copied, setCopied] = useState<boolean>(false)
+  const [hovered, setHovered] = useState<boolean>(false)
+
+  const MotionDiv = motion.div
+
+  const { dataBadge } = classNames ?? {}
+
+  const isLink = Boolean(href) || type === 'link'
+  const isEmail = type === 'email'
+  const El =
+    isLink ? GuiLink
+    : copyToClipboard ? MotionDiv
+    : 'div'
+
+  const handleCopy = async () => {
+    if (!copyToClipboard) return
+    try {
+      await navigator.clipboard.writeText(copyToClipboard.copyValue)
+      setCopied(true)
+      setTimeout(() => setCopied(false), 1500)
+    } catch (err) {
+      console.error('Failed to copy!', err)
+    }
+  }
+
+  return (
+    <El
+      {...(isLink ? { href } : {})}
+      {...(isEmail ? { href: `mailto:${href}` } : {})}
+      {...(copyToClipboard ?
+        {
+          onClick: handleCopy,
+          onHoverStart: () => setHovered(true),
+          onHoverEnd: () => setHovered(false),
+        }
+      : {})}
+      className={cn(
+        'flex items-center text-nowrap text-sm text-foreground',
+        !isLink && 'gap-2',
+        className,
+      )}>
+      <span className="flex items-center justify-center empty:hidden [&>svg]:text-muted-foreground">
+        {Icon && copyToClipboard && (
+          <CopyIcon copied={copied} hovered={hovered} icon={Icon} />
+        )}
+        {Icon && !copyToClipboard && <Icon size={16} />}
+        {!Icon && isLink && <LucideLink size={16} />}
+      </span>
+      {count && (
+        <DataBadge
+          classNames={dataBadge}
+          tooltip={dataBadgeTooltip}
+          variant="count"
+          content={String(count)}
+        />
+      )}
+      <span className="text-sm">{children}</span>
+    </El>
+  )
+}
+
+export { Aside, AsideHeader, AsideSection, AsideItem }

--- a/src/gui/src/components/explorer-grid/selected-item/aside/index.tsx
+++ b/src/gui/src/components/explorer-grid/selected-item/aside/index.tsx
@@ -1,0 +1,31 @@
+import { Aside } from '@/components/explorer-grid/selected-item/aside/aside.tsx'
+import { AsideFunding } from '@/components/explorer-grid/selected-item/aside/aside-funding.tsx'
+import { AsideRepo } from '@/components/explorer-grid/selected-item/aside/aside-repo.tsx'
+import { AsideBugs } from '@/components/explorer-grid/selected-item/aside/aside-bugs.tsx'
+import { AsideMetadata } from '@/components/explorer-grid/selected-item/aside/aside-metadata.tsx'
+import { useEmptyCheck } from '@/components/explorer-grid/selected-item/aside/use-empty-check.tsx'
+
+interface AsideOverviewProps {
+  className?: string
+}
+
+export const AsideOverview = ({ className }: AsideOverviewProps) => {
+  const {
+    isRepoEmpty,
+    isFundingEmpty,
+    isBugsEmpty,
+    isMetadataEmpty,
+  } = useEmptyCheck()
+
+  if (isRepoEmpty && isFundingEmpty && isBugsEmpty && isMetadataEmpty)
+    return null
+
+  return (
+    <Aside className={className}>
+      <AsideRepo />
+      <AsideFunding />
+      <AsideBugs />
+      <AsideMetadata />
+    </Aside>
+  )
+}

--- a/src/gui/src/components/explorer-grid/selected-item/aside/use-empty-check.tsx
+++ b/src/gui/src/components/explorer-grid/selected-item/aside/use-empty-check.tsx
@@ -1,0 +1,72 @@
+import { useSelectedItemStore } from '@/components/explorer-grid/selected-item/context.tsx'
+import type { NormalizedManifest } from '@vltpkg/types'
+import type { Version } from '@/lib/external-info.ts'
+
+interface EmptyCheckResult {
+  isRepoEmpty: boolean
+  isFundingEmpty: boolean
+  isBugsEmpty: boolean
+  isMetadataEmpty: boolean
+}
+
+const checkMetadataEmpty = (
+  manifest: NormalizedManifest | null,
+  currentVersion: Version | undefined,
+): boolean => {
+  if (!manifest && !currentVersion) return true
+
+  return (
+    !manifest?.engines &&
+    !manifest?.type &&
+    !currentVersion?.unpackedSize &&
+    !currentVersion?.tarball &&
+    !currentVersion?.integrity
+  )
+}
+
+export const useEmptyCheck = (): EmptyCheckResult => {
+  const manifest = useSelectedItemStore(state => state.manifest)
+  const versions = useSelectedItemStore(state => state.versions)
+  const stargazersCount = useSelectedItemStore(
+    state => state.stargazersCount,
+  )
+  const openIssueCount = useSelectedItemStore(
+    state => state.openIssueCount,
+  )
+  const openPullRequestCount = useSelectedItemStore(
+    state => state.openPullRequestCount,
+  )
+
+  const currentVersion = versions?.find(
+    version => version.version === manifest?.version,
+  )
+  const funding = manifest?.funding
+  const bugs = manifest?.bugs
+
+  const isRepoEmpty =
+    !stargazersCount &&
+    !openIssueCount &&
+    !openPullRequestCount &&
+    !manifest?.homepage &&
+    !manifest?.repository &&
+    !manifest?.license
+
+  const isFundingEmpty =
+    !manifest ||
+    !funding ||
+    (!Array.isArray(funding) && [funding].length === 0)
+
+  const isBugsEmpty =
+    !manifest ||
+    !bugs ||
+    (!Array.isArray(bugs) && [bugs].length === 0)
+
+  const isMetadataEmpty = checkMetadataEmpty(manifest, currentVersion)
+
+  return {
+    isRepoEmpty,
+    isFundingEmpty,
+    isBugsEmpty,
+    isMetadataEmpty,
+  }
+}

--- a/src/gui/src/components/explorer-grid/selected-item/context.tsx
+++ b/src/gui/src/components/explorer-grid/selected-item/context.tsx
@@ -247,9 +247,13 @@ const processInsights = (
 }
 
 const processFunding = (
-  funding: NormalizedFunding,
+  manifestFunding: NormalizedFunding,
   depFunding: DepFunding,
 ) => {
+  const funding =
+    !Array.isArray(manifestFunding) ?
+      [manifestFunding]
+    : manifestFunding
   for (const entry of funding) {
     if (!entry.url) return
 
@@ -380,6 +384,7 @@ type SelectedItemStoreState = DetailsInfo & {
   depWarnings: DepWarning[] | undefined
   duplicatedDeps: DuplicatedDeps | undefined
   depFunding: DepFunding | undefined
+  asideOveriewVisible?: boolean
 }
 
 type SelectedItemStoreAction = {
@@ -402,6 +407,9 @@ type SelectedItemStoreAction = {
   setDepFunding: (
     depFunding: SelectedItemStoreState['depFunding'],
   ) => void
+  setAsideOverviewVisible?: (
+    asideOveriewVisible: SelectedItemStoreState['asideOveriewVisible'],
+  ) => void
 }
 
 export type SelectedItemStore = SelectedItemStoreState &
@@ -413,11 +421,13 @@ const SelectedItemContext = createContext<
 
 type SelectedItemProviderProps = PropsWithChildren & {
   selectedItem: GridItemData
+  asideOveriewVisible?: boolean
 }
 
 export const SelectedItemProvider = ({
   children,
   selectedItem,
+  asideOveriewVisible = true,
 }: SelectedItemProviderProps) => {
   const specOptions = useGraphStore(state => state.specOptions)
   const q = useGraphStore(state => state.q)
@@ -434,6 +444,7 @@ export const SelectedItemProvider = ({
   const selectedItemStore = useRef(
     createStore<SelectedItemStore>(set => ({
       selectedItem,
+      asideOveriewVisible,
       manifest: selectedItem.to?.manifest ?? null,
       rawManifest: selectedItem.to?.rawManifest ?? null,
       packageScore: selectedItem.to?.insights.score,
@@ -465,6 +476,9 @@ export const SelectedItemProvider = ({
       setDepFunding: (
         depFunding: SelectedItemStoreState['depFunding'],
       ) => set(() => ({ depFunding })),
+      setAsideOverviewVisible: (
+        asideOveriewVisible: SelectedItemStoreState['asideOveriewVisible'],
+      ) => set(() => ({ asideOveriewVisible })),
     })),
   ).current
 

--- a/src/gui/src/components/explorer-grid/selected-item/focused-view/aside.tsx
+++ b/src/gui/src/components/explorer-grid/selected-item/focused-view/aside.tsx
@@ -1,7 +1,7 @@
 import { useParams } from 'react-router'
-import { TabContentAside } from '@/components/explorer-grid/selected-item/tabs-overview.tsx'
 import { DependencySideBar } from '@/components/explorer-grid/dependency-sidebar/index.tsx'
 import { motion, AnimatePresence } from 'framer-motion'
+import { AsideOverview } from '@/components/explorer-grid/selected-item/aside/index.tsx'
 
 import type {
   SubTabDependencies,
@@ -51,8 +51,8 @@ export const FocusedAside = ({
     <div className="col-span-full lg:col-span-3 lg:pl-4 lg:pr-0">
       <AnimatePresence>
         {tabAsideSet.has(activeTab) ?
-          <motion.div {...motionVariants}>
-            <TabContentAside className="h-fit border-l-[1.6px] border-muted py-0" />
+          <motion.div {...motionVariants} className="p-0">
+            <AsideOverview className="h-fit py-0" />
           </motion.div>
         : activeTab === 'dependencies' ?
           <motion.aside
@@ -65,7 +65,7 @@ export const FocusedAside = ({
               importerId={importerId}
             />
           </motion.aside>
-        : <TabContentAside className="py-0" />}
+        : null}
       </AnimatePresence>
     </div>
   )

--- a/src/gui/src/components/explorer-grid/selected-item/focused-view/index.tsx
+++ b/src/gui/src/components/explorer-grid/selected-item/focused-view/index.tsx
@@ -24,7 +24,9 @@ export const FocusedView = ({
   importerId,
 }: FocusedViewProps) => {
   return (
-    <SelectedItemProvider selectedItem={item}>
+    <SelectedItemProvider
+      selectedItem={item}
+      asideOveriewVisible={false}>
       <motion.section
         initial={{
           opacity: 0,
@@ -40,7 +42,13 @@ export const FocusedView = ({
         }}
         transition={{ ease: 'easeInOut', duration: 0.25 }}
         className="relative pb-4">
-        <ItemHeader className="pb-0">
+        <ItemHeader
+          classNames={{
+            wrapperClassName: 'pb-0',
+            contentClassName: 'grid grid-cols-12',
+            breadCrumbWrapperClassName: 'col-span-12',
+            packageImageSpecClassName: 'col-span-full lg:col-span-9',
+          }}>
           <FocusButton />
         </ItemHeader>
         <div className="mx-6 grid grid-cols-12">

--- a/src/gui/src/components/explorer-grid/selected-item/item-header.tsx
+++ b/src/gui/src/components/explorer-grid/selected-item/item-header.tsx
@@ -13,16 +13,10 @@ import {
   Tooltip,
   TooltipContent,
   TooltipProvider,
+  TooltipPortal,
   TooltipTrigger,
 } from '@/components/ui/tooltip.tsx'
-import {
-  Home,
-  Scale,
-  ArrowBigUpDash,
-  EyeOff,
-  Download,
-  Package,
-} from 'lucide-react'
+import { Home, ArrowBigUpDash } from 'lucide-react'
 import { splitDepID } from '@vltpkg/dep-id/browser'
 import { defaultRegistry } from '@vltpkg/spec/browser'
 import {
@@ -30,52 +24,20 @@ import {
   scoreColors,
 } from '@/components/explorer-grid/selected-item/insight-score-helper.ts'
 import { cn } from '@/lib/utils.ts'
-import { isRecord } from '@/utils/typeguards.ts'
 import { formatDistanceStrict } from 'date-fns'
-import { formatDownloadSize } from '@/utils/format-download-size.ts'
 import {
   ScrollArea,
   ScrollBar,
 } from '@/components/ui/scroll-area.tsx'
-import { isSemver } from '@/lib/external-info.ts'
 import { DataBadge } from '@/components/ui/data-badge.tsx'
-import {
-  Npm,
-  Node,
-  Yarn,
-  Pnpm,
-  Deno,
-  Bun,
-} from '@/components/icons/index.ts'
 import { ProgressCircle } from '@/components/ui/progress-circle.tsx'
-import { toHumanNumber } from '@/utils/human-number.ts'
-import { LICENSE_TYPES } from '@/lib/constants/index.ts'
 import { CrumbNav } from '@/components/navigation/crumb-nav.tsx'
 import { useFocusState } from '@/components/explorer-grid/selected-item/focused-view/use-focus-state.tsx'
+import { toHumanNumber } from '@/utils/human-number.ts'
 
 import type { SpecOptionsFilled } from '@vltpkg/spec/browser'
 import type { GridItemData } from '@/components/explorer-grid/types.ts'
 import type { ProgressCircleVariant } from '@/components/ui/progress-circle.tsx'
-import type { LucideIcon } from 'lucide-react'
-
-const getEngine = (engine: string): LucideIcon => {
-  switch (engine) {
-    case 'node':
-      return Node
-    case 'npm':
-      return Npm
-    case 'yarn':
-      return Yarn
-    case 'pnpm':
-      return Pnpm
-    case 'deno':
-      return Deno
-    case 'bun':
-      return Bun
-    default:
-      return Node
-  }
-}
 
 const SpecOrigin = ({
   item,
@@ -96,6 +58,9 @@ const SpecOrigin = ({
               <DataBadge
                 variant="mono"
                 content={`${item.title}@${item.version}`}
+                classNames={{
+                  wrapperClassName: 'truncate overflow-hidden',
+                }}
                 tooltip={{
                   content: String(scopeValue),
                 }}
@@ -107,6 +72,9 @@ const SpecOrigin = ({
           <DataBadge
             variant="mono"
             content={`${ref || 'npm'}:${item.title}@${item.version}`}
+            classNames={{
+              wrapperClassName: 'truncate overflow-hidden',
+            }}
             tooltip={{
               content:
                 ref && specOptions.registries[ref] ?
@@ -121,7 +89,13 @@ const SpecOrigin = ({
       case 'file':
       case 'remote': {
         return (
-          <DataBadge variant="mono" content={`${depType}:${ref}`} />
+          <DataBadge
+            variant="mono"
+            classNames={{
+              wrapperClassName: 'truncate overflow-hidden',
+            }}
+            content={`${depType}:${ref}`}
+          />
         )
       }
     }
@@ -130,45 +104,46 @@ const SpecOrigin = ({
 }
 
 interface ItemHeaderProps extends React.PropsWithChildren {
-  className?: string
+  classNames?: {
+    wrapperClassName?: string
+    contentClassName?: string
+    breadCrumbWrapperClassName?: string
+    packageImageSpecClassName?: string
+  }
 }
 
 export const ItemHeader = ({
-  className,
+  classNames,
   children,
 }: ItemHeaderProps) => {
   const breadcrumbs = useSelectedItemStore(
     state => state.selectedItem.breadcrumbs,
   )
+  const {
+    wrapperClassName,
+    contentClassName,
+    breadCrumbWrapperClassName,
+    packageImageSpecClassName,
+  } = classNames ?? {}
 
   return (
     <motion.div
       animate={{ opacity: 1 }}
       initial={{ opacity: 0 }}
-      className={cn(
-        'flex flex-col divide-y-[1px] divide-muted pb-3',
-        className,
-      )}>
-      <div className="flex w-full flex-col">
+      className={cn('flex flex-col', wrapperClassName)}>
+      <div className={cn('flex w-full flex-col', contentClassName)}>
         <div
           className={cn(
             'flex h-10 w-full items-center border-b-[1px] border-muted pr-6 empty:hidden',
             breadcrumbs ? 'justify-between' : 'justify-end',
+            breadCrumbWrapperClassName,
           )}>
           <ItemBreadcrumbs />
           {children}
         </div>
-        <div className="flex w-full justify-between py-4">
-          <PackageImageSpec className="pl-6" />
-          <PackageOverallScore className="pr-6" />
-        </div>
-      </div>
-      <div className="flex h-10 w-full items-center justify-between px-6 py-2 empty:hidden">
-        <Publisher />
-        <PackageDownloadCount />
-      </div>
-      <div className="flex w-full divide-x-[1px] divide-muted empty:hidden">
-        <PackageMetadata className="w-full" />
+        <PackageImageSpec
+          className={cn('px-6 py-4', packageImageSpecClassName)}
+        />
       </div>
     </motion.div>
   )
@@ -204,141 +179,6 @@ const ItemBreadcrumbs = () => {
   )
 }
 
-const PackageDownloadCount = () => {
-  const manifest = useSelectedItemStore(state => state.manifest)
-  const downloadsPerVersion = useSelectedItemStore(
-    state => state.downloadsPerVersion,
-  )
-
-  const version = manifest?.version
-
-  if (
-    !version ||
-    !isSemver(version) ||
-    !downloadsPerVersion?.[version]
-  )
-    return null
-
-  const downloadCount = toHumanNumber(downloadsPerVersion[version])
-
-  return (
-    <DataBadge value={downloadCount} content="Downloads last week" />
-  )
-}
-
-const PackageMetadata = ({ className }: { className?: string }) => {
-  const versions = useSelectedItemStore(state => state.versions)
-  const manifest = useSelectedItemStore(state => state.manifest)
-  const { focused } = useFocusState()
-  const currentVersion = versions?.find(
-    version => version.version === manifest?.version,
-  )
-  const tarballUrl = currentVersion?.tarball
-  const integrity = currentVersion?.integrity
-  const integrityShort = integrity?.split('-')[1]?.slice(0, 6)
-
-  const hasMetadata =
-    manifest &&
-    (manifest.engines ??
-      manifest.type ??
-      currentVersion?.unpackedSize ??
-      currentVersion?.tarball ??
-      currentVersion?.integrity ??
-      manifest.private ??
-      manifest.license)
-
-  if (!hasMetadata) return null
-
-  return (
-    <ScrollArea
-      className={cn(
-        'relative w-full overflow-hidden py-3',
-        !focused && 'border-b-[1px] border-muted',
-        className,
-      )}>
-      <div
-        className={cn(
-          'pointer-events-none absolute right-0 top-0 z-[100] h-full w-[24px] bg-gradient-to-l',
-          focused ? 'from-background' : 'from-card',
-        )}
-      />
-      <div
-        className={cn(
-          'pointer-events-none absolute left-0 top-0 z-[100] h-full w-[24px] bg-gradient-to-r',
-          focused ? 'from-background' : 'from-card',
-        )}
-      />
-
-      <div className="flex w-max gap-2 overflow-x-hidden px-6">
-        {manifest.private && (
-          <DataBadge icon={EyeOff} content="Private Package" />
-        )}
-        {manifest.license &&
-          LICENSE_TYPES.some(
-            i =>
-              i.toLowerCase() ===
-              manifest.license?.trim().toLowerCase(),
-          ) && (
-            <DataBadge
-              icon={Scale}
-              value={manifest.license}
-              content="License"
-            />
-          )}
-        {manifest.type && (
-          <DataBadge
-            content={manifest.type === 'module' ? 'ESM' : 'CJS'}
-          />
-        )}
-        {manifest.engines &&
-          isRecord(manifest.engines) &&
-          Object.entries(manifest.engines).map(
-            ([engine, version], idx) => (
-              <DataBadge
-                key={`${engine}-${version}-${idx}`}
-                icon={getEngine(engine)}
-                value={version}
-                content="Engines"
-              />
-            ),
-          )}
-        {currentVersion?.unpackedSize && (
-          <DataBadge
-            icon={Download}
-            value={formatDownloadSize(currentVersion.unpackedSize)}
-            content="Install size"
-          />
-        )}
-        {tarballUrl && (
-          <DataBadge
-            icon={Package}
-            content="Tarball"
-            tooltip={{
-              content: 'Copy tarball URL',
-            }}
-            copyToClipboard={{
-              copyValue: tarballUrl,
-            }}
-          />
-        )}
-        {integrity && (
-          <DataBadge
-            value={integrityShort}
-            content="Integrity"
-            tooltip={{
-              content: `Copy Integrity value: ${integrityShort}`,
-            }}
-            copyToClipboard={{
-              copyValue: integrity,
-            }}
-          />
-        )}
-      </div>
-      <ScrollBar className="z-[102]" orientation="horizontal" />
-    </ScrollArea>
-  )
-}
-
 const PackageOverallScore = ({
   className,
 }: {
@@ -360,29 +200,26 @@ const PackageOverallScore = ({
 
   return (
     <div className={className}>
-      <div
-        onClick={onClick}
-        className="duration-250 after:duration-250 relative z-[1] flex cursor-default flex-row gap-3 self-start transition-colors after:absolute after:inset-0 after:-left-[0.5rem] after:-top-[0.5rem] after:z-[-1] after:h-[calc(100%+1rem)] after:w-[calc(100%+1rem)] after:rounded-sm after:transition-colors after:content-[''] hover:after:bg-neutral-100 dark:hover:after:bg-neutral-800">
-        <ProgressCircle
-          value={averageScore}
-          variant={chartColor as ProgressCircleVariant}
-          strokeWidth={5}
-          className="size-9">
-          <p
-            className="font-mono text-xs font-medium tabular-nums"
-            style={{ color: textColor }}>
-            {averageScore}
-          </p>
-        </ProgressCircle>
-        <div className="flex flex-col">
-          <p className="text-sm font-semibold text-neutral-600 dark:text-neutral-300">
-            Package score
-          </p>
-          <p className="font-mono text-xs font-medium tabular-nums text-neutral-400">
-            {averageScore}/100
-          </p>
-        </div>
-      </div>
+      <TooltipProvider delayDuration={150}>
+        <Tooltip>
+          <TooltipTrigger onClick={onClick}>
+            <ProgressCircle
+              value={averageScore}
+              variant={chartColor as ProgressCircleVariant}
+              strokeWidth={5}
+              className="size-9">
+              <p
+                className="font-mono text-xs font-medium tabular-nums"
+                style={{ color: textColor }}>
+                {averageScore}
+              </p>
+            </ProgressCircle>
+          </TooltipTrigger>
+          <TooltipPortal>
+            <TooltipContent>See more insights</TooltipContent>
+          </TooltipPortal>
+        </Tooltip>
+      </TooltipProvider>
     </div>
   )
 }
@@ -437,7 +274,9 @@ const PackageNewerVersionsAvailable = () => {
             />
           </div>
         </TooltipTrigger>
-        <TooltipContent>Newer versions available</TooltipContent>
+        <TooltipPortal>
+          <TooltipContent>Newer versions available</TooltipContent>
+        </TooltipPortal>
       </Tooltip>
     </TooltipProvider>
   )
@@ -450,33 +289,43 @@ const PackageImageSpec = ({ className }: { className?: string }) => {
   const specOptions = useGraphStore(state => state.specOptions)
 
   return (
-    <div className={cn('flex gap-4 overflow-hidden', className)}>
-      <PackageImage />
+    <div
+      className={cn(
+        'flex flex-col gap-2 overflow-hidden',
+        className,
+      )}>
+      <div className="flex justify-between gap-4 overflow-hidden">
+        <div className="flex gap-4">
+          <PackageImage />
+          <ScrollArea className="w-full overflow-x-scroll">
+            <div className="flex h-full w-full flex-col justify-between">
+              <div className="flex w-full flex-col gap-0.5">
+                <div className="flex items-center gap-2">
+                  <h1 className="w-fit max-w-full cursor-default align-baseline text-lg font-medium">
+                    {selectedItem.title}
+                    <span className="ml-2 font-courier text-sm text-muted-foreground">
+                      {selectedItem.version}
+                    </span>
+                  </h1>
+                  <PackageNewerVersionsAvailable />
+                </div>
 
-      <ScrollArea className="w-full overflow-x-scroll">
-        <div className="flex h-full w-full flex-col justify-between">
-          <div className="flex w-full flex-col gap-0.5">
-            <div className="flex items-center gap-2">
-              <h1 className="w-fit max-w-full cursor-default align-baseline text-lg font-medium">
-                {selectedItem.title}
-                <span className="ml-2 font-courier text-sm text-muted-foreground">
-                  v{selectedItem.version}
-                </span>
-              </h1>
-              <PackageNewerVersionsAvailable />
+                {specOptions && (
+                  <SpecOrigin
+                    item={selectedItem}
+                    specOptions={specOptions}
+                  />
+                )}
+              </div>
             </div>
 
-            {specOptions && (
-              <SpecOrigin
-                item={selectedItem}
-                specOptions={specOptions}
-              />
-            )}
-          </div>
+            <ScrollBar orientation="horizontal" />
+          </ScrollArea>
         </div>
 
-        <ScrollBar orientation="horizontal" />
-      </ScrollArea>
+        <PackageOverallScore />
+      </div>
+      <Publisher />
     </div>
   )
 }
@@ -492,47 +341,72 @@ const Publisher = ({ className }: { className?: string }) => {
     state => state.publisherAvatar,
   )
   const gitHeadShort = currentVersion?.gitHead?.slice(0, 6)
+  const downloads = useSelectedItemStore(
+    state => state.downloadsPerVersion,
+  )
+
+  const downloadCount = toHumanNumber(
+    (currentVersion?.version &&
+      downloads?.[currentVersion.version]) ??
+      0,
+  )
 
   if (!publisher) return null
 
   return (
     <div
       className={cn(
-        'flex h-[31.508px] items-center gap-2',
+        'flex w-full items-center justify-between gap-2 py-1',
         className,
       )}>
-      <Avatar>
-        <AvatarImage
-          className="size-5 rounded-sm border-[1px] border-border"
-          src={publisherAvatar?.src}
-          alt={publisherAvatar?.alt ?? 'Publisher Avatar'}
-        />
-        <AvatarFallback className="flex size-5 items-center justify-center rounded-sm bg-secondary bg-gradient-to-t from-neutral-100 to-neutral-400 p-0.5 outline outline-[1px] outline-border dark:from-neutral-500 dark:to-neutral-800" />
-      </Avatar>
-      <TooltipProvider>
-        <Tooltip>
-          <TooltipTrigger className="text-baseline cursor-default text-xs font-medium text-muted-foreground">
-            Published by:{' '}
-            <span className="text-foreground">{publisher.name}</span>
-            {currentVersion?.publishedDate && (
-              <span className="ml-2">
-                {gitHeadShort}
-                {' • '}
-                {formatDistanceStrict(
-                  currentVersion.publishedDate,
-                  new Date(),
-                  {
-                    addSuffix: true,
-                  },
-                )}
+      <div className="flex items-center gap-2">
+        <Avatar>
+          <AvatarImage
+            className="size-5 rounded-sm border-[1px] border-border"
+            src={publisherAvatar?.src}
+            alt={publisherAvatar?.alt ?? 'Publisher Avatar'}
+          />
+          <AvatarFallback className="flex size-5 items-center justify-center rounded-sm bg-secondary bg-gradient-to-t from-neutral-100 to-neutral-400 p-0.5 outline outline-[1px] outline-border dark:from-neutral-500 dark:to-neutral-800" />
+        </Avatar>
+        <TooltipProvider>
+          <Tooltip>
+            <TooltipTrigger className="text-baseline cursor-default text-xs font-medium text-muted-foreground">
+              Published by:{' '}
+              <span className="text-foreground">
+                {publisher.name}
               </span>
-            )}
-          </TooltipTrigger>
-          <TooltipContent align="start">
-            {publisher.name} {publisher.email}
-          </TooltipContent>
-        </Tooltip>
-      </TooltipProvider>
+              {currentVersion?.publishedDate && (
+                <span className="ml-2">
+                  {gitHeadShort}
+                  {' • '}
+                  {formatDistanceStrict(
+                    currentVersion.publishedDate,
+                    new Date(),
+                    {
+                      addSuffix: true,
+                    },
+                  )}
+                </span>
+              )}
+            </TooltipTrigger>
+            <TooltipPortal>
+              <TooltipContent align="start">
+                {publisher.name} {publisher.email}
+              </TooltipContent>
+            </TooltipPortal>
+          </Tooltip>
+        </TooltipProvider>
+      </div>
+      {downloadCount && (
+        <div className="flex items-center gap-2">
+          <p className="text-baseline cursor-default text-xs font-medium text-muted-foreground">
+            <span className="mr-1 text-foreground">
+              {downloadCount}
+            </span>
+            Downloads last week
+          </p>
+        </div>
+      )}
     </div>
   )
 }

--- a/src/gui/src/components/explorer-grid/selected-item/tabs-contributors.tsx
+++ b/src/gui/src/components/explorer-grid/selected-item/tabs-contributors.tsx
@@ -147,7 +147,7 @@ export const ContributorList = () => {
           )}
         </div>
         <Button
-          className="duration-250 font-muted-foreground h-fit rounded-full border-[1px] border-neutral-200 bg-neutral-100 px-3 py-1.5 text-sm font-normal text-foreground transition-colors hover:border-muted-foreground/20 hover:bg-muted-foreground/15 hover:text-foreground dark:border-[#313131] dark:bg-neutral-800 dark:hover:bg-neutral-700/70"
+          className="duration-250 font-muted-foreground h-7 rounded-full border-[1px] border-neutral-200 bg-neutral-100 px-3 py-1.5 text-sm font-normal text-foreground transition-colors hover:border-muted-foreground/20 hover:bg-muted-foreground/15 hover:text-foreground dark:border-[#313131] dark:bg-neutral-800 dark:hover:bg-neutral-700/70"
           variant="default"
           onClick={handleToContributors}>
           See all contributors

--- a/src/gui/src/components/explorer-grid/selected-item/tabs-overview.tsx
+++ b/src/gui/src/components/explorer-grid/selected-item/tabs-overview.tsx
@@ -1,29 +1,14 @@
 import { TabsTrigger } from '@/components/ui/tabs.tsx'
 import { useSelectedItemStore } from '@/components/explorer-grid/selected-item/context.tsx'
 import Markdown from 'react-markdown'
-import {
-  FileText,
-  Globe,
-  Bug,
-  RectangleHorizontal,
-  Star,
-  CircleDot,
-  GitPullRequest,
-  Link as LucideLink,
-} from 'lucide-react'
+import { FileText, RectangleHorizontal } from 'lucide-react'
 import { DataBadge } from '@/components/ui/data-badge.tsx'
-import { Link } from '@/components/ui/link.tsx'
-import { toHumanNumber } from '@/utils/human-number.ts'
-import { Github } from '@/components/icons/index.ts'
-import { getRepositoryUrl } from '@/utils/get-repo-url.ts'
 import { ContributorList } from '@/components/explorer-grid/selected-item/tabs-contributors.tsx'
 import {
   MotionTabsContent,
   tabMotion,
 } from '@/components/explorer-grid/selected-item/helpers.tsx'
-import { cn } from '@/lib/utils.ts'
-import { useFocusState } from '@/components/explorer-grid/selected-item/focused-view/use-focus-state.tsx'
-import { getKnownHostname } from '@/utils/get-known-hostname.ts'
+import { AsideOverview } from '@/components/explorer-grid/selected-item/aside/index.tsx'
 
 export const OverviewTabButton = () => {
   return (
@@ -36,194 +21,11 @@ export const OverviewTabButton = () => {
   )
 }
 
-interface AsideEmptyStateProps {
-  className?: string
-}
-
-export const AsideEmptyState = ({
-  className,
-}: AsideEmptyStateProps) => {
-  return (
-    <aside
-      className={cn(
-        'flex h-72 w-full flex-col items-center justify-center rounded-xl border-[1px] border-muted bg-white px-6 py-4 dark:bg-neutral-900',
-        className,
-      )}>
-      <p className="w-2/3 text-pretty text-center text-sm text-muted-foreground">
-        We couldn't create an overview for this project.
-      </p>
-    </aside>
-  )
-}
-
-interface TabContentAsideProps {
-  className?: string
-}
-
-export const TabContentAside = ({
-  className,
-}: TabContentAsideProps) => {
-  const manifest = useSelectedItemStore(state => state.manifest)
-  const stargazers = useSelectedItemStore(
-    state => state.stargazersCount,
-  )
-  const openIssue = useSelectedItemStore(
-    state => state.openIssueCount,
-  )
-  const openPR = useSelectedItemStore(
-    state => state.openPullRequestCount,
-  )
-  const { focused } = useFocusState()
-
-  const asideEmpty =
-    !stargazers &&
-    !openIssue &&
-    !openPR &&
-    !manifest?.homepage &&
-    !manifest?.repository &&
-    !manifest?.bugs &&
-    !manifest?.funding
-
-  if (asideEmpty && !focused) return null
-
-  if (asideEmpty && focused) return <AsideEmptyState />
-
-  return (
-    <aside
-      className={cn(
-        'order-1 flex cursor-default flex-col gap-4 px-6 py-4 xl:order-2 xl:col-span-4',
-        className,
-      )}>
-      <div className="flex flex-col gap-2">
-        <h4 className="text-sm font-medium capitalize text-muted-foreground">
-          about
-        </h4>
-        <div className="flex flex-col gap-2">
-          {manifest?.homepage && (
-            <Link
-              href={manifest.homepage}
-              className="text-sm text-foreground">
-              <span className="flex items-center justify-center">
-                <Globe size={16} className="text-muted-foreground" />
-              </span>
-              <span>Website</span>
-            </Link>
-          )}
-          {manifest?.repository && (
-            <Link
-              href={
-                getRepositoryUrl(manifest.repository) ?? undefined
-              }
-              className="text-sm text-foreground">
-              <span className="flex w-4 items-center justify-center">
-                <Github size={16} className="text-muted-foreground" />
-              </span>
-              <span>Repository</span>
-            </Link>
-          )}
-          {manifest?.bugs?.length &&
-            manifest.bugs.map((bug, idx) => {
-              let href: string | undefined
-
-              if (bug.url) {
-                href = bug.url
-              } else if (bug.email) {
-                href = `mailto:${bug.email}`
-              }
-
-              return href ?
-                  <Link
-                    key={`bug-${encodeURIComponent(href)}-${idx}`}
-                    href={href}
-                    className="text-sm text-foreground">
-                    <span className="flex items-center justify-center">
-                      <Bug
-                        size={16}
-                        className="text-muted-foreground"
-                      />
-                    </span>
-                    <span>Bug reports</span>
-                  </Link>
-                : null
-            })}
-          {openPR && (
-            <div className="flex items-center gap-2">
-              <GitPullRequest
-                size={16}
-                className="text-muted-foreground"
-              />
-              <div className="flex gap-1">
-                <DataBadge variant="count" content={openPR} />
-                <p className="text-sm">Pull requests</p>
-              </div>
-            </div>
-          )}
-          {openIssue && (
-            <div className="flex items-center gap-2">
-              <CircleDot
-                size={16}
-                className="text-muted-foreground"
-              />
-              <div className="flex gap-1">
-                <DataBadge variant="count" content={openIssue} />
-                <p className="text-sm">Issues</p>
-              </div>
-            </div>
-          )}
-          {(stargazers ?? 0) > 0 && (
-            <div className="flex items-center gap-2">
-              <Star size={16} className="text-muted-foreground" />
-              <div className="flex gap-1">
-                <DataBadge
-                  variant="count"
-                  content={toHumanNumber(stargazers ?? 0)}
-                />
-                <p className="text-sm">Stars</p>
-              </div>
-            </div>
-          )}
-        </div>
-      </div>
-      {manifest?.funding && (
-        <div className="flex flex-col gap-2">
-          <h4 className="text-sm font-medium capitalize text-muted-foreground">
-            funding
-          </h4>
-          <div className="flex flex-col gap-2">
-            {(() => {
-              const entries =
-                Array.isArray(manifest.funding) ?
-                  manifest.funding
-                : [manifest.funding]
-
-              return entries.map((entry, idx) => {
-                const url =
-                  typeof entry === 'string' ? entry : entry.url
-                if (!url) return null
-
-                return (
-                  <Link
-                    key={`${url}-${idx}`}
-                    href={url}
-                    className="text-sm text-foreground">
-                    <span className="flex items-center justify-center text-muted-foreground">
-                      <LucideLink size={16} />
-                    </span>
-                    <span>{getKnownHostname(url) ?? 'Website'}</span>
-                  </Link>
-                )
-              })
-            })()}
-          </div>
-        </div>
-      )}
-    </aside>
-  )
-}
-
 export const OverviewTabContent = () => {
   const manifest = useSelectedItemStore(state => state.manifest)
-  const { focused } = useFocusState()
+  const asideOverviewVisible = useSelectedItemStore(
+    state => state.asideOveriewVisible,
+  )
 
   const keywords = manifest?.keywords
 
@@ -231,7 +33,7 @@ export const OverviewTabContent = () => {
     <MotionTabsContent
       {...tabMotion}
       value="overview"
-      className="divide-x-none group flex grid-cols-12 flex-col divide-muted xl:grid xl:divide-x-[1px] [&>aside]:border-b-[1px] [&>aside]:border-red-500 xl:[&>aside]:border-b-[0px]">
+      className="divide-x-none group flex grid-cols-12 flex-col divide-muted xl:grid xl:divide-x-[1px] [&>aside]:border-b-[1px] xl:[&>aside]:border-b-[0px]">
       <div className="order-2 flex flex-col gap-4 xl:order-1 xl:col-span-12 xl:group-[&:has(aside)]:col-span-8">
         {manifest?.description ?
           <div className="flex flex-col gap-2 px-6 py-4">
@@ -247,7 +49,7 @@ export const OverviewTabContent = () => {
         <ContributorList />
 
         {keywords && (
-          <div className="flex grow flex-col justify-end gap-2 px-6 pb-4">
+          <div className="mt-auto flex flex-col justify-end gap-2 px-6 py-4">
             <h4 className="text-sm font-medium capitalize text-muted-foreground">
               keywords
             </h4>
@@ -265,7 +67,7 @@ export const OverviewTabContent = () => {
           </div>
         )}
       </div>
-      {!focused && <TabContentAside />}
+      {asideOverviewVisible && <AsideOverview />}
     </MotionTabsContent>
   )
 }

--- a/src/gui/src/components/ui/data-badge.tsx
+++ b/src/gui/src/components/ui/data-badge.tsx
@@ -55,7 +55,7 @@ const dataBadgeVariants = tv({
   },
 })
 
-interface DataBadgeProps
+export interface DataBadgeProps
   extends React.ComponentProps<'div'>,
     VariantProps<typeof dataBadgeVariants> {
   classNames?: {

--- a/src/gui/test/components/explorer-grid/selected-item/__snapshots__/item-header.tsx.snap
+++ b/src/gui/test/components/explorer-grid/selected-item/__snapshots__/item-header.tsx.snap
@@ -3,114 +3,127 @@
 exports[`ItemHeader renders with a package score 1`] = `
 
 <div
-  class="flex flex-col divide-y-[1px] divide-muted pb-3"
+  class="flex flex-col"
   style="opacity: 0;"
 >
   <div class="flex w-full flex-col">
     <div class="flex h-10 w-full items-center border-b-[1px] border-muted pr-6 empty:hidden justify-end">
     </div>
-    <div class="flex w-full justify-between py-4">
-      <div class="flex gap-4 overflow-hidden pl-6">
-        <gui-avatar classname="aspect-square size-16">
-          <gui-avatar-image
-            classname="aspect-square size-16 rounded-md border-[1px] bg-secondary object-cover"
-            src="https://example.com/favicon.png"
-            alt="Example Favicon"
-          >
-          </gui-avatar-image>
-          <gui-avatar-fallback classname="flex aspect-square size-16 h-full w-full items-center justify-center rounded-md border-[1px]">
-            <div class="h-full w-full rounded-md bg-gradient-to-t from-neutral-200 to-neutral-400 dark:from-neutral-500 dark:to-neutral-800">
-            </div>
-          </gui-avatar-fallback>
-        </gui-avatar>
-        <gui-scroll-area classname="w-full overflow-x-scroll">
-          <div class="flex h-full w-full flex-col justify-between">
-            <div class="flex w-full flex-col gap-0.5">
-              <div class="flex items-center gap-2">
-                <h1 class="w-fit max-w-full cursor-default align-baseline text-lg font-medium">
-                  item
-                  <span class="ml-2 font-courier text-sm text-muted-foreground">
-                    v1.0.0
-                  </span>
-                </h1>
-                <gui-tooltip-provider>
-                  <gui-tooltip delayduration="150">
-                    <gui-tooltip-trigger classname="flex items-center justify-center">
-                      <div class="cursor-default rounded-sm border-[1px] border-green-600 bg-green-400/30 p-0.5 transition-colors duration-150 hover:bg-green-400/40 dark:border-green-500 dark:bg-green-500/30 dark:hover:bg-green-500/40">
-                        <gui-arrow-big-up-dash-icon
-                          classname="text-green-600 dark:text-green-500"
-                          size="16"
-                        >
-                        </gui-arrow-big-up-dash-icon>
-                      </div>
-                    </gui-tooltip-trigger>
-                    <gui-tooltip-content>
-                      Newer versions available
-                    </gui-tooltip-content>
-                  </gui-tooltip>
-                </gui-tooltip-provider>
+    <div class="flex flex-col gap-2 overflow-hidden px-6 py-4">
+      <div class="flex justify-between gap-4 overflow-hidden">
+        <div class="flex gap-4">
+          <gui-avatar classname="aspect-square size-16">
+            <gui-avatar-image
+              classname="aspect-square size-16 rounded-md border-[1px] bg-secondary object-cover"
+              src="https://example.com/favicon.png"
+              alt="Example Favicon"
+            >
+            </gui-avatar-image>
+            <gui-avatar-fallback classname="flex aspect-square size-16 h-full w-full items-center justify-center rounded-md border-[1px]">
+              <div class="h-full w-full rounded-md bg-gradient-to-t from-neutral-200 to-neutral-400 dark:from-neutral-500 dark:to-neutral-800">
+              </div>
+            </gui-avatar-fallback>
+          </gui-avatar>
+          <gui-scroll-area classname="w-full overflow-x-scroll">
+            <div class="flex h-full w-full flex-col justify-between">
+              <div class="flex w-full flex-col gap-0.5">
+                <div class="flex items-center gap-2">
+                  <h1 class="w-fit max-w-full cursor-default align-baseline text-lg font-medium">
+                    item
+                    <span class="ml-2 font-courier text-sm text-muted-foreground">
+                      1.0.0
+                    </span>
+                  </h1>
+                  <gui-tooltip-provider>
+                    <gui-tooltip delayduration="150">
+                      <gui-tooltip-trigger classname="flex items-center justify-center">
+                        <div class="cursor-default rounded-sm border-[1px] border-green-600 bg-green-400/30 p-0.5 transition-colors duration-150 hover:bg-green-400/40 dark:border-green-500 dark:bg-green-500/30 dark:hover:bg-green-500/40">
+                          <gui-arrow-big-up-dash-icon
+                            classname="text-green-600 dark:text-green-500"
+                            size="16"
+                          >
+                          </gui-arrow-big-up-dash-icon>
+                        </div>
+                      </gui-tooltip-trigger>
+                      <gui-tooltip-portal>
+                        <gui-tooltip-content>
+                          Newer versions available
+                        </gui-tooltip-content>
+                      </gui-tooltip-portal>
+                    </gui-tooltip>
+                  </gui-tooltip-provider>
+                </div>
               </div>
             </div>
-          </div>
-          <gui-scroll-bar orientation="horizontal">
-          </gui-scroll-bar>
-        </gui-scroll-area>
+            <gui-scroll-bar orientation="horizontal">
+            </gui-scroll-bar>
+          </gui-scroll-area>
+        </div>
+        <div>
+          <gui-tooltip-provider delayduration="150">
+            <gui-tooltip>
+              <gui-tooltip-trigger>
+                <gui-progress-circle
+                  value="80"
+                  variant="success"
+                  strokewidth="5"
+                  classname="size-9"
+                >
+                  <p
+                    class="font-mono text-xs font-medium tabular-nums"
+                    style="color: oklch(0.696 0.17 162.48);"
+                  >
+                    80
+                  </p>
+                </gui-progress-circle>
+              </gui-tooltip-trigger>
+              <gui-tooltip-portal>
+                <gui-tooltip-content>
+                  See more insights
+                </gui-tooltip-content>
+              </gui-tooltip-portal>
+            </gui-tooltip>
+          </gui-tooltip-provider>
+        </div>
       </div>
-      <div class="pr-6">
-        <div class="duration-250 after:duration-250 relative z-[1] flex cursor-default flex-row gap-3 self-start transition-colors after:absolute after:inset-0 after:-left-[0.5rem] after:-top-[0.5rem] after:z-[-1] after:h-[calc(100%+1rem)] after:w-[calc(100%+1rem)] after:rounded-sm after:transition-colors after:content-[''] hover:after:bg-neutral-100 dark:hover:after:bg-neutral-800">
-          <gui-progress-circle
-            value="80"
-            variant="success"
-            strokewidth="5"
-            classname="size-9"
-          >
-            <p
-              class="font-mono text-xs font-medium tabular-nums"
-              style="color: oklch(0.696 0.17 162.48);"
+      <div class="flex w-full items-center justify-between gap-2 py-1">
+        <div class="flex items-center gap-2">
+          <gui-avatar>
+            <gui-avatar-image
+              classname="size-5 rounded-sm border-[1px] border-border"
+              src="https://example.com/avatar.png"
+              alt="John Doe"
             >
-              80
-            </p>
-          </gui-progress-circle>
-          <div class="flex flex-col">
-            <p class="text-sm font-semibold text-neutral-600 dark:text-neutral-300">
-              Package score
-            </p>
-            <p class="font-mono text-xs font-medium tabular-nums text-neutral-400">
-              80/100
-            </p>
-          </div>
+            </gui-avatar-image>
+            <gui-avatar-fallback classname="flex size-5 items-center justify-center rounded-sm bg-secondary bg-gradient-to-t from-neutral-100 to-neutral-400 p-0.5 outline outline-[1px] outline-border dark:from-neutral-500 dark:to-neutral-800">
+            </gui-avatar-fallback>
+          </gui-avatar>
+          <gui-tooltip-provider>
+            <gui-tooltip>
+              <gui-tooltip-trigger classname="text-baseline cursor-default text-xs font-medium text-muted-foreground">
+                Published by:
+                <span class="text-foreground">
+                  John Doe
+                </span>
+              </gui-tooltip-trigger>
+              <gui-tooltip-portal>
+                <gui-tooltip-content align="start">
+                  John Doe john@example.com
+                </gui-tooltip-content>
+              </gui-tooltip-portal>
+            </gui-tooltip>
+          </gui-tooltip-provider>
+        </div>
+        <div class="flex items-center gap-2">
+          <p class="text-baseline cursor-default text-xs font-medium text-muted-foreground">
+            <span class="mr-1 text-foreground">
+              0
+            </span>
+            Downloads last week
+          </p>
         </div>
       </div>
     </div>
-  </div>
-  <div class="flex h-10 w-full items-center justify-between px-6 py-2 empty:hidden">
-    <div class="flex h-[31.508px] items-center gap-2">
-      <gui-avatar>
-        <gui-avatar-image
-          classname="size-5 rounded-sm border-[1px] border-border"
-          src="https://example.com/avatar.png"
-          alt="John Doe"
-        >
-        </gui-avatar-image>
-        <gui-avatar-fallback classname="flex size-5 items-center justify-center rounded-sm bg-secondary bg-gradient-to-t from-neutral-100 to-neutral-400 p-0.5 outline outline-[1px] outline-border dark:from-neutral-500 dark:to-neutral-800">
-        </gui-avatar-fallback>
-      </gui-avatar>
-      <gui-tooltip-provider>
-        <gui-tooltip>
-          <gui-tooltip-trigger classname="text-baseline cursor-default text-xs font-medium text-muted-foreground">
-            Published by:
-            <span class="text-foreground">
-              John Doe
-            </span>
-          </gui-tooltip-trigger>
-          <gui-tooltip-content align="start">
-            John Doe john@example.com
-          </gui-tooltip-content>
-        </gui-tooltip>
-      </gui-tooltip-provider>
-    </div>
-  </div>
-  <div class="flex w-full divide-x-[1px] divide-muted empty:hidden">
   </div>
 </div>
 
@@ -119,130 +132,104 @@ exports[`ItemHeader renders with a package score 1`] = `
 exports[`ItemHeader renders with a version information 1`] = `
 
 <div
-  class="flex flex-col divide-y-[1px] divide-muted pb-3"
+  class="flex flex-col"
   style="opacity: 0;"
 >
   <div class="flex w-full flex-col">
     <div class="flex h-10 w-full items-center border-b-[1px] border-muted pr-6 empty:hidden justify-end">
     </div>
-    <div class="flex w-full justify-between py-4">
-      <div class="flex gap-4 overflow-hidden pl-6">
-        <gui-avatar classname="aspect-square size-16">
-          <gui-avatar-image
-            classname="aspect-square size-16 rounded-md border-[1px] bg-secondary object-cover"
-            src="https://example.com/favicon.png"
-            alt="Example Favicon"
-          >
-          </gui-avatar-image>
-          <gui-avatar-fallback classname="flex aspect-square size-16 h-full w-full items-center justify-center rounded-md border-[1px]">
-            <div class="h-full w-full rounded-md bg-gradient-to-t from-neutral-200 to-neutral-400 dark:from-neutral-500 dark:to-neutral-800">
-            </div>
-          </gui-avatar-fallback>
-        </gui-avatar>
-        <gui-scroll-area classname="w-full overflow-x-scroll">
-          <div class="flex h-full w-full flex-col justify-between">
-            <div class="flex w-full flex-col gap-0.5">
-              <div class="flex items-center gap-2">
-                <h1 class="w-fit max-w-full cursor-default align-baseline text-lg font-medium">
-                  item
-                  <span class="ml-2 font-courier text-sm text-muted-foreground">
-                    v1.0.0
-                  </span>
-                </h1>
-                <gui-tooltip-provider>
-                  <gui-tooltip delayduration="150">
-                    <gui-tooltip-trigger classname="flex items-center justify-center">
-                      <div class="cursor-default rounded-sm border-[1px] border-green-600 bg-green-400/30 p-0.5 transition-colors duration-150 hover:bg-green-400/40 dark:border-green-500 dark:bg-green-500/30 dark:hover:bg-green-500/40">
-                        <gui-arrow-big-up-dash-icon
-                          classname="text-green-600 dark:text-green-500"
-                          size="16"
-                        >
-                        </gui-arrow-big-up-dash-icon>
-                      </div>
-                    </gui-tooltip-trigger>
-                    <gui-tooltip-content>
-                      Newer versions available
-                    </gui-tooltip-content>
-                  </gui-tooltip>
-                </gui-tooltip-provider>
+    <div class="flex flex-col gap-2 overflow-hidden px-6 py-4">
+      <div class="flex justify-between gap-4 overflow-hidden">
+        <div class="flex gap-4">
+          <gui-avatar classname="aspect-square size-16">
+            <gui-avatar-image
+              classname="aspect-square size-16 rounded-md border-[1px] bg-secondary object-cover"
+              src="https://example.com/favicon.png"
+              alt="Example Favicon"
+            >
+            </gui-avatar-image>
+            <gui-avatar-fallback classname="flex aspect-square size-16 h-full w-full items-center justify-center rounded-md border-[1px]">
+              <div class="h-full w-full rounded-md bg-gradient-to-t from-neutral-200 to-neutral-400 dark:from-neutral-500 dark:to-neutral-800">
+              </div>
+            </gui-avatar-fallback>
+          </gui-avatar>
+          <gui-scroll-area classname="w-full overflow-x-scroll">
+            <div class="flex h-full w-full flex-col justify-between">
+              <div class="flex w-full flex-col gap-0.5">
+                <div class="flex items-center gap-2">
+                  <h1 class="w-fit max-w-full cursor-default align-baseline text-lg font-medium">
+                    item
+                    <span class="ml-2 font-courier text-sm text-muted-foreground">
+                      1.0.0
+                    </span>
+                  </h1>
+                  <gui-tooltip-provider>
+                    <gui-tooltip delayduration="150">
+                      <gui-tooltip-trigger classname="flex items-center justify-center">
+                        <div class="cursor-default rounded-sm border-[1px] border-green-600 bg-green-400/30 p-0.5 transition-colors duration-150 hover:bg-green-400/40 dark:border-green-500 dark:bg-green-500/30 dark:hover:bg-green-500/40">
+                          <gui-arrow-big-up-dash-icon
+                            classname="text-green-600 dark:text-green-500"
+                            size="16"
+                          >
+                          </gui-arrow-big-up-dash-icon>
+                        </div>
+                      </gui-tooltip-trigger>
+                      <gui-tooltip-portal>
+                        <gui-tooltip-content>
+                          Newer versions available
+                        </gui-tooltip-content>
+                      </gui-tooltip-portal>
+                    </gui-tooltip>
+                  </gui-tooltip-provider>
+                </div>
               </div>
             </div>
-          </div>
-          <gui-scroll-bar orientation="horizontal">
-          </gui-scroll-bar>
-        </gui-scroll-area>
+            <gui-scroll-bar orientation="horizontal">
+            </gui-scroll-bar>
+          </gui-scroll-area>
+        </div>
+      </div>
+      <div class="flex w-full items-center justify-between gap-2 py-1">
+        <div class="flex items-center gap-2">
+          <gui-avatar>
+            <gui-avatar-image
+              classname="size-5 rounded-sm border-[1px] border-border"
+              src="https://example.com/avatar.png"
+              alt="John Doe"
+            >
+            </gui-avatar-image>
+            <gui-avatar-fallback classname="flex size-5 items-center justify-center rounded-sm bg-secondary bg-gradient-to-t from-neutral-100 to-neutral-400 p-0.5 outline outline-[1px] outline-border dark:from-neutral-500 dark:to-neutral-800">
+            </gui-avatar-fallback>
+          </gui-avatar>
+          <gui-tooltip-provider>
+            <gui-tooltip>
+              <gui-tooltip-trigger classname="text-baseline cursor-default text-xs font-medium text-muted-foreground">
+                Published by:
+                <span class="text-foreground">
+                  John Doe
+                </span>
+                <span class="ml-2">
+                  abc123 • 3 years ago
+                </span>
+              </gui-tooltip-trigger>
+              <gui-tooltip-portal>
+                <gui-tooltip-content align="start">
+                  John Doe john@example.com
+                </gui-tooltip-content>
+              </gui-tooltip-portal>
+            </gui-tooltip>
+          </gui-tooltip-provider>
+        </div>
+        <div class="flex items-center gap-2">
+          <p class="text-baseline cursor-default text-xs font-medium text-muted-foreground">
+            <span class="mr-1 text-foreground">
+              123.5K
+            </span>
+            Downloads last week
+          </p>
+        </div>
       </div>
     </div>
-  </div>
-  <div class="flex h-10 w-full items-center justify-between px-6 py-2 empty:hidden">
-    <div class="flex h-[31.508px] items-center gap-2">
-      <gui-avatar>
-        <gui-avatar-image
-          classname="size-5 rounded-sm border-[1px] border-border"
-          src="https://example.com/avatar.png"
-          alt="John Doe"
-        >
-        </gui-avatar-image>
-        <gui-avatar-fallback classname="flex size-5 items-center justify-center rounded-sm bg-secondary bg-gradient-to-t from-neutral-100 to-neutral-400 p-0.5 outline outline-[1px] outline-border dark:from-neutral-500 dark:to-neutral-800">
-        </gui-avatar-fallback>
-      </gui-avatar>
-      <gui-tooltip-provider>
-        <gui-tooltip>
-          <gui-tooltip-trigger classname="text-baseline cursor-default text-xs font-medium text-muted-foreground">
-            Published by:
-            <span class="text-foreground">
-              John Doe
-            </span>
-            <span class="ml-2">
-              abc123 • 3 years ago
-            </span>
-          </gui-tooltip-trigger>
-          <gui-tooltip-content align="start">
-            John Doe john@example.com
-          </gui-tooltip-content>
-        </gui-tooltip>
-      </gui-tooltip-provider>
-    </div>
-    <gui-data-badge
-      value="123.5K"
-      content="Downloads last week"
-    >
-    </gui-data-badge>
-  </div>
-  <div class="flex w-full divide-x-[1px] divide-muted empty:hidden">
-    <gui-scroll-area classname="relative overflow-hidden py-3 border-b-[1px] border-muted w-full">
-      <div class="pointer-events-none absolute right-0 top-0 z-[100] h-full w-[24px] bg-gradient-to-l from-card">
-      </div>
-      <div class="pointer-events-none absolute left-0 top-0 z-[100] h-full w-[24px] bg-gradient-to-r from-card">
-      </div>
-      <div class="flex w-max gap-2 overflow-x-hidden px-6">
-        <gui-data-badge
-          icon="gui-download-icon"
-          value="121 KB"
-          content="Install size"
-        >
-        </gui-data-badge>
-        <gui-data-badge
-          icon="gui-package-icon"
-          content="Tarball"
-          tooltip="[object Object]"
-          copytoclipboard="[object Object]"
-        >
-        </gui-data-badge>
-        <gui-data-badge
-          value="abc123"
-          content="Integrity"
-          tooltip="[object Object]"
-          copytoclipboard="[object Object]"
-        >
-        </gui-data-badge>
-      </div>
-      <gui-scroll-bar
-        classname="z-[102]"
-        orientation="horizontal"
-      >
-      </gui-scroll-bar>
-    </gui-scroll-area>
   </div>
 </div>
 
@@ -251,95 +238,108 @@ exports[`ItemHeader renders with a version information 1`] = `
 exports[`ItemHeader renders with custom registry item 1`] = `
 
 <div
-  class="flex flex-col divide-y-[1px] divide-muted pb-3"
+  class="flex flex-col"
   style="opacity: 0;"
 >
   <div class="flex w-full flex-col">
     <div class="flex h-10 w-full items-center border-b-[1px] border-muted pr-6 empty:hidden justify-end">
     </div>
-    <div class="flex w-full justify-between py-4">
-      <div class="flex gap-4 overflow-hidden pl-6">
-        <gui-avatar classname="aspect-square size-16">
-          <gui-avatar-image
-            classname="aspect-square size-16 rounded-md border-[1px] bg-secondary object-cover"
-            src="https://example.com/favicon.png"
-            alt="Example Favicon"
-          >
-          </gui-avatar-image>
-          <gui-avatar-fallback classname="flex aspect-square size-16 h-full w-full items-center justify-center rounded-md border-[1px]">
-            <div class="h-full w-full rounded-md bg-gradient-to-t from-neutral-200 to-neutral-400 dark:from-neutral-500 dark:to-neutral-800">
-            </div>
-          </gui-avatar-fallback>
-        </gui-avatar>
-        <gui-scroll-area classname="w-full overflow-x-scroll">
-          <div class="flex h-full w-full flex-col justify-between">
-            <div class="flex w-full flex-col gap-0.5">
-              <div class="flex items-center gap-2">
-                <h1 class="w-fit max-w-full cursor-default align-baseline text-lg font-medium">
-                  item
-                  <span class="ml-2 font-courier text-sm text-muted-foreground">
-                    v1.0.0
-                  </span>
-                </h1>
-                <gui-tooltip-provider>
-                  <gui-tooltip delayduration="150">
-                    <gui-tooltip-trigger classname="flex items-center justify-center">
-                      <div class="cursor-default rounded-sm border-[1px] border-green-600 bg-green-400/30 p-0.5 transition-colors duration-150 hover:bg-green-400/40 dark:border-green-500 dark:bg-green-500/30 dark:hover:bg-green-500/40">
-                        <gui-arrow-big-up-dash-icon
-                          classname="text-green-600 dark:text-green-500"
-                          size="16"
-                        >
-                        </gui-arrow-big-up-dash-icon>
-                      </div>
-                    </gui-tooltip-trigger>
-                    <gui-tooltip-content>
-                      Newer versions available
-                    </gui-tooltip-content>
-                  </gui-tooltip>
-                </gui-tooltip-provider>
+    <div class="flex flex-col gap-2 overflow-hidden px-6 py-4">
+      <div class="flex justify-between gap-4 overflow-hidden">
+        <div class="flex gap-4">
+          <gui-avatar classname="aspect-square size-16">
+            <gui-avatar-image
+              classname="aspect-square size-16 rounded-md border-[1px] bg-secondary object-cover"
+              src="https://example.com/favicon.png"
+              alt="Example Favicon"
+            >
+            </gui-avatar-image>
+            <gui-avatar-fallback classname="flex aspect-square size-16 h-full w-full items-center justify-center rounded-md border-[1px]">
+              <div class="h-full w-full rounded-md bg-gradient-to-t from-neutral-200 to-neutral-400 dark:from-neutral-500 dark:to-neutral-800">
               </div>
-              <gui-data-badge
-                variant="mono"
-                content="custom:item@1.0.0"
-                tooltip="[object Object]"
-              >
-              </gui-data-badge>
+            </gui-avatar-fallback>
+          </gui-avatar>
+          <gui-scroll-area classname="w-full overflow-x-scroll">
+            <div class="flex h-full w-full flex-col justify-between">
+              <div class="flex w-full flex-col gap-0.5">
+                <div class="flex items-center gap-2">
+                  <h1 class="w-fit max-w-full cursor-default align-baseline text-lg font-medium">
+                    item
+                    <span class="ml-2 font-courier text-sm text-muted-foreground">
+                      1.0.0
+                    </span>
+                  </h1>
+                  <gui-tooltip-provider>
+                    <gui-tooltip delayduration="150">
+                      <gui-tooltip-trigger classname="flex items-center justify-center">
+                        <div class="cursor-default rounded-sm border-[1px] border-green-600 bg-green-400/30 p-0.5 transition-colors duration-150 hover:bg-green-400/40 dark:border-green-500 dark:bg-green-500/30 dark:hover:bg-green-500/40">
+                          <gui-arrow-big-up-dash-icon
+                            classname="text-green-600 dark:text-green-500"
+                            size="16"
+                          >
+                          </gui-arrow-big-up-dash-icon>
+                        </div>
+                      </gui-tooltip-trigger>
+                      <gui-tooltip-portal>
+                        <gui-tooltip-content>
+                          Newer versions available
+                        </gui-tooltip-content>
+                      </gui-tooltip-portal>
+                    </gui-tooltip>
+                  </gui-tooltip-provider>
+                </div>
+                <gui-data-badge
+                  variant="mono"
+                  content="custom:item@1.0.0"
+                  classnames="[object Object]"
+                  tooltip="[object Object]"
+                >
+                </gui-data-badge>
+              </div>
             </div>
-          </div>
-          <gui-scroll-bar orientation="horizontal">
-          </gui-scroll-bar>
-        </gui-scroll-area>
+            <gui-scroll-bar orientation="horizontal">
+            </gui-scroll-bar>
+          </gui-scroll-area>
+        </div>
+      </div>
+      <div class="flex w-full items-center justify-between gap-2 py-1">
+        <div class="flex items-center gap-2">
+          <gui-avatar>
+            <gui-avatar-image
+              classname="size-5 rounded-sm border-[1px] border-border"
+              src="https://example.com/avatar.png"
+              alt="John Doe"
+            >
+            </gui-avatar-image>
+            <gui-avatar-fallback classname="flex size-5 items-center justify-center rounded-sm bg-secondary bg-gradient-to-t from-neutral-100 to-neutral-400 p-0.5 outline outline-[1px] outline-border dark:from-neutral-500 dark:to-neutral-800">
+            </gui-avatar-fallback>
+          </gui-avatar>
+          <gui-tooltip-provider>
+            <gui-tooltip>
+              <gui-tooltip-trigger classname="text-baseline cursor-default text-xs font-medium text-muted-foreground">
+                Published by:
+                <span class="text-foreground">
+                  John Doe
+                </span>
+              </gui-tooltip-trigger>
+              <gui-tooltip-portal>
+                <gui-tooltip-content align="start">
+                  John Doe john@example.com
+                </gui-tooltip-content>
+              </gui-tooltip-portal>
+            </gui-tooltip>
+          </gui-tooltip-provider>
+        </div>
+        <div class="flex items-center gap-2">
+          <p class="text-baseline cursor-default text-xs font-medium text-muted-foreground">
+            <span class="mr-1 text-foreground">
+              0
+            </span>
+            Downloads last week
+          </p>
+        </div>
       </div>
     </div>
-  </div>
-  <div class="flex h-10 w-full items-center justify-between px-6 py-2 empty:hidden">
-    <div class="flex h-[31.508px] items-center gap-2">
-      <gui-avatar>
-        <gui-avatar-image
-          classname="size-5 rounded-sm border-[1px] border-border"
-          src="https://example.com/avatar.png"
-          alt="John Doe"
-        >
-        </gui-avatar-image>
-        <gui-avatar-fallback classname="flex size-5 items-center justify-center rounded-sm bg-secondary bg-gradient-to-t from-neutral-100 to-neutral-400 p-0.5 outline outline-[1px] outline-border dark:from-neutral-500 dark:to-neutral-800">
-        </gui-avatar-fallback>
-      </gui-avatar>
-      <gui-tooltip-provider>
-        <gui-tooltip>
-          <gui-tooltip-trigger classname="text-baseline cursor-default text-xs font-medium text-muted-foreground">
-            Published by:
-            <span class="text-foreground">
-              John Doe
-            </span>
-          </gui-tooltip-trigger>
-          <gui-tooltip-content align="start">
-            John Doe john@example.com
-          </gui-tooltip-content>
-        </gui-tooltip>
-      </gui-tooltip-provider>
-    </div>
-  </div>
-  <div class="flex w-full divide-x-[1px] divide-muted empty:hidden">
   </div>
 </div>
 
@@ -348,94 +348,107 @@ exports[`ItemHeader renders with custom registry item 1`] = `
 exports[`ItemHeader renders with default git host item 1`] = `
 
 <div
-  class="flex flex-col divide-y-[1px] divide-muted pb-3"
+  class="flex flex-col"
   style="opacity: 0;"
 >
   <div class="flex w-full flex-col">
     <div class="flex h-10 w-full items-center border-b-[1px] border-muted pr-6 empty:hidden justify-end">
     </div>
-    <div class="flex w-full justify-between py-4">
-      <div class="flex gap-4 overflow-hidden pl-6">
-        <gui-avatar classname="aspect-square size-16">
-          <gui-avatar-image
-            classname="aspect-square size-16 rounded-md border-[1px] bg-secondary object-cover"
-            src="https://example.com/favicon.png"
-            alt="Example Favicon"
-          >
-          </gui-avatar-image>
-          <gui-avatar-fallback classname="flex aspect-square size-16 h-full w-full items-center justify-center rounded-md border-[1px]">
-            <div class="h-full w-full rounded-md bg-gradient-to-t from-neutral-200 to-neutral-400 dark:from-neutral-500 dark:to-neutral-800">
-            </div>
-          </gui-avatar-fallback>
-        </gui-avatar>
-        <gui-scroll-area classname="w-full overflow-x-scroll">
-          <div class="flex h-full w-full flex-col justify-between">
-            <div class="flex w-full flex-col gap-0.5">
-              <div class="flex items-center gap-2">
-                <h1 class="w-fit max-w-full cursor-default align-baseline text-lg font-medium">
-                  item
-                  <span class="ml-2 font-courier text-sm text-muted-foreground">
-                    v1.0.0
-                  </span>
-                </h1>
-                <gui-tooltip-provider>
-                  <gui-tooltip delayduration="150">
-                    <gui-tooltip-trigger classname="flex items-center justify-center">
-                      <div class="cursor-default rounded-sm border-[1px] border-green-600 bg-green-400/30 p-0.5 transition-colors duration-150 hover:bg-green-400/40 dark:border-green-500 dark:bg-green-500/30 dark:hover:bg-green-500/40">
-                        <gui-arrow-big-up-dash-icon
-                          classname="text-green-600 dark:text-green-500"
-                          size="16"
-                        >
-                        </gui-arrow-big-up-dash-icon>
-                      </div>
-                    </gui-tooltip-trigger>
-                    <gui-tooltip-content>
-                      Newer versions available
-                    </gui-tooltip-content>
-                  </gui-tooltip>
-                </gui-tooltip-provider>
+    <div class="flex flex-col gap-2 overflow-hidden px-6 py-4">
+      <div class="flex justify-between gap-4 overflow-hidden">
+        <div class="flex gap-4">
+          <gui-avatar classname="aspect-square size-16">
+            <gui-avatar-image
+              classname="aspect-square size-16 rounded-md border-[1px] bg-secondary object-cover"
+              src="https://example.com/favicon.png"
+              alt="Example Favicon"
+            >
+            </gui-avatar-image>
+            <gui-avatar-fallback classname="flex aspect-square size-16 h-full w-full items-center justify-center rounded-md border-[1px]">
+              <div class="h-full w-full rounded-md bg-gradient-to-t from-neutral-200 to-neutral-400 dark:from-neutral-500 dark:to-neutral-800">
               </div>
-              <gui-data-badge
-                variant="mono"
-                content="git:github:a/b"
-              >
-              </gui-data-badge>
+            </gui-avatar-fallback>
+          </gui-avatar>
+          <gui-scroll-area classname="w-full overflow-x-scroll">
+            <div class="flex h-full w-full flex-col justify-between">
+              <div class="flex w-full flex-col gap-0.5">
+                <div class="flex items-center gap-2">
+                  <h1 class="w-fit max-w-full cursor-default align-baseline text-lg font-medium">
+                    item
+                    <span class="ml-2 font-courier text-sm text-muted-foreground">
+                      1.0.0
+                    </span>
+                  </h1>
+                  <gui-tooltip-provider>
+                    <gui-tooltip delayduration="150">
+                      <gui-tooltip-trigger classname="flex items-center justify-center">
+                        <div class="cursor-default rounded-sm border-[1px] border-green-600 bg-green-400/30 p-0.5 transition-colors duration-150 hover:bg-green-400/40 dark:border-green-500 dark:bg-green-500/30 dark:hover:bg-green-500/40">
+                          <gui-arrow-big-up-dash-icon
+                            classname="text-green-600 dark:text-green-500"
+                            size="16"
+                          >
+                          </gui-arrow-big-up-dash-icon>
+                        </div>
+                      </gui-tooltip-trigger>
+                      <gui-tooltip-portal>
+                        <gui-tooltip-content>
+                          Newer versions available
+                        </gui-tooltip-content>
+                      </gui-tooltip-portal>
+                    </gui-tooltip>
+                  </gui-tooltip-provider>
+                </div>
+                <gui-data-badge
+                  variant="mono"
+                  classnames="[object Object]"
+                  content="git:github:a/b"
+                >
+                </gui-data-badge>
+              </div>
             </div>
-          </div>
-          <gui-scroll-bar orientation="horizontal">
-          </gui-scroll-bar>
-        </gui-scroll-area>
+            <gui-scroll-bar orientation="horizontal">
+            </gui-scroll-bar>
+          </gui-scroll-area>
+        </div>
+      </div>
+      <div class="flex w-full items-center justify-between gap-2 py-1">
+        <div class="flex items-center gap-2">
+          <gui-avatar>
+            <gui-avatar-image
+              classname="size-5 rounded-sm border-[1px] border-border"
+              src="https://example.com/avatar.png"
+              alt="John Doe"
+            >
+            </gui-avatar-image>
+            <gui-avatar-fallback classname="flex size-5 items-center justify-center rounded-sm bg-secondary bg-gradient-to-t from-neutral-100 to-neutral-400 p-0.5 outline outline-[1px] outline-border dark:from-neutral-500 dark:to-neutral-800">
+            </gui-avatar-fallback>
+          </gui-avatar>
+          <gui-tooltip-provider>
+            <gui-tooltip>
+              <gui-tooltip-trigger classname="text-baseline cursor-default text-xs font-medium text-muted-foreground">
+                Published by:
+                <span class="text-foreground">
+                  John Doe
+                </span>
+              </gui-tooltip-trigger>
+              <gui-tooltip-portal>
+                <gui-tooltip-content align="start">
+                  John Doe john@example.com
+                </gui-tooltip-content>
+              </gui-tooltip-portal>
+            </gui-tooltip>
+          </gui-tooltip-provider>
+        </div>
+        <div class="flex items-center gap-2">
+          <p class="text-baseline cursor-default text-xs font-medium text-muted-foreground">
+            <span class="mr-1 text-foreground">
+              0
+            </span>
+            Downloads last week
+          </p>
+        </div>
       </div>
     </div>
-  </div>
-  <div class="flex h-10 w-full items-center justify-between px-6 py-2 empty:hidden">
-    <div class="flex h-[31.508px] items-center gap-2">
-      <gui-avatar>
-        <gui-avatar-image
-          classname="size-5 rounded-sm border-[1px] border-border"
-          src="https://example.com/avatar.png"
-          alt="John Doe"
-        >
-        </gui-avatar-image>
-        <gui-avatar-fallback classname="flex size-5 items-center justify-center rounded-sm bg-secondary bg-gradient-to-t from-neutral-100 to-neutral-400 p-0.5 outline outline-[1px] outline-border dark:from-neutral-500 dark:to-neutral-800">
-        </gui-avatar-fallback>
-      </gui-avatar>
-      <gui-tooltip-provider>
-        <gui-tooltip>
-          <gui-tooltip-trigger classname="text-baseline cursor-default text-xs font-medium text-muted-foreground">
-            Published by:
-            <span class="text-foreground">
-              John Doe
-            </span>
-          </gui-tooltip-trigger>
-          <gui-tooltip-content align="start">
-            John Doe john@example.com
-          </gui-tooltip-content>
-        </gui-tooltip>
-      </gui-tooltip-provider>
-    </div>
-  </div>
-  <div class="flex w-full divide-x-[1px] divide-muted empty:hidden">
   </div>
 </div>
 
@@ -444,89 +457,101 @@ exports[`ItemHeader renders with default git host item 1`] = `
 exports[`ItemHeader renders with default item 1`] = `
 
 <div
-  class="flex flex-col divide-y-[1px] divide-muted pb-3"
+  class="flex flex-col"
   style="opacity: 0;"
 >
   <div class="flex w-full flex-col">
     <div class="flex h-10 w-full items-center border-b-[1px] border-muted pr-6 empty:hidden justify-end">
     </div>
-    <div class="flex w-full justify-between py-4">
-      <div class="flex gap-4 overflow-hidden pl-6">
-        <gui-avatar classname="aspect-square size-16">
-          <gui-avatar-image
-            classname="aspect-square size-16 rounded-md border-[1px] bg-secondary object-cover"
-            src="https://example.com/favicon.png"
-            alt="Example Favicon"
-          >
-          </gui-avatar-image>
-          <gui-avatar-fallback classname="flex aspect-square size-16 h-full w-full items-center justify-center rounded-md border-[1px]">
-            <div class="h-full w-full rounded-md bg-gradient-to-t from-neutral-200 to-neutral-400 dark:from-neutral-500 dark:to-neutral-800">
-            </div>
-          </gui-avatar-fallback>
-        </gui-avatar>
-        <gui-scroll-area classname="w-full overflow-x-scroll">
-          <div class="flex h-full w-full flex-col justify-between">
-            <div class="flex w-full flex-col gap-0.5">
-              <div class="flex items-center gap-2">
-                <h1 class="w-fit max-w-full cursor-default align-baseline text-lg font-medium">
-                  item
-                  <span class="ml-2 font-courier text-sm text-muted-foreground">
-                    v1.0.0
-                  </span>
-                </h1>
-                <gui-tooltip-provider>
-                  <gui-tooltip delayduration="150">
-                    <gui-tooltip-trigger classname="flex items-center justify-center">
-                      <div class="cursor-default rounded-sm border-[1px] border-green-600 bg-green-400/30 p-0.5 transition-colors duration-150 hover:bg-green-400/40 dark:border-green-500 dark:bg-green-500/30 dark:hover:bg-green-500/40">
-                        <gui-arrow-big-up-dash-icon
-                          classname="text-green-600 dark:text-green-500"
-                          size="16"
-                        >
-                        </gui-arrow-big-up-dash-icon>
-                      </div>
-                    </gui-tooltip-trigger>
-                    <gui-tooltip-content>
-                      Newer versions available
-                    </gui-tooltip-content>
-                  </gui-tooltip>
-                </gui-tooltip-provider>
+    <div class="flex flex-col gap-2 overflow-hidden px-6 py-4">
+      <div class="flex justify-between gap-4 overflow-hidden">
+        <div class="flex gap-4">
+          <gui-avatar classname="aspect-square size-16">
+            <gui-avatar-image
+              classname="aspect-square size-16 rounded-md border-[1px] bg-secondary object-cover"
+              src="https://example.com/favicon.png"
+              alt="Example Favicon"
+            >
+            </gui-avatar-image>
+            <gui-avatar-fallback classname="flex aspect-square size-16 h-full w-full items-center justify-center rounded-md border-[1px]">
+              <div class="h-full w-full rounded-md bg-gradient-to-t from-neutral-200 to-neutral-400 dark:from-neutral-500 dark:to-neutral-800">
+              </div>
+            </gui-avatar-fallback>
+          </gui-avatar>
+          <gui-scroll-area classname="w-full overflow-x-scroll">
+            <div class="flex h-full w-full flex-col justify-between">
+              <div class="flex w-full flex-col gap-0.5">
+                <div class="flex items-center gap-2">
+                  <h1 class="w-fit max-w-full cursor-default align-baseline text-lg font-medium">
+                    item
+                    <span class="ml-2 font-courier text-sm text-muted-foreground">
+                      1.0.0
+                    </span>
+                  </h1>
+                  <gui-tooltip-provider>
+                    <gui-tooltip delayduration="150">
+                      <gui-tooltip-trigger classname="flex items-center justify-center">
+                        <div class="cursor-default rounded-sm border-[1px] border-green-600 bg-green-400/30 p-0.5 transition-colors duration-150 hover:bg-green-400/40 dark:border-green-500 dark:bg-green-500/30 dark:hover:bg-green-500/40">
+                          <gui-arrow-big-up-dash-icon
+                            classname="text-green-600 dark:text-green-500"
+                            size="16"
+                          >
+                          </gui-arrow-big-up-dash-icon>
+                        </div>
+                      </gui-tooltip-trigger>
+                      <gui-tooltip-portal>
+                        <gui-tooltip-content>
+                          Newer versions available
+                        </gui-tooltip-content>
+                      </gui-tooltip-portal>
+                    </gui-tooltip>
+                  </gui-tooltip-provider>
+                </div>
               </div>
             </div>
-          </div>
-          <gui-scroll-bar orientation="horizontal">
-          </gui-scroll-bar>
-        </gui-scroll-area>
+            <gui-scroll-bar orientation="horizontal">
+            </gui-scroll-bar>
+          </gui-scroll-area>
+        </div>
+      </div>
+      <div class="flex w-full items-center justify-between gap-2 py-1">
+        <div class="flex items-center gap-2">
+          <gui-avatar>
+            <gui-avatar-image
+              classname="size-5 rounded-sm border-[1px] border-border"
+              src="https://example.com/avatar.png"
+              alt="John Doe"
+            >
+            </gui-avatar-image>
+            <gui-avatar-fallback classname="flex size-5 items-center justify-center rounded-sm bg-secondary bg-gradient-to-t from-neutral-100 to-neutral-400 p-0.5 outline outline-[1px] outline-border dark:from-neutral-500 dark:to-neutral-800">
+            </gui-avatar-fallback>
+          </gui-avatar>
+          <gui-tooltip-provider>
+            <gui-tooltip>
+              <gui-tooltip-trigger classname="text-baseline cursor-default text-xs font-medium text-muted-foreground">
+                Published by:
+                <span class="text-foreground">
+                  John Doe
+                </span>
+              </gui-tooltip-trigger>
+              <gui-tooltip-portal>
+                <gui-tooltip-content align="start">
+                  John Doe john@example.com
+                </gui-tooltip-content>
+              </gui-tooltip-portal>
+            </gui-tooltip>
+          </gui-tooltip-provider>
+        </div>
+        <div class="flex items-center gap-2">
+          <p class="text-baseline cursor-default text-xs font-medium text-muted-foreground">
+            <span class="mr-1 text-foreground">
+              0
+            </span>
+            Downloads last week
+          </p>
+        </div>
       </div>
     </div>
-  </div>
-  <div class="flex h-10 w-full items-center justify-between px-6 py-2 empty:hidden">
-    <div class="flex h-[31.508px] items-center gap-2">
-      <gui-avatar>
-        <gui-avatar-image
-          classname="size-5 rounded-sm border-[1px] border-border"
-          src="https://example.com/avatar.png"
-          alt="John Doe"
-        >
-        </gui-avatar-image>
-        <gui-avatar-fallback classname="flex size-5 items-center justify-center rounded-sm bg-secondary bg-gradient-to-t from-neutral-100 to-neutral-400 p-0.5 outline outline-[1px] outline-border dark:from-neutral-500 dark:to-neutral-800">
-        </gui-avatar-fallback>
-      </gui-avatar>
-      <gui-tooltip-provider>
-        <gui-tooltip>
-          <gui-tooltip-trigger classname="text-baseline cursor-default text-xs font-medium text-muted-foreground">
-            Published by:
-            <span class="text-foreground">
-              John Doe
-            </span>
-          </gui-tooltip-trigger>
-          <gui-tooltip-content align="start">
-            John Doe john@example.com
-          </gui-tooltip-content>
-        </gui-tooltip>
-      </gui-tooltip-provider>
-    </div>
-  </div>
-  <div class="flex w-full divide-x-[1px] divide-muted empty:hidden">
   </div>
 </div>
 
@@ -535,89 +560,101 @@ exports[`ItemHeader renders with default item 1`] = `
 exports[`ItemHeader renders with insights 1`] = `
 
 <div
-  class="flex flex-col divide-y-[1px] divide-muted pb-3"
+  class="flex flex-col"
   style="opacity: 0;"
 >
   <div class="flex w-full flex-col">
     <div class="flex h-10 w-full items-center border-b-[1px] border-muted pr-6 empty:hidden justify-end">
     </div>
-    <div class="flex w-full justify-between py-4">
-      <div class="flex gap-4 overflow-hidden pl-6">
-        <gui-avatar classname="aspect-square size-16">
-          <gui-avatar-image
-            classname="aspect-square size-16 rounded-md border-[1px] bg-secondary object-cover"
-            src="https://example.com/favicon.png"
-            alt="Example Favicon"
-          >
-          </gui-avatar-image>
-          <gui-avatar-fallback classname="flex aspect-square size-16 h-full w-full items-center justify-center rounded-md border-[1px]">
-            <div class="h-full w-full rounded-md bg-gradient-to-t from-neutral-200 to-neutral-400 dark:from-neutral-500 dark:to-neutral-800">
-            </div>
-          </gui-avatar-fallback>
-        </gui-avatar>
-        <gui-scroll-area classname="w-full overflow-x-scroll">
-          <div class="flex h-full w-full flex-col justify-between">
-            <div class="flex w-full flex-col gap-0.5">
-              <div class="flex items-center gap-2">
-                <h1 class="w-fit max-w-full cursor-default align-baseline text-lg font-medium">
-                  item
-                  <span class="ml-2 font-courier text-sm text-muted-foreground">
-                    v1.0.0
-                  </span>
-                </h1>
-                <gui-tooltip-provider>
-                  <gui-tooltip delayduration="150">
-                    <gui-tooltip-trigger classname="flex items-center justify-center">
-                      <div class="cursor-default rounded-sm border-[1px] border-green-600 bg-green-400/30 p-0.5 transition-colors duration-150 hover:bg-green-400/40 dark:border-green-500 dark:bg-green-500/30 dark:hover:bg-green-500/40">
-                        <gui-arrow-big-up-dash-icon
-                          classname="text-green-600 dark:text-green-500"
-                          size="16"
-                        >
-                        </gui-arrow-big-up-dash-icon>
-                      </div>
-                    </gui-tooltip-trigger>
-                    <gui-tooltip-content>
-                      Newer versions available
-                    </gui-tooltip-content>
-                  </gui-tooltip>
-                </gui-tooltip-provider>
+    <div class="flex flex-col gap-2 overflow-hidden px-6 py-4">
+      <div class="flex justify-between gap-4 overflow-hidden">
+        <div class="flex gap-4">
+          <gui-avatar classname="aspect-square size-16">
+            <gui-avatar-image
+              classname="aspect-square size-16 rounded-md border-[1px] bg-secondary object-cover"
+              src="https://example.com/favicon.png"
+              alt="Example Favicon"
+            >
+            </gui-avatar-image>
+            <gui-avatar-fallback classname="flex aspect-square size-16 h-full w-full items-center justify-center rounded-md border-[1px]">
+              <div class="h-full w-full rounded-md bg-gradient-to-t from-neutral-200 to-neutral-400 dark:from-neutral-500 dark:to-neutral-800">
+              </div>
+            </gui-avatar-fallback>
+          </gui-avatar>
+          <gui-scroll-area classname="w-full overflow-x-scroll">
+            <div class="flex h-full w-full flex-col justify-between">
+              <div class="flex w-full flex-col gap-0.5">
+                <div class="flex items-center gap-2">
+                  <h1 class="w-fit max-w-full cursor-default align-baseline text-lg font-medium">
+                    item
+                    <span class="ml-2 font-courier text-sm text-muted-foreground">
+                      1.0.0
+                    </span>
+                  </h1>
+                  <gui-tooltip-provider>
+                    <gui-tooltip delayduration="150">
+                      <gui-tooltip-trigger classname="flex items-center justify-center">
+                        <div class="cursor-default rounded-sm border-[1px] border-green-600 bg-green-400/30 p-0.5 transition-colors duration-150 hover:bg-green-400/40 dark:border-green-500 dark:bg-green-500/30 dark:hover:bg-green-500/40">
+                          <gui-arrow-big-up-dash-icon
+                            classname="text-green-600 dark:text-green-500"
+                            size="16"
+                          >
+                          </gui-arrow-big-up-dash-icon>
+                        </div>
+                      </gui-tooltip-trigger>
+                      <gui-tooltip-portal>
+                        <gui-tooltip-content>
+                          Newer versions available
+                        </gui-tooltip-content>
+                      </gui-tooltip-portal>
+                    </gui-tooltip>
+                  </gui-tooltip-provider>
+                </div>
               </div>
             </div>
-          </div>
-          <gui-scroll-bar orientation="horizontal">
-          </gui-scroll-bar>
-        </gui-scroll-area>
+            <gui-scroll-bar orientation="horizontal">
+            </gui-scroll-bar>
+          </gui-scroll-area>
+        </div>
+      </div>
+      <div class="flex w-full items-center justify-between gap-2 py-1">
+        <div class="flex items-center gap-2">
+          <gui-avatar>
+            <gui-avatar-image
+              classname="size-5 rounded-sm border-[1px] border-border"
+              src="https://example.com/avatar.png"
+              alt="John Doe"
+            >
+            </gui-avatar-image>
+            <gui-avatar-fallback classname="flex size-5 items-center justify-center rounded-sm bg-secondary bg-gradient-to-t from-neutral-100 to-neutral-400 p-0.5 outline outline-[1px] outline-border dark:from-neutral-500 dark:to-neutral-800">
+            </gui-avatar-fallback>
+          </gui-avatar>
+          <gui-tooltip-provider>
+            <gui-tooltip>
+              <gui-tooltip-trigger classname="text-baseline cursor-default text-xs font-medium text-muted-foreground">
+                Published by:
+                <span class="text-foreground">
+                  John Doe
+                </span>
+              </gui-tooltip-trigger>
+              <gui-tooltip-portal>
+                <gui-tooltip-content align="start">
+                  John Doe john@example.com
+                </gui-tooltip-content>
+              </gui-tooltip-portal>
+            </gui-tooltip>
+          </gui-tooltip-provider>
+        </div>
+        <div class="flex items-center gap-2">
+          <p class="text-baseline cursor-default text-xs font-medium text-muted-foreground">
+            <span class="mr-1 text-foreground">
+              0
+            </span>
+            Downloads last week
+          </p>
+        </div>
       </div>
     </div>
-  </div>
-  <div class="flex h-10 w-full items-center justify-between px-6 py-2 empty:hidden">
-    <div class="flex h-[31.508px] items-center gap-2">
-      <gui-avatar>
-        <gui-avatar-image
-          classname="size-5 rounded-sm border-[1px] border-border"
-          src="https://example.com/avatar.png"
-          alt="John Doe"
-        >
-        </gui-avatar-image>
-        <gui-avatar-fallback classname="flex size-5 items-center justify-center rounded-sm bg-secondary bg-gradient-to-t from-neutral-100 to-neutral-400 p-0.5 outline outline-[1px] outline-border dark:from-neutral-500 dark:to-neutral-800">
-        </gui-avatar-fallback>
-      </gui-avatar>
-      <gui-tooltip-provider>
-        <gui-tooltip>
-          <gui-tooltip-trigger classname="text-baseline cursor-default text-xs font-medium text-muted-foreground">
-            Published by:
-            <span class="text-foreground">
-              John Doe
-            </span>
-          </gui-tooltip-trigger>
-          <gui-tooltip-content align="start">
-            John Doe john@example.com
-          </gui-tooltip-content>
-        </gui-tooltip>
-      </gui-tooltip-provider>
-    </div>
-  </div>
-  <div class="flex w-full divide-x-[1px] divide-muted empty:hidden">
   </div>
 </div>
 
@@ -626,95 +663,108 @@ exports[`ItemHeader renders with insights 1`] = `
 exports[`ItemHeader renders with scoped registry item 1`] = `
 
 <div
-  class="flex flex-col divide-y-[1px] divide-muted pb-3"
+  class="flex flex-col"
   style="opacity: 0;"
 >
   <div class="flex w-full flex-col">
     <div class="flex h-10 w-full items-center border-b-[1px] border-muted pr-6 empty:hidden justify-end">
     </div>
-    <div class="flex w-full justify-between py-4">
-      <div class="flex gap-4 overflow-hidden pl-6">
-        <gui-avatar classname="aspect-square size-16">
-          <gui-avatar-image
-            classname="aspect-square size-16 rounded-md border-[1px] bg-secondary object-cover"
-            src="https://example.com/favicon.png"
-            alt="Example Favicon"
-          >
-          </gui-avatar-image>
-          <gui-avatar-fallback classname="flex aspect-square size-16 h-full w-full items-center justify-center rounded-md border-[1px]">
-            <div class="h-full w-full rounded-md bg-gradient-to-t from-neutral-200 to-neutral-400 dark:from-neutral-500 dark:to-neutral-800">
-            </div>
-          </gui-avatar-fallback>
-        </gui-avatar>
-        <gui-scroll-area classname="w-full overflow-x-scroll">
-          <div class="flex h-full w-full flex-col justify-between">
-            <div class="flex w-full flex-col gap-0.5">
-              <div class="flex items-center gap-2">
-                <h1 class="w-fit max-w-full cursor-default align-baseline text-lg font-medium">
-                  item
-                  <span class="ml-2 font-courier text-sm text-muted-foreground">
-                    v1.0.0
-                  </span>
-                </h1>
-                <gui-tooltip-provider>
-                  <gui-tooltip delayduration="150">
-                    <gui-tooltip-trigger classname="flex items-center justify-center">
-                      <div class="cursor-default rounded-sm border-[1px] border-green-600 bg-green-400/30 p-0.5 transition-colors duration-150 hover:bg-green-400/40 dark:border-green-500 dark:bg-green-500/30 dark:hover:bg-green-500/40">
-                        <gui-arrow-big-up-dash-icon
-                          classname="text-green-600 dark:text-green-500"
-                          size="16"
-                        >
-                        </gui-arrow-big-up-dash-icon>
-                      </div>
-                    </gui-tooltip-trigger>
-                    <gui-tooltip-content>
-                      Newer versions available
-                    </gui-tooltip-content>
-                  </gui-tooltip>
-                </gui-tooltip-provider>
+    <div class="flex flex-col gap-2 overflow-hidden px-6 py-4">
+      <div class="flex justify-between gap-4 overflow-hidden">
+        <div class="flex gap-4">
+          <gui-avatar classname="aspect-square size-16">
+            <gui-avatar-image
+              classname="aspect-square size-16 rounded-md border-[1px] bg-secondary object-cover"
+              src="https://example.com/favicon.png"
+              alt="Example Favicon"
+            >
+            </gui-avatar-image>
+            <gui-avatar-fallback classname="flex aspect-square size-16 h-full w-full items-center justify-center rounded-md border-[1px]">
+              <div class="h-full w-full rounded-md bg-gradient-to-t from-neutral-200 to-neutral-400 dark:from-neutral-500 dark:to-neutral-800">
               </div>
-              <gui-data-badge
-                variant="mono"
-                content="item@1.0.0"
-                tooltip="[object Object]"
-              >
-              </gui-data-badge>
+            </gui-avatar-fallback>
+          </gui-avatar>
+          <gui-scroll-area classname="w-full overflow-x-scroll">
+            <div class="flex h-full w-full flex-col justify-between">
+              <div class="flex w-full flex-col gap-0.5">
+                <div class="flex items-center gap-2">
+                  <h1 class="w-fit max-w-full cursor-default align-baseline text-lg font-medium">
+                    item
+                    <span class="ml-2 font-courier text-sm text-muted-foreground">
+                      1.0.0
+                    </span>
+                  </h1>
+                  <gui-tooltip-provider>
+                    <gui-tooltip delayduration="150">
+                      <gui-tooltip-trigger classname="flex items-center justify-center">
+                        <div class="cursor-default rounded-sm border-[1px] border-green-600 bg-green-400/30 p-0.5 transition-colors duration-150 hover:bg-green-400/40 dark:border-green-500 dark:bg-green-500/30 dark:hover:bg-green-500/40">
+                          <gui-arrow-big-up-dash-icon
+                            classname="text-green-600 dark:text-green-500"
+                            size="16"
+                          >
+                          </gui-arrow-big-up-dash-icon>
+                        </div>
+                      </gui-tooltip-trigger>
+                      <gui-tooltip-portal>
+                        <gui-tooltip-content>
+                          Newer versions available
+                        </gui-tooltip-content>
+                      </gui-tooltip-portal>
+                    </gui-tooltip>
+                  </gui-tooltip-provider>
+                </div>
+                <gui-data-badge
+                  variant="mono"
+                  content="item@1.0.0"
+                  classnames="[object Object]"
+                  tooltip="[object Object]"
+                >
+                </gui-data-badge>
+              </div>
             </div>
-          </div>
-          <gui-scroll-bar orientation="horizontal">
-          </gui-scroll-bar>
-        </gui-scroll-area>
+            <gui-scroll-bar orientation="horizontal">
+            </gui-scroll-bar>
+          </gui-scroll-area>
+        </div>
+      </div>
+      <div class="flex w-full items-center justify-between gap-2 py-1">
+        <div class="flex items-center gap-2">
+          <gui-avatar>
+            <gui-avatar-image
+              classname="size-5 rounded-sm border-[1px] border-border"
+              src="https://example.com/avatar.png"
+              alt="John Doe"
+            >
+            </gui-avatar-image>
+            <gui-avatar-fallback classname="flex size-5 items-center justify-center rounded-sm bg-secondary bg-gradient-to-t from-neutral-100 to-neutral-400 p-0.5 outline outline-[1px] outline-border dark:from-neutral-500 dark:to-neutral-800">
+            </gui-avatar-fallback>
+          </gui-avatar>
+          <gui-tooltip-provider>
+            <gui-tooltip>
+              <gui-tooltip-trigger classname="text-baseline cursor-default text-xs font-medium text-muted-foreground">
+                Published by:
+                <span class="text-foreground">
+                  John Doe
+                </span>
+              </gui-tooltip-trigger>
+              <gui-tooltip-portal>
+                <gui-tooltip-content align="start">
+                  John Doe john@example.com
+                </gui-tooltip-content>
+              </gui-tooltip-portal>
+            </gui-tooltip>
+          </gui-tooltip-provider>
+        </div>
+        <div class="flex items-center gap-2">
+          <p class="text-baseline cursor-default text-xs font-medium text-muted-foreground">
+            <span class="mr-1 text-foreground">
+              0
+            </span>
+            Downloads last week
+          </p>
+        </div>
       </div>
     </div>
-  </div>
-  <div class="flex h-10 w-full items-center justify-between px-6 py-2 empty:hidden">
-    <div class="flex h-[31.508px] items-center gap-2">
-      <gui-avatar>
-        <gui-avatar-image
-          classname="size-5 rounded-sm border-[1px] border-border"
-          src="https://example.com/avatar.png"
-          alt="John Doe"
-        >
-        </gui-avatar-image>
-        <gui-avatar-fallback classname="flex size-5 items-center justify-center rounded-sm bg-secondary bg-gradient-to-t from-neutral-100 to-neutral-400 p-0.5 outline outline-[1px] outline-border dark:from-neutral-500 dark:to-neutral-800">
-        </gui-avatar-fallback>
-      </gui-avatar>
-      <gui-tooltip-provider>
-        <gui-tooltip>
-          <gui-tooltip-trigger classname="text-baseline cursor-default text-xs font-medium text-muted-foreground">
-            Published by:
-            <span class="text-foreground">
-              John Doe
-            </span>
-          </gui-tooltip-trigger>
-          <gui-tooltip-content align="start">
-            John Doe john@example.com
-          </gui-tooltip-content>
-        </gui-tooltip>
-      </gui-tooltip-provider>
-    </div>
-  </div>
-  <div class="flex w-full divide-x-[1px] divide-muted empty:hidden">
   </div>
 </div>
 

--- a/src/gui/test/components/explorer-grid/selected-item/__snapshots__/tabs-contributors.tsx.snap
+++ b/src/gui/test/components/explorer-grid/selected-item/__snapshots__/tabs-contributors.tsx.snap
@@ -56,7 +56,7 @@ exports[`ContributorList renders with less than 6 contributors 1`] = `
       </gui-avatar>
     </div>
     <gui-button
-      classname="duration-250 font-muted-foreground h-fit rounded-full border-[1px] border-neutral-200 bg-neutral-100 px-3 py-1.5 text-sm font-normal text-foreground transition-colors hover:border-muted-foreground/20 hover:bg-muted-foreground/15 hover:text-foreground dark:border-[#313131] dark:bg-neutral-800 dark:hover:bg-neutral-700/70"
+      classname="duration-250 font-muted-foreground h-7 rounded-full border-[1px] border-neutral-200 bg-neutral-100 px-3 py-1.5 text-sm font-normal text-foreground transition-colors hover:border-muted-foreground/20 hover:bg-muted-foreground/15 hover:text-foreground dark:border-[#313131] dark:bg-neutral-800 dark:hover:bg-neutral-700/70"
       variant="default"
     >
       See all contributors
@@ -164,7 +164,7 @@ exports[`ContributorList renders with more than 6 contributors 1`] = `
       </div>
     </div>
     <gui-button
-      classname="duration-250 font-muted-foreground h-fit rounded-full border-[1px] border-neutral-200 bg-neutral-100 px-3 py-1.5 text-sm font-normal text-foreground transition-colors hover:border-muted-foreground/20 hover:bg-muted-foreground/15 hover:text-foreground dark:border-[#313131] dark:bg-neutral-800 dark:hover:bg-neutral-700/70"
+      classname="duration-250 font-muted-foreground h-7 rounded-full border-[1px] border-neutral-200 bg-neutral-100 px-3 py-1.5 text-sm font-normal text-foreground transition-colors hover:border-muted-foreground/20 hover:bg-muted-foreground/15 hover:text-foreground dark:border-[#313131] dark:bg-neutral-800 dark:hover:bg-neutral-700/70"
       variant="default"
     >
       See all contributors

--- a/src/gui/test/components/explorer-grid/selected-item/__snapshots__/tabs-overview.tsx.snap
+++ b/src/gui/test/components/explorer-grid/selected-item/__snapshots__/tabs-overview.tsx.snap
@@ -16,7 +16,7 @@ exports[`OverviewTabContent renders default 1`] = `
 
 <gui-tabs-content
   value="overview"
-  classname="divide-x-none group flex grid-cols-12 flex-col divide-muted xl:grid xl:divide-x-[1px] [&amp;>aside]:border-b-[1px] [&amp;>aside]:border-red-500 xl:[&amp;>aside]:border-b-[0px]"
+  classname="divide-x-none group flex grid-cols-12 flex-col divide-muted xl:grid xl:divide-x-[1px] [&amp;>aside]:border-b-[1px] xl:[&amp;>aside]:border-b-[0px]"
   style="opacity: 0; filter: blur(2px);"
 >
   <div class="order-2 flex flex-col gap-4 xl:order-1 xl:col-span-12 xl:group-[&amp;:has(aside)]:col-span-8">
@@ -55,7 +55,7 @@ exports[`OverviewTabContent renders with an aside and content 1`] = `
 
 <gui-tabs-content
   value="overview"
-  classname="divide-x-none group flex grid-cols-12 flex-col divide-muted xl:grid xl:divide-x-[1px] [&amp;>aside]:border-b-[1px] [&amp;>aside]:border-red-500 xl:[&amp;>aside]:border-b-[0px]"
+  classname="divide-x-none group flex grid-cols-12 flex-col divide-muted xl:grid xl:divide-x-[1px] [&amp;>aside]:border-b-[1px] xl:[&amp;>aside]:border-b-[0px]"
   style="opacity: 0; filter: blur(2px);"
 >
   <div class="order-2 flex flex-col gap-4 xl:order-1 xl:col-span-12 xl:group-[&amp;:has(aside)]:col-span-8">
@@ -86,130 +86,6 @@ exports[`OverviewTabContent renders with an aside and content 1`] = `
     <gui-contributor-list>
     </gui-contributor-list>
   </div>
-  <aside class="order-1 flex cursor-default flex-col gap-4 px-6 py-4 xl:order-2 xl:col-span-4">
-    <div class="flex flex-col gap-2">
-      <h4 class="text-sm font-medium capitalize text-muted-foreground">
-        about
-      </h4>
-      <div class="flex flex-col gap-2">
-        <gui-link
-          href="https://acme.com"
-          classname="text-sm text-foreground"
-        >
-          <span class="flex items-center justify-center">
-            <gui-globe-icon
-              size="16"
-              classname="text-muted-foreground"
-            >
-            </gui-globe-icon>
-          </span>
-          <span>
-            Website
-          </span>
-        </gui-link>
-        <gui-link
-          href="https://github.com/acme/repo"
-          classname="text-sm text-foreground"
-        >
-          <span class="flex w-4 items-center justify-center">
-            <gui-github-icon
-              size="16"
-              classname="text-muted-foreground"
-            >
-            </gui-github-icon>
-          </span>
-          <span>
-            Repository
-          </span>
-        </gui-link>
-        <gui-link
-          href="https://acme.com/bugs"
-          classname="text-sm text-foreground"
-        >
-          <span class="flex items-center justify-center">
-            <gui-bug-icon
-              size="16"
-              classname="text-muted-foreground"
-            >
-            </gui-bug-icon>
-          </span>
-          <span>
-            Bug reports
-          </span>
-        </gui-link>
-        <div class="flex items-center gap-2">
-          <gui-git-pull-request-icon
-            size="16"
-            classname="text-muted-foreground"
-          >
-          </gui-git-pull-request-icon>
-          <div class="flex gap-1">
-            <gui-data-badge
-              variant="count"
-              content="5"
-            >
-            </gui-data-badge>
-            <p class="text-sm">
-              Pull requests
-            </p>
-          </div>
-        </div>
-        <div class="flex items-center gap-2">
-          <gui-circle-dot-icon
-            size="16"
-            classname="text-muted-foreground"
-          >
-          </gui-circle-dot-icon>
-          <div class="flex gap-1">
-            <gui-data-badge
-              variant="count"
-              content="10"
-            >
-            </gui-data-badge>
-            <p class="text-sm">
-              Issues
-            </p>
-          </div>
-        </div>
-        <div class="flex items-center gap-2">
-          <gui-star-icon
-            size="16"
-            classname="text-muted-foreground"
-          >
-          </gui-star-icon>
-          <div class="flex gap-1">
-            <gui-data-badge
-              variant="count"
-              content="100"
-            >
-            </gui-data-badge>
-            <p class="text-sm">
-              Stars
-            </p>
-          </div>
-        </div>
-      </div>
-    </div>
-    <div class="flex flex-col gap-2">
-      <h4 class="text-sm font-medium capitalize text-muted-foreground">
-        funding
-      </h4>
-      <div class="flex flex-col gap-2">
-        <gui-link
-          href="https://acme.com/funding"
-          classname="text-sm text-foreground"
-        >
-          <span class="flex items-center justify-center text-muted-foreground">
-            <gui-link-icon size="16">
-            </gui-link-icon>
-          </span>
-          <span>
-            Website
-          </span>
-        </gui-link>
-      </div>
-    </div>
-  </aside>
 </gui-tabs-content>
 
 `;
@@ -218,7 +94,7 @@ exports[`OverviewTabContent renders with content 1`] = `
 
 <gui-tabs-content
   value="overview"
-  classname="divide-x-none group flex grid-cols-12 flex-col divide-muted xl:grid xl:divide-x-[1px] [&amp;>aside]:border-b-[1px] [&amp;>aside]:border-red-500 xl:[&amp;>aside]:border-b-[0px]"
+  classname="divide-x-none group flex grid-cols-12 flex-col divide-muted xl:grid xl:divide-x-[1px] [&amp;>aside]:border-b-[1px] xl:[&amp;>aside]:border-b-[0px]"
   style="opacity: 0; filter: blur(2px);"
 >
   <div class="order-2 flex flex-col gap-4 xl:order-1 xl:col-span-12 xl:group-[&amp;:has(aside)]:col-span-8">
@@ -236,7 +112,7 @@ This is a custom description
     </div>
     <gui-contributor-list>
     </gui-contributor-list>
-    <div class="flex grow flex-col justify-end gap-2 px-6 pb-4">
+    <div class="mt-auto flex flex-col justify-end gap-2 px-6 py-4">
       <h4 class="text-sm font-medium capitalize text-muted-foreground">
         keywords
       </h4>

--- a/src/gui/test/components/explorer-grid/selected-item/aside/__snapshots__/aside-bugs.tsx.snap
+++ b/src/gui/test/components/explorer-grid/selected-item/aside/__snapshots__/aside-bugs.tsx.snap
@@ -1,0 +1,28 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`AsideBugs renders nothing when bugs is empty 1`] = `
+
+
+`;
+
+exports[`AsideBugs renders with bugs data 1`] = `
+
+<gui-aside-section>
+  <gui-aside-header>
+    Bug reports
+  </gui-aside-header>
+  <gui-aside-item
+    type="link"
+    href="https://www.acme.com/bugs1"
+  >
+    Website
+  </gui-aside-item>
+  <gui-aside-item
+    type="link"
+    href="https://www.acme.com/bugs2"
+  >
+    Website
+  </gui-aside-item>
+</gui-aside-section>
+
+`;

--- a/src/gui/test/components/explorer-grid/selected-item/aside/__snapshots__/aside-funding.tsx.snap
+++ b/src/gui/test/components/explorer-grid/selected-item/aside/__snapshots__/aside-funding.tsx.snap
@@ -1,0 +1,22 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`AsideFunding renders nothing when funding is empty 1`] = `
+
+
+`;
+
+exports[`AsideFunding renders with funding data 1`] = `
+
+<gui-aside-section>
+  <gui-aside-header>
+    Funding
+  </gui-aside-header>
+  <gui-aside-item href="https://www.acme.com/funding1">
+    Website
+  </gui-aside-item>
+  <gui-aside-item href="https://www.acme.com/funding2">
+    Website
+  </gui-aside-item>
+</gui-aside-section>
+
+`;

--- a/src/gui/test/components/explorer-grid/selected-item/aside/__snapshots__/aside-metadata.tsx.snap
+++ b/src/gui/test/components/explorer-grid/selected-item/aside/__snapshots__/aside-metadata.tsx.snap
@@ -1,0 +1,55 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`AsideMetadata renders nothing when there is no metadata 1`] = `
+
+
+`;
+
+exports[`AsideMetadata renders with all metadata 1`] = `
+
+<gui-aside-section>
+  <gui-aside-header>
+    Metadata
+  </gui-aside-header>
+  <gui-aside-item
+    icon="gui-download"
+    count="1 KB"
+  >
+  </gui-aside-item>
+  <gui-aside-item icon="gui-package">
+    ESM
+  </gui-aside-item>
+  <gui-aside-item
+    icon="gui-file-lock2"
+    copytoclipboard="[object Object]"
+  >
+    Integrity Value
+  </gui-aside-item>
+  <gui-aside-item
+    icon="gui-circle-fading-arrow-up"
+    copytoclipboard="[object Object]"
+  >
+    Tarball URL
+  </gui-aside-item>
+</gui-aside-section>
+<gui-aside-section>
+  <gui-aside-header>
+    Engines
+  </gui-aside-header>
+  <gui-aside-item
+    count=">=14.0.0"
+    classnames="[object Object]"
+    databadgetooltip="[object Object]"
+    icon="gui-node"
+  >
+  </gui-aside-item>
+  <gui-aside-item
+    count=">=6.0.0"
+    classnames="[object Object]"
+    databadgetooltip="[object Object]"
+    icon="gui-npm"
+  >
+  </gui-aside-item>
+</gui-aside-section>
+
+`;

--- a/src/gui/test/components/explorer-grid/selected-item/aside/__snapshots__/aside-repo.tsx.snap
+++ b/src/gui/test/components/explorer-grid/selected-item/aside/__snapshots__/aside-repo.tsx.snap
@@ -1,0 +1,46 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`AsideRepo renders nothing when there is no repo data 1`] = `
+
+
+`;
+
+exports[`AsideRepo renders with all repo data 1`] = `
+
+<gui-aside-section>
+  <gui-aside-header>
+    About
+  </gui-aside-header>
+  <gui-aside-item
+    icon="[object Object]"
+    href="https://www.acme.com"
+  >
+    Website
+  </gui-aside-item>
+  <gui-aside-item icon="[object Object]">
+    Repository
+  </gui-aside-item>
+  <gui-aside-item
+    count="3"
+    icon="[object Object]"
+  >
+    Pull Requests
+  </gui-aside-item>
+  <gui-aside-item
+    count="5"
+    icon="[object Object]"
+  >
+    Issues
+  </gui-aside-item>
+  <gui-aside-item
+    count="100"
+    icon="[object Object]"
+  >
+    Stars
+  </gui-aside-item>
+  <gui-aside-item icon="[object Object]">
+    MIT
+  </gui-aside-item>
+</gui-aside-section>
+
+`;

--- a/src/gui/test/components/explorer-grid/selected-item/aside/__snapshots__/aside.tsx.snap
+++ b/src/gui/test/components/explorer-grid/selected-item/aside/__snapshots__/aside.tsx.snap
@@ -1,0 +1,77 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`AsideHeader renders with text 1`] = `
+
+<h4 class="text-sm font-medium capitalize text-muted-foreground">
+  Test Header
+</h4>
+
+`;
+
+exports[`AsideItem renders with a copy to clipboard feature 1`] = `
+
+<div class="flex items-center text-nowrap text-sm text-foreground gap-2">
+  <span class="flex items-center justify-center empty:hidden [&amp;>svg]:text-muted-foreground">
+  </span>
+  <span class="text-sm">
+    Copy this text
+  </span>
+</div>
+
+`;
+
+exports[`AsideItem renders with a count badge 1`] = `
+
+<div class="flex items-center text-nowrap text-sm text-foreground gap-2">
+  <span class="flex items-center justify-center empty:hidden [&amp;>svg]:text-muted-foreground">
+  </span>
+  <gui-data-badge
+    variant="count"
+    content="5"
+  >
+  </gui-data-badge>
+  <span class="text-sm">
+    Test Count Item
+  </span>
+</div>
+
+`;
+
+exports[`AsideItem renders with a link 1`] = `
+
+<gui-link
+  href="https://www.acme.com"
+  classname="flex items-center text-nowrap text-sm text-foreground"
+>
+  <span class="flex items-center justify-center empty:hidden [&amp;>svg]:text-muted-foreground">
+    <gui-link-icon size="16">
+    </gui-link-icon>
+  </span>
+  <span class="text-sm">
+    https://www.acme.com
+  </span>
+</gui-link>
+
+`;
+
+exports[`AsideItem renders with an icon 1`] = `
+
+<div class="flex items-center text-nowrap text-sm text-foreground gap-2">
+  <span class="flex items-center justify-center empty:hidden [&amp;>svg]:text-muted-foreground">
+    <gui-smile-icon size="16">
+    </gui-smile-icon>
+  </span>
+  <span class="text-sm">
+    Test Item
+  </span>
+</div>
+
+`;
+
+exports[`AsideSection renders with children 1`] = `
+
+<div class="flex flex-col gap-2">
+  Test Section Content
+</div>
+
+`;

--- a/src/gui/test/components/explorer-grid/selected-item/aside/__snapshots__/index.tsx.snap
+++ b/src/gui/test/components/explorer-grid/selected-item/aside/__snapshots__/index.tsx.snap
@@ -1,0 +1,16 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`AsideOverview renders with the correct structure 1`] = `
+
+<gui-aside>
+  <gui-aside-repo>
+  </gui-aside-repo>
+  <gui-aside-funding>
+  </gui-aside-funding>
+  <gui-aside-bugs>
+  </gui-aside-bugs>
+  <gui-aside-metadata>
+  </gui-aside-metadata>
+</gui-aside>
+
+`;

--- a/src/gui/test/components/explorer-grid/selected-item/aside/aside-bugs.tsx
+++ b/src/gui/test/components/explorer-grid/selected-item/aside/aside-bugs.tsx
@@ -1,0 +1,91 @@
+import { test, expect, vi, beforeEach, afterEach } from 'vitest'
+import { cleanup, render } from '@testing-library/react'
+import html from 'diffable-html'
+import { useGraphStore as useStore } from '@/state/index.ts'
+import { useSelectedItemStore } from '@/components/explorer-grid/selected-item/context.tsx'
+import { AsideBugs } from '@/components/explorer-grid/selected-item/aside/aside-bugs.tsx'
+
+import type { SelectedItemStore } from '@/components/explorer-grid/selected-item/context.tsx'
+
+vi.mock(
+  '@/components/explorer-grid/selected-item/context.tsx',
+  () => ({
+    useSelectedItemStore: vi.fn(),
+    SelectedItemProvider: 'gui-selected-item-provider',
+    useTabNavigation: vi.fn(() => ({
+      tab: 'overview',
+      subTab: undefined,
+      setActiveTab: vi.fn(),
+      setActiveSubTab: vi.fn(),
+    })),
+  }),
+)
+
+vi.mock(
+  '@/components/explorer-grid/selected-item/aside/aside.tsx',
+  () => ({
+    AsideHeader: 'gui-aside-header',
+    AsideSection: 'gui-aside-section',
+    AsideItem: 'gui-aside-item',
+  }),
+)
+
+expect.addSnapshotSerializer({
+  serialize: v => html(v),
+  test: () => true,
+})
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+afterEach(() => {
+  const CleanUp = () => (useStore(state => state.reset)(), '')
+  render(<CleanUp />)
+  cleanup()
+})
+
+test('AsideBugs renders nothing when bugs is empty', () => {
+  const mockState = {
+    manifest: {},
+  } as unknown as SelectedItemStore
+
+  vi.mocked(useSelectedItemStore).mockImplementation(selector =>
+    selector(mockState),
+  )
+
+  const Container = () => {
+    return <AsideBugs />
+  }
+
+  const { container } = render(<Container />)
+  expect(container.innerHTML).toMatchSnapshot()
+})
+
+test('AsideBugs renders with bugs data', () => {
+  const mockState = {
+    manifest: {
+      bugs: [
+        {
+          type: 'link',
+          url: 'https://www.acme.com/bugs1',
+        },
+        {
+          type: 'link',
+          url: 'https://www.acme.com/bugs2',
+        },
+      ],
+    } as SelectedItemStore['manifest'],
+  } as unknown as SelectedItemStore
+
+  vi.mocked(useSelectedItemStore).mockImplementation(selector =>
+    selector(mockState),
+  )
+
+  const Container = () => {
+    return <AsideBugs />
+  }
+
+  const { container } = render(<Container />)
+  expect(container.innerHTML).toMatchSnapshot()
+})

--- a/src/gui/test/components/explorer-grid/selected-item/aside/aside-funding.tsx
+++ b/src/gui/test/components/explorer-grid/selected-item/aside/aside-funding.tsx
@@ -1,0 +1,147 @@
+import { test, expect, vi, beforeEach, afterEach } from 'vitest'
+import { cleanup, render } from '@testing-library/react'
+import html from 'diffable-html'
+import { useGraphStore as useStore } from '@/state/index.ts'
+import { useSelectedItemStore } from '@/components/explorer-grid/selected-item/context.tsx'
+import { AsideFunding } from '@/components/explorer-grid/selected-item/aside/aside-funding.tsx'
+
+import type { SelectedItemStore } from '@/components/explorer-grid/selected-item/context.tsx'
+
+vi.mock(
+  '@/components/explorer-grid/selected-item/context.tsx',
+  () => ({
+    useSelectedItemStore: vi.fn(),
+    SelectedItemProvider: 'gui-selected-item-provider',
+    useTabNavigation: vi.fn(() => ({
+      tab: 'overview',
+      subTab: undefined,
+      setActiveTab: vi.fn(),
+      setActiveSubTab: vi.fn(),
+    })),
+  }),
+)
+
+vi.mock(
+  '@/components/explorer-grid/selected-item/aside/aside.tsx',
+  () => ({
+    AsideHeader: 'gui-aside-header',
+    AsideSection: 'gui-aside-section',
+    AsideItem: 'gui-aside-item',
+  }),
+)
+
+expect.addSnapshotSerializer({
+  serialize: v => html(v),
+  test: () => true,
+})
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+afterEach(() => {
+  const CleanUp = () => (useStore(state => state.reset)(), '')
+  render(<CleanUp />)
+  cleanup()
+})
+
+test('AsideFunding renders nothing when funding is empty', () => {
+  const mockState = {
+    manifest: {},
+  } as unknown as SelectedItemStore
+
+  vi.mocked(useSelectedItemStore).mockImplementation(selector =>
+    selector(mockState),
+  )
+
+  const Container = () => {
+    return <AsideFunding />
+  }
+
+  const { container } = render(<Container />)
+  expect(container.innerHTML).toMatchSnapshot()
+})
+
+test('AsideFunding renders with funding data', () => {
+  const mockState = {
+    manifest: {
+      funding: [
+        {
+          type: 'url',
+          url: 'https://www.acme.com/funding1',
+        },
+        {
+          type: 'url',
+          url: 'https://www.acme.com/funding2',
+        },
+      ],
+    } as SelectedItemStore['manifest'],
+  } as unknown as SelectedItemStore
+
+  vi.mocked(useSelectedItemStore).mockImplementation(selector =>
+    selector(mockState),
+  )
+
+  const Container = () => {
+    return <AsideFunding />
+  }
+
+  const { container } = render(<Container />)
+  expect(container.innerHTML).toMatchSnapshot()
+})
+
+//const mockBugs = [
+//  {
+//    url: 'https://www.acme.com/bugs',
+//  },
+//] satisfies NormalizedBugs
+//
+//const mockManifest = {
+//  homepage: 'https://www.acme.com',
+//  license: 'MIT',
+//  repository: 'https://www.acme.com',
+//  version: '1.0.0',
+//  engines: {
+//    node: '>=14.0.0',
+//  },
+//  type: 'module',
+//  funding: mockFunding as unknown as FundingEntry[],
+//  bugs: mockBugs as unknown as Bugs,
+//} satisfies SelectedItemStore['manifest']
+//
+//const mockVersions = [
+//  {
+//    version: '1.0.0',
+//    unpackedSize: 123456,
+//    tarball: 'https://registry.acme.com/tarball-1.0.0.tgz',
+//    integrity: 'sha512-abc123',
+//  },
+//] satisfies SelectedItemStore['versions']
+//
+//const mockState = {
+//  selectedItem: SELECTED_ITEM,
+//  manifest: mockManifest,
+//  rawManifest: null,
+//  packageScore: undefined,
+//  insights: undefined,
+//  author: undefined,
+//  versions: mockVersions,
+//  depCount: undefined,
+//  setDepCount: vi.fn(),
+//  scannedDeps: undefined,
+//  setScannedDeps: vi.fn(),
+//  depsAverageScore: undefined,
+//  setDepsAverageScore: vi.fn(),
+//  depLicenses: undefined,
+//  setDepLicenses: vi.fn(),
+//  depWarnings: undefined,
+//  setDepWarnings: vi.fn(),
+//  duplicatedDeps: undefined,
+//  setDuplicatedDeps: vi.fn(),
+//  depFunding: undefined,
+//  setDepFunding: vi.fn(),
+//  stargazersCount: 100,
+//  openIssueCount: '5',
+//  openPullRequestCount: '4',
+//  ...SELECTED_ITEM_DETAILS,
+//} satisfies SelectedItemStore

--- a/src/gui/test/components/explorer-grid/selected-item/aside/aside-metadata.tsx
+++ b/src/gui/test/components/explorer-grid/selected-item/aside/aside-metadata.tsx
@@ -1,0 +1,112 @@
+import { test, expect, vi, beforeEach, afterEach } from 'vitest'
+import { cleanup, render } from '@testing-library/react'
+import html from 'diffable-html'
+import { useGraphStore as useStore } from '@/state/index.ts'
+import { useSelectedItemStore } from '@/components/explorer-grid/selected-item/context.tsx'
+import { AsideMetadata } from '@/components/explorer-grid/selected-item/aside/aside-metadata.tsx'
+
+import type { SelectedItemStore } from '@/components/explorer-grid/selected-item/context.tsx'
+
+vi.mock(
+  '@/components/explorer-grid/selected-item/context.tsx',
+  () => ({
+    useSelectedItemStore: vi.fn(),
+    SelectedItemProvider: 'gui-selected-item-provider',
+    useTabNavigation: vi.fn(() => ({
+      tab: 'overview',
+      subTab: undefined,
+      setActiveTab: vi.fn(),
+      setActiveSubTab: vi.fn(),
+    })),
+  }),
+)
+
+vi.mock('lucide-react', () => ({
+  CircleFadingArrowUp: 'gui-circle-fading-arrow-up',
+  Download: 'gui-download',
+  FileLock2: 'gui-file-lock2',
+  Package: 'gui-package',
+}))
+
+vi.mock('@/components/icons/index.ts', () => ({
+  Node: 'gui-node',
+  Npm: 'gui-npm',
+  Yarn: 'gui-yarn',
+  Pnpm: 'gui-pnpm',
+  Deno: 'gui-deno',
+  Bun: 'gui-bun',
+}))
+
+vi.mock(
+  '@/components/explorer-grid/selected-item/aside/aside.tsx',
+  () => ({
+    AsideHeader: 'gui-aside-header',
+    AsideSection: 'gui-aside-section',
+    AsideItem: 'gui-aside-item',
+  }),
+)
+
+expect.addSnapshotSerializer({
+  serialize: v => html(v),
+  test: () => true,
+})
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+afterEach(() => {
+  const CleanUp = () => (useStore(state => state.reset)(), '')
+  render(<CleanUp />)
+  cleanup()
+})
+
+test('AsideMetadata renders nothing when there is no metadata', () => {
+  const mockState = {
+    manifest: {},
+    versions: [],
+  } as unknown as SelectedItemStore
+
+  vi.mocked(useSelectedItemStore).mockImplementation(selector =>
+    selector(mockState),
+  )
+
+  const Container = () => {
+    return <AsideMetadata />
+  }
+
+  const { container } = render(<Container />)
+  expect(container.innerHTML).toMatchSnapshot()
+})
+
+test('AsideMetadata renders with all metadata', () => {
+  const mockState = {
+    manifest: {
+      version: '1.0.0',
+      type: 'module',
+      engines: {
+        node: '>=14.0.0',
+        npm: '>=6.0.0',
+      },
+    } as SelectedItemStore['manifest'],
+    versions: [
+      {
+        version: '1.0.0',
+        tarball: 'https://registry.acme.com/tarball.tgz',
+        integrity: 'sha512-abc123',
+        unpackedSize: 1024,
+      },
+    ] as SelectedItemStore['versions'],
+  } as unknown as SelectedItemStore
+
+  vi.mocked(useSelectedItemStore).mockImplementation(selector =>
+    selector(mockState),
+  )
+
+  const Container = () => {
+    return <AsideMetadata />
+  }
+
+  const { container } = render(<Container />)
+  expect(container.innerHTML).toMatchSnapshot()
+})

--- a/src/gui/test/components/explorer-grid/selected-item/aside/aside-repo.tsx
+++ b/src/gui/test/components/explorer-grid/selected-item/aside/aside-repo.tsx
@@ -1,0 +1,87 @@
+import { test, expect, vi, beforeEach, afterEach } from 'vitest'
+import { cleanup, render } from '@testing-library/react'
+import html from 'diffable-html'
+import { useGraphStore as useStore } from '@/state/index.ts'
+import { useSelectedItemStore } from '@/components/explorer-grid/selected-item/context.tsx'
+import { AsideRepo } from '@/components/explorer-grid/selected-item/aside/aside-repo.tsx'
+
+import type { SelectedItemStore } from '@/components/explorer-grid/selected-item/context.tsx'
+
+vi.mock(
+  '@/components/explorer-grid/selected-item/context.tsx',
+  () => ({
+    useSelectedItemStore: vi.fn(),
+    SelectedItemProvider: 'gui-selected-item-provider',
+    useTabNavigation: vi.fn(() => ({
+      tab: 'overview',
+      subTab: undefined,
+      setActiveTab: vi.fn(),
+      setActiveSubTab: vi.fn(),
+    })),
+  }),
+)
+
+vi.mock(
+  '@/components/explorer-grid/selected-item/aside/aside.tsx',
+  () => ({
+    AsideHeader: 'gui-aside-header',
+    AsideSection: 'gui-aside-section',
+    AsideItem: 'gui-aside-item',
+  }),
+)
+
+expect.addSnapshotSerializer({
+  serialize: v => html(v),
+  test: () => true,
+})
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+afterEach(() => {
+  const CleanUp = () => (useStore(state => state.reset)(), '')
+  render(<CleanUp />)
+  cleanup()
+})
+
+test('AsideRepo renders nothing when there is no repo data', () => {
+  const mockState = {
+    manifest: {},
+  } as unknown as SelectedItemStore
+
+  vi.mocked(useSelectedItemStore).mockImplementation(selector =>
+    selector(mockState),
+  )
+
+  const Container = () => {
+    return <AsideRepo />
+  }
+
+  const { container } = render(<Container />)
+  expect(container.innerHTML).toMatchSnapshot()
+})
+
+test('AsideRepo renders with all repo data', () => {
+  const mockState = {
+    manifest: {
+      homepage: 'https://www.acme.com',
+      repository: 'https://repo.acme.com',
+      license: 'MIT',
+    } as SelectedItemStore['manifest'],
+    stargazersCount: '100',
+    openIssueCount: '5',
+    openPullRequestCount: '3',
+  } as unknown as SelectedItemStore
+
+  vi.mocked(useSelectedItemStore).mockImplementation(selector =>
+    selector(mockState),
+  )
+
+  const Container = () => {
+    return <AsideRepo />
+  }
+
+  const { container } = render(<Container />)
+  expect(container.innerHTML).toMatchSnapshot()
+})

--- a/src/gui/test/components/explorer-grid/selected-item/aside/aside.tsx
+++ b/src/gui/test/components/explorer-grid/selected-item/aside/aside.tsx
@@ -1,0 +1,125 @@
+import { test, expect, vi, beforeEach, afterEach } from 'vitest'
+import { cleanup, render } from '@testing-library/react'
+import html from 'diffable-html'
+import { useGraphStore as useStore } from '@/state/index.ts'
+import {
+  AsideHeader,
+  AsideSection,
+  AsideItem,
+} from '@/components/explorer-grid/selected-item/aside/aside.tsx'
+import { Link, Smile } from 'lucide-react'
+
+vi.mock('@/components/ui/data-badge.tsx', () => ({
+  DataBadge: 'gui-data-badge',
+}))
+
+vi.mock('@/components/ui/link.tsx', () => ({
+  Link: 'gui-link',
+}))
+
+vi.mock('lucide-react', () => ({
+  Smile: 'gui-smile-icon',
+  Link: 'gui-link-icon',
+  Copy: 'gui-copy-icon',
+  Check: 'gui-check-icon',
+}))
+
+expect.addSnapshotSerializer({
+  serialize: v => html(v),
+  test: () => true,
+})
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+afterEach(() => {
+  const CleanUp = () => (useStore(state => state.reset)(), '')
+  render(<CleanUp />)
+  cleanup()
+})
+
+test('AsideHeader renders with text', () => {
+  const mockContent = 'Test Header'
+
+  const Container = () => {
+    return <AsideHeader>{mockContent}</AsideHeader>
+  }
+
+  const { container } = render(<Container />)
+  expect(container.innerHTML).toMatchSnapshot()
+  expect(container.innerHTML).toContain(mockContent)
+})
+
+test('AsideSection renders with children', () => {
+  const mockContent = 'Test Section Content'
+
+  const Container = () => {
+    return <AsideSection>{mockContent}</AsideSection>
+  }
+
+  const { container } = render(<Container />)
+  expect(container.innerHTML).toMatchSnapshot()
+  expect(container.innerHTML).toContain(mockContent)
+})
+
+test('AsideItem renders with an icon', () => {
+  const mockText = 'Test Item'
+
+  const Container = () => {
+    return <AsideItem icon={Smile}>{mockText}</AsideItem>
+  }
+
+  const { container } = render(<Container />)
+  expect(container.innerHTML).toMatchSnapshot()
+  expect(container.innerHTML).toContain(mockText)
+  expect(container.innerHTML).toContain('gui-smile-icon')
+})
+
+test('AsideItem renders with a link', () => {
+  const mockHref = 'https://www.acme.com'
+
+  const Container = () => {
+    return (
+      <AsideItem icon={Link} href={mockHref}>
+        {mockHref}
+      </AsideItem>
+    )
+  }
+
+  const { container } = render(<Container />)
+  expect(container.innerHTML).toMatchSnapshot()
+  expect(container.innerHTML).toContain('gui-link-icon')
+  expect(container.innerHTML).toContain('gui-link')
+  expect(container.innerHTML).toContain(mockHref)
+})
+
+test('AsideItem renders with a count badge', () => {
+  const mockCount = 5
+  const mockText = 'Test Count Item'
+
+  const Container = () => {
+    return <AsideItem count={mockCount}>{mockText}</AsideItem>
+  }
+
+  const { container } = render(<Container />)
+  expect(container.innerHTML).toMatchSnapshot()
+  expect(container.innerHTML).toContain(mockText)
+  expect(container.innerHTML).toContain(mockCount.toString())
+  expect(container.innerHTML).toContain('gui-data-badge')
+})
+
+test('AsideItem renders with a copy to clipboard feature', () => {
+  const mockCopyText = 'Copy this text'
+
+  const Container = () => {
+    return (
+      <AsideItem copyToClipboard={{ copyValue: mockCopyText }}>
+        {mockCopyText}
+      </AsideItem>
+    )
+  }
+
+  const { container } = render(<Container />)
+  expect(container.innerHTML).toMatchSnapshot()
+})

--- a/src/gui/test/components/explorer-grid/selected-item/aside/index.tsx
+++ b/src/gui/test/components/explorer-grid/selected-item/aside/index.tsx
@@ -1,0 +1,90 @@
+import { test, expect, vi, beforeEach, afterEach } from 'vitest'
+import { cleanup, render } from '@testing-library/react'
+import html from 'diffable-html'
+import { useGraphStore as useStore } from '@/state/index.ts'
+import { AsideOverview } from '@/components/explorer-grid/selected-item/aside/index.tsx'
+
+vi.mock(
+  '@/components/explorer-grid/selected-item/context.tsx',
+  () => ({
+    useSelectedItemStore: vi.fn(),
+    SelectedItemProvider: 'gui-selected-item-provider',
+    useTabNavigation: vi.fn(() => ({
+      tab: 'overview',
+      subTab: undefined,
+      setActiveTab: vi.fn(),
+      setActiveSubTab: vi.fn(),
+    })),
+  }),
+)
+
+vi.mock(
+  '@/components/explorer-grid/selected-item/aside/aside.tsx',
+  () => ({
+    Aside: 'gui-aside',
+  }),
+)
+
+vi.mock(
+  '@/components/explorer-grid/selected-item/aside/aside-funding.tsx',
+  () => ({
+    AsideFunding: 'gui-aside-funding',
+  }),
+)
+
+vi.mock(
+  '@/components/explorer-grid/selected-item/aside/aside-repo.tsx',
+  () => ({
+    AsideRepo: 'gui-aside-repo',
+  }),
+)
+
+vi.mock(
+  '@/components/explorer-grid/selected-item/aside/aside-bugs.tsx',
+  () => ({
+    AsideBugs: 'gui-aside-bugs',
+  }),
+)
+
+vi.mock(
+  '@/components/explorer-grid/selected-item/aside/aside-metadata.tsx',
+  () => ({
+    AsideMetadata: 'gui-aside-metadata',
+  }),
+)
+
+vi.mock(
+  '@/components/explorer-grid/selected-item/aside/use-empty-check.tsx',
+  () => ({
+    useEmptyCheck: vi.fn(() => ({
+      isRepoEmpty: false,
+      isFundingEmpty: false,
+      isBugsEmpty: false,
+      isMetadataEmpty: false,
+    })),
+  }),
+)
+
+expect.addSnapshotSerializer({
+  serialize: v => html(v),
+  test: () => true,
+})
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+afterEach(() => {
+  const CleanUp = () => (useStore(state => state.reset)(), '')
+  render(<CleanUp />)
+  cleanup()
+})
+
+test('AsideOverview renders with the correct structure', () => {
+  const Container = () => {
+    return <AsideOverview />
+  }
+
+  const { container } = render(<Container />)
+  expect(container.innerHTML).toMatchSnapshot()
+})

--- a/src/gui/test/components/explorer-grid/selected-item/focused-view/__snapshots__/aside.tsx.snap
+++ b/src/gui/test/components/explorer-grid/selected-item/focused-view/__snapshots__/aside.tsx.snap
@@ -3,9 +3,12 @@
 exports[`FocusedAside renders default 1`] = `
 
 <div class="col-span-full lg:col-span-3 lg:pl-4 lg:pr-0">
-  <div style="opacity: 0; filter: blur(2px); transform: translateY(2px);">
-    <gui-tab-content-aside classname="h-fit border-l-[1.6px] border-muted py-0">
-    </gui-tab-content-aside>
+  <div
+    class="p-0"
+    style="opacity: 0; filter: blur(2px); transform: translateY(2px);"
+  >
+    <gui-aside-overview classname="h-fit py-0">
+    </gui-aside-overview>
   </div>
 </div>
 

--- a/src/gui/test/components/explorer-grid/selected-item/focused-view/__snapshots__/index.tsx.snap
+++ b/src/gui/test/components/explorer-grid/selected-item/focused-view/__snapshots__/index.tsx.snap
@@ -2,12 +2,15 @@
 
 exports[`FocusedView renders default 1`] = `
 
-<gui-selected-item-provider selecteditem="[object Object]">
+<gui-selected-item-provider
+  selecteditem="[object Object]"
+  asideoveriewvisible="false"
+>
   <section
     class="relative pb-4"
     style="opacity: 0; filter: blur(2px);"
   >
-    <gui-item-header classname="pb-0">
+    <gui-item-header classnames="[object Object]">
       <gui-focused-button>
       </gui-focused-button>
     </gui-item-header>

--- a/src/gui/test/components/explorer-grid/selected-item/focused-view/aside.tsx
+++ b/src/gui/test/components/explorer-grid/selected-item/focused-view/aside.tsx
@@ -14,16 +14,16 @@ vi.mock('react-router', () => ({
 }))
 
 vi.mock(
-  '@/components/explorer-grid/selected-item/tabs-overview.tsx',
+  '@/components/explorer-grid/dependency-sidebar/index.tsx',
   () => ({
-    TabContentAside: 'gui-tab-content-aside',
+    DependencySideBar: 'gui-dependency-sidebar',
   }),
 )
 
 vi.mock(
-  '@/components/explorer-grid/dependency-sidebar/index.tsx',
+  '@/components/explorer-grid/selected-item/aside/index.tsx',
   () => ({
-    DependencySideBar: 'gui-dependency-sidebar',
+    AsideOverview: 'gui-aside-overview',
   }),
 )
 

--- a/src/gui/test/components/explorer-grid/selected-item/item-header.tsx
+++ b/src/gui/test/components/explorer-grid/selected-item/item-header.tsx
@@ -59,28 +59,12 @@ vi.mock('@/components/ui/tooltip.tsx', () => ({
   TooltipContent: 'gui-tooltip-content',
   TooltipTrigger: 'gui-tooltip-trigger',
   TooltipProvider: 'gui-tooltip-provider',
+  TooltipPortal: 'gui-tooltip-portal',
 }))
 
 vi.mock('lucide-react', () => ({
   Home: 'gui-home-icon',
-  Scale: 'gui-scale-icon',
   ArrowBigUpDash: 'gui-arrow-big-up-dash-icon',
-  EyeOff: 'gui-eye-off-icon',
-  Download: 'gui-download-icon',
-  Package: 'gui-package-icon',
-}))
-
-vi.mock('@/components/ui/progress-bar.tsx', () => ({
-  ProgressBar: 'gui-progress-bar',
-}))
-
-vi.mock('@/components/icons/index.ts', () => ({
-  Npm: 'gui-npm-icon',
-  Node: 'gui-node-icon',
-  Yarn: 'gui-yarn-icon',
-  Pnpm: 'gui-pnpm-icon',
-  Deno: 'gui-deno-icon',
-  Bun: 'gui-bun-icon',
 }))
 
 vi.mock('@/components/ui/scroll-area.tsx', () => ({

--- a/src/gui/test/components/explorer-grid/selected-item/tabs-overview.tsx
+++ b/src/gui/test/components/explorer-grid/selected-item/tabs-overview.tsx
@@ -64,25 +64,11 @@ vi.mock('react-markdown', () => ({
 
 vi.mock('lucide-react', () => ({
   FileText: 'gui-file-text-icon',
-  Globe: 'gui-globe-icon',
-  Bug: 'gui-bug-icon',
   RectangleHorizontal: 'gui-rectangle-horizontal-icon',
-  Star: 'gui-star-icon',
-  CircleDot: 'gui-circle-dot-icon',
-  GitPullRequest: 'gui-git-pull-request-icon',
-  Link: 'gui-link-icon',
-}))
-
-vi.mock('@/components/icons/index.ts', () => ({
-  Github: 'gui-github-icon',
 }))
 
 vi.mock('@/components/ui/data-badge.tsx', () => ({
   DataBadge: 'gui-data-badge',
-}))
-
-vi.mock('@/components/ui/link.tsx', () => ({
-  Link: 'gui-link',
 }))
 
 vi.mock(
@@ -93,12 +79,9 @@ vi.mock(
 )
 
 vi.mock(
-  '@/components/explorer-grid/selected-item/focused-view/use-focus-state.tsx',
+  '@/components/explorer-grid/selected-item/aside/index.tsx',
   () => ({
-    useFocusState: () => ({
-      isFocused: false,
-      setIsFocused: vi.fn(),
-    }),
+    AsideOverview: 'gui-aside-overview',
   }),
 )
 


### PR DESCRIPTION
| Unfocused | Focused |
| --- | --- |
| <img width="636" height="686" alt="Screenshot 2025-07-16 at 1134 14" src="https://github.com/user-attachments/assets/5629ebea-aeea-42b1-90f8-74f3e482439f" /> | <img width="1344" height="664" alt="Screenshot 2025-07-16 at 11 34 56" src="https://github.com/user-attachments/assets/f006f5b4-5527-49d4-a4e9-13ae854875b6" /> |

## Overview

This PR moves a lot of the metadata from the `item-header` into the `aside` to free up the vertical realestate on the `selected-item`

### Aside

This PR creates a generic `aside` component inside the `selected-item/` that will render out the normalized metadata from the `selected-item` object.

#### Changelog
- **feat: creates `aside` components**
- **feat: relocates helpers**
- **feat: creates component for `bugs`**
- **feat: creates components for `funding`**
- **feat: creates components for `repo`**
- **feat: creates components for `metadata`**
- **feat: creates `aside-overview` component**
- **feat: removes old `aside` from `tabs-overview`**
- **feat: adds new `aside-overview` to the `focused` view**
- **feat: removes old `metadata` from `item-header`**
