### PR TITLE
fix(cli-sdk): output human views in CI

### DIFF
--- a/.github/workflows/vlt.yml
+++ b/.github/workflows/vlt.yml
@@ -117,7 +117,7 @@ jobs:
           check-latest: true
 
       - name: Boostrap
-        run: npx vlt install
+        run: npx vlt install --view=json
 
       - name: Build vlt
         run: node --run build:bundle
@@ -126,7 +126,7 @@ jobs:
         run: echo "$GITHUB_WORKSPACE/scripts/bins/bundle" >> $GITHUB_PATH
       
       - name: Install Dependencies
-        run: vlt install
+        run: vlt install --view=json
 
       - name: Run Typecheck
         continue-on-error: true

--- a/.github/workflows/vlt.yml
+++ b/.github/workflows/vlt.yml
@@ -26,7 +26,7 @@ jobs:
           check-latest: true
 
       - name: Boostrap
-        run: npx vlt install
+        run: npx vlt install --view=json
 
       - name: Build vlt
         run: node --run build:bundle
@@ -35,7 +35,7 @@ jobs:
         run: echo "$GITHUB_WORKSPACE/scripts/bins/bundle" >> $GITHUB_PATH
       
       - name: Install Dependencies
-        run: vlt install
+        run: vlt install --view=json
 
       - name: Formatting
         id: format

--- a/src/cli-sdk/src/config/definition.ts
+++ b/src/cli-sdk/src/config/definition.ts
@@ -2,7 +2,15 @@ import { error } from '@vltpkg/error-cause'
 import { XDG } from '@vltpkg/xdg'
 import { jack } from 'jackspeak'
 
-export const defaultView = process.stdout.isTTY ? 'human' : 'json'
+export const defaultView =
+  // If stdout is a TTY, use human output
+  process.stdout.isTTY ? 'human'
+    // If its not a TTY but is a CI environment, use human output
+    // TODO: make a better view option for CI environments
+  : /* c8 ignore next */
+  process.env.CI ? 'human'
+    // Otherwise, use json output
+  : 'json'
 
 export const defaultEditor = () =>
   process.env.EDITOR ||

--- a/src/cli-sdk/src/config/definition.ts
+++ b/src/cli-sdk/src/config/definition.ts
@@ -7,8 +7,7 @@ export const defaultView =
   process.stdout.isTTY ? 'human'
     // If its not a TTY but is a CI environment, use human output
     // TODO: make a better view option for CI environments
-  : /* c8 ignore next */
-  process.env.CI ? 'human'
+  : process.env.CI ? 'human'
     // Otherwise, use json output
   : 'json'
 

--- a/src/cli-sdk/test/config/definition.ts
+++ b/src/cli-sdk/test/config/definition.ts
@@ -74,12 +74,27 @@ t.test('default view depends on stdout TTY status', t => {
   t.test('tty false', async t => {
     delete process.env.VLT_VIEW
     t.intercept(process.stdout, 'isTTY', { value: false })
+    t.intercept(process, 'env', {
+      value: { ...process.env, CI: false },
+    })
     t.equal(process.stdout.isTTY, false)
     const { definition } = await t.mockImport<
       typeof import('../../src/config/definition.ts')
     >('../../src/config/definition.ts')
     const { values } = definition.parse([])
     t.equal(values.view, 'json')
+    t.end()
+  })
+  t.test('ci true', async t => {
+    delete process.env.VLT_VIEW
+    t.intercept(process, 'env', {
+      value: { ...process.env, CI: true },
+    })
+    const { definition } = await t.mockImport<
+      typeof import('../../src/config/definition.ts')
+    >('../../src/config/definition.ts')
+    const { values } = definition.parse([])
+    t.equal(values.view, 'human')
     t.end()
   })
   t.end()

--- a/src/cli-sdk/test/output.ts
+++ b/src/cli-sdk/test/output.ts
@@ -5,7 +5,7 @@ t.intercept(process.stderr, 'isTTY', { value: false })
 t.intercept(process, 'env', {
   value: Object.fromEntries(
     Object.entries(process.env).filter(
-      ([k]) => !['FORCE_COLOR', 'NO_COLOR'].includes(k),
+      ([k]) => !['FORCE_COLOR', 'NO_COLOR', 'CI'].includes(k),
     ),
   ),
 })


### PR DESCRIPTION
This preserves the behavior of the view being inferred as JSON when
piping between commands, except when that is done in a CI environment.
