### PR TITLE
graph: add lockfile only option

### DIFF
--- a/src/cli-sdk/src/commands/ci.ts
+++ b/src/cli-sdk/src/commands/ci.ts
@@ -33,6 +33,7 @@ export const command: CommandFn<CIResult> = async conf => {
     expectLockfile: true,
     frozenLockfile: true,
     cleanInstall: true,
+    lockfileOnly: conf.options['lockfile-only'],
   }
 
   const { graph } = await install(ciOptions)

--- a/src/cli-sdk/src/commands/install.ts
+++ b/src/cli-sdk/src/commands/install.ts
@@ -49,6 +49,7 @@ export const command: CommandFn<InstallResult> = async conf => {
   const { add } = parseAddArgs(conf, monorepo)
   const frozenLockfile = conf.options['frozen-lockfile']
   const expectLockfile = conf.options['expect-lockfile']
+  const lockfileOnly = conf.options['lockfile-only']
   /* c8 ignore start */
   const allowScripts =
     conf.get('allow-scripts') ?
@@ -61,6 +62,7 @@ export const command: CommandFn<InstallResult> = async conf => {
       frozenLockfile,
       expectLockfile,
       allowScripts,
+      lockfileOnly,
     },
     add,
   )

--- a/src/cli-sdk/src/config/definition.ts
+++ b/src/cli-sdk/src/config/definition.ts
@@ -638,6 +638,10 @@ export const definition = j
       description:
         'Fail if lockfile is missing or out of sync with package.json. Prevents any lockfile modifications.',
     },
