### PR TITLE
gui: bugfix dedupe query match labels

### DIFF
--- a/src/gui/src/components/directory-select.tsx
+++ b/src/gui/src/components/directory-select.tsx
@@ -99,7 +99,7 @@ export const DirectorySelect = ({
       <PopoverTrigger asChild>
         <Button
           className={cn(
-            'group flex h-[40px] w-full items-center justify-between border-[1px] border-muted bg-white text-muted-foreground shadow-none hover:bg-accent dark:bg-muted-foreground/5 dark:hover:bg-muted-foreground/10',
+            'group flex h-10 w-full items-center justify-between rounded-lg border-[1px] border-muted bg-white text-muted-foreground shadow-none hover:bg-accent dark:bg-muted-foreground/5 dark:hover:bg-muted-foreground/10',
             className,
           )}>
           {displayPath}

--- a/src/gui/src/components/explorer-grid/save-query.tsx
+++ b/src/gui/src/components/explorer-grid/save-query.tsx
@@ -1,5 +1,4 @@
 import { useEffect, useState, useRef, useMemo } from 'react'
-import type { ChangeEvent } from 'react'
 import { Star, ChevronsUpDown } from 'lucide-react'
 import { CardHeader, CardTitle } from '@/components/ui/card.tsx'
 import { useTheme } from '@/components/ui/theme-provider.tsx'
@@ -19,11 +18,13 @@ import { Label } from '@/components/ui/label.tsx'
 import { Input } from '@/components/ui/input.tsx'
 import { useAnimate } from 'framer-motion'
 import { useGraphStore } from '@/state/index.ts'
-import type { QueryLabel, SavedQuery } from '@/state/types.ts'
 import { LabelSelect } from '@/components/labels/label-select.tsx'
 import { LabelBadge } from '@/components/labels/label-badge.tsx'
 import { v4 as uuidv4 } from 'uuid'
 import { DeleteQuery } from '@/components/queries/delete-query.tsx'
+
+import type { ChangeEvent } from 'react'
+import type { QueryLabel, SavedQuery } from '@/state/types.ts'
 
 interface SaveQueryPopoverProps {
   isOpen: boolean
@@ -63,13 +64,13 @@ const SaveQueryButton = () => {
           <Tooltip>
             <TooltipTrigger
               asChild
-              className="flex h-[1.5rem] w-[1.5rem] cursor-default items-center justify-center rounded-sm bg-input transition-colors hover:bg-neutral-300 dark:hover:bg-neutral-700">
+              className="flex size-6 cursor-default items-center justify-center rounded-md border border-neutral-200 bg-neutral-100 transition-colors hover:bg-neutral-300 dark:border-neutral-700 dark:bg-muted dark:hover:bg-neutral-700">
               <div
                 onClick={() =>
                   setShowSaveQueryPopover(!showSaveQueryPopover)
                 }
-                className="inline-flex h-[1.5rem] w-[1.5rem] items-center justify-center gap-2 whitespace-nowrap rounded-md border border-input bg-background text-sm font-medium ring-offset-background transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0">
-                <Star ref={scope} size={20} fill={starColor} />
+                className="inline-flex size-5 items-center justify-center gap-2 whitespace-nowrap rounded-md border border-input bg-background text-sm font-medium ring-offset-background transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-[15px] [&_svg]:shrink-0">
+                <Star ref={scope} fill={starColor} />
               </div>
             </TooltipTrigger>
             <TooltipContent>
@@ -78,7 +79,7 @@ const SaveQueryButton = () => {
           </Tooltip>
         </TooltipProvider>
       </PopoverTrigger>
-      <PopoverContent className="w-full p-0" align="end">
+      <PopoverContent className="w-full rounded-xl p-0" align="end">
         <SaveQueryPopover
           isOpen={showSaveQueryPopover}
           setIsOpen={setShowSaveQueryPopover}
@@ -222,30 +223,32 @@ const SaveQueryPopover = ({
 
   return (
     <div className="flex w-[325px] flex-col">
-      <CardHeader className="px-6 py-4">
-        <CardTitle className="text-lg font-medium">
+      <CardHeader className="px-6 py-3">
+        <CardTitle className="text-md font-medium">
           {savedQuery ? 'Edit Query' : 'Added Query!'}
         </CardTitle>
       </CardHeader>
       <div className="flex flex-col gap-2 border-t-[1px] border-muted-foreground/20 px-6 py-4">
-        <Label className="border-none font-medium">Name</Label>
+        <Label className="border-none p-0 font-medium">Name</Label>
         <Input
           type="text"
           autoComplete="off"
           placeholder="Name"
+          className="rounded-lg"
           value={queryName}
           onChange={(e: ChangeEvent<HTMLInputElement>) => {
             const value = e.currentTarget.value
             setQueryName(value)
           }}
         />
-        <Label className="mt-2 border-none font-medium">
+        <Label className="mt-2 border-none p-0 font-medium">
           Directory
         </Label>
         <Input
           id="query-context"
           type="text"
           autoComplete="off"
+          className="rounded-lg"
           placeholder="Directory (optional)"
           value={editContext}
           onChange={(e: ChangeEvent<HTMLInputElement>) => {
@@ -253,9 +256,11 @@ const SaveQueryPopover = ({
             setEditContext(value)
           }}
         />
-        <Label className="mt-2 border-none font-medium">Labels</Label>
+        <Label className="mt-2 border-none p-0 font-medium">
+          Labels
+        </Label>
         {selectedLabels.length !== 0 && (
-          <div className="ml-2 flex flex-wrap gap-2">
+          <div className="flex flex-wrap gap-2">
             {selectedLabels.map((label, idx) => (
               <LabelBadge
                 key={idx}
@@ -270,7 +275,7 @@ const SaveQueryPopover = ({
             <Button
               variant="outline"
               role="combobox"
-              className="w-full justify-between font-normal">
+              className="w-full justify-between rounded-lg font-normal">
               Select labels
               <ChevronsUpDown className="opacity-50" />
             </Button>
@@ -289,6 +294,7 @@ const SaveQueryPopover = ({
               <DeleteQuery
                 type="button"
                 text="Remove"
+                className="rounded-lg"
                 deleteDialogOpen={deleteDialogOpen}
                 setDeleteDialogOpen={setDeleteDialogOpen}
                 onClose={() => setIsOpen(false)}
@@ -303,7 +309,12 @@ const SaveQueryPopover = ({
                 ]}
               />
             )}
-            <Button onClick={() => setIsOpen(false)}>Done</Button>
+            <Button
+              size="sm"
+              className="rounded-lg"
+              onClick={() => setIsOpen(false)}>
+              Done
+            </Button>
           </div>
         </div>
       </div>

--- a/src/gui/src/components/labels/label-badge.tsx
+++ b/src/gui/src/components/labels/label-badge.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react'
 import { Badge } from '@/components/ui/badge.tsx'
 import { useTheme } from '@/components/ui/theme-provider.tsx'
+import { cn } from '@/lib/utils.ts'
 
 interface LabelBadgeProps {
   name: string
@@ -41,10 +42,10 @@ const getContrastTextColor = (hex: string, theme: string): string => {
   return luminance > 0.618 ? 'black' : 'white'
 }
 
-const LabelBadge = ({
+export const LabelBadge = ({
   name,
   color,
-  className = '',
+  className,
 }: LabelBadgeProps) => {
   const { resolvedTheme: theme } = useTheme()
   const [textColor, setTextColor] = useState<string>('')
@@ -61,10 +62,8 @@ const LabelBadge = ({
         backgroundColor: color,
         color: textColor,
       }}
-      className={`font-medium ${className}`}>
+      className={cn('font-medium', className)}>
       {name}
     </Badge>
   )
 }
-
-export { LabelBadge }

--- a/src/gui/src/components/labels/label-select.tsx
+++ b/src/gui/src/components/labels/label-select.tsx
@@ -7,13 +7,14 @@ import {
   CommandList,
 } from '@/components/ui/command.tsx'
 import { Check, Pencil } from 'lucide-react'
-import type { QueryLabel } from '@/state/types.ts'
 import { useGraphStore } from '@/state/index.ts'
 import { useEffect, useRef, useState } from 'react'
 import { cn } from '@/lib/utils.ts'
 import { Button } from '@/components/ui/button.tsx'
 import { CreateLabelModal } from '@/components/labels/create-label-dialog.tsx'
 import { Dialog, DialogTrigger } from '@/components/ui/dialog.tsx'
+
+import type { QueryLabel } from '@/state/types.ts'
 
 interface LabelSelect {
   setIsOpen: (isOpen: boolean) => void
@@ -22,11 +23,11 @@ interface LabelSelect {
   className?: string
 }
 
-const LabelSelect = ({
+export const LabelSelect = ({
   setIsOpen,
   setItems,
   selectedItems,
-  className = '',
+  className,
 }: LabelSelect) => {
   const savedLabels = useGraphStore(state => state.savedQueryLabels)
   const boxRef = useRef<HTMLDivElement>(null)
@@ -83,7 +84,7 @@ const LabelSelect = ({
         className="w-full"
         placeholder="Search labels"
       />
-      <CommandList className="rounded-sm">
+      <CommandList className="rounded-xl">
         <CommandEmpty className="my-3 items-center px-3 py-2">
           <Dialog
             open={isCreateModalOpen}
@@ -155,5 +156,3 @@ const LabelSelect = ({
     </Command>
   )
 }
-
-export { LabelSelect }

--- a/src/gui/src/components/labels/label.tsx
+++ b/src/gui/src/components/labels/label.tsx
@@ -15,9 +15,11 @@ import {
   ColorPicker,
   DEFAULT_COLOR,
 } from '@/components/ui/color-picker.tsx'
-import type { Color, QueryLabel } from '@/state/types.ts'
 import { useGraphStore } from '@/state/index.ts'
 import { useToast } from '@/components/hooks/use-toast.ts'
+import { cn } from '@/lib/utils.ts'
+
+import type { Color, QueryLabel } from '@/state/types.ts'
 
 interface LabelProps {
   queryLabel: QueryLabel
@@ -25,7 +27,11 @@ interface LabelProps {
   handleSelect: (label: QueryLabel) => void
 }
 
-const Label = ({ queryLabel, checked, handleSelect }: LabelProps) => {
+export const Label = ({
+  queryLabel,
+  checked,
+  handleSelect,
+}: LabelProps) => {
   const navigate = useNavigate()
   const [isExpanded, setIsExpanded] = useState<boolean>(false)
   const [editDescription, setEditDescription] = useState<string>('')
@@ -83,13 +89,19 @@ const Label = ({ queryLabel, checked, handleSelect }: LabelProps) => {
 
   return (
     <div
-      className={`group rounded-sm border border-[1px] bg-card transition-colors transition-opacity hover:bg-card-accent ${isExpanded ? 'border-muted-foreground' : 'border-muted'}`}>
+      className={cn(
+        'group rounded-xl border border-[1px] bg-card transition-colors transition-opacity hover:bg-card-accent',
+        isExpanded ? 'border-muted-foreground' : 'border-muted',
+      )}>
       <div className="flex grid grid-cols-8 items-center px-3 py-2">
         <div className="col-span-2 flex items-center gap-3">
           <Checkbox
             onCheckedChange={() => handleSelect(queryLabel)}
             checked={checked}
-            className={`border-muted-foreground/25 opacity-0 group-hover:border-muted-foreground/50 group-hover:opacity-100 ${checked ? 'opacity-100' : 'opacity-0'}`}
+            className={cn(
+              'border-muted-foreground/25 opacity-0 group-hover:border-muted-foreground/50 group-hover:opacity-100',
+              checked ? 'opacity-100' : 'opacity-0',
+            )}
           />
           <LabelBadge
             name={editName.trim() !== '' ? editName : 'Label preview'}
@@ -104,7 +116,7 @@ const Label = ({ queryLabel, checked, handleSelect }: LabelProps) => {
         <div className="flex items-center justify-center">
           <Button
             variant="ghost"
-            className="flex items-center justify-center gap-1"
+            className="flex items-center justify-center gap-1 rounded-lg"
             onClick={() =>
               queriesReferenced ? navigateToRef() : undefined
             }>
@@ -115,7 +127,7 @@ const Label = ({ queryLabel, checked, handleSelect }: LabelProps) => {
         <div className="flex items-center justify-end">
           <Button
             variant="outline"
-            className="h-[2rem] rounded-sm border border-[1px] border-muted-foreground/25 px-3 text-sm"
+            className="h-[2rem] rounded-lg border border-[1px] border-muted-foreground/25 px-3 text-sm"
             onClick={handleEdit}>
             {isExpanded ? 'Close' : 'Edit'}
           </Button>
@@ -135,6 +147,7 @@ const Label = ({ queryLabel, checked, handleSelect }: LabelProps) => {
                 value={editName}
                 onChange={e => setEditName(e.target.value)}
                 placeholder="Name"
+                className="rounded-lg"
               />
             </div>
             <div className="flex grow flex-col gap-2">
@@ -146,6 +159,7 @@ const Label = ({ queryLabel, checked, handleSelect }: LabelProps) => {
                 value={editDescription}
                 onChange={e => setEditDescription(e.target.value)}
                 placeholder="Description (optional)"
+                className="rounded-lg"
               />
             </div>
             <div className="flex flex-col gap-2">
@@ -155,13 +169,13 @@ const Label = ({ queryLabel, checked, handleSelect }: LabelProps) => {
               <Popover>
                 <PopoverTrigger asChild>
                   <Button
-                    className="w-[120px] font-normal"
+                    className="w-[120px] rounded-lg font-normal"
                     variant="outline">
                     <Palette />
                     <span>{editColor}</span>
                   </Button>
                 </PopoverTrigger>
-                <PopoverContent>
+                <PopoverContent className="rounded-xl">
                   <ColorPicker
                     defaultInput={editColor}
                     defaultColor={editColor}
@@ -170,7 +184,7 @@ const Label = ({ queryLabel, checked, handleSelect }: LabelProps) => {
                 </PopoverContent>
               </Popover>
             </div>
-            <div className="mb-0.5 flex items-end">
+            <div className="flex items-end">
               <Button
                 disabled={
                   editName.trim() === '' ||
@@ -178,7 +192,8 @@ const Label = ({ queryLabel, checked, handleSelect }: LabelProps) => {
                 }
                 onClick={handleSaveChanges}
                 variant="default"
-                size="sm">
+                size="sm"
+                className="h-10 rounded-lg">
                 Save changes
               </Button>
             </div>
@@ -188,5 +203,3 @@ const Label = ({ queryLabel, checked, handleSelect }: LabelProps) => {
     </div>
   )
 }
-
-export { Label }

--- a/src/gui/src/components/navigation/header/explorer.tsx
+++ b/src/gui/src/components/navigation/header/explorer.tsx
@@ -19,7 +19,7 @@ export const ExplorerHeader = () => {
           <div className="relative mr-3 hidden items-center gap-1 md:flex">
             <QueryMatches />
             <SaveQueryButton />
-            <Kbd className='before:content-[" "] relative ml-3 before:absolute before:-ml-10 before:h-[0.75rem] before:w-[1.25px] before:rounded-sm before:bg-neutral-600'>
+            <Kbd className='before:content-[" "] relative ml-3 before:absolute before:-ml-10 before:h-[0.75rem] before:w-[2px] before:rounded-sm before:bg-neutral-200 before:dark:bg-neutral-700'>
               <Command size={12} />
             </Kbd>
             <Kbd className="text-sm">k</Kbd>

--- a/src/gui/src/components/queries/delete-query.tsx
+++ b/src/gui/src/components/queries/delete-query.tsx
@@ -76,7 +76,13 @@ const DeleteQuery = ({
                 variant="ghost">
                 <Trash />
               </Button>
-            : <Button variant="destructive">{text}</Button>}
+            : <Button
+                variant="destructive"
+                size="sm"
+                className="rounded-lg">
+                {text}
+              </Button>
+            }
           </DialogTrigger>
           <TooltipContent>
             Delete {selectedQueries.length <= 1 ? 'Query' : 'Queries'}

--- a/src/gui/src/components/queries/saved-item.tsx
+++ b/src/gui/src/components/queries/saved-item.tsx
@@ -1,11 +1,5 @@
 import { useNavigate } from 'react-router'
 import { useEffect, useState, useMemo } from 'react'
-import type {
-  SavedQuery,
-  Action,
-  QueryLabel,
-  DashboardData,
-} from '@/state/types.ts'
 import { useGraphStore } from '@/state/index.ts'
 import { Input } from '@/components/ui/input.tsx'
 import { Button } from '@/components/ui/button.tsx'
@@ -27,6 +21,14 @@ import {
   TooltipContent,
 } from '@/components/ui/tooltip.tsx'
 import { DirectorySelect } from '@/components/directory-select.tsx'
+import { cn } from '@/lib/utils.ts'
+
+import type {
+  SavedQuery,
+  Action,
+  QueryLabel,
+  DashboardData,
+} from '@/state/types.ts'
 
 type SelectQueryOptions = {
   navigate: (route: string) => void
@@ -83,7 +85,7 @@ export const selectQuery = async ({
   }
 }
 
-const SavedQueryItem = ({
+export const SavedQueryItem = ({
   item,
   handleSelect,
   checked,
@@ -158,13 +160,19 @@ const SavedQueryItem = ({
 
   return (
     <div
-      className={`group flex flex-col rounded-sm border border-[1px] bg-card transition-colors transition-opacity hover:bg-card-accent ${isExpanded ? 'border-muted-foreground' : 'border-muted'}`}>
+      className={cn(
+        'group flex flex-col rounded-xl border border-[1px] bg-card transition-colors transition-opacity hover:bg-card-accent',
+        isExpanded ? 'border-muted-foreground' : 'border-muted',
+      )}>
       <div className="grid grid-cols-12 gap-4 px-3 py-2">
         <div className="col-span-2 flex grow items-center gap-3">
           <Checkbox
             checked={checked}
             onCheckedChange={() => handleSelect(item)}
-            className={`border-muted-foreground/25 opacity-0 group-hover:border-muted-foreground/50 group-hover:opacity-100 ${checked ? 'opacity-100' : ''}`}
+            className={cn(
+              'border-muted-foreground/25 opacity-0 group-hover:border-muted-foreground/50 group-hover:opacity-100',
+              checked && 'opacity-100',
+            )}
           />
           <p className="truncate text-sm font-medium">
             {editName.trim() !== '' ? editName : 'Query Name'}
@@ -198,14 +206,14 @@ const SavedQueryItem = ({
         <div className="col-span-2 flex items-center justify-end gap-4">
           <Button
             variant="outline"
-            className="h-[2rem] rounded-sm border border-[1px] border-muted-foreground/25 px-3 text-sm"
+            className="h-8 rounded-lg border border-[1px] border-muted-foreground/25 px-3 text-sm"
             onClick={handleEdit}>
             {isExpanded ? 'Close' : 'Edit'}
           </Button>
           {editContext.trim() !== '' && (
             <Button
               variant="outline"
-              className="h-[2rem] rounded-sm border border-[1px] border-muted-foreground/25 px-3 text-sm"
+              className="h-8 rounded-lg border border-[1px] border-muted-foreground/25 px-3 text-sm"
               role="link"
               onClick={() => void runQuery()}>
               <span>Run</span>
@@ -229,6 +237,7 @@ const SavedQueryItem = ({
                 value={editName}
                 onChange={e => setEditName(e.target.value)}
                 placeholder="Name"
+                className="rounded-lg"
               />
             </div>
             <div className="flex grow flex-col gap-2">
@@ -240,7 +249,7 @@ const SavedQueryItem = ({
                 placeholder="Query"
                 value={editQuery}
                 onChange={e => setEditQuery(e.target.value)}
-                className="w-full"
+                className="w-full rounded-lg"
               />
             </div>
             <div className="flex grow flex-col gap-2">
@@ -277,13 +286,14 @@ const SavedQueryItem = ({
                     variant="outline"
                     role="combobox"
                     aria-expanded={popoverOpen}
-                    className="w-full justify-between">
+                    className="w-full justify-between rounded-lg">
                     Select labels
                     <ChevronsUpDown className="opacity-50" />
                   </Button>
                 </PopoverTrigger>
-                <PopoverContent className="p-0">
+                <PopoverContent className="rounded-xl p-0">
                   <LabelSelect
+                    className="rounded-xl"
                     selectedItems={selectedLabels}
                     setItems={setSelectedLabels}
                     setIsOpen={setLabelSelectOpen}
@@ -296,6 +306,7 @@ const SavedQueryItem = ({
           {/* footer */}
           <div className="mb-0.5 flex items-end justify-end">
             <Button
+              className="rounded-lg"
               disabled={!isValid}
               onClick={handleSaveChanges}
               variant="default"
@@ -308,5 +319,3 @@ const SavedQueryItem = ({
     </div>
   )
 }
-
-export { SavedQueryItem }

--- a/src/gui/src/components/ui/color-picker.tsx
+++ b/src/gui/src/components/ui/color-picker.tsx
@@ -62,7 +62,7 @@ export function ColorPicker({
     <div className="mx-auto w-full max-w-md px-2 py-1">
       <div className="relative w-full">
         <Input
-          className="w-full"
+          className="w-full rounded-lg"
           type="text"
           value={inputColor}
           onChange={handleInputChange}
@@ -81,7 +81,7 @@ export function ColorPicker({
                 onChange(e.target.value)
               }
             }}
-            className="relative h-[20px] w-[20px] cursor-default opacity-0"
+            className="relative h-5 w-5 cursor-default opacity-0"
             type="color"
           />
         </div>

--- a/src/gui/src/components/ui/kbd.tsx
+++ b/src/gui/src/components/ui/kbd.tsx
@@ -1,14 +1,18 @@
 import React from 'react'
+import { cn } from '@/lib/utils.ts'
 
 interface KbdProps {
   children: React.ReactNode
   className?: string
 }
 
-export const Kbd = ({ children, className = '' }: KbdProps) => {
+export const Kbd = ({ children, className }: KbdProps) => {
   return (
     <kbd
-      className={`flex h-[1.5rem] w-[1.5rem] items-center justify-center rounded-sm bg-muted font-mono text-xs text-muted-foreground ${className}`}>
+      className={cn(
+        'flex size-6 items-center justify-center rounded-md border border-neutral-200 bg-neutral-100 font-mono text-xs text-muted-foreground dark:border-neutral-700 dark:bg-muted',
+        className,
+      )}>
       {children}
     </kbd>
   )

--- a/src/gui/test/components/__snapshots__/directory-select.tsx.snap
+++ b/src/gui/test/components/__snapshots__/directory-select.tsx.snap
@@ -4,7 +4,7 @@ exports[`directory select > renders correctly 1`] = `
 
 <gui-popover>
   <gui-popover-trigger aschild="true">
-    <gui-button classname="group flex h-[40px] w-full items-center justify-between border-[1px] border-muted bg-white text-muted-foreground shadow-none hover:bg-accent dark:bg-muted-foreground/5 dark:hover:bg-muted-foreground/10">
+    <gui-button classname="group flex h-10 w-full items-center justify-between rounded-lg border-[1px] border-muted bg-white text-muted-foreground shadow-none hover:bg-accent dark:bg-muted-foreground/5 dark:hover:bg-muted-foreground/10">
       Global
       <gui-chevron-down-icon classname="text-foreground opacity-50 duration-300 group-data-[state=open]:-rotate-180">
       </gui-chevron-down-icon>

--- a/src/gui/test/components/explorer-grid/__snapshots__/query-matches.tsx.snap
+++ b/src/gui/test/components/explorer-grid/__snapshots__/query-matches.tsx.snap
@@ -19,11 +19,13 @@ exports[`save-query > should render correctly 1`] = `
       </gui-tooltip>
     </gui-tooltip-provider>
   </gui-popover-trigger>
-  <gui-popover-content>
-    <p class="mb-2 font-semibold">
-      Labels
-    </p>
-    <div class="flex flex-wrap gap-2">
+  <gui-popover-content classname="rounded-xl">
+    <div class="flex flex-col gap-2">
+      <p class="font-medium">
+        Labels
+      </p>
+      <div class="flex flex-wrap gap-2">
+      </div>
     </div>
   </gui-popover-content>
 </gui-popover>

--- a/src/gui/test/components/explorer-grid/__snapshots__/save-query.tsx.snap
+++ b/src/gui/test/components/explorer-grid/__snapshots__/save-query.tsx.snap
@@ -8,13 +8,13 @@ exports[`save-query > should render correctly 1`] = `
       <gui-tooltip>
         <gui-tooltip-trigger
           aschild="true"
-          classname="flex h-[1.5rem] w-[1.5rem] cursor-default items-center justify-center rounded-sm bg-input transition-colors hover:bg-neutral-300 dark:hover:bg-neutral-700"
+          classname="flex size-6 cursor-default items-center justify-center rounded-md border border-neutral-200 bg-neutral-100 transition-colors hover:bg-neutral-300 dark:border-neutral-700 dark:bg-muted dark:hover:bg-neutral-700"
         >
-          <div class="inline-flex h-[1.5rem] w-[1.5rem] items-center justify-center gap-2 whitespace-nowrap rounded-md border border-input bg-background text-sm font-medium ring-offset-background transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&amp;_svg]:pointer-events-none [&amp;_svg]:size-4 [&amp;_svg]:shrink-0">
+          <div class="inline-flex size-5 items-center justify-center gap-2 whitespace-nowrap rounded-md border border-input bg-background text-sm font-medium ring-offset-background transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&amp;_svg]:pointer-events-none [&amp;_svg]:size-[15px] [&amp;_svg]:shrink-0">
             <svg
               xmlns="http://www.w3.org/2000/svg"
-              width="20"
-              height="20"
+              width="24"
+              height="24"
               viewbox="0 0 24 24"
               fill="#fafafa"
               stroke="currentColor"
@@ -38,7 +38,7 @@ exports[`save-query > should render correctly 1`] = `
     </gui-tooltip-provider>
   </gui-popover-trigger>
   <gui-popover-content
-    classname="w-full p-0"
+    classname="w-full rounded-xl p-0"
     align="end"
   >
   </gui-popover-content>

--- a/src/gui/test/components/labels/__snapshots__/label-badge.tsx.snap
+++ b/src/gui/test/components/labels/__snapshots__/label-badge.tsx.snap
@@ -4,7 +4,7 @@ exports[`label-badge > should render correctly 1`] = `
 
 <gui-badge
   style="background-color: rgb(6, 182, 212); color: black;"
-  classname="font-medium "
+  classname="font-medium"
 >
   mock-label-1
 </gui-badge>

--- a/src/gui/test/components/labels/__snapshots__/label-select.tsx.snap
+++ b/src/gui/test/components/labels/__snapshots__/label-select.tsx.snap
@@ -2,14 +2,14 @@
 
 exports[`label-select > should render correctly 1`] = `
 
-<gui-command classname>
+<gui-command>
   <gui-command-input
     value
     classname="w-full"
     placeholder="Search labels"
   >
   </gui-command-input>
-  <gui-command-list classname="rounded-sm">
+  <gui-command-list classname="rounded-xl">
     <gui-command-empty classname="my-3 items-center px-3 py-2">
       <gui-dialog open="false">
         <div class="flex w-full flex-col items-center gap-3">

--- a/src/gui/test/components/labels/__snapshots__/label.tsx.snap
+++ b/src/gui/test/components/labels/__snapshots__/label.tsx.snap
@@ -2,12 +2,12 @@
 
 exports[`label > should render correctly 1`] = `
 
-<div class="group rounded-sm border border-[1px] bg-card transition-colors transition-opacity hover:bg-card-accent border-muted">
+<div class="group rounded-xl border-[1px] bg-card transition-opacity hover:bg-card-accent border-muted">
   <div class="flex grid grid-cols-8 items-center px-3 py-2">
     <div class="col-span-2 flex items-center gap-3">
       <gui-checkbox
         checked="false"
-        classname="border-muted-foreground/25 opacity-0 group-hover:border-muted-foreground/50 group-hover:opacity-100 opacity-0"
+        classname="border-muted-foreground/25 group-hover:border-muted-foreground/50 group-hover:opacity-100 opacity-0"
       >
       </gui-checkbox>
       <gui-label-badge
@@ -24,7 +24,7 @@ exports[`label > should render correctly 1`] = `
     <div class="flex items-center justify-center">
       <gui-button
         variant="ghost"
-        classname="flex items-center justify-center gap-1"
+        classname="flex items-center justify-center gap-1 rounded-lg"
       >
         <span>
           0
@@ -36,7 +36,7 @@ exports[`label > should render correctly 1`] = `
     <div class="flex items-center justify-end">
       <gui-button
         variant="outline"
-        classname="h-[2rem] rounded-sm border border-[1px] border-muted-foreground/25 px-3 text-sm"
+        classname="h-[2rem] rounded-lg border border-[1px] border-muted-foreground/25 px-3 text-sm"
       >
         Edit
       </gui-button>

--- a/src/gui/test/components/queries/__snapshots__/delete-query.tsx.snap
+++ b/src/gui/test/components/queries/__snapshots__/delete-query.tsx.snap
@@ -6,7 +6,11 @@ exports[`delete-query > labels render default 1`] = `
   <gui-tooltip-provider>
     <gui-tooltip open="false">
       <gui-dialog-trigger aschild="true">
-        <gui-button variant="destructive">
+        <gui-button
+          variant="destructive"
+          size="sm"
+          classname="rounded-lg"
+        >
           Delete
         </gui-button>
       </gui-dialog-trigger>

--- a/src/gui/test/components/queries/__snapshots__/saved-item.tsx.snap
+++ b/src/gui/test/components/queries/__snapshots__/saved-item.tsx.snap
@@ -2,12 +2,12 @@
 
 exports[`labels view > labels render default 1`] = `
 
-<div class="group flex flex-col rounded-sm border border-[1px] bg-card transition-colors transition-opacity hover:bg-card-accent border-muted">
+<div class="group flex flex-col rounded-xl border-[1px] bg-card transition-opacity hover:bg-card-accent border-muted">
   <div class="grid grid-cols-12 gap-4 px-3 py-2">
     <div class="col-span-2 flex grow items-center gap-3">
       <gui-checkbox
         checked="false"
-        classname="border-muted-foreground/25 opacity-0 group-hover:border-muted-foreground/50 group-hover:opacity-100 "
+        classname="border-muted-foreground/25 opacity-0 group-hover:border-muted-foreground/50 group-hover:opacity-100"
       >
       </gui-checkbox>
       <p class="truncate text-sm font-medium">
@@ -36,13 +36,13 @@ exports[`labels view > labels render default 1`] = `
     <div class="col-span-2 flex items-center justify-end gap-4">
       <gui-button
         variant="outline"
-        classname="h-[2rem] rounded-sm border border-[1px] border-muted-foreground/25 px-3 text-sm"
+        classname="h-8 rounded-lg border border-[1px] border-muted-foreground/25 px-3 text-sm"
       >
         Edit
       </gui-button>
       <gui-button
         variant="outline"
-        classname="h-[2rem] rounded-sm border border-[1px] border-muted-foreground/25 px-3 text-sm"
+        classname="h-8 rounded-lg border border-[1px] border-muted-foreground/25 px-3 text-sm"
         role="link"
       >
         <span>

--- a/src/gui/test/components/ui/__snapshots__/color-picker.tsx.snap
+++ b/src/gui/test/components/ui/__snapshots__/color-picker.tsx.snap
@@ -6,7 +6,7 @@ exports[`color-picker > should render correctly 1`] = `
   <div class="relative w-full">
     <input
       type="text"
-      class="clear-none flex h-10 rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 dark:bg-neutral-900 w-full"
+      class="clear-none flex h-10 border border-input bg-background px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 dark:bg-neutral-900 w-full rounded-lg"
       placeholder="#00FF5F"
       value="#00FF5F"
     >
@@ -15,7 +15,7 @@ exports[`color-picker > should render correctly 1`] = `
       style="background-color: rgb(0, 255, 95);"
     >
       <input
-        class="relative h-[20px] w-[20px] cursor-default opacity-0"
+        class="relative h-5 w-5 cursor-default opacity-0"
         type="color"
       >
     </div>


### PR DESCRIPTION
### Overview
This PR bugfixes deduping of the 'query matches' cleans up some outstanding styles on the `queries` and `labels` route since the gui redesign.

Notably it also updates some trivial radius styles and light / dark styles across the `queries` and `labels` components and ensures we prefer to consolidate conditional classNames using the `cn` utility instead of relying on template literals.
