### PR TITLE
graph: deterministic append nodes

### DIFF
--- a/src/graph/src/ideal/append-nodes.ts
+++ b/src/graph/src/ideal/append-nodes.ts
@@ -5,7 +5,11 @@ import type { PackageInfoClient } from '@vltpkg/package-info'
 import { Spec } from '@vltpkg/spec'
 import type { SpecOptions } from '@vltpkg/spec'
 import { longDependencyTypes, normalizeManifest } from '@vltpkg/types'
-import type { DependencyTypeLong, Manifest } from '@vltpkg/types'
+import type {
+  DependencyTypeLong,
+  DependencySaveType,
+  Manifest,
+} from '@vltpkg/types'
 import type { PathScurry } from 'path-scurry'
 import { asDependency, shorten } from '../dependencies.ts'
 import type { Dependency } from '../dependencies.ts'
@@ -69,6 +73,275 @@ const getFileTypeInfo = (
 const isStringArray = (a: unknown): a is string[] =>
   Array.isArray(a) && !a.some(b => typeof b !== 'string')
 
+/**
+ * Represents a manifest fetch operation with all the context needed.
+ */
+type ManifestFetchTask = {
+  spec: Spec
+  type: DependencySaveType
+  fromNode: Node
+  fileTypeInfo?: FileTypeInfo
+  activeModifier?: ModifierActiveEntry
+  queryModifier?: string
+  edgeOptional: boolean
+  manifestPromise: Promise<Manifest | undefined>
+  depth: number
+}
+
+/**
+ * Represents a node placement operation that depends on a resolved manifest.
+ */
+type NodePlacementTask = {
+  fetchTask: ManifestFetchTask
+  manifest: Manifest | undefined
+  node?: Node
+  childDeps?: Dependency[]
+  childModifierRefs?: Map<string, ModifierActiveEntry>
+}
+
+/**
+ * Represents an ongoing append operation for a node and its dependencies.
+ */
+type AppendNodeEntry = {
+  node: Node
+  deps: Dependency[]
+  modifierRefs?: Map<string, ModifierActiveEntry>
+  depth: number
+}
+
+/**
+ * Fetch manifests for dependencies and create placement tasks.
+ */
+const fetchManifestsForDeps = async (
+  packageInfo: PackageInfoClient,
+  graph: Graph,
+  fromNode: Node,
+  deps: Dependency[],
+  scurry: PathScurry,
+  modifierRefs?: Map<string, ModifierActiveEntry>,
+  depth = 0,
+): Promise<NodePlacementTask[]> => {
+  // Create fetch tasks for all dependencies at this level
+  const fetchTasks: ManifestFetchTask[] = []
+
+  for (const { spec: originalSpec, type } of deps) {
+    let spec = originalSpec
+    const fileTypeInfo = getFileTypeInfo(spec, fromNode, scurry)
+    const activeModifier = modifierRefs?.get(spec.name)
+
+    // here is the place we swap specs if a edge modifier was defined
+    const queryModifier = activeModifier?.modifier.query
+    const completeModifier =
+      activeModifier &&
+      activeModifier.interactiveBreadcrumb.current ===
+        activeModifier.modifier.breadcrumb.last
+    if (
+      queryModifier &&
+      completeModifier &&
+      'spec' in activeModifier.modifier
+    ) {
+      spec = activeModifier.modifier.spec
+      if (spec.bareSpec === '-') {
+        continue
+      }
+    }
+
+    const existingNode = graph.findResolution(
+      spec,
+      fromNode,
+      queryModifier,
+    )
+    if (existingNode) {
+      graph.addEdge(type, spec, fromNode, existingNode)
+      continue
+    }
+
+    const edgeOptional =
+      type === 'optional' || type === 'peerOptional'
+
+    // Start manifest fetch immediately for parallel processing
+    const manifestPromise = packageInfo
+      .manifest(spec, { from: scurry.resolve(fromNode.location) })
+      .then(manifest => manifest as Manifest | undefined)
+      .catch((er: unknown) => {
+        // optional deps ignored if inaccessible
+        if (edgeOptional || fromNode.optional) {
+          return undefined
+        }
+        throw er
+      })
+
+    const fetchTask: ManifestFetchTask = {
+      spec,
+      type,
+      fromNode,
+      fileTypeInfo,
+      activeModifier,
+      queryModifier,
+      edgeOptional,
+      manifestPromise,
+      depth,
+    }
+
+    fetchTasks.push(fetchTask)
+  }
+
+  // Create placement tasks
+  const placementTasks: NodePlacementTask[] = []
+  for (const fetchTask of fetchTasks) {
+    const manifest = await fetchTask.manifestPromise
+
+    placementTasks.push({
+      fetchTask,
+      manifest,
+    })
+  }
+
+  return placementTasks
+}
+
+/**
+ * Process placement tasks and collect child dependencies
+ */
+const processPlacementTasks = async (
+  add: Map<string, Dependency>,
+  graph: Graph,
+  options: SpecOptions,
+  placementTasks: NodePlacementTask[],
+  modifiers?: GraphModifier,
+): Promise<{
+  childDepsToProcess: Omit<AppendNodeEntry, 'depth'>[]
+}> => {
+  const childDepsToProcess: Omit<AppendNodeEntry, 'depth'>[] = []
+
+  for (const placementTask of placementTasks) {
+    const { fetchTask, manifest } = placementTask
+    let { spec } = fetchTask
+    const type = fetchTask.type
+    const fromNode = fetchTask.fromNode
+    const fileTypeInfo = fetchTask.fileTypeInfo
+    const activeModifier = fetchTask.activeModifier
+    const queryModifier = fetchTask.queryModifier
+    const edgeOptional = fetchTask.edgeOptional
+
+    // Handle nameless dependencies
+    if (manifest?.name && spec.name === '(unknown)') {
+      const s = add.get(String(spec))
+      if (s) {
+        // removes the previous, placeholder entry key
+        add.delete(String(spec))
+        // replaces spec with a version with the correct name
+        spec = Spec.parse(manifest.name, spec.bareSpec, options)
+        // updates the add map with the fixed up spec
+        const n = asDependency({
+          ...s,
+          spec,
+        })
+        add.set(manifest.name, n)
+      }
+    }
+
+    // handles missing manifest resolution
+    if (!manifest) {
+      if (!edgeOptional && fromNode.isOptional()) {
+        // failed resolution of a non-optional dep of an optional node
+        // have to clean up the dependents
+        removeOptionalSubgraph(graph, fromNode)
+        continue
+      } else if (edgeOptional) {
+        // failed resolution of an optional dep, just ignore it,
+        // nothing to prune because we never added it in the first place.
+        continue
+      } else {
+        throw error('failed to resolve dependency', {
+          spec,
+          from: fromNode.location,
+        })
+      }
+    }
+
+    // places a new node in the graph representing a newly seen dependency
+    const node = graph.placePackage(
+      fromNode,
+      type,
+      spec,
+      normalizeManifest(manifest),
+      fileTypeInfo?.id,
+      queryModifier,
+    )
+
+    /* c8 ignore start - not possible, already ensured manifest */
+    if (!node) {
+      throw error('failed to place package', {
+        from: fromNode.location,
+        spec,
+      })
+    }
+    /* c8 ignore stop */
+
+    // update the node modifier tracker
+    if (activeModifier) {
+      modifiers?.updateActiveEntry(node, activeModifier)
+    }
+
+    // updates graph node information
+    if (fileTypeInfo?.path && fileTypeInfo.isDirectory) {
+      node.location = fileTypeInfo.path
+    }
+    node.setResolved()
+
+    // Collect child dependencies for processing in the next level
+    const bundleDeps = manifest.bundleDependencies
+    const bundled = new Set<string>(
+      (
+        node.id.startsWith('git') ||
+        node.importer ||
+        !isStringArray(bundleDeps)
+      ) ?
+        []
+      : bundleDeps,
+    )
+
+    // recursively process all child dependencies in the manifest
+    const nextDeps: Dependency[] = []
+
+    for (const depTypeName of longDependencyTypes) {
+      const depRecord: Record<string, string> | undefined =
+        manifest[depTypeName]
+
+      if (depRecord && shouldInstallDepType(node, depTypeName)) {
+        for (const [name, bareSpec] of Object.entries(depRecord)) {
+          if (bundled.has(name)) continue
+          nextDeps.push({
+            type: shorten(depTypeName, name, manifest),
+            spec: Spec.parse(name, bareSpec, {
+              ...options,
+              registry: spec.registry,
+            }),
+          })
+        }
+      }
+    }
+
+    if (nextDeps.length > 0) {
+      childDepsToProcess.push({
+        node,
+        deps: nextDeps,
+        modifierRefs: modifiers?.tryDependencies(node, nextDeps),
+      })
+    }
+  }
+
+  return { childDepsToProcess }
+}
+
+/**
+ * Append new nodes in the given `graph` for dependencies specified at `add`
+ * and missing dependencies from the `deps` parameter.
+ *
+ * It also applies any modifiers that applies to a given node as it processes
+ * and builds the graph.
+ */
 export const appendNodes = async (
   add: Map<string, Dependency>,
   packageInfo: PackageInfoClient,
@@ -85,165 +358,67 @@ export const appendNodes = async (
   if (seen.has(fromNode.id)) return
   seen.add(fromNode.id)
 
-  await Promise.all(
-    deps.map(async ({ spec, type }) => {
-      // see if there's a satisfying node in the graph currently
-      const fileTypeInfo = getFileTypeInfo(spec, fromNode, scurry)
-      const activeModifier = modifierRefs?.get(spec.name)
+  // Use a queue for breadth-first processing
+  let currentLevelDeps: AppendNodeEntry[] = [
+    { node: fromNode, deps, modifierRefs, depth: 0 },
+  ]
 
-      // here is the place we swap specs if a edge modifier was defined
-      const queryModifier = activeModifier?.modifier.query
-      const completeModifier =
-        activeModifier &&
-        activeModifier.interactiveBreadcrumb.current ===
-          activeModifier.modifier.breadcrumb.last
-      if (
-        queryModifier &&
-        completeModifier &&
-        'spec' in activeModifier.modifier
-      ) {
-        spec = activeModifier.modifier.spec
-        if (spec.bareSpec === '-') {
-          return
-        }
-      }
+  while (currentLevelDeps.length > 0) {
+    const nextLevelDeps: AppendNodeEntry[] = []
 
-      const existingNode = graph.findResolution(
-        spec,
-        fromNode,
-        queryModifier,
-      )
-      if (existingNode) {
-        graph.addEdge(type, spec, fromNode, existingNode)
-        return
-      }
+    // Process all nodes at the current level in parallel
+    const levelResults = await Promise.all(
+      currentLevelDeps.map(
+        async ({
+          node,
+          deps: nodeDeps,
+          modifierRefs: nodeModifierRefs,
+          depth,
+        }: AppendNodeEntry) => {
+          // Mark node as seen when we start processing its dependencies
+          seen.add(node.id)
 
-      const edgeOptional =
-        type === 'optional' || type === 'peerOptional'
-      const mani = await packageInfo
-        .manifest(spec, { from: scurry.resolve(fromNode.location) })
-        .catch((er: unknown) => {
-          // optional deps ignored if inaccessible
-          if (edgeOptional || fromNode.optional) {
-            return undefined
-          }
-          throw er
-        })
-
-      // when an user is adding a nameless dependency, e.g: `github:foo/bar`,
-      // `file:./foo/bar`, we need to update the `add` option value to set the
-      // correct name once we have it, so that it can properly be stored in
-      // the `package.json` file at the end of reify.
-      if (mani?.name && spec.name === '(unknown)') {
-        const s = add.get(String(spec))
-        if (s) {
-          // removes the previous, placeholder entry key
-          add.delete(String(spec))
-          // replaces spec with a version with the correct name
-          spec = Spec.parse(mani.name, spec.bareSpec, options)
-          // updates the add map with the fixed up spec
-          const n = asDependency({
-            ...s,
-            spec,
-          })
-          add.set(mani.name, n)
-        }
-      }
-
-      if (!mani) {
-        if (!edgeOptional && fromNode.isOptional()) {
-          // failed resolution of a non-optional dep of an optional node
-          // have to clean up the dependents
-          removeOptionalSubgraph(graph, fromNode)
-          return
-        } else if (edgeOptional) {
-          // failed resolution of an optional dep, just ignore it,
-          // nothing to prune because we never added it in the first place.
-          return
-        } else {
-          throw error('failed to resolve dependency', {
-            spec,
-            from: fromNode.location,
-          })
-        }
-      }
-
-      const node = graph.placePackage(
-        fromNode,
-        type,
-        spec,
-        normalizeManifest(mani as Manifest),
-        fileTypeInfo?.id,
-        queryModifier,
-      )
-
-      /* c8 ignore start - not possible, already ensured manifest */
-      if (!node) {
-        throw error('failed to place package', {
-          from: fromNode.location,
-          spec,
-        })
-      }
-      /* c8 ignore stop */
-
-      if (activeModifier) {
-        modifiers?.updateActiveEntry(node, activeModifier)
-      }
-
-      if (fileTypeInfo?.path && fileTypeInfo.isDirectory) {
-        node.location = fileTypeInfo.path
-      }
-      node.setResolved()
-      const nestedAppends: Promise<unknown>[] = []
-
-      const bundleDeps = node.manifest?.bundleDependencies
-      const bundled = new Set<string>(
-        (
-          node.id.startsWith('git') ||
-          node.importer ||
-          !isStringArray(bundleDeps)
-        ) ?
-          []
-        : bundleDeps,
-      )
-
-      const nextDeps: Dependency[] = []
-
-      for (const depTypeName of longDependencyTypes) {
-        const depRecord: Record<string, string> | undefined =
-          mani[depTypeName]
-
-        if (depRecord && shouldInstallDepType(node, depTypeName)) {
-          for (const [name, bareSpec] of Object.entries(depRecord)) {
-            if (bundled.has(name)) continue
-            nextDeps.push({
-              type: shorten(depTypeName, name, mani),
-              spec: Spec.parse(name, bareSpec, {
-                ...options,
-                registry: spec.registry,
-              }),
-            })
-          }
-        }
-      }
-
-      if (nextDeps.length) {
-        nestedAppends.push(
-          appendNodes(
-            add,
+          // Fetch manifests for this node's dependencies
+          const placementTasks = await fetchManifestsForDeps(
             packageInfo,
             graph,
             node,
-            nextDeps,
+            // Sort dependencies by spec.name for deterministic ordering
+            nodeDeps.sort((a, b) =>
+              a.spec.name.localeCompare(b.spec.name, 'en'),
+            ),
             scurry,
+            nodeModifierRefs,
+            depth,
+          )
+
+          // Process the placement tasks and get child dependencies
+          return await processPlacementTasks(
+            add,
+            graph,
             options,
-            seen,
+            placementTasks,
             modifiers,
-            modifiers?.tryDependencies(node, nextDeps),
-          ),
-        )
+          )
+        },
+      ),
+    )
+
+    // Collect all child dependencies for the next level
+    for (const { childDepsToProcess } of levelResults) {
+      for (const childDep of childDepsToProcess) {
+        if (!seen.has(childDep.node.id)) {
+          /* c8 ignore next */
+          const currentDepth = currentLevelDeps[0]?.depth ?? 0
+          nextLevelDeps.push({
+            ...childDep,
+            depth: currentDepth + 1,
+          })
+        }
       }
-      await Promise.all(nestedAppends)
-    }),
-  )
+    }
+
+    // Move to the next level
+    currentLevelDeps = nextLevelDeps
+  }
 }

--- a/src/graph/test/ideal/append-nodes.ts
+++ b/src/graph/test/ideal/append-nodes.ts
@@ -864,3 +864,111 @@ t.test(
     t.ok(barNode, 'bar node should be added as a nested dependency')
   },
 )
+
+// Failing test capturing nondeterminism from concurrent manifest resolution
+t.test(
+  'appendNodes produces deterministic graphs under varying timings',
+  async t => {
+    const mainManifest = {
+      name: 'root',
+      version: '1.0.0',
+      dependencies: {
+        '@vltpkg/a': '1',
+        '@vltpkg/b': '1',
+      },
+    }
+
+    const sleep = (ms: number) => new Promise(r => setTimeout(r, ms))
+
+    const makePackageInfo = (delays: {
+      a: number
+      b: number
+      c1: number
+      c12: number
+    }) => {
+      const pkgInfo = {
+        async manifest(spec: Spec) {
+          const name = spec.name
+          switch (name) {
+            case '@vltpkg/a': {
+              await sleep(delays.a)
+              return {
+                name,
+                version: '1.0.0',
+                dependencies: { '@vltpkg/c': '1' },
+              }
+            }
+            case '@vltpkg/b': {
+              await sleep(delays.b)
+              return {
+                name,
+                version: '1.0.0',
+                dependencies: { '@vltpkg/c': '1 || 2' },
+              }
+            }
+            case '@vltpkg/c': {
+              // choose version based on requested range, with different delays
+              if (spec.bareSpec.trim() === '1') {
+                await sleep(delays.c1)
+                return { name, version: '1.0.0' }
+              } else {
+                await sleep(delays.c12)
+                return { name, version: '2.0.0' }
+              }
+            }
+            default:
+              return null
+          }
+        },
+      } as unknown as PackageInfoClient
+      return pkgInfo
+    }
+
+    const buildGraph = async (delays: {
+      a: number
+      b: number
+      c1: number
+      c12: number
+    }) => {
+      const graph = new Graph({
+        projectRoot: t.testdirName,
+        ...configData,
+        mainManifest,
+      })
+      const deps: Dependency[] = [
+        asDependency({
+          spec: Spec.parse('@vltpkg/a', '1'),
+          type: 'prod',
+        }),
+        asDependency({
+          spec: Spec.parse('@vltpkg/b', '1'),
+          type: 'prod',
+        }),
+      ]
+      const add = new Map(deps.map(d => [d.spec.name, d]))
+      await appendNodes(
+        add,
+        makePackageInfo(delays),
+        graph,
+        graph.mainImporter,
+        deps,
+        new PathScurry(t.testdirName),
+        configData,
+        new Set(),
+      )
+      return graph
+    }
+
+    // First build: favor resolving b and c@2 first
+    const graph1 = await buildGraph({ a: 20, b: 0, c1: 30, c12: 0 })
+
+    // Second build: favor resolving a and c@1 first
+    const graph2 = await buildGraph({ a: 0, b: 20, c1: 0, c12: 30 })
+
+    t.same(
+      graph1.toJSON(),
+      graph2.toJSON(),
+      'graphs should be equal regardless of manifest resolution timing',
+    )
+  },
+)


### PR DESCRIPTION
Refactors the append nodes step of building an ideal graph so that the manifest fetching logic is split from the graph-building logic, allowing for concurrently retrieving manifest data while adding determinism to the graph building order.

Refs: https://github.com/vltpkg/vltpkg/issues/748
Refs: https://github.com/vltpkg/vltpkg/pull/1094