+    'lockfile-only': {
+      description:
+        'Only update the lockfile (vlt-lock.json) and package.json files, skip all node_modules operations including package extraction and filesystem changes.',
+    },
   })
   .opt({
     'allow-scripts': {

--- a/src/cli-sdk/tap-snapshots/test/config/definition.ts.test.cjs
+++ b/src/cli-sdk/tap-snapshots/test/config/definition.ts.test.cjs
@@ -277,6 +277,10 @@ Object {
     "multiple": true,
     "type": "string",
   },
+  "lockfile-only": Object {
+    "description": "Only update the lockfile (vlt-lock.json) and package.json files, skip all node_modules operations including package extraction and filesystem changes.",
+    "type": "boolean",
+  },
   "no-bail": Object {
     "description": "When running scripts across multiple workspaces, continue on failure, running the script for all workspaces.",
     "short": "B",
@@ -519,6 +523,7 @@ Array [
   "--identity=<name>",
   "--if-present",
   "--jsr-registries=<name=url>",
+  "--lockfile-only",
   "--no-bail",
   "--no-color",
   "--node-version=<version>",
@@ -577,6 +582,7 @@ Array [
   "identity",
   "if-present",
   "jsr-registries",
+  "lockfile-only",
   "no-bail",
   "no-color",
   "node-version",

--- a/src/cli-sdk/tap-snapshots/test/index.ts.test.cjs
+++ b/src/cli-sdk/tap-snapshots/test/index.ts.test.cjs
@@ -60,6 +60,7 @@ Unknown option '--unknown'. To specify a positional argument starting with a '-'
     --identity=<name>
     --if-present
     --jsr-registries=<name=url>
+    --lockfile-only
     --no-bail
     --no-color
     --node-version=<version>
@@ -121,6 +122,7 @@ Unknown config option: asdf
     identity
     if-present
     jsr-registries
+    lockfile-only
     no-bail
     no-color
     node-version

--- a/src/cli-sdk/test/commands/ci.ts
+++ b/src/cli-sdk/test/commands/ci.ts
@@ -80,3 +80,37 @@ t.test('command description and examples', t => {
 
   t.end()
 })
+
+t.test('lockfile-only flag', async t => {
+  const options = {
+    'lockfile-only': true,
+  }
+
+  let log = ''
+  const Command = await t.mockImport<
+    typeof import('../../src/commands/ci.ts')
+  >('../../src/commands/ci.ts', {
+    '@vltpkg/graph': {
+      async install(opts: any) {
+        log += `install expectLockfile=${opts.expectLockfile} cleanInstall=${opts.cleanInstall} lockfileOnly=${opts.lockfileOnly}\n`
+        return {
+          graph: {},
+        }
+      },
+    },
+  })
+
+  await Command.command({
+    positionals: [],
+    values: {},
+    options,
+    get: () => undefined,
+  } as unknown as LoadedConfig)
+
+  t.match(
+    log,
+    /install expectLockfile=true cleanInstall=true lockfileOnly=true/,
+    'should pass lockfileOnly along with other ci options',
+  )
+  t.end()
+})

--- a/src/cli-sdk/test/commands/install.ts
+++ b/src/cli-sdk/test/commands/install.ts
@@ -163,3 +163,48 @@ t.test('frozen-lockfile flag', async t => {
     'should pass frozenLockfile to install',
   )
 })
+
+t.test('lockfile-only flag', async t => {
+  const dir = t.testdir({
+    'package.json': JSON.stringify({
+      name: 'test',
+      version: '1.0.0',
+    }),
+  })
+
+  const options = {
+    projectRoot: dir,
+    'lockfile-only': true,
+  }
+
+  let log = ''
+  const Command = await t.mockImport<
+    typeof import('../../src/commands/install.ts')
+  >('../../src/commands/install.ts', {
+    '@vltpkg/graph': {
+      async install(opts: any, add: any) {
+        log += `install lockfileOnly=${opts.lockfileOnly}\n`
+        if (add && add.size > 0) {
+          log += `add packages: ${add.size}\n`
+        }
+        return {
+          graph: {},
+        }
+      },
+      asDependency: (dep: any) => dep,
+    },
+  })
+
+  await Command.command({
+    positionals: [],
+    values: {},
+    options,
+    get: () => undefined,
+  } as unknown as LoadedConfig)
+
+  t.match(
+    log,
+    /install lockfileOnly=true/,
+    'should pass lockfileOnly to install',
+  )
+})

--- a/src/graph/src/actual/load.ts
+++ b/src/graph/src/actual/load.ts
@@ -65,6 +65,7 @@ export type LoadOptions = SpecOptions & {
    * Load only importers into the graph if the modifiers have changed.
    */
   skipLoadingNodesOnModifiersChange?: boolean
+  // TODO: move the lockfile-related options to a separate type file
   /**
    * If set to `true`, fail if lockfile is missing or out of date.
    * Used by ci command to enforce lockfile integrity.
@@ -75,6 +76,11 @@ export type LoadOptions = SpecOptions & {
    * Prevents any lockfile modifications and is stricter than expectLockfile.
    */
   frozenLockfile?: boolean
+  /**
+   * If set to `true`, only update the lockfile without performing any node_modules
+   * operations. Skips package extraction, filesystem operations, and hidden lockfile saves.
+   */
+  lockfileOnly?: boolean
 }
 
 export type ReadEntry = {

--- a/src/graph/src/uninstall.ts
+++ b/src/graph/src/uninstall.ts
@@ -2,8 +2,11 @@ import type { PackageInfoClient } from '@vltpkg/package-info'
 import type { LoadOptions } from './actual/load.ts'
 import { load as actualLoad } from './actual/load.ts'
 import type { RemoveImportersDependenciesMap } from './dependencies.ts'
+import { GraphModifier } from './modifiers.ts'
 import { build as idealBuild } from './ideal/build.ts'
 import { reify } from './reify/index.ts'
+import { lockfile } from './index.ts'
+import { updatePackageJson } from './reify/update-importers-package-json.ts'
 
 export type UninstallOptions = LoadOptions & {
   packageInfo: PackageInfoClient
@@ -15,6 +18,7 @@ export const uninstall = async (
   remove?: RemoveImportersDependenciesMap,
 ) => {
   const mainManifest = options.packageJson.read(options.projectRoot)
+  const modifiers = GraphModifier.maybeLoad(options)
 
   const graph = await idealBuild({
     ...options,
@@ -27,6 +31,24 @@ export const uninstall = async (
     mainManifest,
     loadManifests: true,
   })
+
+  // If lockfileOnly is enabled, skip reify and only save the lockfile
+  if (options.lockfileOnly) {
+    // Save only the main lockfile, skip all filesystem operations
+    lockfile.save({ graph, modifiers })
+    const saveImportersPackageJson =
+      /* c8 ignore next */
+      remove?.modifiedDependencies ?
+        updatePackageJson({
+          ...options,
+          remove,
+          graph,
+        })
+      : undefined
+    saveImportersPackageJson?.()
+    return { graph, diff: undefined }
+  }
+
   const diff = await reify({
     ...options,
     remove,

--- a/src/graph/test/uninstall.ts
+++ b/src/graph/test/uninstall.ts
@@ -3,11 +3,25 @@ import t from 'tap'
 import type { RemoveImportersDependenciesMap } from '../src/dependencies.ts'
 import type { BuildIdealRemoveOptions } from '../src/ideal/types.ts'
 import type { UninstallOptions } from '../src/uninstall.ts'
+import { PackageJson } from '@vltpkg/package-json'
+import { PathScurry } from 'path-scurry'
+import { mockPackageInfo as mockPackageInfoBase } from './fixtures/reify.ts'
+import type { PackageInfoClient } from '@vltpkg/package-info'
 
 t.cleanSnapshot = s =>
   s.replace(/^(\s+)"?projectRoot"?: .*$/gm, '$1projectRoot: #')
 
-class PackageJson {
+const createMockPackageInfo = (
+  overrides: Partial<typeof mockPackageInfoBase> = {},
+) =>
+  ({
+    ...mockPackageInfoBase,
+    ...overrides,
+  }) as unknown as PackageInfoClient
+
+const mockPackageInfo = createMockPackageInfo()
+
+class PackageJsonMock {
   read() {
     return {
       name: 'my-project',
@@ -22,7 +36,7 @@ class PackageJson {
 t.test('uninstall', async t => {
   const options = {
     projectRoot: t.testdirName,
-    packageJson: new PackageJson(),
+    packageJson: new PackageJsonMock(),
     scurry: {},
   } as unknown as UninstallOptions
   let log = ''
@@ -46,7 +60,7 @@ t.test('uninstall', async t => {
       },
     },
     '@vltpkg/package-json': {
-      PackageJson,
+      PackageJson: PackageJsonMock,
     },
     'path-scurry': {
       PathScurry: {},
@@ -66,3 +80,154 @@ t.test('uninstall', async t => {
 
   t.matchSnapshot(log, 'should call build removing a dependency')
 })
+
+t.test('uninstall with lockfileOnly option', async t => {
+  const dir = t.testdir({
+    'package.json': JSON.stringify({
+      name: 'test',
+      version: '1.0.0',
+      dependencies: {
+        abbrev: '^1.0.0',
+      },
+    }),
+  })
+
+  const options = {
+    projectRoot: dir,
+    scurry: new PathScurry(),
+    packageJson: new PackageJson(),
+    packageInfo: mockPackageInfo,
+    lockfileOnly: true,
+    allowScripts: ':not(*)',
+  } as unknown as UninstallOptions
+
+  let reifyCalled = false
+  let lockfileSaveCalled = false
+
+  const { uninstall } = await t.mockImport<
+    typeof import('../src/uninstall.ts')
+  >('../src/uninstall.ts', {
+    '../src/ideal/build.ts': {
+      build: async () => ({
+        nodes: new Map(),
+        importers: [],
+        projectRoot: dir,
+      }),
+    },
+    '../src/reify/index.ts': {
+      reify: async () => {
+        reifyCalled = true
+        return { hasChanges: () => false }
+      },
+    },
+    '../src/index.ts': {
+      lockfile: {
+        save: () => {
+          lockfileSaveCalled = true
+        },
+      },
+    },
+  })
+
+  const result = await uninstall(
+    options,
+    new Map() as RemoveImportersDependenciesMap,
+  )
+
+  t.notOk(
+    reifyCalled,
+    'should NOT call reify when lockfileOnly is true',
+  )
+  t.ok(
+    lockfileSaveCalled,
+    'should call lockfile.save when lockfileOnly is true',
+  )
+  t.ok(result.graph, 'should return graph')
+  t.equal(
+    result.diff,
+    undefined,
+    'should return undefined for diff when lockfileOnly is true',
+  )
+})
+
+t.test(
+  'uninstall with lockfileOnly and removing packages (updatePackageJson)',
+  async t => {
+    const dir = t.testdir({
+      'package.json': JSON.stringify({
+        name: 'test',
+        version: '1.0.0',
+        dependencies: {
+          abbrev: '^1.0.0',
+        },
+      }),
+    })
+
+    const options = {
+      projectRoot: dir,
+      scurry: new PathScurry(),
+      packageJson: new PackageJson(),
+      packageInfo: mockPackageInfo,
+      lockfileOnly: true,
+      allowScripts: ':not(*)',
+    } as unknown as UninstallOptions
+
+    let reifyCalled = false
+    let lockfileSaveCalled = false
+    let updatePackageJsonCalled = false
+    let updatePackageJsonOptions: any = null
+
+    const { uninstall } = await t.mockImport<
+      typeof import('../src/uninstall.ts')
+    >('../src/uninstall.ts', {
+      '../src/ideal/build.ts': {
+        build: async () => ({
+          nodes: new Map(),
+          importers: [],
+          projectRoot: dir,
+        }),
+      },
+      '../src/reify/index.ts': {
+        reify: async () => {
+          reifyCalled = true
+          return { hasChanges: () => false }
+        },
+      },
+      '../src/index.ts': {
+        lockfile: {
+          save: () => {
+            lockfileSaveCalled = true
+          },
+        },
+      },
+      '../src/reify/update-importers-package-json.ts': {
+        updatePackageJson: (opts: any) => {
+          updatePackageJsonCalled = true
+          updatePackageJsonOptions = opts
+          return () => {}
+        },
+      },
+    })
+
+    const rootDepID = joinDepIDTuple(['file', '.'])
+    const removeMap = new Map([
+      [rootDepID, new Set(['abbrev'])],
+    ]) as RemoveImportersDependenciesMap
+    Object.assign(removeMap, { modifiedDependencies: true })
+
+    const result = await uninstall(options, removeMap)
+
+    t.notOk(reifyCalled, 'should NOT call reify with lockfileOnly')
+    t.ok(lockfileSaveCalled, 'should call lockfile.save')
+    t.ok(
+      updatePackageJsonCalled,
+      'should call updatePackageJson when removing packages',
+    )
+    t.ok(
+      updatePackageJsonOptions?.remove,
+      'should pass remove map to updatePackageJson',
+    )
+    t.ok(result.graph, 'should return graph')
+    t.equal(result.diff, undefined, 'should return undefined diff')
+  },
+)


### PR DESCRIPTION
Add a `--lockfile-only` option to the CLI and the support to a `lockfileOnly` option in the `@vltpkg/graph` library so that installs are limited to only saving to the `vlt-lock.json` and `package.json` files while avoiding any `node_modules` related file system operations.

Refs: https://docs.npmjs.com/cli/v11/commands/npm-install#package-lock-only
Refs: https://pnpm.io/cli/install#--lockfile-only