### PR TITLE
registry-client: memory management cleanup

### DIFF
--- a/src/error-cause/src/index.ts
+++ b/src/error-cause/src/index.ts
@@ -114,7 +114,7 @@ export type ErrorCauseOptions = {
     | {
         statusCode: number
         headers?:
-          | Buffer[]
+          | Uint8Array[]
           | Record<string, string[] | string>
           | IncomingHttpHeaders
         text?: () => string

--- a/src/registry-client/src/cache-entry.ts
+++ b/src/registry-client/src/cache-entry.ts
@@ -590,7 +590,7 @@ export class CacheEntry {
     // header chunks: [len, bytes] for each header item
     const headerChunks: Uint8Array[] = []
     for (const h of this.#headers) {
-      const l = 4 + h.byteLength
+      const l = headLenBytes.byteLength + h.byteLength
       const lb = new Uint8Array(4)
       lb[0] = (l >> 24) & 0xff
       lb[1] = (l >> 16) & 0xff
@@ -606,7 +606,9 @@ export class CacheEntry {
       headerChunks.reduce((n, b) => n + b.byteLength, 0) +
       this._body.byteLength
 
-    const out = new Uint8Array(total)
+    // returns the concatenate buffer with all the pieces
+    const outBuffer = new ArrayBuffer(total)
+    const out = Buffer.from(outBuffer, 0, total)
     let off = 0
     out.set(headLenBytes, off)
     off += headLenBytes.byteLength
@@ -617,7 +619,7 @@ export class CacheEntry {
       off += chunk.byteLength
     }
     out.set(this._body, off)
-    return Buffer.from(out)
+    return out
   }
 }
 

--- a/src/registry-client/src/cache-entry.ts
+++ b/src/registry-client/src/cache-entry.ts
@@ -28,10 +28,14 @@ import type { InspectOptions } from 'node:util'
 import { inspect } from 'node:util'
 import { gunzipSync } from 'node:zlib'
 import { getRawHeader, setRawHeader } from './raw-header.ts'
+import {
+  getDecodedValue,
+  getEncondedValue,
+} from './string-encoding.ts'
 
 export type JSONObj = Record<string, JSONField>
 
-const readSize = (buf: Buffer, offset: number) => {
+const readSize = (buf: Uint8Array, offset: number) => {
   const a = buf[offset]
   const b = buf[offset + 1]
   const c = buf[offset + 2]
@@ -57,6 +61,21 @@ const readSize = (buf: Buffer, offset: number) => {
 const kCustomInspect = Symbol.for('nodejs.util.inspect.custom')
 
 export type CacheEntryOptions = {
+  /**
+   * An optional body to use.
+   *
+   * This is used when decoding a cache entry from a buffer, and the body
+   * is already in a ArrayBuffer we can use. When this option is
+   * provided the `addBody` method should not be used.
+   */
+  body?: Uint8Array
+
+  /**
+   * An optional content length of the body to use, if undefined the
+   * content-length header will be used.
+   */
+  contentLength?: number
+
   /**
    * The expected integrity value for this response body
    */
@@ -91,9 +110,12 @@ export type CacheEntryOptions = {
 
 export class CacheEntry {
   #statusCode: number
-  #headers: Buffer[]
-  #body: Buffer[] = []
+  #headers: Uint8Array[]
+  #body?: Uint8Array
+  #bodyParts: Uint8Array[] = []
+  /** Used to track the length of the body while reading chunks */
   #bodyLength = 0
+  #contentLength?: number
   #integrity?: Integrity
   #integrityActual?: Integrity
   #json?: JSONObj
@@ -102,12 +124,14 @@ export class CacheEntry {
 
   constructor(
     statusCode: number,
-    headers: Buffer[],
+    headers: Uint8Array[],
     {
+      body,
       integrity,
       trustIntegrity = false,
       'stale-while-revalidate-factor':
         staleWhileRevalidateFactor = 60,
+      contentLength,
     }: CacheEntryOptions = {},
   ) {
     this.#headers = headers
@@ -115,13 +139,34 @@ export class CacheEntry {
     this.#trustIntegrity = trustIntegrity
     this.#staleWhileRevalidateFactor = staleWhileRevalidateFactor
     if (integrity) this.integrity = integrity
+
+    // if content-legnth is known then we'll only allocate that much memory
+    // and we'll avoid copying memory around when adding new chunks.
+    if (contentLength != null && typeof contentLength === 'number') {
+      this.#contentLength = contentLength
+    }
+
+    // if a body is provided then use that, in this case the `addBody`
+    // method should no longer be used.
+    if (body) {
+      const buffer = new ArrayBuffer(body.byteLength)
+      this.#body = new Uint8Array(buffer, 0, body.byteLength)
+      this.#body.set(body, 0)
+      this.#bodyLength = body.byteLength
+      /* c8 ignore start */
+    } else if (this.#contentLength) {
+      const buffer = new ArrayBuffer(this.#contentLength)
+      this.#body = new Uint8Array(buffer, 0, this.#contentLength)
+      this.#bodyLength = 0
+    }
+    /* c8 ignore stop */
   }
 
   get #headersAsObject(): [string, string][] {
     const ret: [string, string][] = []
     for (let i = 0; i < this.#headers.length - 1; i += 2) {
-      const key = String(this.#headers[i])
-      const val = String(this.#headers[i + 1])
+      const key = getDecodedValue(this.#headers[i])
+      const val = getDecodedValue(this.#headers[i + 1])
       ret.push([key, val])
     }
     return ret
@@ -178,7 +223,7 @@ export class CacheEntry {
   #date?: Date
   get date(): Date | undefined {
     if (this.#date) return this.#date
-    const dh = this.getHeader('date')?.toString()
+    const dh = this.getHeaderString('date')
     if (dh) this.#date = new Date(dh)
     return this.#date
   }
@@ -197,7 +242,7 @@ export class CacheEntry {
   #cacheControl?: ccp.CacheControl
   get cacheControl(): ccp.CacheControl {
     if (this.#cacheControl) return this.#cacheControl
-    const cc = this.getHeader('cache-control')?.toString()
+    const cc = this.getHeaderString('cache-control')
     this.#cacheControl = cc ? ccp.parse(cc) : {}
     return this.#cacheControl
   }
@@ -219,8 +264,7 @@ export class CacheEntry {
   #contentType?: string
   get contentType() {
     if (this.#contentType !== undefined) return this.#contentType
-    this.#contentType =
-      this.getHeader('content-type')?.toString() ?? ''
+    this.#contentType = this.getHeaderString('content-type') ?? ''
     return this.#contentType
   }
 
@@ -250,16 +294,39 @@ export class CacheEntry {
     return this.#valid
   }
 
-  addBody(b: Buffer) {
-    this.#body.push(b)
-    this.#bodyLength += b.byteLength
+  /**
+   * Add contents to the entry body.
+   */
+  addBody(b: Uint8Array) {
+    // when the content length is uknown we copy memory and concatenate
+    // it into a new buffer, otherwise we just append the new chunk of
+    // bytes to the already allocated buffer.
+    if (!this.#body) {
+      this.#bodyParts.push(b)
+      this.#bodyLength += b.byteLength
+    } else {
+      this.#body.set(b, this.#bodyLength)
+      this.#bodyLength += b.byteLength
+    }
   }
 
   get statusCode() {
     return this.#statusCode
   }
-  get headers() {
+  get headers(): Uint8Array[] {
     return this.#headers
+  }
+
+  get _body(): Uint8Array {
+    if (this.#body) return this.#body
+    const buffer = new ArrayBuffer(this.#bodyLength)
+    const b = new Uint8Array(buffer, 0, this.#bodyLength)
+    let off = 0
+    for (const part of this.#bodyParts) {
+      b.set(part, off)
+      off += part.byteLength
+    }
+    return b
   }
 
   /**
@@ -294,7 +361,7 @@ export class CacheEntry {
   get integrityActual(): Integrity {
     if (this.#integrityActual) return this.#integrityActual
     const hash = createHash('sha512')
-    for (const buf of this.#body) hash.update(buf)
+    hash.update(this._body)
     const i: Integrity = `sha512-${hash.digest('base64')}`
     this.integrityActual = i
     return i
@@ -318,14 +385,24 @@ export class CacheEntry {
   /**
    * Give it a key, and it'll return the buffer of that header value
    */
-  getHeader(h: string) {
+  getHeader(h: string): Uint8Array | undefined {
     return getRawHeader(this.#headers, h)
+  }
+
+  /**
+   * Give it a key, and it'll return the decoded string of that header value
+   */
+  getHeaderString(h: string): string | undefined {
+    const value = getRawHeader(this.#headers, h)
+    if (value) {
+      return getDecodedValue(value)
+    }
   }
 
   /**
    * Set a header to a specific value
    */
-  setHeader(h: string, value: Buffer | string) {
+  setHeader(h: string, value: Uint8Array | string) {
     this.#headers = setRawHeader(this.#headers, h, value)
   }
 
@@ -333,24 +410,23 @@ export class CacheEntry {
    * Return the body of the entry as a Buffer
    */
   buffer(): Buffer {
-    const b = this.#body[0]
-    if (!b) return Buffer.allocUnsafe(0)
-    if (this.#body.length === 1) return b
-    const cat = Buffer.concat(this.#body, this.#bodyLength)
-    this.#body = [cat]
-    return cat
+    return Buffer.from(
+      this._body.buffer,
+      this._body.byteOffset,
+      this._body.byteLength,
+    )
   }
 
   // return the buffer if it's a tarball, or the parsed
   // JSON if it's not.
-  get body(): Buffer | Record<string, any> {
+  get body(): Uint8Array | Record<string, any> {
     return this.isJSON ? this.json() : this.buffer()
   }
 
   #isJSON?: boolean
   get isJSON(): boolean {
     if (this.#isJSON !== undefined) return this.#isJSON
-    const ct = this.getHeader('content-type')?.toString()
+    const ct = this.getHeaderString('content-type')
     // if it says it's json, assume json
     if (ct) return (this.#isJSON = /\bjson\b/.test(ct))
     const text = this.text()
@@ -365,9 +441,9 @@ export class CacheEntry {
   #isGzip?: boolean
   get isGzip(): boolean {
     if (this.#isGzip !== undefined) return this.#isGzip
-    const ce = this.getHeader('content-encoding')?.toString()
+    const ce = this.getHeaderString('content-encoding')
     if (ce && !/\bgzip\b/.test(ce)) return (this.#isGzip = false)
-    const buf = this.buffer()
+    const buf = this._body
     if (buf.length < 2) return false
     this.#isGzip = buf[0] === 0x1f && buf[1] === 0x8b
     if (this.#isGzip) {
@@ -389,14 +465,16 @@ export class CacheEntry {
       // we know that if we know it's gzip, that the body has been
       // flattened to a single buffer, so save the extra call.
       /* c8 ignore start */
-      if (this.#body[0] == null)
+      if (this._body.length === 0)
         throw error('Invalid buffer, cant unzip')
       /* c8 ignore stop */
-      const b = gunzipSync(this.#body[0])
+      const b = gunzipSync(this._body)
       this.setHeader('content-encoding', 'identity')
-      this.#body = [b]
-      this.#bodyLength = b.byteLength
-      this.setHeader('content-length', String(this.#bodyLength))
+      const u8 = new Uint8Array(b.buffer, b.byteOffset, b.byteLength)
+      this.#body = u8
+      this.#bodyLength = u8.byteLength
+      this.#contentLength = u8.byteLength
+      this.setHeader('content-length', String(this.#contentLength))
       this.#isGzip = false
       return true
     }
@@ -409,7 +487,7 @@ export class CacheEntry {
    */
   text() {
     this.unzip()
-    return this.buffer().toString()
+    return getDecodedValue(this._body)
   }
 
   /**
@@ -428,7 +506,7 @@ export class CacheEntry {
    * and this static method will decode it into a CacheEntry representing
    * the cached response.
    */
-  static decode(buffer: Buffer): CacheEntry {
+  static decode(buffer: Uint8Array): CacheEntry {
     if (buffer.length < 4) {
       return emptyCacheEntry
     }
@@ -436,21 +514,22 @@ export class CacheEntry {
     if (buffer.length < headSize) {
       return emptyCacheEntry
     }
-    const statusCode = Number(buffer.subarray(4, 7).toString())
+    const statusCode = Number(getDecodedValue(buffer.subarray(4, 7)))
     const headersBuffer = buffer.subarray(7, headSize)
-    // walk through the headers array, building up the rawHeaders Buffer[]
-    const headers: Buffer[] = []
+    // walk through the headers array, building up the rawHeaders
+    const headers: Uint8Array[] = []
     let i = 0
     let integrity: Integrity | undefined = undefined
     while (i < headersBuffer.length - 4) {
       const size = readSize(headersBuffer, i)
       const val = headersBuffer.subarray(i + 4, i + size)
       // if the last one was the key integrity, then this one is the value
-      if (
-        headers.length % 2 === 1 &&
-        String(headers[headers.length - 1]) === 'integrity'
-      ) {
-        integrity = String(val) as Integrity
+      if (headers.length % 2 === 1) {
+        const k = getDecodedValue(
+          headers[headers.length - 1],
+        ).toLowerCase()
+        if (k === 'integrity')
+          integrity = getDecodedValue(val) as Integrity
       }
       headers.push(val)
       i += size
@@ -465,13 +544,13 @@ export class CacheEntry {
         String(body.byteLength),
       ),
       {
+        body,
         integrity,
         trustIntegrity: true,
+        contentLength: body.byteLength,
       },
     )
 
-    c.#body = [body]
-    c.#bodyLength = body.byteLength
     if (c.isJSON) {
       try {
         c.json()
@@ -482,7 +561,7 @@ export class CacheEntry {
     return c
   }
 
-  static isGzipEntry(buffer: Buffer): boolean {
+  static isGzipEntry(buffer: Uint8Array): boolean {
     if (buffer.length < 4) return false
     const headSize = readSize(buffer, 0)
     const gzipBytes = buffer.subarray(headSize, headSize + 2)
@@ -492,43 +571,54 @@ export class CacheEntry {
   /**
    * Encode the entry as a single Buffer for writing to the cache
    */
-  // TODO: should this maybe not concat, and just return Buffer[]?
-  // Then we can writev it to the cache file and save the memory copy
   encode(): Buffer {
     if (this.isJSON) this.json()
-    const sb = Buffer.from(String(this.#statusCode))
-    const chunks: Buffer[] = [sb]
-    let headLength = sb.byteLength + 4
+    const statusStr = String(this.#statusCode)
+    const statusBytes = getEncondedValue(statusStr)
+
+    // compute headLength = 4 (length field itself) + statusBytes + Σ(4 + headerLen) for each header item
+    let headLength = 4 + statusBytes.byteLength
+    for (const h of this.#headers) headLength += 4 + h.byteLength
+
+    // allocate and fill head length prefix (big-endian)
+    const headLenBytes = new Uint8Array(4)
+    headLenBytes[0] = (headLength >> 24) & 0xff
+    headLenBytes[1] = (headLength >> 16) & 0xff
+    headLenBytes[2] = (headLength >> 8) & 0xff
+    headLenBytes[3] = headLength & 0xff
+
+    // header chunks: [len, bytes] for each header item
+    const headerChunks: Uint8Array[] = []
     for (const h of this.#headers) {
-      const hlBuf = Buffer.allocUnsafe(4)
-      const hl = h.byteLength + 4
-      headLength += hl
-      hlBuf.set(
-        [
-          (hl >> 24) & 0xff,
-          (hl >> 16) & 0xff,
-          (hl >> 8) & 0xff,
-          hl & 0xff,
-        ],
-        0,
-      )
-      chunks.push(hlBuf, h)
+      const l = 4 + h.byteLength
+      const lb = new Uint8Array(4)
+      lb[0] = (l >> 24) & 0xff
+      lb[1] = (l >> 16) & 0xff
+      lb[2] = (l >> 8) & 0xff
+      lb[3] = l & 0xff
+      headerChunks.push(lb, h)
     }
 
-    const hlBuf = Buffer.allocUnsafe(4)
-    hlBuf.set(
-      [
-        (headLength >> 24) & 0xff,
-        (headLength >> 16) & 0xff,
-        (headLength >> 8) & 0xff,
-        headLength & 0xff,
-      ],
-      0,
-    )
-    chunks.unshift(hlBuf)
-    chunks.push(...this.#body)
-    return Buffer.concat(chunks, headLength + this.#bodyLength)
+    // total size
+    const total =
+      headLenBytes.byteLength +
+      statusBytes.byteLength +
+      headerChunks.reduce((n, b) => n + b.byteLength, 0) +
+      this._body.byteLength
+
+    const out = new Uint8Array(total)
+    let off = 0
+    out.set(headLenBytes, off)
+    off += headLenBytes.byteLength
+    out.set(statusBytes, off)
+    off += statusBytes.byteLength
+    for (const chunk of headerChunks) {
+      out.set(chunk, off)
+      off += chunk.byteLength
+    }
+    out.set(this._body, off)
+    return Buffer.from(out)
   }
 }
 
-const emptyCacheEntry = new CacheEntry(0, [])
+const emptyCacheEntry = new CacheEntry(0, [], { contentLength: 0 })

--- a/src/registry-client/src/handle-304-response.ts
+++ b/src/registry-client/src/handle-304-response.ts
@@ -9,7 +9,7 @@ export const handle304Response = (
 
   const d =
     String(resp.headers.date ?? '') || new Date().toUTCString()
-  entry.setHeader('date', Buffer.from(d))
+  entry.setHeader('date', d)
   // shouldn't have a body, but just in case.
   resp.body.resume()
   return true

--- a/src/registry-client/src/raw-header.ts
+++ b/src/registry-client/src/raw-header.ts
@@ -1,14 +1,22 @@
+import {
+  getDecodedValue,
+  getEncondedValue,
+} from './string-encoding.ts'
+
 /**
- * Give it a key, and it'll return the buffer of that header value
+ * Give it a key, and it'll return the value of that header as a Uint8Array
  */
-export const getRawHeader = (headers: Buffer[], k: string) => {
-  k = k.toLowerCase()
+export const getRawHeader = (
+  headers: Uint8Array[],
+  key: string,
+): Uint8Array | undefined => {
+  const k = key.toLowerCase()
   for (let i = 0; i < headers.length; i += 2) {
     const name = headers[i]
     if (
       name &&
-      name.length === k.length &&
-      name.toString().toLowerCase() === k
+      name.length === key.length &&
+      getDecodedValue(name).toLowerCase() === k
     ) {
       return headers[i + 1]
     }
@@ -19,25 +27,26 @@ export const getRawHeader = (headers: Buffer[], k: string) => {
  * Give it a key and value, and it'll overwrite or add the header entry
  */
 export const setRawHeader = (
-  headers: Buffer[],
-  k: string,
-  v: Buffer | string,
-): Buffer[] => {
-  k = k.toLowerCase()
-  const value = typeof v === 'string' ? Buffer.from(v) : v
+  headers: Uint8Array[],
+  key: string,
+  value: Uint8Array | string,
+): Uint8Array[] => {
+  const k = key.toLowerCase()
+  const encVal =
+    typeof value === 'string' ? getEncondedValue(value) : value
   for (let i = 0; i < headers.length; i += 2) {
     const name = headers[i]
     if (
       name &&
       name.length === k.length &&
-      name.toString().toLowerCase() === k
+      getDecodedValue(name).toLowerCase() === k
     ) {
       return [
         ...headers.slice(0, i + 1),
-        value,
+        encVal,
         ...headers.slice(i + 2),
       ]
     }
   }
-  return [...headers, Buffer.from(k), value]
+  return [...headers, getEncondedValue(k), encVal]
 }

--- a/src/registry-client/src/redirect.ts
+++ b/src/registry-client/src/redirect.ts
@@ -10,7 +10,7 @@ const redirectStatuses = new Set([301, 302, 303, 307, 308])
 
 export type RedirectResponse = CacheEntry & {
   statusCode: RedirectStatus
-  getHeader(key: 'location'): Buffer
+  getHeader(key: 'location'): Uint8Array | undefined
 }
 
 export const isRedirect = (
@@ -47,7 +47,11 @@ export const redirect = (
       url: from,
     })
   }
-  const location = String(response.getHeader('location'))
+  const location = response.getHeaderString('location')
+  /* c8 ignore start */
+  if (!location)
+    throw error('Location header missing from redirect response')
+  /* c8 ignore stop */
   const nextURL = new URL(location, from)
   if (redirections.has(String(nextURL))) {
     throw error('Redirection cycle detected', {

--- a/src/registry-client/src/set-raw-header.ts
+++ b/src/registry-client/src/set-raw-header.ts
@@ -1,25 +1,31 @@
+import {
+  getDecodedValue,
+  getEncondedValue,
+} from './string-encoding.ts'
+
 /**
  * Given a rawHeaders array of [key, value, key2, value2, ...],
  * overwrite the current value of a header, or if not found, append
  */
 export const setRawHeader = (
-  headers: Buffer[],
+  headers: Uint8Array[],
   key: string,
-  value: Buffer | string,
-) => {
+  value: Uint8Array | string,
+): Uint8Array[] => {
   key = key.toLowerCase()
-  const keyBuf = Buffer.from(key)
-  const valBuf = Buffer.isBuffer(value) ? value : Buffer.from(value)
+  const keyBuf = getEncondedValue(key)
+  const valBuf = getEncondedValue(value)
   for (let i = 0; i < headers.length; i += 2) {
     const k = headers[i]
     if (
       k &&
       k.length === keyBuf.length &&
-      String(k).toLowerCase() === key
+      getDecodedValue(k).toLowerCase() === key
     ) {
       headers[i + 1] = valBuf
-      return
+      return headers
     }
   }
   headers.push(keyBuf, valBuf)
+  return headers
 }

--- a/src/registry-client/src/string-encoding.ts
+++ b/src/registry-client/src/string-encoding.ts
@@ -1,0 +1,28 @@
+const decoder = new TextDecoder()
+const encoder = new TextEncoder()
+
+/**
+ * Decodes a string from a Uint8Array
+ */
+export const getDecodedValue = (
+  value: string | Uint8Array | undefined,
+): string => {
+  if (value == undefined) return ''
+  if (typeof value === 'string') return value
+  const res = decoder.decode(value)
+  return res
+}
+
+/**
+ * Encodes a string to a Uint8Array
+ */
+export const getEncondedValue = (
+  value: Uint8Array | string | undefined,
+): Uint8Array => {
+  if (value == undefined) return new Uint8Array(0)
+  if (typeof value === 'string') {
+    const res = encoder.encode(value)
+    return res
+  }
+  return value
+}

--- a/src/registry-client/test/fixtures/to-raw-headers.ts
+++ b/src/registry-client/test/fixtures/to-raw-headers.ts
@@ -1,7 +1,10 @@
-export const toRawHeaders = (h: Record<string, string>): Buffer[] => {
-  const r: Buffer[] = []
+const encoder = new TextEncoder()
+export const toRawHeaders = (
+  h: Record<string, string>,
+): Uint8Array[] => {
+  const r: Uint8Array[] = []
   for (const [k, v] of Object.entries(h)) {
-    r.push(Buffer.from(k), Buffer.from(v))
+    r.push(encoder.encode(k), encoder.encode(v))
   }
   return r
 }

--- a/src/registry-client/test/raw-header.ts
+++ b/src/registry-client/test/raw-header.ts
@@ -2,57 +2,60 @@ import t from 'tap'
 import { getRawHeader, setRawHeader } from '../src/raw-header.ts'
 
 t.strictSame(
-  getRawHeader([Buffer.from('x'), Buffer.from('y')], 'asdf'),
+  getRawHeader(
+    [new Uint8Array([120]), new Uint8Array([121])],
+    'asdf',
+  ), // 'x', 'y'
   undefined,
 )
 t.strictSame(
-  getRawHeader([Buffer.from('x'), Buffer.from('y')], 'x'),
-  Buffer.from('y'),
+  getRawHeader([new Uint8Array([120]), new Uint8Array([121])], 'x'), // 'x', 'y'
+  new Uint8Array([121]), // 'y'
 )
 t.strictSame(
-  getRawHeader([Buffer.from('x'), Buffer.from('y')], 'X'),
-  Buffer.from('y'),
+  getRawHeader([new Uint8Array([120]), new Uint8Array([121])], 'X'), // 'x', 'y'
+  new Uint8Array([121]), // 'y'
 )
 t.strictSame(
-  getRawHeader([Buffer.from('X'), Buffer.from('y')], 'x'),
-  Buffer.from('y'),
+  getRawHeader([new Uint8Array([88]), new Uint8Array([121])], 'x'), // 'X', 'y'
+  new Uint8Array([121]), // 'y'
 )
 t.strictSame(
-  getRawHeader([Buffer.from('X'), Buffer.from('y')], 'X'),
-  Buffer.from('y'),
+  getRawHeader([new Uint8Array([88]), new Uint8Array([121])], 'X'), // 'X', 'y'
+  new Uint8Array([121]), // 'y'
 )
 
-const h = [Buffer.from('x'), Buffer.from('y')]
+const h = [new Uint8Array([120]), new Uint8Array([121])] // 'x', 'y'
 t.strictSame(setRawHeader(h, 'x', 'a'), [
-  Buffer.from('x'),
-  Buffer.from('a'),
+  new Uint8Array([120]), // 'x'
+  new Uint8Array([97]), // 'a'
 ])
 t.strictSame(setRawHeader(h, 'X', 'b'), [
-  Buffer.from('x'),
-  Buffer.from('b'),
+  new Uint8Array([120]), // 'x'
+  new Uint8Array([98]), // 'b'
 ])
-h[0] = Buffer.from('X')
+h[0] = new Uint8Array([88]) // 'X'
 
 t.strictSame(setRawHeader(h, 'x', 'c'), [
-  Buffer.from('X'),
-  Buffer.from('c'),
+  new Uint8Array([88]), // 'X'
+  new Uint8Array([99]), // 'c'
 ])
 
 const i = setRawHeader(h, 'X', 'd')
-t.strictSame(i, [Buffer.from('X'), Buffer.from('d')])
+t.strictSame(i, [new Uint8Array([88]), new Uint8Array([100])]) // 'X', 'd'
 const j = setRawHeader(i, 'a', 'b')
 t.strictSame(j, [
-  Buffer.from('X'),
-  Buffer.from('d'),
-  Buffer.from('a'),
-  Buffer.from('b'),
+  new Uint8Array([88]), // 'X'
+  new Uint8Array([100]), // 'd'
+  new Uint8Array([97]), // 'a'
+  new Uint8Array([98]), // 'b'
 ])
-const k = setRawHeader(j, 'C', Buffer.from('d'))
+const k = setRawHeader(j, 'C', new Uint8Array([100])) // 'd'
 t.strictSame(k, [
-  Buffer.from('X'),
-  Buffer.from('d'),
-  Buffer.from('a'),
-  Buffer.from('b'),
-  Buffer.from('c'),
-  Buffer.from('d'),
+  new Uint8Array([88]), // 'X'
+  new Uint8Array([100]), // 'd'
+  new Uint8Array([97]), // 'a'
+  new Uint8Array([98]), // 'b'
+  new Uint8Array([99]), // 'c'
+  new Uint8Array([100]), // 'd'
 ])

--- a/src/registry-client/test/set-raw-header.ts
+++ b/src/registry-client/test/set-raw-header.ts
@@ -1,17 +1,17 @@
 import t from 'tap'
 import { setRawHeader } from '../src/set-raw-header.ts'
 
-const h: Buffer[] = []
+const h: Uint8Array[] = []
 
 setRawHeader(h, 'x', 'y')
-t.strictSame(h, [Buffer.from('x'), Buffer.from('y')])
+t.strictSame(h, [new Uint8Array([120]), new Uint8Array([121])]) // 'x', 'y'
 setRawHeader(h, 'x', 'x')
-t.strictSame(h, [Buffer.from('x'), Buffer.from('x')])
-setRawHeader(h, 'asdf', Buffer.from('foo'))
+t.strictSame(h, [new Uint8Array([120]), new Uint8Array([120])]) // 'x', 'x'
+setRawHeader(h, 'asdf', new Uint8Array([102, 111, 111])) // 'foo'
 
 t.strictSame(h, [
-  Buffer.from('x'),
-  Buffer.from('x'),
-  Buffer.from('asdf'),
-  Buffer.from('foo'),
+  new Uint8Array([120]), // 'x'
+  new Uint8Array([120]), // 'x'
+  new Uint8Array([97, 115, 100, 102]), // 'asdf'
+  new Uint8Array([102, 111, 111]), // 'foo'
 ])


### PR DESCRIPTION
- Normalizes usage of lower level `Uint8Array` objects
- Avoids unnecessary memory copies
- Uses fixed-size buffers when `content-length` is known

Refs: https://github.com/vltpkg/vltpkg/issues/1088