### PR TITLE
gui: fix security-archive integration

### DIFF
--- a/src/graph/src/virtual-root.ts
+++ b/src/graph/src/virtual-root.ts
@@ -81,6 +81,7 @@ export const createVirtualRoot = (
         type: 'prod',
       } satisfies EdgeLike
       res.edgesOut.set(name, edge)
+      importer.edgesIn.add(edge)
     }
   }
   return res

--- a/src/query/src/types.ts
+++ b/src/query/src/types.ts
@@ -11,7 +11,7 @@ export type HostContextsMapResult = {
   initialNodes: NodeLike[]
   edges: EdgeLike[]
   nodes: NodeLike[]
-  securityArchive: SecurityArchiveLike
+  securityArchive: SecurityArchiveLike | undefined
 }
 
 export type HostContextsMap = Map<

--- a/src/server/src/handle-request.ts
+++ b/src/server/src/handle-request.ts
@@ -200,11 +200,7 @@ export const handleRequest = async (
             }
 
             // load each individual graph
-            const graph = actual.load({
-              ...config.options,
-              projectRoot: folder.fullpath(),
-              skipLoadingNodesOnModifiersChange: false,
-            })
+            const graph = actual.load(config.options)
             const importers: NodeLike[] = []
             nodes.push(...graph.nodes.values())
             importers.push(...graph.importers)


### PR DESCRIPTION
Fixes security archive data integration with actual loaded data and transfering to the GUI, particularly when using the `:host()` selector.