### PR TITLE
chore: rename host-context selector

### DIFF
--- a/src/cli-sdk/src/commands/list.ts
+++ b/src/cli-sdk/src/commands/list.ts
@@ -208,8 +208,7 @@ export const command: CommandFn<ListResult> = async conf => {
     ) ?
       selectImportersQueryString
     : projectQueryString
-  const defaultLocalScopeQueryString =
-    ':host-context(local) :root > *'
+  const defaultLocalScopeQueryString = ':host(local) :root > *'
 
   // retrieve the selected nodes and edges
   /* c8 ignore start */

--- a/src/cli-sdk/src/commands/query.ts
+++ b/src/cli-sdk/src/commands/query.ts
@@ -164,7 +164,7 @@ export const command: CommandFn<QueryResult> = async conf => {
 
   // retrieve default values and set up host contexts
   const defaultProjectQueryString = '*'
-  const defaultLocalScopeQueryString = ':host-context(local) *'
+  const defaultLocalScopeQueryString = ':host(local) *'
   const positionalQueryString = conf.positionals[0]
   const targetQueryString = conf.get('target')
   const scopeQueryString = conf.get('scope')

--- a/src/cli-sdk/src/query-host-contexts.ts
+++ b/src/cli-sdk/src/query-host-contexts.ts
@@ -65,7 +65,7 @@ const getPossibleProjectKeys = (
 }
 
 /**
- * Creates a Map of host context functions that can be used by the :host-context
+ * Creates a Map of host context functions that can be used by the :host
  * pseudo selector to dynamically load graphs from different sources.
  */
 export const createHostContextsMap = async (

--- a/src/cli-sdk/test/commands/list.ts
+++ b/src/cli-sdk/test/commands/list.ts
@@ -450,7 +450,7 @@ t.test('list', async t => {
         {
           positionals: [],
           values: {
-            target: `:host-context("file:${projectFolder}")`,
+            target: `:host("file:${projectFolder}")`,
             view: 'human',
           },
           options,

--- a/src/cli-sdk/test/commands/query.ts
+++ b/src/cli-sdk/test/commands/query.ts
@@ -488,7 +488,7 @@ t.test('query', async t => {
     t.matchSnapshot(
       await runCommand(
         {
-          positionals: [`:host-context("file:${projectFolder}")`],
+          positionals: [`:host("file:${projectFolder}")`],
           values: {
             view: 'human',
           },

--- a/src/gui/src/components/query-builder/options.ts
+++ b/src/gui/src/components/query-builder/options.ts
@@ -100,7 +100,7 @@ export const COMBINATOR_LABELS: Record<Combinator, string> = {
 export const SELECTOR_GROUP_LABEL = 'and'
 
 export const PROJECT_SELECTORS = [
-  ':host-context',
+  ':host',
   ':project',
   ':workspace',
   ':root',

--- a/src/gui/src/lib/constants/selectors.ts
+++ b/src/gui/src/lib/constants/selectors.ts
@@ -275,8 +275,8 @@ export const PSEUDO_RELATIONSHIP_SELECTORS = {
 } as const satisfies Record<string, Selector>
 
 export const PSEUDO_PROJECT_SELECTORS = {
-  ':host-context(local)': {
-    selector: ':host-context(local)',
+  ':host(local)': {
+    selector: ':host(local)',
     label: 'All configured projects',
     category: 'pseudo',
     description:

--- a/src/gui/src/lib/query-host-contexts.ts
+++ b/src/gui/src/lib/query-host-contexts.ts
@@ -73,7 +73,7 @@ const projectLoadContextFunction =
   }
 
 /**
- * Creates a Map of host context functions that can be used by the :host-context
+ * Creates a Map of host context functions that can be used by the :host
  * pseudo selector to dynamically load graphs from different sources.
  * This is the browser-based implementation that fetches data from the server.
  * Returns a Map where keys are context names and values are functions that return HostContextsMapResult

--- a/src/gui/src/lib/update-dependents-item.ts
+++ b/src/gui/src/lib/update-dependents-item.ts
@@ -149,13 +149,13 @@ const getFromDirectWorkspaceDepName = (
 }
 
 /**
- * Checks if any segment of the query has a :host-context selector.
+ * Checks if any segment of the query has a :host selector.
  */
 const hasHostContextToken = (
   queryTokens: ParsedSelectorToken[],
 ): boolean => {
   for (const segment of queryTokens) {
-    if (segment.value === ':host-context') {
+    if (segment.value === ':host') {
       return true
     }
   }
@@ -170,15 +170,15 @@ export const updateDependentsItem =
   ({ item, isParent }: OnDependentClickOptions) =>
   (e: React.MouseEvent | MouseEvent) => {
     e.preventDefault()
-    // handle :host-context() selector if present
+    // handle :host() selector if present
     const queryTokens = Query.getQueryTokens(query)
     let newQuery = query.trim()
     let prefix = ''
     if (hasHostContextToken(queryTokens)) {
-      const [, ...rest] = query.split(':host-context(')
+      const [, ...rest] = query.split(':host(')
       const [key, ...after] = rest.join('').split(')')
       newQuery = after.join(')')
-      prefix = `:host-context(${key}) `
+      prefix = `:host(${key}) `
     }
 
     if (prefix && item.id === VIRTUAL_ROOT_ID) {

--- a/src/gui/src/lib/update-result-item.ts
+++ b/src/gui/src/lib/update-result-item.ts
@@ -46,13 +46,13 @@ const hasImporterToken = (
 }
 
 /**
- * Checks if any segment of the query has a :host-context selector.
+ * Checks if any segment of the query has a :host selector.
  */
 const hasHostContextToken = (
   queryTokens: ParsedSelectorToken[],
 ): boolean => {
   for (const segment of queryTokens) {
-    if (segment.value === ':host-context') {
+    if (segment.value === ':host') {
       return true
     }
   }
@@ -69,14 +69,14 @@ export const updateResultItem =
     if (!item.to) return
     const query = q.trim()
     let newQuery = query
-    // handle :host-context() selector if present
+    // handle :host() selector if present
     const queryTokens = Query.getQueryTokens(query)
     let prefix = ''
     if (hasHostContextToken(queryTokens)) {
-      const [, ...rest] = query.split(':host-context(')
+      const [, ...rest] = query.split(':host(')
       const [key, ...after] = rest.join('').split(')')
       newQuery = after.join(')')
-      prefix = `:host-context(${key}) `
+      prefix = `:host(${key}) `
     }
     // if it's a stacked item we make sure we select the unique node so that
     // either we get down to a single item or the user is presented with the

--- a/src/query/src/pseudo.ts
+++ b/src/query/src/pseudo.ts
@@ -21,7 +21,7 @@ import { entropic } from './pseudo/entropic.ts'
 import { env } from './pseudo/env.ts'
 import { evalParser } from './pseudo/eval.ts'
 import { fs } from './pseudo/fs.ts'
-import { hostContext } from './pseudo/host-context.ts'
+import { hostContext } from './pseudo/host.ts'
 import { license } from './pseudo/license.ts'
 import { link } from './pseudo/link.ts'
 import { malware } from './pseudo/malware.ts'
@@ -305,7 +305,7 @@ const pseudoSelectors = new Map<string, ParserFn>(
     env,
     fs,
     has,
-    'host-context': hostContext,
+    host: hostContext,
     is,
     license,
     link,

--- a/src/query/src/pseudo/host.ts
+++ b/src/query/src/pseudo/host.ts
@@ -11,7 +11,7 @@ import type { ParserState } from '../types.ts'
 import type { PostcssNode } from '@vltpkg/dss-parser'
 
 /**
- * Parses the internal parameters of the :host-context() pseudo selector.
+ * Parses the internal parameters of the :host() pseudo selector.
  * Returns the context key that should be used to look up the host context function.
  */
 export const parseInternals = (nodes: PostcssNode[]): string => {
@@ -32,16 +32,14 @@ export const parseInternals = (nodes: PostcssNode[]): string => {
   }
 
   if (!contextKey) {
-    throw error(
-      'Expected a context key parameter for :host-context selector',
-    )
+    throw error('Expected a context key parameter for :host selector')
   }
 
   return contextKey
 }
 
 /**
- * :host-context Pseudo-Selector, switches the current graph context to a new
+ * :host Pseudo-Selector, switches the current graph context to a new
  * set of graphs loaded from a specific host context.
  *
  * This selector accepts a single parameter that specifies which host context
@@ -49,13 +47,11 @@ export const parseInternals = (nodes: PostcssNode[]): string => {
  * to the Query constructor.
  *
  * Example:
- * - :host-context(local) - Switches to graphs loaded from the local context
+ * - :host(local) - Switches to graphs loaded from the local context
  */
 export const hostContext = async (state: ParserState) => {
   if (!state.hostContexts) {
-    throw error(
-      'No host contexts available for :host-context selector',
-    )
+    throw error('No host contexts available for :host selector')
   }
 
   let contextKey: string
@@ -64,7 +60,7 @@ export const hostContext = async (state: ParserState) => {
       asPostcssNodeWithChildren(state.current).nodes,
     )
   } catch (err) {
-    throw error('Failed to parse :host-context selector', {
+    throw error('Failed to parse :host selector', {
       cause: err,
     })
   }

--- a/src/query/test/pseudo/host-context.ts
+++ b/src/query/test/pseudo/host-context.ts
@@ -7,13 +7,13 @@ import type {
   HostContextsMapResult,
 } from '../../src/types.ts'
 import type { GraphLike, EdgeLike } from '@vltpkg/types'
-import { hostContext } from '../../src/pseudo/host-context.ts'
+import { hostContext } from '../../src/pseudo/host.ts'
 import {
   getSimpleGraph,
   getMultiWorkspaceGraph,
 } from '../fixtures/graph.ts'
 
-t.test('host-context selector', async t => {
+t.test('host selector', async t => {
   // Helper function to convert GraphLike objects to HostContextsMapResult
   const graphsToHostContextResult = (
     graphs: GraphLike[],
@@ -80,7 +80,7 @@ t.test('host-context selector', async t => {
     )
 
     const state = getState(
-      ':host-context(test-context)',
+      ':host(test-context)',
       testGraph1,
       hostContexts,
     )
@@ -110,7 +110,7 @@ t.test('host-context selector', async t => {
       )
 
       const state = getState(
-        ':host-context(multi-context)',
+        ':host(multi-context)',
         getSimpleGraph(),
         hostContexts,
       )
@@ -136,7 +136,7 @@ t.test('host-context selector', async t => {
     })
 
     const state = getState(
-      ':host-context(async-context)',
+      ':host(async-context)',
       getSimpleGraph(),
       hostContexts,
     )
@@ -149,11 +149,11 @@ t.test('host-context selector', async t => {
   await t.test(
     'throws error when no host contexts available',
     async t => {
-      const state = getState(':host-context(test)')
+      const state = getState(':host(test)')
 
       await t.rejects(
         hostContext(state),
-        /No host contexts available for :host-context selector/,
+        /No host contexts available for :host selector/,
         'should throw when hostContexts is undefined',
       )
     },
@@ -166,7 +166,7 @@ t.test('host-context selector', async t => {
     )
 
     const state = getState(
-      ':host-context(unknown)',
+      ':host(unknown)',
       getSimpleGraph(),
       hostContexts,
     )
@@ -181,14 +181,14 @@ t.test('host-context selector', async t => {
   await t.test('handles empty context key', async t => {
     const hostContexts: HostContextsMap = new Map()
     const state = getState(
-      ':host-context("")',
+      ':host("")',
       getSimpleGraph(),
       hostContexts,
     )
 
     await t.rejects(
       hostContext(state),
-      /Failed to parse :host-context selector/,
+      /Failed to parse :host selector/,
       'should throw for empty context key',
     )
   })
@@ -201,9 +201,7 @@ t.test('host-context selector', async t => {
     )
 
     // Create state with unquoted parameter
-    const ast = postcssSelectorParser().astSync(
-      ':host-context(unquoted)',
-    )
+    const ast = postcssSelectorParser().astSync(':host(unquoted)')
     const current = ast.first.first
     const state: ParserState = {
       comment: '',
@@ -247,7 +245,7 @@ t.test('host-context selector', async t => {
       )
 
       const state = getState(
-        ':host-context(replace-context)',
+        ':host(replace-context)',
         originalGraph,
         hostContexts,
       )

--- a/www/docs/src/content/docs/cli/security.mdx
+++ b/www/docs/src/content/docs/cli/security.mdx
@@ -212,7 +212,7 @@ $ vlt query ':license(copyleft)'`} title="Terminal" lang="bash" />
 
 <Code
   code={
-    "# Scan multiple projects using host-context\n$ vlt query ':host-context(local) :malware'\n\n# Specific project security check\n$ vlt query ':host-context(\"file:~/my-project\") :malware'"
+    "# Scan multiple projects using host\n$ vlt query ':host(local) :malware'\n\n# Specific project security check\n$ vlt query ':host(\"file:~/my-project\") :malware'"
   }
   title="Terminal"
   lang="bash"
@@ -224,7 +224,7 @@ $ vlt query ':license(copyleft)'`} title="Terminal" lang="bash" />
 
 1. **Daily Quick Check**: `vlt query ':malware'`
 2. **Weekly Comprehensive Scan**:
-   `vlt query ':host-context(local) :is(:malware, :not(:scanned))'`
+   `vlt query ':host(local) :is(:malware, :not(:scanned))'`
 3. **Before Releasing Projects**:
    `vlt query ':root :is(:malware, :score("<0.6"))'`
 

--- a/www/docs/src/content/docs/cli/selectors.mdx
+++ b/www/docs/src/content/docs/cli/selectors.mdx
@@ -74,22 +74,22 @@ e.g: `#foo` is the same as `[name=foo]`
   results for the selector expression used. As an example, here is a
   query that matches all packages that have a peer dependency on
   `react`: `:has(.peer[name=react])`
-- `:host-context(<context>)` Switches the current graph context to a
-  new set of graphs loaded from a specific host context. This selector
-  allows querying across multiple projects or switching to different
-  project scopes. The context parameter can be:
+- `:host(<context>)` Switches the current graph context to a new set
+  of graphs loaded from a specific host context. This selector allows
+  querying across multiple projects or switching to different project
+  scopes. The context parameter can be:
   - A specific project folder path (e.g., `"file:~/my-project"`)
   - The special `local` context which loads all configured projects
     from your vlt dashboard Examples with CLI commands:
-  - `vlt query ':host-context(local) :malware'` - Find malware across
-    all configured projects
-  - `vlt version patch --scope=':host-context("file:~/tmp/test-vite")'`
+  - `vlt query ':host(local) :malware'` - Find malware across all
+    configured projects
+  - `vlt version patch --scope=':host("file:~/tmp/test-vite")'`
     - Bump version for a specific project
-  - `vlt pkg pick name version --scope=':host-context(local) > :root > *'`
+  - `vlt pkg pick name version --scope=':host(local) > :root > *'`
     - Get name and version of all direct dependencies across all
       configured projects
-  - `vlt query ':host-context("file:~/my-app") :outdated'` - Find
-    outdated packages in a specific project
+  - `vlt query ':host("file:~/my-app") :outdated'` - Find outdated
+    packages in a specific project
 - `:is(<forgiving-selector-list>)` Useful for writing large selectors
   in a more compact form, the `:is()` pseudo-class takes a selector
   list as its arguments and selects any element that can be selected


### PR DESCRIPTION
The previously named `:host-context` query selector is now named `:host`.