### PR TITLE
chore(benchmark): set binary through hyperfine parameter list

### DIFF
--- a/infra/cli-benchmarks/scripts/variations/cache-lockfile-node-modules.sh
+++ b/infra/cli-benchmarks/scripts/variations/cache-lockfile-node-modules.sh
@@ -15,4 +15,5 @@ hyperfine \
   --setup="bash $BENCH_SCRIPTS/clean-helpers.sh clean_all" \
   --prepare="sleep 1" \
   --cleanup="bash $BENCH_SCRIPTS/clean-helpers.sh clean_all" \
-  --command-name="vlt install: $BENCH_FIXTURE & $BENCH_VARIATION" "$BENCH_COMMAND_VLT"
+  --parameter-list "binary" "$BENCH_BINARY" \
+  --command-name="{binary} install: $BENCH_FIXTURE & $BENCH_VARIATION" "$BENCH_COMMAND_VLT"

--- a/infra/cli-benchmarks/scripts/variations/cache-lockfile.sh
+++ b/infra/cli-benchmarks/scripts/variations/cache-lockfile.sh
@@ -16,4 +16,5 @@ hyperfine \
   --prepare="sleep 1; bash $BENCH_SCRIPTS/clean-helpers.sh clean_node_modules" \
   --conclude="sleep 1; bash $BENCH_SCRIPTS/clean-helpers.sh clean_node_modules" \
   --cleanup="bash $BENCH_SCRIPTS/clean-helpers.sh clean_all" \
-  --command-name="vlt install: $BENCH_FIXTURE & $BENCH_VARIATION" "$BENCH_COMMAND_VLT"
+  --parameter-list "binary" "$BENCH_BINARY" \
+  --command-name="{binary} install: $BENCH_FIXTURE & $BENCH_VARIATION" "$BENCH_COMMAND_VLT"

--- a/infra/cli-benchmarks/scripts/variations/clean.sh
+++ b/infra/cli-benchmarks/scripts/variations/clean.sh
@@ -15,4 +15,5 @@ hyperfine \
   --prepare="sleep 1; bash $BENCH_SCRIPTS/clean-helpers.sh clean_all" \
   --conclude="sleep 1; bash $BENCH_SCRIPTS/clean-helpers.sh clean_all" \
   --cleanup="bash $BENCH_SCRIPTS/clean-helpers.sh clean_all" \
-  --command-name="vlt install: $BENCH_FIXTURE & $BENCH_VARIATION" "$BENCH_COMMAND_VLT"
+  --parameter-list "binary" "$BENCH_BINARY" \
+  --command-name="{binary} install: $BENCH_FIXTURE & $BENCH_VARIATION" "$BENCH_COMMAND_VLT"

--- a/infra/cli-benchmarks/scripts/variations/common.sh
+++ b/infra/cli-benchmarks/scripts/variations/common.sh
@@ -34,7 +34,8 @@ fi
 BENCH_WARMUP="${BENCH_WARMUP:=2}"
 BENCH_RUNS="${BENCH_RUNS:=10}"
 BENCH_OUTPUT_FOLDER="$BENCH_RESULTS/$BENCH_FIXTURE/$BENCH_VARIATION"
-BENCH_COMMAND_VLT="vlt install --view=human --cache=.vlt-cache > $BENCH_OUTPUT_FOLDER/vlt-output-\${HYPERFINE_ITERATION}.log 2>&1"
+BENCH_BINARY="${BENCH_BINARY:=vlt}"
+BENCH_COMMAND_VLT="{binary} install --view=human --cache=.vlt-cache > $BENCH_OUTPUT_FOLDER/vlt-output-\${HYPERFINE_ITERATION}.log 2>&1"
 
 # Clean up & create the results directory
 rm -rf "$BENCH_OUTPUT_FOLDER"

--- a/infra/cli-benchmarks/scripts/variations/lockfile.sh
+++ b/infra/cli-benchmarks/scripts/variations/lockfile.sh
@@ -16,4 +16,5 @@ hyperfine \
   --prepare="sleep 1; bash $BENCH_SCRIPTS/clean-helpers.sh clean_all_cache clean_node_modules" \
   --conclude="sleep 1; bash $BENCH_SCRIPTS/clean-helpers.sh clean_all_cache clean_node_modules" \
   --cleanup="bash $BENCH_SCRIPTS/clean-helpers.sh clean_all" \
-  --command-name="vlt install: $BENCH_FIXTURE & $BENCH_VARIATION" "$BENCH_COMMAND_VLT"
+  --parameter-list "binary" "$BENCH_BINARY" \
+  --command-name="{binary} install: $BENCH_FIXTURE & $BENCH_VARIATION" "$BENCH_COMMAND_VLT"


### PR DESCRIPTION
This has no effect on CI benchmarks but now the `vlt` binary is supplied to hyperfine via `--parameter-list`. This allows for locally running the benchmarks against a baseline to help debug performance.

Here's how I'm using it locally with two local copies of the `vltpkg/vltpkg` repo:

```sh
export BENCH_BINARY="$(pwd)/scripts/bins/bundle/vlt,/Users/lukekarrys/projects/vltpkg/vltpkg-clean/scripts/bins/bundle/vlt"
bash ./infra/cli-benchmarks/scripts/benchmark.sh abbrev clean
```