### PR TITLE
Add lockfile only install option

### DIFF
--- a/src/cli-sdk/src/commands/ci.ts
+++ b/src/cli-sdk/src/commands/ci.ts
@@ -24,11 +24,13 @@ export const views = {
 } as const satisfies Views<Graph>
 
 export const command: CommandFn<Graph> = async conf => {
+  const lockfileOnly = conf.options['lockfile-only']
   const ciOptions = {
     ...conf.options,
     expectLockfile: true,
     frozenLockfile: true,
     cleanInstall: true,
+    lockfileOnly,
   }
 
   const { graph } = await install(ciOptions)

--- a/src/cli-sdk/src/commands/install.ts
+++ b/src/cli-sdk/src/commands/install.ts
@@ -24,11 +24,13 @@ export const command: CommandFn<Graph> = async conf => {
   const { add } = parseAddArgs(conf, monorepo)
   const frozenLockfile = conf.options['frozen-lockfile']
   const expectLockfile = conf.options['expect-lockfile']
+  const lockfileOnly = conf.options['lockfile-only']
   const { graph } = await install(
     {
       ...conf.options,
       frozenLockfile,
       expectLockfile,
+      lockfileOnly,
     },
     add,
   )

--- a/src/cli-sdk/src/config/definition.ts
+++ b/src/cli-sdk/src/config/definition.ts
@@ -617,6 +617,10 @@ export const definition = j
       description:
         'Fail if lockfile is missing or out of sync with package.json. Prevents any lockfile modifications.',
     },
+    'lockfile-only': {
+      description:
+        'Only update the lockfile (vlt-lock.json), skip all node_modules operations including package extraction and filesystem changes.',
+    },
   })
   .opt({
     access: {

--- a/src/cli-sdk/tap-snapshots/test/config/definition.ts.test.cjs
+++ b/src/cli-sdk/tap-snapshots/test/config/definition.ts.test.cjs
@@ -256,6 +256,10 @@ Object {
     "multiple": true,
     "type": "string",
   },
+  "lockfile-only": Object {
+    "description": "Only update the lockfile (vlt-lock.json), skip all node_modules operations including package extraction and filesystem changes.",
+    "type": "boolean",
+  },
   "no-bail": Object {
     "description": "When running scripts across multiple workspaces, continue on failure, running the script for all workspaces.",
     "short": "B",
@@ -484,6 +488,7 @@ Array [
   "--help",
   "--identity=<name>",
   "--jsr-registries=<name=url>",
+  "--lockfile-only",
   "--no-bail",
   "--no-color",
   "--node-version=<version>",
@@ -538,6 +543,7 @@ Array [
   "help",
   "identity",
   "jsr-registries",
+  "lockfile-only",
   "no-bail",
   "no-color",
   "node-version",

--- a/src/cli-sdk/tap-snapshots/test/index.ts.test.cjs
+++ b/src/cli-sdk/tap-snapshots/test/index.ts.test.cjs
@@ -58,6 +58,7 @@ Unknown option '--unknown'. To specify a positional argument starting with a '-'
     --help
     --identity=<name>
     --jsr-registries=<name=url>
+    --lockfile-only
     --no-bail
     --no-color
     --node-version=<version>
@@ -115,6 +116,7 @@ Unknown config option: asdf
     help
     identity
     jsr-registries
+    lockfile-only
     no-bail
     no-color
     node-version

--- a/src/cli-sdk/test/commands/ci.ts
+++ b/src/cli-sdk/test/commands/ci.ts
@@ -77,3 +77,36 @@ t.test('command description and examples', t => {
 
   t.end()
 })
+
+t.test('lockfile-only flag', async t => {
+  const options = {
+    'lockfile-only': true,
+  }
+
+  let log = ''
+  const Command = await t.mockImport<
+    typeof import('../../src/commands/ci.ts')
+  >('../../src/commands/ci.ts', {
+    '@vltpkg/graph': {
+      async install(opts: any) {
+        log += `install expectLockfile=${opts.expectLockfile} cleanInstall=${opts.cleanInstall} lockfileOnly=${opts.lockfileOnly}\n`
+        return {
+          graph: {},
+        }
+      },
+    },
+  })
+
+  await Command.command({
+    positionals: [],
+    values: {},
+    options,
+  } as unknown as LoadedConfig)
+
+  t.match(
+    log,
+    /install expectLockfile=true cleanInstall=true lockfileOnly=true/,
+    'should pass lockfileOnly along with other ci options',
+  )
+  t.end()
+})

--- a/src/cli-sdk/test/commands/install.ts
+++ b/src/cli-sdk/test/commands/install.ts
@@ -106,3 +106,47 @@ t.test('frozen-lockfile flag', async t => {
     'should pass frozenLockfile to install',
   )
 })
+
+t.test('lockfile-only flag', async t => {
+  const dir = t.testdir({
+    'package.json': JSON.stringify({
+      name: 'test',
+      version: '1.0.0',
+    }),
+  })
+
+  const options = {
+    projectRoot: dir,
+    'lockfile-only': true,
+  }
+
+  let log = ''
+  const Command = await t.mockImport<
+    typeof import('../../src/commands/install.ts')
+  >('../../src/commands/install.ts', {
+    '@vltpkg/graph': {
+      async install(opts: any, add: any) {
+        log += `install lockfileOnly=${opts.lockfileOnly}\n`
+        if (add && add.size > 0) {
+          log += `add packages: ${add.size}\n`
+        }
+        return {
+          graph: {},
+        }
+      },
+      asDependency: (dep: any) => dep,
+    },
+  })
+
+  await Command.command({
+    positionals: [],
+    values: {},
+    options,
+  } as unknown as LoadedConfig)
+
+  t.match(
+    log,
+    /install lockfileOnly=true/,
+    'should pass lockfileOnly to install',
+  )
+})

--- a/src/graph/src/actual/load.ts
+++ b/src/graph/src/actual/load.ts
@@ -75,6 +75,11 @@ export type LoadOptions = SpecOptions & {
    * Prevents any lockfile modifications and is stricter than expectLockfile.
    */
   frozenLockfile?: boolean
+  /**
+   * If set to `true`, only update the lockfile without performing any node_modules
+   * operations. Skips package extraction, filesystem operations, and hidden lockfile saves.
+   */
+  lockfileOnly?: boolean
 }
 
 export type ReadEntry = {

--- a/src/graph/test/install.ts
+++ b/src/graph/test/install.ts
@@ -1251,3 +1251,102 @@ t.test(
     t.ok(rolledBack, 'should rollback removal after error')
   },
 )
+
+t.test('install with lockfileOnly option', async t => {
+  const dir = t.testdir({
+    'package.json': JSON.stringify({
+      name: 'test',
+      version: '1.0.0',
+      dependencies: {
+        abbrev: '^1.0.0',
+      },
+    }),
+  })
+
+  const options = {
+    projectRoot: dir,
+    scurry: new PathScurry(),
+    packageJson: new PackageJson(),
+    packageInfo: mockPackageInfo,
+    lockfileOnly: true,
+  } as unknown as InstallOptions
+
+  let reifyCalled = false
+  let lockfileSaveCalled = false
+  let lockfileSaveOptions: any = null
+
+  const { install } = await t.mockImport<
+    typeof import('../src/install.ts')
+  >('../src/install.ts', {
+    '../src/ideal/build.ts': {
+      build: async () => ({
+        nodes: new Map(),
+        importers: [],
+        projectRoot: dir,
+      }),
+    },
+    '../src/reify/index.ts': {
+      reify: async () => {
+        reifyCalled = true
+        return { hasChanges: () => false }
+      },
+    },
+    '../src/index.ts': {
+      lockfile: {
+        save: (opts: any) => {
+          lockfileSaveCalled = true
+          lockfileSaveOptions = opts
+        },
+      },
+    },
+  })
+
+  const result = await install(
+    options,
+    new Map() as AddImportersDependenciesMap,
+  )
+
+  t.notOk(
+    reifyCalled,
+    'should NOT call reify when lockfileOnly is true',
+  )
+  t.ok(
+    lockfileSaveCalled,
+    'should call lockfile.save when lockfileOnly is true',
+  )
+  t.ok(lockfileSaveOptions, 'should pass options to lockfile.save')
+  t.ok(result.graph, 'should return graph')
+  t.equal(
+    result.diff,
+    undefined,
+    'should return undefined for diff when lockfileOnly is true',
+  )
+})
+
+t.test('lockfileOnly incompatible with cleanInstall', async t => {
+  const dir = t.testdir({
+    'package.json': JSON.stringify({
+      name: 'test',
+      version: '1.0.0',
+    }),
+  })
+
+  const options = {
+    projectRoot: dir,
+    scurry: new PathScurry(),
+    packageJson: new PackageJson(),
+    packageInfo: mockPackageInfo,
+    lockfileOnly: true,
+    cleanInstall: true, // This should cause an error
+  } as unknown as InstallOptions
+
+  const { install } = await t.mockImport<
+    typeof import('../src/install.ts')
+  >('../src/install.ts', {})
+
+  await t.rejects(
+    install(options, new Map() as AddImportersDependenciesMap),
+    /Cannot use --lockfile-only with --clean-install/,
+    'should throw error when lockfileOnly and cleanInstall are both set',
+  )
+})


### PR DESCRIPTION
Adds a `--lockfile-only` option to `vlt install` to update only the lockfile without modifying `node_modules`.

---
<a href="https://cursor.com/background-agent?bcId=bc-dfc5e1bc-e60d-4ae0-95e8-f3a349427e18">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-dfc5e1bc-e60d-4ae0-95e8-f3a349427e18">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

