### PR TITLE
fix: actions version to be explicit

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Add to GitHub Project
-        uses: actions/add-to-project@1
+        uses: actions/add-to-project@v1.0.2
         with:
           project-url: https://github.com/orgs/vltpkg/projects/3
         env:

--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -14,5 +14,4 @@ jobs:
         uses: actions/add-to-project@v1.0.2
         with:
           project-url: https://github.com/orgs/vltpkg/projects/3
-        env:
-          GITHUB_TOKEN: ${{ secrets.PROJECT_PAT }}
+          github-token: ${{ secrets.PROJECT_PAT }}


### PR DESCRIPTION
- github hasn't added semver resolution to actions yet (most actions previously supported `v{n}`/`{n}` tags but `actions/add-to-project` doesn't seem to have that on the marketplace)
- this changes the spec to use the exact `v1.0.2` tag