### PR TITLE
graph: fix various graph issues

### DIFF
--- a/src/dep-id/src/browser.ts
+++ b/src/dep-id/src/browser.ts
@@ -187,7 +187,7 @@ export const hydrateTuple = (
         throw error('no remoteURL found on remote id', {
           found: tuple,
         })
-      return Spec.parse(name ?? '(unknown)', first)
+      return Spec.parse(name ?? '(unknown)', first, options)
     }
     case 'file': {
       if (!first) {
@@ -210,9 +210,9 @@ export const hydrateTuple = (
       }
       if (!first) {
         // just a normal name@version on the default registry
-        const s = Spec.parse(second)
+        const s = Spec.parseArgs(second, options)
         if (name && s.name !== name) {
-          return Spec.parse(`${name}@npm:${second}`)
+          return Spec.parse(name, `npm:${second}`, options)
         } else {
           return s
         }
@@ -237,7 +237,7 @@ export const hydrateTuple = (
         options,
       )
       return name && s.final.name !== name ?
-          Spec.parse(s.final.name + '@' + s.bareSpec)
+          Spec.parse(s.final.name, s.bareSpec, options)
         : s
     }
     case 'git': {

--- a/src/graph/src/actual/load.ts
+++ b/src/graph/src/actual/load.ts
@@ -280,8 +280,10 @@ const parseDir = (
       if (depId) {
         let h = hydrate(depId, alias, {
           ...options,
-          registry: fromNode.registry,
         })
+        // if the parsed registry value is using the default value, then
+        // the node should inherit the registry value from its parent node
+        h.inheritedRegistry = fromNode.registry
 
         // Check for active modifiers and replace spec even when not loading manifests
         const { spec: modifiedSpec, queryModifier } =
@@ -329,8 +331,10 @@ const parseDir = (
       const depType = shorten(type, alias, fromNode.manifest)
       let spec = Spec.parse(alias, bareSpec, {
         ...options,
-        registry: fromNode.registry,
       })
+      // if the parsed registry value is using the default value, then
+      // the node should inherit the registry value from its parent node
+      spec.inheritedRegistry = fromNode.registry
 
       // Check for active modifiers and replace spec if a modifier is complete
       const { spec: modifiedSpec, queryModifier } =
@@ -388,8 +392,10 @@ const parseDir = (
       const depType = shorten(type, name, fromNode.manifest)
       let spec = Spec.parse(name, bareSpec, {
         ...options,
-        registry: fromNode.registry,
       })
+      // if the parsed registry value is using the default value, then
+      // the node should inherit the registry value from its parent node
+      spec.inheritedRegistry = fromNode.registry
 
       // Check for active modifiers and replace spec for missing dependencies
       const { spec: modifiedSpec, queryModifier } =

--- a/src/graph/src/ideal/build-ideal-from-starting-graph.ts
+++ b/src/graph/src/ideal/build-ideal-from-starting-graph.ts
@@ -52,12 +52,17 @@ export const buildIdealFromStartingGraph = async (
     }
   }
 
-  // add nodes, fetching remote manifests for each dependency to be added
-  await addNodes(options)
+  // hydrate the resolution cache
+  if (options.add.modifiedDependencies) {
+    options.graph.resetResolution()
 
-  // move things into their default locations, if possible
-  for (const node of options.graph.nodes.values()) {
-    node.setDefaultLocation()
+    // add nodes, fetching remote manifests for each dependency to be added
+    await addNodes(options)
+
+    // move things into their default locations, if possible
+    for (const node of options.graph.nodes.values()) {
+      node.setDefaultLocation()
+    }
   }
 
   // removes any dependencies that are listed in the `remove` option

--- a/src/graph/src/lockfile/load-edges.ts
+++ b/src/graph/src/lockfile/load-edges.ts
@@ -48,6 +48,10 @@ export const loadEdges = (
         },
       })
     }
+
+    // sets a registry for this spec to inherit from
+    spec.inheritedRegistry = from.registry
+
     const to =
       toId === 'MISSING' ? undefined : graph.nodes.get(asDepID(toId))
     if (!isDependencyTypeShort(depType)) {
@@ -55,6 +59,7 @@ export const loadEdges = (
         validOptions: [...longDependencyTypes],
       })
     }
+
     graph.addEdge(depType, spec, from, to)
   }
 }

--- a/src/graph/tap-snapshots/test/graph.ts.test.cjs
+++ b/src/graph/tap-snapshots/test/graph.ts.test.cjs
@@ -9,6 +9,30 @@ exports[`test/graph.ts > TAP > Graph > should print with special tag name 1`] = 
 @vltpkg/graph.Graph { lockfileVersion: 0, options: [Object], nodes: {}, edges: {} }
 `
 
+exports[`test/graph.ts > TAP > using placePackage > should add a type=git package 1`] = `
+@vltpkg/graph.Graph {
+  lockfileVersion: 0,
+  options: { registries: {} },
+  nodes: {
+    '··bar@1.0.0': [
+      0,
+      'bar',
+      <3 empty items>,
+      { name: 'bar', version: '1.0.0', dependencies: [Object] }
+    ],
+    '··foo@1.0.0': [ 0, 'foo', <3 empty items>, { name: 'foo', version: '1.0.0' } ],
+    'file·a': [ 0, 'a', <3 empty items>, { name: 'a', version: '1.0.0' } ],
+    'git·github%3Afoo§bar·': [ 0, 'bar', <3 empty items>, { name: 'bar', version: '1.0.0' } ]
+  },
+  edges: {
+    'file·. missing': 'prod ^1.0.0 MISSING',
+    'file·. foo': 'prod ^1.0.0 ··foo@1.0.0',
+    'file·. a': 'prod file:./a file·a',
+    'file·. bar': 'prod github:foo/bar git·github%3Afoo§bar·'
+  }
+}
+`
+
 exports[`test/graph.ts > TAP > using placePackage > should find and fix nameless spec packages 1`] = `
 @vltpkg/graph.Graph {
   lockfileVersion: 0,

--- a/src/graph/tap-snapshots/test/ideal/append-nodes.ts.test.cjs
+++ b/src/graph/tap-snapshots/test/ideal/append-nodes.ts.test.cjs
@@ -99,20 +99,50 @@ exports[`test/ideal/append-nodes.ts > TAP > resolve against the correct registri
     registries: { a: 'https://a.example.com/', b: 'https://b.example.com/' }
   },
   nodes: {
-    '·a·bar@1.2.3': [ 0, 'bar', <3 empty items>, [Object] ],
-    '·a·x@1.99.99': [ 0, 'x', <3 empty items>, [Object] ],
-    '·a·y@1.99.99': [ 0, 'y', <3 empty items>, [Object] ],
-    '·b·baz@1.2.3': [ 0, 'baz', <3 empty items>, [Object] ],
-    '·b·x@1.99.99': [ 0, 'x', <3 empty items>, [Object] ],
-    '·b·y@1000.0.0': [ 0, 'y', <3 empty items>, [Object] ]
+    '·a·bar@1.2.3': [
+      0,
+      'bar',
+      <3 empty items>,
+      { name: 'bar', version: '1.2.3', dependencies: { x: '1.x' } }
+    ],
+    '·a·x@1.99.99': [
+      0,
+      'x',
+      <3 empty items>,
+      {
+        name: 'x',
+        version: '1.99.99',
+        description: 'x on a',
+        dependencies: { y: '1' }
+      }
+    ],
+    '·a·y@1.99.99': [ 0, 'y', <3 empty items>, { name: 'y', version: '1.99.99' } ],
+    '·b·baz@1.2.3': [
+      0,
+      'baz',
+      <3 empty items>,
+      { name: 'baz', version: '1.2.3', dependencies: { x: '1.x' } }
+    ],
+    '·b·x@1.1.1': [
+      0,
+      'x',
+      <3 empty items>,
+      {
+        name: 'x',
+        version: '1.1.1',
+        description: 'x on b',
+        dependencies: { y: '1000' }
+      }
+    ],
+    '·b·y@1000.0.0': [ 0, 'y', <3 empty items>, { name: 'y', version: '1000.0.0' } ]
   },
   edges: {
     'file·. bar': 'prod a:bar@1.x ·a·bar@1.2.3',
-    'file·. baz': 'prod b:bar@1.x ·b·baz@1.2.3',
+    'file·. baz': 'prod b:baz@1.x ·b·baz@1.2.3',
     '·a·bar@1.2.3 x': 'prod 1.x ·a·x@1.99.99',
     '·a·x@1.99.99 y': 'prod 1 ·a·y@1.99.99',
-    '·b·baz@1.2.3 x': 'prod 1.x ·b·x@1.99.99',
-    '·b·x@1.99.99 y': 'prod 1000 ·b·y@1000.0.0'
+    '·b·baz@1.2.3 x': 'prod 1.x ·b·x@1.1.1',
+    '·b·x@1.1.1 y': 'prod 1000 ·b·y@1000.0.0'
   }
 }
 `

--- a/src/graph/tap-snapshots/test/ideal/build-ideal-from-starting-graph.ts.test.cjs
+++ b/src/graph/tap-snapshots/test/ideal/build-ideal-from-starting-graph.ts.test.cjs
@@ -97,7 +97,7 @@ exports[`test/ideal/build-ideal-from-starting-graph.ts > TAP > build from an act
         location: './node_modules/.vlt/··missing@1.0.0/node_modules/missing',
         resolved: 'https://registry.npmjs.org/missing/-/missing-1.0.0.tgz'
       },
-      Edge spec(baz@^1.0.0) -prod-> to: Node {
+      Edge spec(baz@custom:baz@^1.0.0) -prod-> to: Node {
         id: '·custom·baz@1.0.0',
         location: './node_modules/.vlt/·custom·baz@1.0.0/node_modules/baz'
       }
@@ -108,7 +108,11 @@ exports[`test/ideal/build-ideal-from-starting-graph.ts > TAP > build from an act
     location: './packages/workspace-b',
     importer: true,
     edgesOut: [
-      Edge spec(baz@^1.0.0) -prod-> to: Node { ref: '·custom·baz@1.0.0' }
+      Edge spec(baz@^1.0.0) -prod-> to: Node {
+        id: '··baz@1.0.0',
+        location: './node_modules/.vlt/··baz@1.0.0/node_modules/baz',
+        resolved: 'https://registry.npmjs.org/baz/-/baz-1.0.0.tgz'
+      }
     ]
   },
   Node {

--- a/src/graph/test/ideal/append-nodes.ts
+++ b/src/graph/test/ideal/append-nodes.ts
@@ -433,7 +433,7 @@ t.test('resolve against the correct registries', async t => {
   }
   const bxManifest = {
     name: 'x',
-    version: '1.99.99',
+    version: '1.1.1',
     description: 'x on b',
     dependencies: { y: '1000' },
   }
@@ -497,11 +497,11 @@ t.test('resolve against the correct registries', async t => {
   const deps: Dependency[] = [
     {
       type: 'prod',
-      spec: Spec.parse('bar@a:bar@1.x', { registries }),
+      spec: Spec.parse('bar', 'a:bar@1.x', { registries }),
     },
     {
       type: 'prod',
-      spec: Spec.parse('baz@b:bar@1.x', { registries }),
+      spec: Spec.parse('baz', 'b:baz@1.x', { registries }),
     },
   ]
   const add = new Map(deps.map(dep => [dep.spec.name, dep]))
@@ -517,7 +517,7 @@ t.test('resolve against the correct registries', async t => {
     },
     new Set(),
   )
-  t.matchSnapshot(inspect(graph, { colors: false }))
+  t.matchSnapshot(inspect(graph, { colors: false, depth: 4 }))
 })
 
 // Add a basic test for appendNodes that verifies it can handle

--- a/src/graph/test/ideal/build-ideal-from-starting-graph.ts
+++ b/src/graph/test/ideal/build-ideal-from-starting-graph.ts
@@ -538,21 +538,35 @@ t.test('build from an actual graph', async t => {
     graph: actual,
     scurry: new PathScurry(projectRoot),
     add: new Map([
+      // adding an already present version of baz from the custom registry
       [
         joinDepIDTuple(['file', '.']),
         new Map([
           [
             'baz',
-            { type: 'prod', spec: Spec.parse('baz', '^1.0.0') },
+            {
+              type: 'prod',
+              spec: Spec.parse(
+                'baz',
+                'custom:baz@^1.0.0',
+                configData,
+              ),
+            },
           ],
         ]),
       ],
+      // this version of baz being added to workspace-b is going to
+      // use the default registry, unlike the other versions that
+      // were using the custom registry origin/protocol named `custom`
       [
         joinDepIDTuple(['workspace', 'packages/workspace-b']),
         new Map([
           [
             'baz',
-            { type: 'prod', spec: Spec.parse('baz', '^1.0.0') },
+            {
+              type: 'prod',
+              spec: Spec.parse('baz', '^1.0.0', configData),
+            },
           ],
         ]),
       ],

--- a/src/gui/src/state/load-graph.ts
+++ b/src/gui/src/state/load-graph.ts
@@ -210,9 +210,10 @@ export const load = (transfered: TransferData): LoadResponse => {
 
   // populate nodes and edges from loaded data
   const graph = maybeGraph as GraphLike
-  lockfile.loadNodes(graph, transfered.lockfile.nodes)
   const specOptions = loadSpecOptions(transfered.lockfile)
+  lockfile.loadNodes(graph, transfered.lockfile.nodes)
   lockfile.loadEdges(graph, transfered.lockfile.edges, specOptions)
+
   const securityArchive = SecurityArchive.load(
     transfered.securityArchive,
   )

--- a/src/spec/src/browser.ts
+++ b/src/spec/src/browser.ts
@@ -758,6 +758,20 @@ export class Spec implements SpecLike<Spec> {
   }
 
   /**
+   * Sets a registry value that should be used for this spec in case
+   * it is currently just following the default registry.
+   */
+  set inheritedRegistry(reg: string | undefined) {
+    if (
+      reg != null &&
+      this.type === 'registry' &&
+      this.registry === this.options.registry
+    ) {
+      this.registry = reg
+    }
+  }
+
+  /**
    * Should only ever be called with the bit that comes AFTER the #
    * in the git remote url.
    */

--- a/src/spec/src/types.ts
+++ b/src/spec/src/types.ts
@@ -141,7 +141,7 @@ export type SpecLikeBase = {
   /** Is this a spec that overrides another spec? */
   overridden: boolean
 
-  /** tracks the registry that this spec should inherited from */
+  /** tracks the registry that this spec should inherit from */
   set inheritedRegistry(reg: string | undefined)
 
   toString(): string

--- a/src/spec/src/types.ts
+++ b/src/spec/src/types.ts
@@ -141,6 +141,9 @@ export type SpecLikeBase = {
   /** Is this a spec that overrides another spec? */
   overridden: boolean
 
+  /** tracks the registry that this spec should inherited from */
+  set inheritedRegistry(reg: string | undefined)
+
   toString(): string
 }
 


### PR DESCRIPTION
Various fixes to the graph library and some of its auxiliary libraries with the goal of insuring installs are deterministic.

- Added an inheritedRegistry setter to the `Spec` object.
- Added references to the inherited registry to nodes being loaded from the actual file.
- Fixed `@vltpkg/dep-id` hydration, adding missing spec options forwarding and always referencing a name.
- Added the ability to hydrate the resolution cache with nodes loaded from a lockfile

Refs: https://github.com/vltpkg/vltpkg/issues/748