### PR TITLE
fix(server): port forwarding/dashboard loading in codespace envs

### DIFF
--- a/src/server/src/dashboard.ts
+++ b/src/server/src/dashboard.ts
@@ -1,6 +1,6 @@
 import { writeFileSync } from 'node:fs'
 import { homedir } from 'node:os'
-import { resolve } from 'node:path'
+import { resolve, dirname } from 'node:path'
 import { getUser } from '@vltpkg/git'
 import { getAuthorFromGitUser } from '@vltpkg/init'
 import { getReadablePath } from './get-readable-path.ts'
@@ -69,7 +69,7 @@ export class Dashboard {
       } catch {
         // In restricted environments (like locked-down Codespaces),
         // homedir() might fail. Fall back to current working directory.
-        this.dashboardRoot = [process.cwd()]
+        this.dashboardRoot = [dirname(process.cwd())]
       }
     }
     this.scurry = scurry

--- a/src/server/src/dashboard.ts
+++ b/src/server/src/dashboard.ts
@@ -63,7 +63,15 @@ export class Dashboard {
     } = options
     this.packageJson = packageJson
     this.dashboardRoot = dashboardRoot
-    if (!this.dashboardRoot.length) this.dashboardRoot = [homedir()]
+    if (!this.dashboardRoot.length) {
+      try {
+        this.dashboardRoot = [homedir()]
+      } catch {
+        // In restricted environments (like locked-down Codespaces),
+        // homedir() might fail. Fall back to current working directory.
+        this.dashboardRoot = [process.cwd()]
+      }
+    }
     this.scurry = scurry
     this.publicDir = publicDir
   }

--- a/src/server/src/get-readable-path.ts
+++ b/src/server/src/get-readable-path.ts
@@ -1,4 +1,5 @@
 import { homedir } from 'node:os'
