### PR TITLE
fix(cli-sdk): render elapsed install time as part of ink output

### DIFF
--- a/infra/smoke-test/test/install.ts
+++ b/infra/smoke-test/test/install.ts
@@ -26,7 +26,7 @@ t.test('install a package', async t => {
 })
 
 t.test('tty', { skip: process.platform === 'win32' }, async t => {
-  const { output } = await runMultiple(t, ['i', 'abbrev'], {
+  const { status, output } = await runMultiple(t, ['i', 'abbrev'], {
     tty: true,
     match: ['status'],
     cleanOutput: v =>
@@ -39,4 +39,5 @@ t.test('tty', { skip: process.platform === 'win32' }, async t => {
   t.match(output, 'build')
   t.match(output, 'actual')
   t.match(output, 'reify')
+  t.equal(status, 0)
 })

--- a/src/cli-sdk/src/commands/install/reporter.ts
+++ b/src/cli-sdk/src/commands/install/reporter.ts
@@ -9,7 +9,6 @@ import {
   useEffect,
   useState,
 } from 'react'
-import { stdout } from '../../output.ts'
 import { ViewClass } from '../../view.ts'
 import { asError } from '@vltpkg/types'
 
@@ -32,7 +31,7 @@ const GraphStep = ({ text, step }: { text: string; step: Step }) => {
   return $(Text, { color: 'green' }, text, ' ✓')
 }
 
-const App = () => {
+const App = ({ trailer }: { trailer?: string }) => {
   const [requests, setRequests] = useState(0)
 
   const [steps, setSteps] = useState<
@@ -88,6 +87,7 @@ const App = () => {
       ),
     ),
     requests > 0 ? $(Text, null, `${requests} requests`) : null,
+    trailer ? $(Text, null, trailer) : null,
   )
 }
 
@@ -99,8 +99,7 @@ export class InstallReporter extends ViewClass {
   }
 
   async done(_result: unknown, { time }: { time: number }) {
-    await this.#instance?.waitUntilExit()
-    stdout(`Done in ${time}ms`)
+    this.#instance?.rerender($(App, { trailer: `Done in ${time}ms` }))
     return undefined
   }
 


### PR DESCRIPTION
This allows us to not use waitUntilExit() which for some reason results in
the process exiting with a 13 status code.

Fixes: https://github.com/vltpkg/vltpkg/issues/1123
