### PR TITLE
graph: document graph library

### DIFF
--- a/.cursor/rules/graph/data-structure.mdc
+++ b/.cursor/rules/graph/data-structure.mdc
@@ -1,0 +1,162 @@
+---
+description: Graph core data structures (Graph, Node, Edge, Types)
+globs: src/graph/src/graph.ts,src/graph/src/node.ts,src/graph/src/edge.ts,src/graph/src/types.ts,src/graph/test/graph.ts,src/graph/test/node.ts,src/graph/test/edge.ts
+alwaysApply: false
+---
+# Graph Core Data Structures
+
+Detailed reference for the data model used by `@vltpkg/graph`, covering `Graph`, `Node`, `Edge`, and public type shapes. Use this to inform future implementation work across the graph system.
+
+<rule>
+name: graph_data_structure
+description: In-depth documentation of Graph, Node, Edge, and their invariants and behaviors
+filters:
+  # Core data structure files
+  - type: path
+    pattern: "^src/graph/src/(graph|node|edge|types)\\.ts$"
+  # Files that consume these types frequently
+  - type: path
+    pattern: "^src/graph/src/(ideal|actual|lockfile|reify)/"
+  # Mentions of Graph/Node/Edge in content
+  - type: content
+    pattern: "class Graph|class Node|class Edge|GraphLike|NodeLike|EdgeLike"
+
+actions:
+  - type: guide
+    message: |
+      ## Overview
+
+      The graph library models a project's installable dependency universe using:
+      - `Graph` — global container of nodes and edges, with importer roots, caches, and helpers
+      - `Node` — unique package instance; identity provided by `@vltpkg/dep-id`
+      - `Edge` — directed dependency relationship from `from` to `to` with a parsed `Spec`
+
+      Public type shapes (`GraphLike`, `NodeLike`, `EdgeLike`) are defined in `src/graph/src/types.ts` for loose coupling with higher-level modules.
+
+  - type: architecture_guide
+    message: |
+      ## Graph (`src/graph/src/graph.ts`)
+
+      Construction:
+      - Initializes `mainImporter` from the project root manifest using a `file:.` DepID
+      - Discovers additional importer nodes from `@vltpkg/workspaces`, adding each as a root
+
+      Core fields:
+      - `importers: Set<Node>` — roots of traversal (main project + workspaces)
+      - `mainImporter: Node` — the primary project importer
+      - `nodes: Map<DepID, Node>` — all nodes keyed by unique `DepID`
+      - `nodesByName: Map<string, Set<Node>>` — lookup by package name
+      - `edges: Set<Edge>` — all edges across the graph
+      - `manifests: Map<DepID, NormalizedManifest>` — manifest inventory
+      - `resolutions: Map<string, Node>` / `resolutionsReverse: Map<Node, Set<string>>` — resolution caches
+      - `extraneousDependencies: Set<Edge>` — edges present on disk but not declared when loading Actual graphs
+
+      Important methods:
+      - `addNode(id?, manifest?, spec?, name?, version?)` — creates a node; populates indices and resolution cache
+      - `addEdge(type, spec, from, to?)` — creates/updates an edge; ensures spec naming; de-duplicates similar edges
+      - `placePackage(fromNode, depType, spec, manifest?, id?, extra?)` — high-level placement that either creates a missing edge (if no `manifest`/`id`) or ensures a node exists and connects the edge, setting dev/optional flags
+      - `findResolution(spec, fromNode, queryModifier?)` — searches `nodesByName` for a satisfying node (via `@vltpkg/satisfies`), keyed by spec + from location + modifier for caching
+      - `removeNode(node, replacement?, keepEdges?)` — deletes node and rewires or removes affected edges
+      - `removeEdgeResolution(edge, queryModifier?)` — clears a specific cached resolution and potentially prunes the referenced node if orphaned
+      - `gc()` — trims unreachable nodes/edges not reachable from importers; used after optional failures
+      - `toJSON()` — serializes using `lockfileData()` to produce a stable, deterministic representation
+
+      Resolution cache key:
+      - `getResolutionCacheKey(spec.final, from.location, queryModifier)`; file-based specs include `from.location` to avoid cross-importer leakage
+
+  - type: architecture_guide
+    message: |
+      ## Node (`src/graph/src/node.ts`)
+
+      Identity and metadata:
+      - `id: DepID` — unique identity; from `getId(spec, manifest)` or explicit `id`
+      - `manifest?: NormalizedManifest` — may be undefined when not read (eg. Actual load without manifests)
+      - `name`, `version`, `integrity`, `resolved`, `registry`, `modifier`
+
+      Location and store model:
+      - `location: string` — defaults to `./node_modules/.vlt/<DepID>/node_modules/<name>` if not set
+      - `inVltStore()` — memoized check whether node is located in the store layout
+      - `nodeModules(scurry)` — directory where this node’s dependencies are linked (store parent vs direct `node_modules`)
+      - `setImporterLocation(location)` — marks importer nodes and sets location
+      - `setDefaultLocation()` — relocates nodes into default store path when appropriate
+
+      Dependency flags and propagation:
+      - `dev` and `optional` flags indicate reachability via dev or optional/peerOptional edges
+      - Clearing `dev` or `optional` cascades to non-dev/non-optional children (ensures consistency)
+
+      Confused manifests:
+      - `maybeSetConfusedManifest(spec, manifest?)` sets `confused=true` when manifest name differs from requested spec name; preserves `rawManifest`
+
+  - type: architecture_guide
+    message: |
+      ## Edge (`src/graph/src/edge.ts`)
+
+      - `from: Node`, `to?: Node` — directed relation; `to` may be missing to model missing dependencies
+      - `type: DependencyTypeShort` — one of `prod | dev | peer | peerOptional | optional`
+      - `spec: Spec` — parsed from `@vltpkg/spec`; `spec.name` is enforced during creation for correctness
+      - Convenience flags: `dev`, `optional`, `peer`, `peerOptional`
+      - `valid()` checks satisfaction of `to.id` against `spec` using `@vltpkg/satisfies` with `from.location` and `projectRoot`
+
+  - type: data_format_guide
+    message: |
+      ## Public Type Shapes (`src/graph/src/types.ts`)
+
+      - `GraphLike` — minimal interface exposing graph fields and methods used by clients that should not depend on full implementation details
+      - `NodeLike` — minimal node shape with key fields (`id`, `edgesIn`, `edgesOut`, `manifest`, `location`, `name`, etc.) and behaviors (eg. `setResolved`, `maybeSetConfusedManifest`)
+      - `EdgeLike` — minimal edge shape including `from`, `spec`, `to?`, and flags
+
+      These types enable testing, visualization, and interop with modules like `ideal`, `actual`, `lockfile`, and `reify` without tightly coupling to class implementations.
+
+  - type: architecture_guide
+    message: |
+      ## Invariants and Modeling Notes
+
+      - Node identity (`DepID`) is unique across the graph; `nodes` map keys must not collide
+      - `nodesByName` collects multiple versions/locations of the same package name for resolution and hoisting
+      - `edgesOut` is keyed by `spec.name`; Graph ensures spec name correctness, disallowing missing names for missing edges
+      - Missing dependencies are represented as edges with `to=undefined`
+      - Extraneous dependencies are tracked in `graph.extraneousDependencies` when loading Actual with manifests
+      - Resolution caching is query-modifier aware to reflect modified specs
+      - Deterministic ordering is maintained in serialization to ensure stable lockfiles
+
+  - type: development_workflow
+    message: |
+      ## Practical Usage Tips
+
+      - Prefer `placePackage()` for top-down placement (it handles node creation, flags, and edges)
+      - Use `findResolution()` before creating new nodes to reuse satisfying ones (crucial for Ideal builds)
+      - When removing nodes, consider `replacement` or `keepEdges` to preserve structure where valid
+      - After structural changes that may orphan nodes, use `gc()` to prune unreachable subgraphs
+      - When serializing, rely on `graph.toJSON()` which delegates to lockfile formatting for consistency
+
+examples:
+  - input: |
+      // Find a reusable node satisfying a spec before creating a new one
+      const reuse = graph.findResolution(spec, fromNode)
+      if (reuse) graph.addEdge('prod', spec, fromNode, reuse)
+    output: "Resolution cache leveraged; avoided unnecessary node creation"
+
+  - input: |
+      // Model a missing dependency
+      graph.addEdge('prod', spec, importer)
+    output: "Creates a dangling edge (to=undefined) representing a missing dep"
+
+metadata:
+  priority: high
+  version: 1.0
+  tags:
+    - graph
+    - data-structures
+    - types
+    - nodes
+    - edges
+    - invariants
+  related_rules:
+    - graph_workspace_architecture
+    - graph_lockfiles
+    - graph_modifiers
+    - graph_load_actual
+    - graph_reify
+    - monorepo-structure
+</rule>
+

