### PR TITLE
cli-sdk: add a `--view=silent` option

### DIFF
--- a/src/cli-sdk/src/config/definition.ts
+++ b/src/cli-sdk/src/config/definition.ts
@@ -531,6 +531,7 @@ export const definition = j
                       commands.)
                     - mermaid: Output mermaid diagramming syntax. (Only
                       relevant for certain commands.)
+                    - silent: Suppress all output to stdout.
 
                     If the requested view format is not supported for the
                     current command, or if no option is provided, then it
@@ -542,6 +543,7 @@ export const definition = j
         'mermaid',
         'gui',
         'inspect',
+        'silent',
       ] as const,
     },
   })

--- a/src/cli-sdk/src/exec-command.ts
+++ b/src/cli-sdk/src/exec-command.ts
@@ -84,6 +84,8 @@ export const views = {
     : result,
 } as const satisfies Views<ExecResult>
 
+type ViewValues = 'human' | 'json' | 'inspect' | 'silent'
+
 export class ExecCommand<B extends RunnerBG, F extends RunnerFG> {
   bg: B
   fg: F
@@ -94,16 +96,19 @@ export class ExecCommand<B extends RunnerBG, F extends RunnerFG> {
   spaces?: number
   conf: LoadedConfig
   projectRoot: string
-  view: 'human' | 'json' | 'inspect'
+  view: ViewValues
+  validViewValues = new Map<string, ViewValues>([
+    ['human', 'human'],
+    ['json', 'json'],
+    ['inspect', 'inspect'],
+    ['silent', 'silent'],
+  ])
 
   constructor(conf: LoadedConfig, bg: B, fg: F) {
     this.conf = conf
     this.bg = bg
     this.fg = fg
-    this.view =
-      conf.values.view === 'json' ? 'json'
-      : conf.values.view === 'inspect' ? 'inspect'
-      : 'human'
+    this.view = this.validViewValues.get(conf.values.view) ?? 'human'
     const {
       projectRoot,
       positionals: [arg0, ...args],

--- a/src/cli-sdk/src/output.ts
+++ b/src/cli-sdk/src/output.ts
@@ -49,6 +49,7 @@ export const getView = <T>(
 
   const viewFn =
     viewName === 'inspect' ? identity
+    : viewName === 'silent' ? () => undefined
     : typeof views === 'function' ? views
     : views && typeof views === 'object' ? views[viewName]
     : identity
@@ -61,7 +62,8 @@ export const getView = <T>(
   if (
     !viewFn &&
     conf.values.view !== defaultView &&
-    conf.values.view !== 'json'
+    conf.values.view !== 'json' &&
+    conf.values.view !== 'silent'
   ) {
     conf.values.view = defaultView
     process.env.VLT_VIEW = defaultView
@@ -147,7 +149,7 @@ export const outputCommand = async <T>(
 
   try {
     const output = await onDone(await command(conf))
-    if (output !== undefined) {
+    if (output !== undefined && conf.values.view !== 'silent') {
       stdout(
         conf.values.view === 'json' ?
           JSON.stringify(output, null, 2)

--- a/src/cli-sdk/tap-snapshots/test/config/definition.ts.test.cjs
+++ b/src/cli-sdk/tap-snapshots/test/config/definition.ts.test.cjs
@@ -404,6 +404,7 @@ Object {
       - inspect: Output results with \`util.inspect\`.
       - gui: Start a local web server and opens a browser to explore the results. (Only relevant for certain commands.)
       - mermaid: Output mermaid diagramming syntax. (Only relevant for certain commands.)
+      - silent: Suppress all output to stdout.
       
       If the requested view format is not supported for the current command, or if no option is provided, then it will fall back to the default.
     ),
@@ -415,6 +416,7 @@ Object {
       "mermaid",
       "gui",
       "inspect",
+      "silent",
     ],
   },
   "workspace": Object {

--- a/src/cli-sdk/test/commands/list.ts
+++ b/src/cli-sdk/test/commands/list.ts
@@ -146,11 +146,10 @@ const runCommand = async (
     get: (key: string) => (values as any)[key],
   } as LoadedConfig
   const res = await cmd.command(config)
-  const output = cmd.views[values.view](
-    res,
-    { colors: values.color },
-    config,
-  )
+  const output =
+    values.view === 'silent' ?
+      undefined
+    : cmd.views[values.view](res, { colors: values.color }, config)
   return values.view === 'json' ?
       JSON.stringify(output, null, 2)
     : output

--- a/src/cli-sdk/test/commands/query.ts
+++ b/src/cli-sdk/test/commands/query.ts
@@ -146,11 +146,10 @@ const runCommand = async (
     get: (key: string) => (values as any)[key],
   } as LoadedConfig
   const res = await cmd.command(config)
-  const output = cmd.views[values.view](
-    res,
-    { colors: values.color },
-    config,
-  )
+  const output =
+    values.view === 'silent' ?
+      undefined
+    : cmd.views[values.view](res, { colors: values.color }, config)
   return values.view === 'json' ?
       JSON.stringify(output, null, 2)
     : output

--- a/src/cli-sdk/test/config/definition.ts
+++ b/src/cli-sdk/test/config/definition.ts
@@ -144,3 +144,8 @@ t.test('getSortedCliDefinitions', async t => {
   >('../../src/config/definition.ts')
   t.matchSnapshot(getSortedCliOptions(), 'sorted CLI definitions')
 })
+
+t.test('silent view option is valid', async t => {
+  const { values } = definition.parse(['--view', 'silent'])
+  t.equal(values.view, 'silent')
+})

--- a/src/cli-sdk/test/output.ts
+++ b/src/cli-sdk/test/output.ts
@@ -112,6 +112,15 @@ t.test('outputCommand', async t => {
     t.strictSame(logs(), [['{ ohthehumanity: true }']])
   })
 
+  t.test('success output (silent)', async t => {
+    const logs = t.capture(console, 'log').args
+    const confSilent = {
+      values: { view: 'silent' },
+    } as LoadedConfig
+    await outputCommand(cliCommand, confSilent)
+    t.strictSame(logs(), [], 'no output produced with silent view')
+  })
+
   t.test('undefined output', async t => {
     const logs = t.capture(console, 'log').args
     await outputCommand(


### PR DESCRIPTION
While working in our benchmarking suite:
https://github.com/vltpkg/benchmarks/

I noticed that vlt is the only cli that did not implemented a silent install option.

This changeset adds a new `silent` view option that supresses all output to the terminal to all commands that support the `view` option.