### PR TITLE
graph: fix load hidden lockfile options

### DIFF
--- a/src/graph/src/actual/load.ts
+++ b/src/graph/src/actual/load.ts
@@ -437,6 +437,7 @@ export const load = (options: LoadOptions): Graph => {
     try {
       // if we reach here, the hidden lockfile is valid
       const graph = loadHidden({
+        ...options,
         projectRoot,
         mainManifest,
         packageJson,


### PR DESCRIPTION
The load hidden lockfile method within `actual.load()` was missing proper options forwarding, this was causing the security archive to not properly hydrate data.