### PR TITLE
docs: update sidebar icon format

### DIFF
--- a/www/docs/src/components/sidebar/data.tsx
+++ b/www/docs/src/components/sidebar/data.tsx
@@ -10,12 +10,8 @@ export const labelMap: Record<string, string> = {
 }
 
 export const majorSections = new Set([
-  'documentation',
   'registry',
-  'api',
   'client',
-  'commands',
-  'internals',
   'packages',
 ])
 
@@ -25,9 +21,10 @@ const allIcons = {
   ...VltIcons,
 }
 
-type IconName = keyof typeof allIcons
+export type IconName = keyof typeof allIcons
 
 export const iconMap: Partial<Record<string, IconName>> = {
+  overview: 'Home',
   registry: 'Vsr',
   client: 'Client',
   packages: 'Package',
@@ -37,15 +34,15 @@ export const iconMap: Partial<Record<string, IconName>> = {
   configuring: 'Config',
   deployment: 'Rocket',
   features: 'Star',
-  'getting-started': 'BookOpen',
   'getting started': 'BookOpen',
   commands: 'Command',
+  authentication: 'Authentication',
   auth: 'Authentication',
+  'query selectors': 'Query',
   catalogs: 'Database',
   registries: 'Globe',
   selectors: 'Search',
   workspaces: 'Folder',
-  'graph-modifiers': 'GitBranch',
   'graph modifiers': 'GitBranch',
   cache: 'Cache',
   config: 'Config',
@@ -63,6 +60,7 @@ export const iconMap: Partial<Record<string, IconName>> = {
   pkg: 'Package',
   publish: 'Upload',
   query: 'Query',
+  run: 'Play',
   'run-exec': 'Play',
   token: 'Authentication',
   uninstall: 'Trash2',

--- a/www/docs/src/components/sidebar/sidebar-sublist.tsx
+++ b/www/docs/src/components/sidebar/sidebar-sublist.tsx
@@ -21,7 +21,7 @@ const AppSidebarSublist = ({
   className?: string
 }) => {
   return (
-    <div className="flex h-full flex-col gap-1 overflow-y-auto">
+    <div className="flex h-full flex-col gap-4 overflow-y-auto">
       {renderMenu(sidebar, 0)}
     </div>
   )
@@ -29,6 +29,12 @@ const AppSidebarSublist = ({
 
 const renderMenu = (entries: SidebarEntries, depth: number) => {
   return entries.map((entry, index) => {
+    if (
+      majorSections.has(entry.label.toLowerCase()) &&
+      entry.label.toLowerCase() !== 'packages'
+    ) {
+      return <Section key={index} entry={entry} depth={depth} />
+    }
     if (entry.type === 'group') {
       return (
         <Row key={index} entry={entry} depth={depth}>
@@ -38,6 +44,25 @@ const renderMenu = (entries: SidebarEntries, depth: number) => {
     }
     return <Row key={index} entry={entry} depth={depth} />
   })
+}
+
+const Section = ({
+  entry,
+  depth,
+}: {
+  entry: GroupType | Link
+  depth: number
+}) => {
+  if (entry.type === 'link') return null
+
+  return (
+    <div className="flex flex-col gap-2">
+      <p className="px-3 text-sm font-medium text-neutral-500">
+        {entry.label}
+      </p>
+      <div>{renderMenu(entry.entries, depth)}</div>
+    </div>
+  )
 }
 
 const Row = ({
@@ -51,7 +76,6 @@ const Row = ({
 }) => {
   const key = entry.label.toLowerCase()
   const iconName = iconMap[key]
-  const showBig = majorSections.has(key)
   const isGroup = entry.type === 'group'
   const isCurrent = !isGroup && entry.isCurrent
 
@@ -67,30 +91,25 @@ const Row = ({
         isGroup && depth === 0 && 'mb-1',
       )}
       style={{
-        paddingLeft: `${depth * 0.5}rem`,
+        paddingLeft: `${depth * 0.75}rem`,
       }}>
       <Button
         asChild={!isGroup}
         size="sidebar"
         variant="sidebar"
         className={cn(
-          'w-full',
+          'w-full text-muted-foreground',
           isGroup &&
-            'bg-background [&_svg[data-id=chevron]]:has-[+div[data-state=open]]:rotate-90',
+            '[&_svg[data-id=chevron]]:has-[+div[data-state=open]]:rotate-90',
           !isGroup && isCurrent && 'bg-secondary text-foreground',
         )}>
         {isGroup ?
           <div className="flex w-full items-center gap-2">
-            {iconName ?
-              showBig ?
-                <span className="flex size-6 items-center justify-center rounded-sm border-[1px] border-border bg-background transition-all duration-200 group-hover:bg-secondary">
-                  <Icon name={iconName} className="size-4" />
-                </span>
-              : <span className="flex size-5 items-center justify-center">
-                  <Icon name={iconName} className="size-4" />
-                </span>
-
-            : null}
+            {iconName && (
+              <span className="flex size-5 items-center justify-center">
+                <Icon name={iconName} className="size-4" />
+              </span>
+            )}
             <span
               className={cn(
                 majorSections.has(key) && 'font-semibold',
@@ -109,17 +128,12 @@ const Row = ({
         : <a
             href={entry.href}
             role="link"
-            className="flex items-center gap-2">
-            {iconName ?
-              showBig ?
-                <span className="flex size-6 items-center justify-center rounded-sm border-[1px] border-border bg-background transition-all duration-200 hover:bg-secondary">
-                  <Icon name={iconName} className="size-4" />
-                </span>
-              : <span className="flex size-5 items-center justify-center">
-                  <Icon name={iconName} className="size-4" />
-                </span>
-
-            : null}
+            className="relative flex items-center gap-2">
+            {depth === 0 && iconName && (
+              <span className="flex size-5 items-center justify-center">
+                <Icon name={iconName} className="size-4" />
+              </span>
+            )}
             <span
               className={cn(
                 majorSections.has(key) && 'font-semibold',

--- a/www/docs/src/components/sidebar/sidebar.tsx
+++ b/www/docs/src/components/sidebar/sidebar.tsx
@@ -1,9 +1,6 @@
 import AppSidebarSublist from '@/components/sidebar/sidebar-sublist.tsx'
 import { ScrollArea } from '@/components/ui/scroll-area.tsx'
-import { Button } from '@/components/ui/button.tsx'
-import { BookOpen } from 'lucide-react'
 
-import type { LucideIcon } from 'lucide-react'
 import type { Props } from '@astrojs/starlight/props'
 
 export type SidebarEntries = Props['sidebar']
@@ -11,48 +8,6 @@ export type SidebarEntry = SidebarEntries[0]
 
 export type Link = Extract<SidebarEntry, { type: 'link' }>
 export type Group = Extract<SidebarEntry, { type: 'group' }>
-
-interface SidebarDefaultListItem {
-  slug: string
-  href: string
-  icon: LucideIcon
-  className?: string
-  external?: boolean
-}
-
-const defaultList: SidebarDefaultListItem[] = [
-  {
-    slug: 'Documentation',
-    href: '/',
-    icon: BookOpen,
-  },
-]
-
-const DefaultSublist = () => {
-  return (
-    <div className="mb-1 flex flex-col gap-1">
-      {defaultList.map((item, idx) => (
-        <Button
-          className="group"
-          variant="sidebar"
-          size="sidebar"
-          asChild
-          key={idx}>
-          <a
-            href={item.href}
-            target={item.external ? '_blank' : '_self'}
-            role="link"
-            className={`inline-flex items-center gap-1 ${item.className}`}>
-            <span className="flex size-[24px] items-center justify-center rounded-sm border-[1px] border-border bg-background p-1.5 transition-all duration-200 group-hover:bg-secondary">
-              <item.icon className="text-neutral-500" />
-            </span>
-            {item.slug}
-          </a>
-        </Button>
-      ))}
-    </div>
-  )
-}
 
 const AppSidebar = ({ sidebar }: { sidebar: SidebarEntries }) => {
   return (
@@ -62,7 +17,6 @@ const AppSidebar = ({ sidebar }: { sidebar: SidebarEntries }) => {
       <ScrollArea
         id="sidebar-scroll-area"
         className="max-h-[calc(100svh-104.25px)] min-h-[calc(100svh-104.25px)] w-[260px] overflow-y-auto py-4 pr-2">
-        <DefaultSublist />
         <AppSidebarSublist sidebar={sidebar} />
       </ScrollArea>
     </aside>


### PR DESCRIPTION
## Overview

| Before | After |
| --- | --- |
| <img width="285" height="769" alt="Screenshot 2025-09-09 at 12 58 29" src="https://github.com/user-attachments/assets/3d9fb4ec-0a5c-41fd-ba7f-a26c99ae2370" /> | <img width="285" height="668" alt="Screenshot 2025-09-09 at 12 55 39" src="https://github.com/user-attachments/assets/3b31f467-f8bb-4502-b338-c39961b38852" /> |

This PR updates the docs sidebar so that top level navigation on the sidebar is no longer collapsible, and icons only appear when the depth level is 0.

However this also preserves the `internals` package icons on the sidebar, where those are collapisble sections.

### Changelog:
- creates `SidebarSection` component to wrap the top level segments
- removes icons from the titles
- moves icons to depth 0 (top level routes)
- maintains package icons in `internals`
