### PR TITLE
registry-client: encode strings using buffer from

### DIFF
--- a/src/registry-client/src/string-encoding.ts
+++ b/src/registry-client/src/string-encoding.ts
@@ -1,5 +1,4 @@
 const decoder = new TextDecoder()
-const encoder = new TextEncoder()
 
 /**
  * Decodes a string from a Uint8Array
@@ -21,7 +20,7 @@ export const getEncondedValue = (
 ): Uint8Array => {
   if (value == undefined) return new Uint8Array(0)
   if (typeof value === 'string') {
-    const res = encoder.encode(value)
+    const res = Buffer.from(value)
     return res
   }
   return value

--- a/src/registry-client/test/cache-entry.ts
+++ b/src/registry-client/test/cache-entry.ts
@@ -5,7 +5,6 @@ import t from 'tap'
 import { CacheEntry } from '../src/cache-entry.ts'
 import { toRawHeaders } from './fixtures/to-raw-headers.ts'
 
-const encoder = new TextEncoder()
 const toLenBuf = (b: Uint8Array): Uint8Array => {
   const bl = b.byteLength + 4
   const blBuf = new Uint8Array(4)
@@ -37,7 +36,7 @@ const toRawEntry = (
   headers: Record<string, string>,
   body: Uint8Array,
 ): Uint8Array => {
-  const headerChunks: Uint8Array[] = [encoder.encode(String(status))]
+  const headerChunks: Uint8Array[] = [Buffer.from(String(status))]
   const rawh = toRawHeaders(headers)
   for (const h of rawh) {
     headerChunks.push(toLenBuf(h))
@@ -136,18 +135,18 @@ t.strictSame(
   Buffer.from(JSON.stringify({ hello: 'world' })),
 )
 t.strictSame(ce.headers, [
-  encoder.encode('key'),
-  encoder.encode('value'),
-  encoder.encode('x'),
-  encoder.encode('y'),
-  encoder.encode('integrity'),
-  encoder.encode(ce.integrityActual),
-  encoder.encode('content-encoding'),
-  encoder.encode('identity'),
-  encoder.encode('content-length'),
-  encoder.encode(String(ce.buffer().byteLength)),
-  encoder.encode('content-type'),
-  encoder.encode('text/json'),
+  Buffer.from('key'),
+  Buffer.from('value'),
+  Buffer.from('x'),
+  Buffer.from('y'),
+  Buffer.from('integrity'),
+  Buffer.from(ce.integrityActual),
+  Buffer.from('content-encoding'),
+  Buffer.from('identity'),
+  Buffer.from('content-length'),
+  Buffer.from(String(ce.buffer().byteLength)),
+  Buffer.from('content-type'),
+  Buffer.from('text/json'),
 ])
 
 t.strictSame(CacheEntry.decode(enc), ce)

--- a/src/registry-client/test/fixtures/to-raw-headers.ts
+++ b/src/registry-client/test/fixtures/to-raw-headers.ts
@@ -1,10 +1,9 @@
-const encoder = new TextEncoder()
 export const toRawHeaders = (
   h: Record<string, string>,
 ): Uint8Array[] => {
   const r: Uint8Array[] = []
   for (const [k, v] of Object.entries(h)) {
-    r.push(encoder.encode(k), encoder.encode(v))
+    r.push(Buffer.from(k), Buffer.from(v))
   }
   return r
 }

--- a/src/registry-client/test/raw-header.ts
+++ b/src/registry-client/test/raw-header.ts
@@ -28,34 +28,34 @@ t.strictSame(
 const h = [new Uint8Array([120]), new Uint8Array([121])] // 'x', 'y'
 t.strictSame(setRawHeader(h, 'x', 'a'), [
   new Uint8Array([120]), // 'x'
-  new Uint8Array([97]), // 'a'
+  Buffer.from([97]), // 'a'
 ])
 t.strictSame(setRawHeader(h, 'X', 'b'), [
   new Uint8Array([120]), // 'x'
-  new Uint8Array([98]), // 'b'
+  Buffer.from([98]), // 'b'
 ])
 h[0] = new Uint8Array([88]) // 'X'
 
 t.strictSame(setRawHeader(h, 'x', 'c'), [
   new Uint8Array([88]), // 'X'
-  new Uint8Array([99]), // 'c'
+  Buffer.from([99]), // 'c'
 ])
 
 const i = setRawHeader(h, 'X', 'd')
-t.strictSame(i, [new Uint8Array([88]), new Uint8Array([100])]) // 'X', 'd'
+t.strictSame(i, [new Uint8Array([88]), Buffer.from([100])]) // 'X', 'd'
 const j = setRawHeader(i, 'a', 'b')
 t.strictSame(j, [
   new Uint8Array([88]), // 'X'
-  new Uint8Array([100]), // 'd'
-  new Uint8Array([97]), // 'a'
-  new Uint8Array([98]), // 'b'
+  Buffer.from([100]), // 'd'
+  Buffer.from([97]), // 'a'
+  Buffer.from([98]), // 'b'
 ])
 const k = setRawHeader(j, 'C', new Uint8Array([100])) // 'd'
 t.strictSame(k, [
   new Uint8Array([88]), // 'X'
-  new Uint8Array([100]), // 'd'
-  new Uint8Array([97]), // 'a'
-  new Uint8Array([98]), // 'b'
-  new Uint8Array([99]), // 'c'
+  Buffer.from([100]), // 'd'
+  Buffer.from([97]), // 'a'
+  Buffer.from([98]), // 'b'
+  Buffer.from([99]), // 'c'
   new Uint8Array([100]), // 'd'
 ])

--- a/src/registry-client/test/set-raw-header.ts
+++ b/src/registry-client/test/set-raw-header.ts
@@ -4,14 +4,14 @@ import { setRawHeader } from '../src/set-raw-header.ts'
 const h: Uint8Array[] = []
 
 setRawHeader(h, 'x', 'y')
-t.strictSame(h, [new Uint8Array([120]), new Uint8Array([121])]) // 'x', 'y'
+t.strictSame(h, [Buffer.from([120]), Buffer.from([121])]) // 'x', 'y'
 setRawHeader(h, 'x', 'x')
-t.strictSame(h, [new Uint8Array([120]), new Uint8Array([120])]) // 'x', 'x'
+t.strictSame(h, [Buffer.from([120]), Buffer.from([120])]) // 'x', 'x'
 setRawHeader(h, 'asdf', new Uint8Array([102, 111, 111])) // 'foo'
 
 t.strictSame(h, [
-  new Uint8Array([120]), // 'x'
-  new Uint8Array([120]), // 'x'
-  new Uint8Array([97, 115, 100, 102]), // 'asdf'
+  Buffer.from([120]), // 'x'
+  Buffer.from([120]), // 'x'
+  Buffer.from([97, 115, 100, 102]), // 'asdf'
   new Uint8Array([102, 111, 111]), // 'foo'
 ])


### PR DESCRIPTION
`Buffer.from` is faster for encoding strings.

Refs: https://github.com/vltpkg/vltpkg/issues/1088