### PR TITLE
fix: create path for user level config if it doesnt exist

### DIFF
--- a/src/vlt-json/src/index.ts
+++ b/src/vlt-json/src/index.ts
@@ -1,9 +1,14 @@
 import { error } from '@vltpkg/error-cause'
 import { XDG } from '@vltpkg/xdg'
 import type { Stats } from 'node:fs'
-import { lstatSync, readFileSync, writeFileSync } from 'node:fs'
+import {
+  lstatSync,
+  mkdirSync,
+  readFileSync,
+  writeFileSync,
+} from 'node:fs'
 import { homedir } from 'node:os'
-import { resolve } from 'node:path'
+import { dirname, resolve } from 'node:path'
 import { walkUp } from 'walk-up-path'
 
 import {
@@ -231,6 +236,9 @@ export const save = (
   if (!extraStringifyOptions[kNewline]) {
     extraStringifyOptions[kNewline] = '\n'
   }
+
+  // Ensure the directory exists before writing the file
+  mkdirSync(dirname(path), { recursive: true })
 
   writeFileSync(
     path,

--- a/src/vlt-json/test/index.ts
+++ b/src/vlt-json/test/index.ts
@@ -337,3 +337,53 @@ t.test('do not walk up past a .git folder', async t => {
   unload()
   t.equal(load('root', assertBool), false)
 })
+
+t.test(
+  'create directories when saving to non-existent path',
+  async t => {
+    const dir = t.testdir({
+      a: {
+        b: {
+          'package.json': JSON.stringify({}),
+          c: {},
+        },
+      },
+    })
+    t.chdir(resolve(dir, 'a/b/c'))
+
+    const { load, save, find } = await t.mockImport<
+      typeof import('../src/index.ts')
+    >('../src/index.ts', {
+      'node:os': t.createMock(await import('node:os'), {
+        homedir: () => t.testdirName,
+      }),
+    })
+
+    // The find function should return a path that doesn't exist yet
+    const configPath = find()
+    t.equal(configPath, resolve(dir, 'a/b/vlt.json'))
+
+    // Directory doesn't exist initially
+    t.equal(
+      await lstat(resolve(dir, 'a/b/vlt.json')).catch(() => false),
+      false,
+    )
+
+    const assertBool = (b: unknown): asserts b is boolean => {
+      if (b !== !!b) throw new Error('expected boolean')
+    }
+
+    // Load should return undefined since file doesn't exist
+    t.equal(load('testField', assertBool), undefined)
+
+    // Save should create the directory and file
+    save('testField', true)
+
+    // File should now exist and contain the saved data
+    const content = readFileSync(configPath, 'utf8')
+    t.equal(
+      content,
+      JSON.stringify({ testField: true }, null, 2) + '\n',
+    )
+  },
+)


### PR DESCRIPTION
`vlt config set ... --config=user` silently fails today if the `vlt.json` doesn't exists as it's not able to create it in the path (because the `vlt` dir also doesn't exist in the path to the user-level config).