--- a/.cursor/rules/graph/ideal.mdc
+++ b/.cursor/rules/graph/ideal.mdc
@@ -1,0 +1,123 @@
+---
+description: Build Ideal Graphs from manifests and starting graphs
+globs: src/graph/src/ideal/*
+alwaysApply: false
+---
+# Building Ideal Graphs
+
+Guidance for working with the Ideal Graph builder in `@vltpkg/graph`, which produces the desired end-state graph used for installs.
+
+<rule>
+name: graph_ideal
+description: How Ideal graphs are constructed, merged with add/remove, and expanded via remote manifests
+filters:
+  # Ideal builder implementation and helpers
+  - type: path
+    pattern: "^src/graph/src/ideal/"
+  - type: file_name
+    pattern: "^(build|build-ideal-from-starting-graph|append-nodes|get-importer-specs|remove-satisfied-specs|add-nodes|remove-nodes|types)\\.ts$"
+  # High-level orchestration reference
+  - type: content
+    pattern: "ideal\\.build\(|buildIdealFromStartingGraph\("
+
+actions:
+  - type: guide
+    message: |
+      ## Overview
+
+      The Ideal Graph represents the desired post-install state. It is constructed by:
+      1. Selecting a starting graph: prefer Virtual (lockfile) and fall back to Actual (`node_modules`) when needed.
+      2. Merging user-provided `add`/`remove` requests with importer manifest deltas.
+      3. Expanding dependencies by fetching manifests/artifacts and recursively placing packages.
+      4. Reusing existing nodes that satisfy specs to minimize network and duplication.
+
+      Entry point: `src/graph/src/ideal/build.ts` → `ideal.build(options)`
+
+  - type: architecture_guide
+    message: |
+      ## Starting Graph Selection (`build.ts`)
+
+      - Attempts to load a Virtual Graph from lockfile first with `skipLoadingNodesOnModifiersChange: true`.
+      - On failure, loads the Actual Graph with the same skip flag.
+      - Uses shared instances of `packageJson`, `scurry`, and `monorepo` for efficiency.
+      - Delegates to `buildIdealFromStartingGraph()` for merging and expansion.
+
+  - type: architecture_guide
+    message: |
+      ## Merge and Expansion (`build-ideal-from-starting-graph.ts`)
+
+      - Computes importer deltas via `get-importer-specs.ts`:
+        - Builds `AddImportersDependenciesMap` and `RemoveImportersDependenciesMap` by comparing importer manifests to the starting graph.
+        - Prunes already-satisfied dependencies using `remove-satisfied-specs.ts`.
+        - Flags whether dependencies were modified (`modifiedDependencies`).
+      - Merges user-provided `add`/`remove` over computed deltas; user input wins.
+      - Invokes `add-nodes.ts` to fetch and incorporate remote manifests and expand the graph.
+      - After expansion, calls `setDefaultLocation()` on nodes to normalize store layout hints.
+      - Finally, removes dependencies listed in `remove` via `remove-nodes.ts` and garbage-collects unreachable nodes (`graph.gc()`).
+
+  - type: architecture_guide
+    message: |
+      ## Node Appending and Reuse (`append-nodes.ts`, `add-nodes.ts`)
+
+      - Resolves dependency specs to nodes by first attempting `graph.findResolution()` to reuse existing nodes that satisfy the spec.
+      - When a satisfying node is not found, fetches manifests/artifacts via `@vltpkg/package-info`, selects appropriate versions (respecting platform/engine constraints), and places new nodes with correct flags.
+      - Recursively descends into each newly placed node's dependencies, applying `@vltpkg/spec` parsing and honoring modifiers if present.
+      - Ensures added nodes have consistent `registry`, `resolved`, and `integrity` fields as available.
+
+  - type: integration_guide
+    message: |
+      ## Options and Inputs
+
+      - `projectRoot`, `packageJson`, `scurry`, `monorepo` — Required/shared instances for deterministic traversal and manifest access.
+      - `packageInfo: PackageInfoClient` — Required for remote manifest and artifact retrieval.
+      - `add?: AddImportersDependenciesMap` — Explicit dependencies to add per importer.
+      - `remove?: RemoveImportersDependenciesMap` — Explicit dependency names to remove per importer.
+      - Modifiers integration — If `modifiers` are provided, selectors can adjust specs during resolution; Ideal builder will then record modifier info on nodes for downstream awareness.
+
+      ### Behavior and Guarantees
+      - Reuses nodes whenever they satisfy requested specs.
+      - Expands transitive dependencies recursively using resolved manifests.
+      - Produces a graph ready for hoisting and reification, with stable, default locations set where applicable.
+
+  - type: development_workflow
+    message: |
+      ## Practical Tips
+
+      - Always prefer the lockfile as the starting point for reproducibility.
+      - Keep `add`/`remove` mappings minimal; rely on `get-importer-specs.ts` to detect manifest drift.
+      - Pass shared `packageJson` and `scurry` instances across phases (Actual/Virtual load → Ideal build → Reify).
+      - Use `graph.findResolution()` aggressively in new features to avoid duplicate nodes and redundant network calls.
+
+examples:
+  - input: |
+      import { ideal } from '@vltpkg/graph'
+      const graph = await ideal.build({ projectRoot, packageInfo, packageJson, scurry })
+    output: "Ideal graph built from lockfile or actual as starting point"
+
+  - input: |
+      // Add and remove across importers
+      const add = new Map()
+      const remove = new Map()
+      const g = await ideal.build({ projectRoot, packageInfo, packageJson, scurry, add, remove })
+    output: "Importer deltas merged with user-provided add/remove and expanded"
+
+metadata:
+  priority: high
+  version: 1.0
+  tags:
+    - graph
+    - ideal
+    - build
+    - manifests
+    - modifiers
+    - performance
+  related_rules:
+    - graph_workspace_architecture
+    - graph_data_structure
+    - graph_lockfiles
+    - graph_load_actual
+    - graph_modifiers
+    - graph_reify
+    - monorepo-structure
+</rule>
+

--- a/.cursor/rules/graph/index.mdc
+++ b/.cursor/rules/graph/index.mdc
@@ -1,0 +1,139 @@
+---
+description: Understanding Graph Modifiers
+globs: src/graph/**
+alwaysApply: false
+---
+# Graph
+
+Understanding and working with graphs in the vlt package manager.
+
+<rule>
+name: graph_workspace_architecture
+description: High-level architecture, concepts, and workflows of the @vltpkg/graph workspace
+filters:
+  # Trigger when working inside the graph workspace
+  - type: path
+    pattern: "^src/graph/"
+  # Trigger when editing core graph API entry points
+  - type: file_name
+    pattern: "^(index|graph|node|edge|diff)\.ts$"
+  # Trigger when working with lockfile or reify subsystems
+  - type: path
+    pattern: "^src/graph/src/(lockfile|reify|ideal|actual)/"
+  # Trigger when referencing monorepo-wide deps used by graph
+  - type: path
+    pattern: "^src/(dep-id|spec|semver|package-info|package-json|workspaces)/"
+  # Trigger when editing README/docs for the graph workspace
+  - type: file_name
+    pattern: "README\.md$"
+
+actions:
+  - type: guide
+    message: |
+      ## @vltpkg/graph Overview
+
+      The `@vltpkg/graph` workspace implements a dependency graph that models a JavaScript/TypeScript project's installed and desired package state. It is the foundation used by the installer to compute and apply filesystem changes under `node_modules`.
+
+      - **`@graph/package.json`**: The workspace manifest defining the library name and its dependencies.
+      - **`@graph/src/index.ts`**: The public entry point re-exporting internal types, helpers, and submodules.
+
+      ### Core Data Structures
+      - **`Graph` (`@graph/src/graph.ts`)**: Represents the package relationship graph for a project. It is the authoritative source used to determine how `node_modules` should be structured.
+      - **`Node` (`@graph/src/node.ts`)**: Represents a unique package instance. Uniqueness is defined by `@vltpkg/dep-id` which encodes package identity into a single string identifier.
+      - **`Edge` (`@graph/src/edge.ts`)**: Represents a dependency relationship (eg. entries from `dependencies`, `devDependencies`, `peerDependencies`, etc.) between two nodes.
+      - **`Diff` (`@graph/src/diff.ts`)**: Computes and stores the minimal set of changes to transform one graph (Actual) into another (Ideal).
+
+      See the npm documentation for `package.json` format and semantics: [npm package.json docs](https://raw.githubusercontent.com/npm/cli/refs/heads/latest/docs/lib/content/configuring-npm/package-json.md).
+
+  - type: architecture_guide
+    message: |
+      ## Architectural Dependencies (Workspaces)
+
+      The graph workspace integrates tightly with other internal workspaces:
+      - **`@vltpkg/dep-id`**: Generates unique IDs for packages, enabling `Node` identity and efficient graph operations.
+      - **`@vltpkg/spec`**: Parses and normalizes dependency specs (eg. ranges, tags, git, file, workspace). Provides registry and scope semantics.
+      - **`@vltpkg/semver`**: Semantic Versioning operations underpinning spec satisfaction. Learn more at [semver.org](https://raw.githubusercontent.com/semver/semver.org/refs/heads/gh-pages/index.md).
+      - **`@vltpkg/package-info`**: Fetches remote manifests and artifacts for registry, git, and tarball sources.
+      - **`@vltpkg/package-json`**: Reads and caches local `package.json` files with normalization helpers.
+      - **`@vltpkg/workspaces`**: Discovers and manages monorepo workspaces. Importers in the graph include the main project and all configured workspaces. For an end-user overview of workspaces, see the docs site entry under `www/docs`.
+
+      In the graph, root-level nodes are called **importers**. The `mainImporter` corresponds to the project root (its `package.json`), and other importers come from `@vltpkg/workspaces` discovery. These serve as starting points when loading/constructing graphs.
+
+  - type: architecture_guide
+    message: |
+      ## Graph Construction Modes
+
+      The graph system builds three primary graph variants, which are then used to produce npm-compatible installs:
+
+      - **Virtual Graphs** (Lockfile-based)
+        - Loaded from lockfiles; entry points in `@graph/src/lockfile/`:
+          - Load: `load.ts` (`load()`), Hidden: `loadHidden()`
+          - Save: `save.ts` (`save()` for `vlt-lock.json`, `saveHidden()` for `node_modules/.vlt-lock.json`)
+        - See the lockfile rule for format and integration details.
+
+      - **Actual Graphs** (Filesystem-based)
+        - Loaded from `node_modules` by recursively traversing symlinks and directories: `@graph/src/actual/load.ts`.
+        - May be shortcut by the Hidden Lockfile (`node_modules/.vlt-lock.json`) for performance.
+        - Applied to disk via the `reify/` subsystem, which encodes the minimal filesystem operations required by Node.js module resolution.
+
+      - **Ideal Graphs** (Desired end state)
+        - Entry point: `@graph/src/ideal/build.ts`
+        - Starts from either a Virtual Graph (preferred) or falls back to an Actual Graph.
+        - Merges explicit `add`/`remove` requests with importer manifests via `get-importer-specs.ts`.
+        - Resolves new nodes by fetching manifests/artifacts using `@vltpkg/package-info`, recursively expanding the graph.
+        - Reuses existing nodes that satisfy specs to avoid unnecessary network calls.
+
+      After building the Ideal and loading the Actual, the installer computes a `Diff` and applies it using the `reify/` subsystem to minimize work.
+
+  - type: integration_guide
+    message: |
+      ## Key Entry Points and Public API (`@graph/src/index.ts`)
+
+      The main entry point re-exports the public API:
+      - `actual.load(options)` — Load from `node_modules` (or from Hidden Lockfile when available).
+      - `ideal.build(options)` — Build an Ideal Graph starting from a Virtual or Actual starting point.
+      - `lockfile.load/save` — Read and write lockfiles.
+      - `reify(options)` — Compute a `Diff` between Actual and Ideal and apply filesystem changes.
+      - Types and utilities: `Graph`, `Node`, `Edge`, `Diff`, dependency helpers, visualization outputs, etc.
+
+  - type: development_workflow
+    message: |
+      ## Development Workflow Tips
+
+      - Share instances of `monorepo`, `packageJson`, and `scurry` across loader/build steps for performance.
+      - Prefer Hidden Lockfile (`node_modules/.vlt-lock.json`) when available for faster Actual loads.
+      - When modifiers or installer options change, you'll often rebuild the Ideal Graph with `skipLoadingNodesOnModifiersChange` to avoid loading stale dependency nodes.
+      - Determinism: Node and Edge ordering is intentionally stable to produce reproducible lockfiles.
+
+      ### Useful References
+      - Monorepo concepts and related workspaces: see the monorepo structure rule and `www/docs`.
+      - `package.json` behavior: [npm package.json docs](https://raw.githubusercontent.com/npm/cli/refs/heads/latest/docs/lib/content/configuring-npm/package-json.md)
+      - Semantic Versioning: [semver.org](https://raw.githubusercontent.com/semver/semver.org/refs/heads/gh-pages/index.md)
+
+examples:
+  - input: |
+      // Build an Ideal Graph and reify changes
+      import { ideal, reify } from '@vltpkg/graph'
+      
+      const graph = await ideal.build({ projectRoot, packageInfo, packageJson, scurry })
+      await reify({ graph, packageInfo, packageJson, scurry })
+    output: "Ideal graph built and applied to disk via reify"
+
+metadata:
+  priority: high
+  version: 1.0
+  tags:
+    - graph
+    - architecture
+    - lockfiles
+    - install
+    - workspaces
+  related_rules:
+    - graph_ideal
+    - graph_data_structure
+    - graph_load_actual
+    - graph_lockfiles
+    - graph_modifiers
+    - graph_reify
+</rule>
+

--- a/.cursor/rules/graph/load-actual.mdc
+++ b/.cursor/rules/graph/load-actual.mdc
@@ -1,0 +1,144 @@
+---
+description: Loading Actual Graphs from node_modules
+globs: src/graph/src/actual/*,src/graph/test/actual/*
+alwaysApply: false
+---
+# Loading Actual Graphs (node_modules)
+
+Understanding how `@vltpkg/graph` loads an Actual Graph by traversing a project's `node_modules` and how to use the returned structure.
+
+<rule>
+name: graph_load_actual
+description: Detailed guidance for loading Actual Graphs from node_modules and using the resulting structure
+filters:
+  # Core implementation file and directory
+  - type: path
+    pattern: "^src/graph/src/actual/load\\.ts$"
+  - type: path
+    pattern: "^src/graph/src/actual/"
+  # Hidden lockfile shortcut integration
+  - type: content
+    pattern: "loadHidden\(\)"
+  # Option flags commonly used with actual.load
+  - type: content
+    pattern: "skipHiddenLockfile|loadManifests|skipLoadingNodesOnModifiersChange"
+
+actions:
+  - type: guide
+    message: |
+      ## What is an Actual Graph?
+
+      An Actual Graph is a representation of what's currently installed on disk in a project, derived by traversing `node_modules`. Its purpose is to reflect the real state of the install so that it can be compared to an Ideal Graph for minimal-change reification.
+
+      Entry point: `src/graph/src/actual/load.ts` → `actual.load(options)`
+
+  - type: architecture_guide
+    message: |
+      ## High-level Flow
+
+      1. Resolve `mainManifest` (from `options.mainManifest` or `packageJson.read(projectRoot)`).
+      2. If `skipHiddenLockfile` is not set, attempt fast-path by loading the Hidden Lockfile via `lockfile.loadHidden()` (file: `node_modules/.vlt-lock.json`). If successful, return that Graph.
+      3. Otherwise, construct a new `Graph` seeded with importers (the project and discovered workspaces).
+      4. Optionally compare stored modifiers (`node_modules/.vlt/vlt.json`) to `options.modifiers.config`. If `skipLoadingNodesOnModifiersChange` is true and modifiers changed, only importers are loaded (skip dependency traversal).
+      5. Perform a breadth-first traversal starting from each importer's `node_modules` folder:
+         - Read entries (skipping hidden items), descend into `@scope` folders, and consider only symbolic links as potential dependency links.
+         - Resolve real paths, derive alias (symlink name) and normalized package name (handling scopes) for each entry.
+         - Place nodes and edges in the graph, reading manifests when required.
+      6. Mark extraneous dependencies (present on disk but not listed in importer manifests) when manifests are loaded.
+      7. Add dangling edges for missing dependencies (declared but not found on disk).
+
+      The traversal is implemented by helper functions within `load.ts`:
+      - `readDir(scurry, currDir, fromNodeName?)` — Scans `node_modules`, recursing into `@scope` directories, returning alias/name/realpath for symlink entries.
+      - `parseDir(options, scurry, packageJson, depsFound, graph, fromNode, currDir)` — Places packages, applies modifiers, records extraneous/missing, and queues nested `node_modules` for BFS.
+
+  - type: architecture_guide
+    message: |
+      ## Identity and Path Handling
+
+      - Path-based specs (`file`, `workspace`) get IDs directly from their path via `getPathBasedId()`.
+      - For store-based installs, `findDepID()` walks parent paths until it reaches `.vlt/` store layout (`.vlt/<DepID>/node_modules/<name>`), extracting the `DepID`.
+      - `findNodeModules()` finds the nearest `node_modules` directory for a placed node.
+      - `findName()` normalizes names, including scoped package folders.
+
+      Placed nodes set `node.location` to a relative path like `./node_modules/...` or `./<realpath>`. Nodes outside the store are treated accordingly by `node.nodeModules(scurry)`.
+
+  - type: integration_guide
+    message: |
+      ## Options and Behavior
+
+      - `projectRoot: string` — Required. Project directory to scan.
+      - `packageJson` (required), `scurry` (required), `monorepo` (optional) — Shared instances; reuse them for performance.
+      - `mainManifest?: NormalizedManifest` — Optionally provide the root manifest; otherwise read from disk.
+      - `modifiers?: GraphModifier` — Active modifiers affecting spec resolution and node placement.
+      - `loadManifests?: boolean` —
+        - `true`: Read package manifests for accurate dependency types/specs, and to detect extraneous dependencies.
+        - `false`: Do not read manifests; infer default `prod` edges and hydrate specs from `DepID` when possible. No missing/extraneous detection.
+      - `skipHiddenLockfile?: boolean` — If `false` (default), attempt Hidden Lockfile fast-path.
+      - `skipLoadingNodesOnModifiersChange?: boolean` — Load only importers if modifiers differ from `node_modules/.vlt/vlt.json` saved config.
+      - `expectLockfile?` / `frozenLockfile?` — Reserved for commands that enforce lockfile presence/sync (not central to traversal mechanics).
+
+      ### Modifiers Application
+      - Before placing packages, the loader consults `modifiers.tryDependencies(fromNode, deps)` to find active selectors.
+      - For each dependency, it may replace the spec (eg. apply an override) and record a `queryModifier` that is saved with the `Node` so later phases can reason about modified resolutions.
+      - After traversal, `modifiers.rollbackActiveEntries()` clears any partially applied entries.
+
+  - type: development_workflow
+    message: |
+      ## Using the Returned Actual Graph
+
+      - Nodes may lack manifests when `loadManifests=false`. Avoid relying on dependency type info or declared specs in that mode.
+      - Missing dependencies are represented by edges with no `to` node (dangling edges) when manifests are processed; extraneous dependencies are recorded in `graph.extraneousDependencies`.
+      - Each node has a `location` and can compute its `nodeModules(scurry)` directory for linking operations.
+      - The Actual Graph is commonly diffed against an Ideal Graph using `new Diff(actual, ideal)`, then applied by `reify`.
+      - Prefer the Hidden Lockfile fast-path when available to skip filesystem traversal.
+
+      ### Performance Tips
+      - Reuse `packageJson`, `scurry`, and `monorepo` instances across phases.
+      - Use `skipLoadingNodesOnModifiersChange` strategically when rebuilding after modifier changes.
+
+examples:
+  - input: |
+      // Load Actual with manifests for accurate extraneous/missing detection
+      import { actual } from '@vltpkg/graph'
+      const from = actual.load({
+        projectRoot,
+        packageJson: sharedPackageJson,
+        scurry: sharedScurry,
+        monorepo: sharedMonorepo,
+        loadManifests: true,
+      })
+    output: "Actual graph loaded from node_modules with manifests"
+
+  - input: |
+      // Fast-path from Hidden Lockfile (if present and not skipped)
+      import { actual } from '@vltpkg/graph'
+      const from = actual.load({
+        projectRoot,
+        packageJson,
+        scurry,
+        // skipHiddenLockfile: false (default)
+      })
+    output: "Actual graph loaded from node_modules/.vlt-lock.json when available"
+
+  - input: |
+      // No-manifest mode (faster, limited details, defaults to prod edges)
+      const from = actual.load({ projectRoot, packageJson, scurry, loadManifests: false })
+    output: "Actual graph loaded without reading manifests; no extraneous/missing computed"
+
+metadata:
+  priority: high
+  version: 1.0
+  tags:
+    - graph
+    - actual
+    - node_modules
+    - filesystem
+    - performance
+    - modifiers
+  related_rules:
+    - graph_workspace_architecture
+    - graph_data_structure
+    - graph_lockfiles
+    - graph_modifiers
+</rule>
+

--- a/.cursor/rules/graph/lockfiles.mdc
+++ b/.cursor/rules/graph/lockfiles.mdc
@@ -1,6 +1,6 @@
 ---
 description: Understanding Graph Modifiers
-globs: src/graph/src/lockfile/*
+globs: src/graph/src/lockfile/*,src/graph/test/lockfile/*
 alwaysApply: false
 ---
 # Graph Lockfiles
@@ -257,7 +257,8 @@ metadata:
     - install
     - dependencies
   related_rules:
-    - monorepo-structure      # For workspace navigation
+    - graph_workspace_architecture
+    - graph_data_structure
     - graph/modifiers         # For modifier integration
     - cli-sdk-workspace       # For CLI command integration
 </rule>

--- a/.cursor/rules/graph/modifiers.mdc
+++ b/.cursor/rules/graph/modifiers.mdc
@@ -1,106 +1,151 @@
 ---
 description: Understanding Graph Modifiers
-globs:
+globs: src/graph/src/modifiers.ts,src/graph/test/modifiers.ts
 alwaysApply: false
 ---
 # Graph Modifiers
 
-What we refer to as "Graph Modifiers" is a common API that enables features of the previous-gen package managers capabilities such as:
-- Overrides / Resolutions
-- Package Extensions
+Understanding and working with Graph Modifiers in the vlt package manager.
 
-## Motivation
+<rule>
+name: graph_modifiers
+description: Guide for configuring and integrating Graph Modifiers (overrides/resolutions and package extensions)
+filters:
+  # Modifier core and Ideal integration points
+  - type: path
+    pattern: "^src/graph/src/modifiers\\.ts$"
+  - type: path
+    pattern: "^src/graph/src/ideal/"
+  # DSS parsing/building utilities used by modifiers
+  - type: path
+    pattern: "^src/dss-(parser|breadcrumb)/"
+  # Detect vlt.json modifier usage
+  - type: content
+    pattern: "\"modifiers\"\s*:"
 
-The vlt client needs to be a capable tool that can satisfy power user requirements like customization of a given graph resolution.
-By leveraging the Dependency Selector Syntax as its end-user facing API the client takes advantage of the robustness of the query language to provide fine-grain control to its graph install to advanced users.
+actions:
+  - type: guide
+    message: |
+      ## What are Graph Modifiers?
 
-### Overrides / Resolutions:
+      Graph Modifiers are a common API enabling advanced customization of dependency resolution and graph construction:
+      - **Overrides / Resolutions**: Replace or pin dependency specs throughout the graph (direct or transitive).
+      - **Package Extensions**: Augment package manifests with extra dependency metadata (eg. add missing peerDeps or mark peer deps optional).
 
-Being able to replace dependencies declarations of a given dependency helps end-users getting around problems in their current install graph. Some common examples are:
+      ### Motivation
+      Power users frequently need to patch dependency trees quickly—eg. to address security issues, unify versions, or work around abandoned packages. By using the Dependency Selector Syntax (DSS) as the user-facing language, vlt provides expressive, precise, and composable control over graph shape and versions.
 
-- Replacing a transitive dependency that has known security issues
-- Enforcing usage of a unique package version across the install
-- Updating dependencies of a direct (or transitive) abandoned dependency
-- Forcing the downgrade of a specific package version that would otherwise be satisfied by a greater, spec-fulfilling version
+  - type: architecture_guide
+    message: |
+      ## Key Modules
+      - `src/graph/src/modifiers.ts` — Tracks graph traversal and applies active modifiers to nodes/edges.
+      - `src/graph/src/ideal/*` — Builds the Ideal graph and integrates modifier application during dependency expansion.
+      - `src/dss-parser/` — Parses DSS queries.
+      - `src/dss-breadcrumb/` — Interactive representation that allows walking a query in lockstep with graph traversal.
 
-**Refs:**
+  - type: integration_guide
+    message: |
+      ## User-facing Syntax and UX
 
-- npm Overrides: https://docs.npmjs.com/cli/v10/configuring-npm/package-json?v=true#overrides
-- pnpm Overrides: https://pnpm.io/settings#overrides
-- yarn Resolutions: https://classic.yarnpkg.com/lang/en/docs/selective-version-resolutions/
+      All configuration lives in the project's `vlt.json` under the top-level `"modifiers"` key.
 
-### Package Extensions
+      ### The `modifiers` key
+      ```json
+      {
+        "workspaces": "packages/*",
+        "modifiers": {
+          
+        }
+      }
+      ```
 
-Adding dependency declarations to a dependency can help end-users fixing some specific categories of errors, such as:
+      ### Edge Modifiers (Overrides / Resolutions)
+      Provide a string spec to replace the matched dependency's version/spec:
+      ```json
+      {
+        "modifiers": {
+          ":root > #a > #b": "^1.0.0"
+        }
+      }
+      ```
 
-- Declaring missing peer-dependencies to a given package
-- Defining a peer-dependency as optional
-- Fixing missing dependencies in general
+      When multiple selectors match, the most specific selector wins. Example (result should be `1`):
+      ```json
+      {
+        "dependencies": {
+          "a": "^1.0.0"
+        },
+        "modifiers": {
+          ":root > #a > #b": "1",
+          "#a > #b": "2"
+        }
+      }
+      ```
 
-Refs:
+      Set a unique version for a given dependency across the graph:
+      ```json
+      {
+        "modifiers": {
+          "#react": "^19"
+        }
+      }
+      ```
 
-- Yarn extensions database (serves as a good repository of real-life problems end-users are patching with this feature): https://github.com/yarnpkg/berry/blob/master/packages/yarnpkg-extensions/sources/index.ts
-- pnpm Package Extensions: https://pnpm.io/settings#packageextensions
+      ### Package Extensions
+      Add or adjust dependency declarations for specific packages to fix issues like missing peers or to mark peers optional. Examples vary by selector and extension intent; consult your DSS patterns and package names to scope changes safely.
 
-## Implementation
+      ### References
+      - npm Overrides: <https://docs.npmjs.com/cli/v11/configuring-npm/package-json#overrides>
+      - pnpm Overrides: <https://pnpm.io/settings#overrides>
+      - Yarn Resolutions: <https://classic.yarnpkg.com/lang/en/docs/selective-version-resolutions/>
+      - Yarn Extensions DB: <https://github.com/yarnpkg/berry/blob/master/packages/yarnpkg-extensions/sources/index.ts>
+      - pnpm Package Extensions: <https://pnpm.io/settings#packageextensions>
 
-### User-facing syntax & UX
+  - type: development_workflow
+    message: |
+      ## Development Workflow and Considerations
 
-From the user point of view, all of the configuration and management of the graph modifier API features happens at the `vlt.json` file.
+      - Prefer sharing `monorepo`, `packageJson`, and `scurry` instances across loaders/builders.
+      - Use `skipLoadingNodesOnModifiersChange` when reusing a starting graph but modifiers changed since last build.
+      - Hidden Lockfile (`node_modules/.vlt-lock.json`) accelerates Actual graph loads. If modifiers changed, rebuild Ideal.
+      - Deterministic ordering ensures reproducible lockfiles after modifier changes.
 
-#### The modifiers key
+      ### Testing
+      - Validate selector specificity precedence.
+      - Test overrides across direct and transitive dependencies.
+      - Verify package extensions effect on peer/optional semantics.
+      - Confirm Ideal graph reuses satisfying nodes to avoid unnecessary network fetches.
 
-To configure overrides and package extensions, a new object defined using the `"modifiers"` property of the `vlt.json` file, e.g:
+examples:
+  - input: |
+      # Override a transitive dependency
+      {
+        "modifiers": {
+          ":root > #webpack > #browserslist": "^4.23.0"
+        }
+      }
+    output: "Transitive browserslist spec overridden via DSS selector"
 
-```json
-{
-  "workspaces": "packages/*",
-  "modifiers": {
-    ...
-  }
-}
-```
+  - input: |
+      # Pin a single version across the graph
+      {
+        "modifiers": {
+          "#react": "^19"
+        }
+      }
+    output: "All matching react specs unified to ^19"
 
-#### Setting Edge Modifiers
-
-Edge modifiers are the equivalent of the Overrides feature, they are applied when a string value is used in the modifiers object, e.g:
-
-```json
-{
-  "modifiers": {
-    ":root > #a > #b": "^1.0.0"
-  }
-}
-```
-
-In case of conflicting results among multiple queries, selector specificity is then used to define which one applies to a given edge (result should be `1`):
-
-```json
-{
-  "dependencies": {
-    "a": "^1.0.0"
-  },
-  "modifiers": {
-    ":root > #a > #b": "1",
-    "#a > #b": "2"
-  }
-}
-```
-
-Setting a unique version value for a given dependency:
-
-```json
-{
-  "modifiers": {
-    "#react": "^19"
-  }
-}
-```
-
-#### Code Location
-
-The bulk of the logic to handle modifiers while building the graph is located at `src/graph/src/modifiers.ts` - that module is responsible for tracking seen elements and apply known modifiers to nodes and edges as the graph is traversed, other modules of interest are:
-- `src/dss-parser/` The main Dependency Selector Syntax query language parser
-- `src/dss-breadcrumb/` The library that implements an interactive object representation that is meant to represent the described query while enabling the modifiers module to traverse that query as the graph is traversed.
-- `src/graph/src/ideal/*` The build ideal graph is the place that implements that understanding of Graph modifiers and the ability to replace packages at runtime with user-provided values from the configuration.
-
+metadata:
+  priority: high
+  version: 1.0
+  tags:
+    - modifiers
+    - graph
+    - overrides
+    - extensions
+    - dss
+  related_rules:
+    - graph_workspace_architecture
+    - graph_data_structure
+    - graph_lockfiles
+</rule>

--- a/.cursor/rules/graph/reify.mdc
+++ b/.cursor/rules/graph/reify.mdc
@@ -1,0 +1,148 @@
+---
+description: Reify process (applying Diff to node_modules)
+globs: src/graph/src/reify/*,src/graph/test/reify/*
+alwaysApply: false
+---
+# Reify (Apply Graph Changes to node_modules)
+
+Guidance for working with the Reify step in `@vltpkg/graph`, which transforms an Actual Graph on disk to match an Ideal Graph by applying the minimal set of filesystem operations.
+
+<rule>
+name: graph_reify
+description: How reify computes and applies minimal filesystem changes, with module responsibilities and integration tips
+filters:
+  # Reify implementation and helpers
+  - type: path
+    pattern: "^src/graph/src/reify/"
+  - type: file_name
+    pattern: "^(index|add-nodes|add-edges|add-edge|delete-nodes|delete-edges|delete-edge|internal-hoist|build|rollback|optional-fail|bin-paths|calculate-save-value|update-importers-package-json)\\.ts$"
+  # Diff usage is central to reify
+  - type: content
+    pattern: "new Diff\(actual, graph\)|diff\\.nodes|diff\\.edges"
+
+actions:
+  - type: guide
+    message: |
+      ## Overview
+
+      The `reify(options)` function makes the on-disk install (Actual Graph) match the desired state (Ideal Graph). It:
+      1. Loads the Actual Graph (if not provided) with `loadManifests: true`.
+      2. Computes a `Diff(actual, ideal)` and returns early if there are no changes.
+      3. Applies a minimal sequence of filesystem operations to add/extract nodes, create or remove dependency links, hoist internal links, run lifecycle scripts, and write lockfiles.
+
+      Entry point: `src/graph/src/reify/index.ts` → `reify(options)`
+
+  - type: architecture_guide
+    message: |
+      ## Execution Flow
+
+      - Build `Diff`:
+        - `const diff = new Diff(actual, graph)`; if `!diff.hasChanges()`, return early.
+
+      - Prepare rollback:
+        - Use `RollbackRemove` to ensure all steps are reversible until confirmed.
+
+      - Node extraction and edge deletions:
+        - `addNodes(diff, scurry, remover, options, packageInfo)` → returns async actions to fetch/extract nodes into the `.vlt` store (registry/git/tarball installs). Optional deps use `optionalFail()` to remove subgraphs instead of failing the whole reify.
+        - `deleteEdges(diff, scurry, remover)` → returns async actions removing outdated links and their bins.
+        - Actions run via `callLimit(actions, { limit })` where `limit = (availableParallelism() - 1) * 8`.
+
+      - Link creation:
+        - `addEdges(diff, packageJson, scurry, remover)` → creates symlinks in importer `node_modules` and links package bins into `.bin`. On Windows, uses `@vltpkg/cmd-shim` for executables.
+
+      - Hoisting:
+        - `internalHoist(diff.to, options, remover)` → sets up `node_modules/.vlt/node_modules/<name>` symlinks to preferred candidates per package name. Preference:
+          - Prefer dependencies that are direct deps of an importer.
+          - Prefer registry deps over non-registry.
+          - For registry deps, prefer highest version (via `@vltpkg/semver`).
+          - Otherwise, pick lexicographically highest `DepID`.
+
+      - Build phase:
+        - `build(diff, packageJson, scurry)` walks from importers, reading manifests as needed, then:
+          - Runs `install` lifecycle (preinstall/install/postinstall) where present.
+          - Runs `prepare` for importers, git deps, or non-store deps.
+          - Ensures package bin files are executable (chmod adds `0o111`).
+
+      - Lockfiles and state persistence:
+        - Save minimal main lockfile with `lockfile.save(options)`.
+        - Save hidden lockfile with manifests using `saveHidden(options)`.
+        - Persist resolved ideal data with `saveData(lockfileData(options), scurry.resolve('vlt-lock.json'), false)`.
+        - If `vlt.json` exists, copy to `node_modules/.vlt/vlt.json` to commit modifier config in the store.
+
+      - Cleanup:
+        - If optional failures occurred, call `graph.gc()` and adjust `diff` sets accordingly.
+        - Remove deleted nodes from the store via `deleteNodes(diff, remover, scurry)`.
+        - If `add/remove` modified importer dependencies, write updated `package.json` files via `updatePackageJson()`.
+        - Confirm rollback on success; otherwise `rollback()` cleans partial changes.
+
+  - type: architecture_guide
+    message: |
+      ## Module Responsibilities
+
+      - `index.ts` — Orchestrates the entire reify process; loads Actual, computes Diff, coordinates steps, writes lockfiles.
+      - `add-nodes.ts` — Extracts new nodes into the store using `@vltpkg/package-info.extract()`; handles platform gating and deprecated/optional cases with `optionalFail()`.
+      - `add-edge.ts` / `add-edges.ts` — Creates symlinks and bin links; on Windows, uses cmd shims via `@vltpkg/cmd-shim`.
+      - `delete-edge.ts` / `delete-edges.ts` — Removes outdated links and related `.bin` entries (including `*.cmd`/`*.ps1` on Windows).
+      - `internal-hoist.ts` — Determines and symlinks preferred candidates into `node_modules/.vlt/node_modules`.
+      - `build.ts` — Runs lifecycle scripts and ensures bins are executable; traverses dependency graph using `graph-run`.
+      - `optional-fail.ts` — On failures of optional nodes, removes their reachable optional subgraphs from the target graph via `removeOptionalSubgraph` and flags `diff.hadOptionalFailures`.
+      - `rollback.ts` — Best-effort revert of partially applied changes using a fresh `RollbackRemove` and the accumulated remover.
+      - `update-importers-package-json.ts` / `calculate-save-value.ts` — Writes updated dependency specs to importers based on `add/remove`, preserving expected save semantics (eg. `^` ranges for registry deps).
+
+  - type: integration_guide
+    message: |
+      ## Using reify()
+
+      - Provide: `graph` (Ideal), and either let reify load Actual or pass `actual` explicitly.
+      - Required shared instances: `packageInfo`, `packageJson`, `scurry`. Reuse these across phases.
+      - Side effects:
+        - Filesystem changes under `node_modules` and `.vlt` store
+        - `vlt-lock.json` and `node_modules/.vlt-lock.json` writes
+        - Optional `package.json` updates for importers (when `add/remove` change manifests)
+      - Platform considerations:
+        - Symlinks differ across platforms; Windows uses cmd shims for bins and EEXIST is tolerated when multiple paths could write the same link.
+      - Performance:
+        - Parallelize extraction and deletions with `callLimit`; link and remove steps often batch with `Promise.all`.
+
+  - type: development_workflow
+    message: |
+      ## Practical Tips
+
+      - If you already have `actual` loaded (eg. for inspection), pass it to avoid re-reading.
+      - For dry runs, compute `new Diff(actual, ideal)` yourself and inspect `hasChanges()` and the sets, but note `reify()` always applies changes when invoked.
+      - Ensure modifiers and options used to build the Ideal graph are reflected in lockfile saves to maintain reproducibility.
+      - Handle optional dependency failures gracefully; reify already prunes optional subgraphs instead of failing the install.
+
+examples:
+  - input: |
+      import { actual, ideal, reify } from '@vltpkg/graph'
+      
+      const from = actual.load({ projectRoot, packageJson, scurry, loadManifests: true })
+      const to = await ideal.build({ projectRoot, packageInfo, packageJson, scurry })
+      const diff = await reify({ graph: to, actual: from, packageInfo, packageJson, scurry })
+    output: "Applied minimal changes to align Actual with Ideal; diff returned"
+
+  - input: |
+      // Update importer manifests when add/remove modified dependencies
+      await reify({ graph, packageInfo, packageJson, scurry, add, remove })
+    output: "Importer package.json files updated; lockfiles saved; store hoisted"
+
+metadata:
+  priority: high
+  version: 1.0
+  tags:
+    - graph
+    - reify
+    - diff
+    - lifecycle
+    - lockfiles
+    - hoist
+  related_rules:
+    - graph_workspace_architecture
+    - graph_data_structure
+    - graph_lockfiles
+    - graph_modifiers
+    - graph_load_actual
+    - monorepo-structure
+</rule>
+

--- a/.cursor/rules/monorepo-structure.mdc
+++ b/.cursor/rules/monorepo-structure.mdc
@@ -46,8 +46,13 @@ actions:
       - `src/cache` (`@vltpkg/cache`) - Cache system
       - `src/cache-unzip` (`@vltpkg/cache-unzip`) - Cache entry optimization
       - `src/graph` (`@vltpkg/graph`) - Main data structure managing package installs
+        - 📋 **See `@graph/index.mdc`** for understanding installs and the graph library
+        - 📋 **See `@graph/data-structure.mdc`** for understanding the graph data structure
+        - 📋 **See `@graph/ideal.mdc`** for building Ideal graphs
+        - 📋 **See `@graph/load-actual.mdc`** for understanding loading Graph data from node_modules folders
         - 📋 **See `@graph/modifiers.mdc`** for understanding Graph modifiers
         - 📋 **See `@graph/lockfiles.mdc`** for working with lockfiles
+        - 📋 **See `@graph/reify.mdc`** for understanding how to save packages to node_modules folders
       - `src/types` (`@vltpkg/types`) - Common TypeScript types
       - `src/dep-id` (`@vltpkg/dep-id`) - Unique Graph node identifiers
       - `src/spec` (`@vltpkg/spec`) - Package specifier parsing
@@ -164,6 +169,5 @@ metadata:
     - cli-sdk-workspace           # CLI SDK workspace architecture and patterns
     - gui-validation-workflow     # GUI workspace specific validation workflow
     - query-pseudo-selector-creation  # Guide for implementing new query pseudo-selectors
-    - graph/modifiers             # Understanding Graph modifiers
-    - graph/lockfiles             # Working with lockfiles in the vlt package manager
+    - graph_workspace_architecture  # Understanding installs and the graph library
 </rule>

--- a/src/graph/README.md
+++ b/src/graph/README.md
@@ -168,6 +168,7 @@ to the filesystem.
 ## References
 
 - package.json format and behavior:
-  <https://docs.npmjs.com/cli/v11/configuring-npm/package-json>
-- Semantic Versioning: <https://semver.org/spec/v2.0.0.html>
-- Monorepos: <https://monorepo.tools>
+  [https://docs.npmjs.com/cli/v11/configuring-npm/package-json](https://docs.npmjs.com/cli/v11/configuring-npm/package-json)
+- Semantic Versioning:
+  [https://semver.org/spec/v2.0.0.html](https://semver.org/spec/v2.0.0.html)
+- Monorepos: [https://monorepo.tools](https://monorepo.tools)

--- a/src/graph/README.md
+++ b/src/graph/README.md
@@ -5,7 +5,44 @@
 This is the graph library responsible for representing the packages
 that are involved in a given install.
 
-**[API](#api)** · **[Usage](#usage)**
+**[Overview](#overview)** · **[Concepts](#concepts)** ·
+**[Architecture](#architecture)** · **[API](#api)** ·
+**[Usage](#usage)** · **[Related Workspaces](#related-workspaces)** ·
+**[References](#references)**
+
+## Overview
+
+The `@vltpkg/graph` workspace models a project's dependency
+relationships and drives npm-compatible installs by computing how
+`node_modules` should be structured. It exposes a public API through
+`src/index.ts` that re-exports core types and workflows.
+
+At a glance:
+
+- `Graph` encapsulates the full dependency graph for a project
+  (including monorepo workspaces), and is the source of truth for how
+  to lay out `node_modules`.
+- `Node` represents a unique package instance (uniqueness provided by
+  `@vltpkg/dep-id`).
+- `Edge` represents a dependency relationship from a dependent to a
+  dependency (eg. `dependencies`, `devDependencies`,
+  `peerDependencies`, etc.).
+- `Diff` describes the minimal set of changes required to transform an
+  Actual graph (disk) into an Ideal graph (desired outcome), which is
+  then applied by the `reify` subsystem.
+
+## Concepts
+
+- Importers: Root-level nodes used as starting points of the graph.
+  The `mainImporter` is the project root (its `package.json`), and the
+  remaining importers are workspaces discovered by
+  `@vltpkg/workspaces`.
+- Hidden Lockfile: A performance optimization stored at
+  `node_modules/.vlt-lock.json` mirroring the current on-disk state to
+  accelerate subsequent loads of the Actual graph.
+- Modifiers: Configuration for selectively altering dependency
+  resolution; Ideal/Actual builders support skipping node loads when
+  modifiers change.
 
 ## API
 
@@ -26,6 +63,13 @@ local file system.
 
 Loads the lockfile file found at `projectRoot` and returns the graph.
 
+### `reify(options): Promise<Diff>`
+
+Computes a `Diff` between the Actual and Ideal graphs and applies the
+minimal filesystem changes (creating/deleting links, writing
+lockfiles, hoisting, lifecycle scripts) to make the on-disk install
+match the Ideal graph.
+
 ## Usage
 
 Here's a quick example of how to use the `@vltpkg/graph.ideal.build`
@@ -37,3 +81,93 @@ import { ideal } from '@vltpkg/graph'
 
 const graph = await ideal.build({ projectRoot: process.cwd() })
 ```
+
+### Load Actual Graph and Reify
+
+```ts
+import { actual, ideal, reify } from '@vltpkg/graph'
+
+// Load current on-disk state
+const from = actual.load({
+  projectRoot: process.cwd(),
+  packageJson,
+  scurry,
+})
+
+// Build intended end state (may start from lockfile or actual)
+const to = await ideal.build({
+  projectRoot: process.cwd(),
+  packageInfo,
+  packageJson,
+  scurry,
+})
+
+// Apply minimal changes to match Ideal
+await reify({
+  graph: to,
+  actual: from,
+  packageInfo,
+  packageJson,
+  scurry,
+})
+```
+
+### Working With Lockfiles
+
+```ts
+import { lockfile } from '@vltpkg/graph'
+
+// Load virtual graph from vlt-lock.json
+const g = lockfile.load({
+  projectRoot,
+  mainManifest,
+  packageJson,
+  scurry,
+})
+
+// Save both lockfile formats
+lockfile.save({ graph: g, projectRoot, packageJson, scurry })
+```
+
+## Architecture
+
+Graph construction modes supported by the library:
+
+- Virtual Graphs (lockfile-based)
+  - Load and save via `src/lockfile/load.ts` and
+    `src/lockfile/save.ts`
+  - Hidden lockfile: `node_modules/.vlt-lock.json` for faster loads
+
+- Actual Graphs (filesystem-based)
+  - Loaded by traversing `node_modules` via `src/actual/load.ts`
+  - May shortcut to Hidden Lockfile if present and valid
+  - File layout changes are performed by `src/reify/`
+
+- Ideal Graphs (desired end state)
+  - Entry: `src/ideal/build.ts`
+  - Starts from Virtual (preferred) or falls back to Actual
+  - Merges `add`/`remove` input with importer manifests using
+    `src/ideal/get-importer-specs.ts`
+  - Fetches and expands manifests using `@vltpkg/package-info`, reuses
+    existing nodes that satisfy specs
+
+Finally, `src/diff.ts` computes changes and `src/reify/` applies them
+to the filesystem.
+
+## Related Workspaces
+
+- `@vltpkg/dep-id`: Unique IDs for packages, ensuring `Node` identity
+- `@vltpkg/spec`: Parse/normalize dependency specifiers and registry
+  semantics
+- `@vltpkg/semver`: Semantic version parsing/comparison
+- `@vltpkg/package-info`: Fetch remote manifests and artifacts
+  (registry, git, tarball)
+- `@vltpkg/package-json`: Read and cache local `package.json` files
+- `@vltpkg/workspaces`: Monorepo workspace discovery and grouping
+
+## References
+
+- package.json format and behavior:
+  <https://docs.npmjs.com/cli/v11/configuring-npm/package-json>
+- Semantic Versioning: <https://semver.org/spec/v2.0.0.html>
+- Monorepos: <https://monorepo.tools>


### PR DESCRIPTION
Adds various cursor rule that provides an overview of how to effectively work with the `@vltpkg/graph` library and expanded user documentation in `src/graph/README.md`.

Refs: https://github.com/vltpkg/vltpkg/issues/748