+import { dirname } from 'node:path'
 
 let home: string
 try {
@@ -6,7 +7,7 @@ try {
 } catch {
   // In restricted environments (like locked-down Codespaces),
   // homedir() might fail. Fall back to current working directory.
-  home = process.cwd()
+  home = dirname(process.cwd())
 }
 
 export const getReadablePath = (path: string) =>

--- a/src/server/src/get-readable-path.ts
+++ b/src/server/src/get-readable-path.ts
@@ -1,6 +1,13 @@
 import { homedir } from 'node:os'
 
-const home = homedir()
+let home: string
+try {
+  home = homedir()
+} catch {
+  // In restricted environments (like locked-down Codespaces),
+  // homedir() might fail. Fall back to current working directory.
+  home = process.cwd()
+}
 
 export const getReadablePath = (path: string) =>
   path.startsWith(home) ? '~' + path.substring(home.length) : path

--- a/src/server/src/index.ts
+++ b/src/server/src/index.ts
@@ -127,9 +127,7 @@ export class VltServer extends EventEmitter<{
     ) {
       this.#rootAddress = `https://${process.env.CODESPACE_NAME}-${this.port}.${process.env.GITHUB_CODESPACES_PORT_FORWARDING_DOMAIN}/`
     } else {
-    /* c8 ignore stop */
       this.#rootAddress = `http://localhost:${this.port}/`
-    /* c8 ignore start */
     }
     /* c8 ignore stop */
 

--- a/src/server/src/index.ts
+++ b/src/server/src/index.ts
@@ -118,7 +118,20 @@ export class VltServer extends EventEmitter<{
     if (!this.listening()) {
       throw error('failed to start server')
     }
-    this.#rootAddress = `http://localhost:${this.port}/`
+
+    // In GitHub Codespaces, use the forwarded URL instead of localhost
+    /* c8 ignore start */
+    if (
+      process.env.CODESPACE_NAME &&
+      process.env.GITHUB_CODESPACES_PORT_FORWARDING_DOMAIN
+    ) {
+      this.#rootAddress = `https://${process.env.CODESPACE_NAME}-${this.port}.${process.env.GITHUB_CODESPACES_PORT_FORWARDING_DOMAIN}/`
+    } else {
+    /* c8 ignore stop */
+      this.#rootAddress = `http://localhost:${this.port}/`
+    /* c8 ignore start */
+    }
+    /* c8 ignore stop */
 
     const { publicDir = tmpdir(), assetsDir = await getAssetsDir() } =
       this.options

--- a/src/server/src/listen-carefully.ts
+++ b/src/server/src/listen-carefully.ts
@@ -13,6 +13,10 @@ export const listenCarefully = async (
   end = 1000,
 ): Promise<number> => {
   let port = start
+  // In GitHub Codespaces, bind to 0.0.0.0 to accept forwarded connections
+  /* c8 ignore next */
+  const host = process.env.CODESPACE_NAME ? '0.0.0.0' : undefined
+
   return new Promise<number>((res, rej) => {
     server.once('listening', () => {
       server.removeListener('error', onerr)
@@ -34,10 +38,10 @@ export const listenCarefully = async (
         return
       }
       port++
-      server.listen(port)
+      server.listen(port, host)
     }
 
     server.on('error', onerr)
-    server.listen(port)
+    server.listen(port, host)
   })
 }

--- a/src/server/src/read-project-folders.ts
+++ b/src/server/src/read-project-folders.ts
@@ -118,9 +118,9 @@ const collectResult = async (
   }
 
   const resolved = entry.fullpath()
-const statPackageJson = await scurry.lstat(
-  `${resolved}/package.json`,
-).catch(() => {})
+  const statPackageJson = await scurry
+    .lstat(`${resolved}/package.json`)
+    .catch(() => {})
   const hasValidPackageJson =
     statPackageJson &&
     statPackageJson.isFile() &&

--- a/src/server/src/read-project-folders.ts
+++ b/src/server/src/read-project-folders.ts
@@ -118,13 +118,9 @@ const collectResult = async (
   }
 
   const resolved = entry.fullpath()
-  let statPackageJson
-  try {
-    statPackageJson = await scurry.lstat(`${resolved}/package.json`)
-  } catch {
-    // Ignore files that can't be accessed (permission denied, etc.)
-    statPackageJson = null
-  }
+const statPackageJson = await scurry.lstat(
+  `${resolved}/package.json`,
+).catch(() => {})
   const hasValidPackageJson =
     statPackageJson &&
     statPackageJson.isFile() &&

--- a/src/server/src/read-project-folders.ts
+++ b/src/server/src/read-project-folders.ts
@@ -69,7 +69,7 @@ export const readProjectFolders = async (
           traverse.push(step(child, depth + 1))
         }
       }
-    /* c8 ignore next 4 */
+      /* c8 ignore next 4 */
     } catch {
       // Ignore directories that can't be read (permission denied, etc.)
       // This commonly happens in restricted environments like Codespaces

--- a/src/server/src/read-project-folders.ts
+++ b/src/server/src/read-project-folders.ts
@@ -1,4 +1,5 @@
 import { availableParallelism, homedir } from 'node:os'
+import { dirname } from 'node:path'
 import type { PathBase, PathScurry } from 'path-scurry'
 import { callLimit } from 'promise-call-limit'
 import { ignoredHomedirFolderNames } from './ignored-homedir-folder-names.ts'
@@ -10,7 +11,7 @@ try {
 } catch {
   // In restricted environments, homedir() might fail.
   // Fall back to current working directory.
-  home = process.cwd()
+  home = dirname(process.cwd())
 }
 
 type ProjectFolderOptions = {

--- a/src/server/src/read-project-folders.ts
+++ b/src/server/src/read-project-folders.ts
@@ -8,8 +8,8 @@ let home: string
 try {
   home = homedir()
 } catch {
-  // In restricted environments (like locked-down Codespaces),
-  // homedir() might fail. Fall back to current working directory.
+  // In restricted environments, homedir() might fail.
+  // Fall back to current working directory.
   home = process.cwd()
 }
 
@@ -71,8 +71,8 @@ export const readProjectFolders = async (
       }
       /* c8 ignore next 4 */
     } catch {
-      // Ignore directories that can't be read (permission denied, etc.)
-      // This commonly happens in restricted environments like Codespaces
+      // Ignore directories that can't be read.
+      // This commonly happens in restricted environments.
     }
   }
 

--- a/src/server/test/dashboard.ts
+++ b/src/server/test/dashboard.ts
@@ -1,6 +1,6 @@
 import { PackageJson } from '@vltpkg/package-json'
 import { readFileSync } from 'node:fs'
-import { join, resolve } from 'node:path'
+import { join, resolve, dirname } from 'node:path'
 import { PathScurry } from 'path-scurry'
 import t from 'tap'
 
@@ -74,7 +74,7 @@ t.test('dashboard construction with homedir error', async t => {
     packageJson,
     'dashboard-root': [],
   })
-  t.strictSame(d.dashboardRoot, [process.cwd()])
+  t.strictSame(d.dashboardRoot, [dirname(process.cwd())])
 })
 
 t.test('update projects, with dashboard', async t => {

--- a/src/server/test/dashboard.ts
+++ b/src/server/test/dashboard.ts
@@ -46,7 +46,7 @@ t.test('dashboard construction with homedir error', async t => {
       throw new Error('Permission denied')
     },
   })
-  
+
   const { Dashboard: DashboardWithError } = await t.mockImport<
     typeof import('../src/dashboard.ts')
   >('../src/dashboard.ts', {

--- a/src/server/test/get-readable-path.ts
+++ b/src/server/test/get-readable-path.ts
@@ -1,3 +1,4 @@
+import { dirname } from 'node:path'
 import t from 'tap'
 
 const mockOS = t.createMock(await import('node:os'), {
@@ -25,8 +26,8 @@ t.test('getReadablePath with homedir error', async t => {
       },
     )
 
-  // Should fall back to process.cwd() and still work
-  const cwd = process.cwd()
+  // Should fall back to dirname(process.cwd()) and still work
+  const cwd = dirname(process.cwd())
   t.equal(getReadablePathWithError(`${cwd}/test`), '~/test')
   t.equal(
     getReadablePathWithError('/some/other/path'),

--- a/src/server/test/get-readable-path.ts
+++ b/src/server/test/get-readable-path.ts
@@ -13,18 +13,23 @@ t.equal(getReadablePath('/x/y/'), '~/')
 t.equal(getReadablePath('/a/b/c'), '/a/b/c')
 
 t.test('getReadablePath with homedir error', async t => {
-  const { getReadablePath: getReadablePathWithError } = await t.mockImport<
-    typeof import('../src/get-readable-path.ts')
-  >('../src/get-readable-path.ts', {
-    'node:os': t.createMock(await import('node:os'), {
-      homedir: () => {
-        throw new Error('Permission denied')
+  const { getReadablePath: getReadablePathWithError } =
+    await t.mockImport<typeof import('../src/get-readable-path.ts')>(
+      '../src/get-readable-path.ts',
+      {
+        'node:os': t.createMock(await import('node:os'), {
+          homedir: () => {
+            throw new Error('Permission denied')
+          },
+        }),
       },
-    }),
-  })
+    )
 
   // Should fall back to process.cwd() and still work
   const cwd = process.cwd()
   t.equal(getReadablePathWithError(`${cwd}/test`), '~/test')
-  t.equal(getReadablePathWithError('/some/other/path'), '/some/other/path')
+  t.equal(
+    getReadablePathWithError('/some/other/path'),
+    '/some/other/path',
+  )
 })

--- a/src/server/test/get-readable-path.ts
+++ b/src/server/test/get-readable-path.ts
@@ -11,3 +11,20 @@ t.equal(getReadablePath('/x/y/z'), '~/z')
 t.equal(getReadablePath('/x/y'), '~')
 t.equal(getReadablePath('/x/y/'), '~/')
 t.equal(getReadablePath('/a/b/c'), '/a/b/c')
+
+t.test('getReadablePath with homedir error', async t => {
+  const { getReadablePath: getReadablePathWithError } = await t.mockImport<
+    typeof import('../src/get-readable-path.ts')
+  >('../src/get-readable-path.ts', {
+    'node:os': t.createMock(await import('node:os'), {
+      homedir: () => {
+        throw new Error('Permission denied')
+      },
+    }),
+  })
+
+  // Should fall back to process.cwd() and still work
+  const cwd = process.cwd()
+  t.equal(getReadablePathWithError(`${cwd}/test`), '~/test')
+  t.equal(getReadablePathWithError('/some/other/path'), '/some/other/path')
+})

--- a/src/server/test/read-project-folders.ts
+++ b/src/server/test/read-project-folders.ts
@@ -118,3 +118,124 @@ t.test('read some project folders', async t => {
     expect,
   )
 })
+
+t.test('read project folders with homedir error', async t => {
+  const { readProjectFolders } = await t.mockImport<
+    typeof import('../src/read-project-folders.ts')
+  >('../src/read-project-folders.ts', {
+    'node:os': t.createMock(await import('node:os'), {
+      homedir: () => {
+        throw new Error('Permission denied')
+      },
+    }),
+  })
+
+  const dir = t.testdir({
+    web: {
+      includeme: {
+        'package.json': JSON.stringify({ name: 'foo' }),
+      },
+    },
+  })
+
+  // Should fall back to process.cwd() and still work
+  const result = await readProjectFolders({
+    scurry: new PathScurry(dir),
+    userDefinedProjectPaths: [],
+    path: dir,
+  })
+
+  t.ok(Array.isArray(result), 'returns an array even with homedir error')
+})
+
+t.test('read project folders with file access errors', async t => {
+  const dir = t.testdir({
+    web: {
+      includeme: {
+        'package.json': JSON.stringify({ name: 'foo' }),
+      },
+      restricted: {
+        'package.json': JSON.stringify({ name: 'restricted' }),
+      },
+    },
+  })
+
+  // Create a custom PathScurry that throws errors for certain paths
+  class TestPathScurry extends PathScurry {
+    async lstat(path: string) {
+      if (path.includes('restricted/package.json')) {
+        throw new Error('Permission denied')
+      }
+      return super.lstat(path)
+    }
+  }
+
+  const scurry = new TestPathScurry(dir) as PathScurry
+
+  const { readProjectFolders } = await t.mockImport<
+    typeof import('../src/read-project-folders.ts')
+  >('../src/read-project-folders.ts', {
+    'node:os': t.createMock(await import('node:os'), {
+      homedir: () => dir,
+    }),
+  })
+
+  // Should handle file access errors gracefully
+  const result = await readProjectFolders({
+    scurry,
+    userDefinedProjectPaths: [],
+  })
+
+  t.ok(Array.isArray(result), 'returns an array even with file access errors')
+  // Should still find the accessible project
+  t.ok(result.some(r => r.name === 'includeme'), 'finds accessible projects')
+  // Should not include the restricted project due to lstat error
+  t.notOk(result.some(r => r.name === 'restricted'), 'skips inaccessible projects')
+})
+
+t.test('read project folders with directory readdir errors', async t => {
+  const dir = t.testdir({
+    web: {
+      includeme: {
+        'package.json': JSON.stringify({ name: 'foo' }),
+      },
+    },
+    restricted: {
+      // This directory will throw an error when trying to read it
+      somesubdir: {},
+    },
+  })
+
+  // Create a custom PathScurry that throws errors when reading the root directory
+  class TestPathScurry extends PathScurry {
+    lstatSync(path: string) {
+      const result = super.lstatSync(path)
+      if (result && result.fullpath() === dir) {
+        // Override readdir to throw an error for the root directory
+        const originalReaddir = result.readdir?.bind(result)
+        result.readdir = async () => {
+          throw new Error('Permission denied')
+        }
+      }
+      return result
+    }
+  }
+
+  const scurry = new TestPathScurry(dir) as PathScurry
+
+  const { readProjectFolders } = await t.mockImport<
+    typeof import('../src/read-project-folders.ts')
+  >('../src/read-project-folders.ts', {
+    'node:os': t.createMock(await import('node:os'), {
+      homedir: () => dir,
+    }),
+  })
+
+  // Should handle directory read errors gracefully
+  const result = await readProjectFolders({
+    scurry,
+    userDefinedProjectPaths: [],
+  })
+
+  t.ok(Array.isArray(result), 'returns an array even with directory read errors')
+})

--- a/src/server/test/read-project-folders.ts
+++ b/src/server/test/read-project-folders.ts
@@ -138,7 +138,7 @@ t.test('read project folders with homedir error', async t => {
     },
   })
 
-  // Should fall back to process.cwd() and still work
+  // Should fall back to dirname(process.cwd()) and still work
   const result = await readProjectFolders({
     scurry: new PathScurry(dir),
     userDefinedProjectPaths: [],


### PR DESCRIPTION
- modified the host/port config to accommodate codespace envs where the logged url is wrong/stuck on `localhost` & `dashboard.json` fails to load
- added graceful fallback for `homedir()` if it throws (rare but can happen)
