### PR TITLE
graph: reify exit early on empty diff

### DIFF
--- a/src/graph/src/diff.ts
+++ b/src/graph/src/diff.ts
@@ -138,4 +138,13 @@ ${lines
   .join('\n')}
 }`
   }
+
+  hasChanges(): boolean {
+    return (
+      this.nodes.add.size > 0 ||
+      this.nodes.delete.size > 0 ||
+      this.edges.add.size > 0 ||
+      this.edges.delete.size > 0
+    )
+  }
 }

--- a/src/graph/src/reify/index.ts
+++ b/src/graph/src/reify/index.ts
@@ -58,6 +58,12 @@ export const reify = async (options: ReifyOptions) => {
     })
 
   const diff = new Diff(actual, graph)
+  if (!diff.hasChanges()) {
+    // nothing to do, so just return the diff
+    done()
+    return diff
+  }
+
   const remover = new RollbackRemove()
   let success = false
   try {


### PR DESCRIPTION
If there are no diffs to be applied by the reify step then it should just exit the earliest as possible.

Refs: https://github.com/vltpkg/statusboard/issues/198