### PR TITLE
feat(graph): add missing pseudo states/selectors

### DIFF
--- a/src/query/tap-snapshots/test/pseudo/license.ts.test.cjs
+++ b/src/query/tap-snapshots/test/pseudo/license.ts.test.cjs
@@ -5,6 +5,18 @@
  * Make sure to inspect the output below.  Do not ignore changes!
  */
 'use strict'
+exports[`test/pseudo/license.ts > TAP > pseudo state form - :license without parameters > should match packages with any license defined (not none) 1`] = `
+Object {
+  "edges": Array [
+    "file·.->··e@1.0.0",
+    "··d@1.0.0->··e@1.0.0",
+  ],
+  "nodes": Array [
+    "··e@1.0.0",
+  ],
+}
+`
+
 exports[`test/pseudo/license.ts > TAP > selects packages with a specific license kind > filter out any node that does not have the license > must match snapshot 1`] = `
 Object {
   "edges": Array [

--- a/src/query/tap-snapshots/test/pseudo/published.ts.test.cjs
+++ b/src/query/tap-snapshots/test/pseudo/published.ts.test.cjs
@@ -5,6 +5,26 @@
  * Make sure to inspect the output below.  Do not ignore changes!
  */
 'use strict'
+exports[`test/pseudo/published.ts > TAP > pseudo state form - :published without parameters > should match packages with published metadata (registry packages) 1`] = `
+Object {
+  "edges": Array [
+    "file·.->··a@1.0.0",
+    "file·.->··b@1.0.0",
+    "file·.->··e@1.0.0",
+    "··b@1.0.0->··c@1.0.0",
+    "··d@1.0.0->··e@1.0.0",
+    "··d@1.0.0->··f@1.0.0",
+  ],
+  "nodes": Array [
+    "··a@1.0.0",
+    "··b@1.0.0",
+    "··c@1.0.0",
+    "··e@1.0.0",
+    "··f@1.0.0",
+  ],
+}
+`
+
 exports[`test/pseudo/published.ts > TAP > select from published definition > published exact date > must match snapshot 1`] = `
 Object {
   "edges": Array [

--- a/src/query/tap-snapshots/test/pseudo/score.ts.test.cjs
+++ b/src/query/tap-snapshots/test/pseudo/score.ts.test.cjs
@@ -5,6 +5,28 @@
  * Make sure to inspect the output below.  Do not ignore changes!
  */
 'use strict'
+exports[`test/pseudo/score.ts > TAP > pseudo state form - :score without parameters > should match any packages with score data (scanned packages) 1`] = `
+Object {
+  "edges": Array [
+    "file·.->··a@1.0.0",
+    "file·.->··b@1.0.0",
+    "file·.->··e@1.0.0",
+    "··b@1.0.0->··c@1.0.0",
+    "··b@1.0.0->··d@1.0.0",
+    "··d@1.0.0->··e@1.0.0",
+    "··d@1.0.0->··f@1.0.0",
+  ],
+  "nodes": Array [
+    "··a@1.0.0",
+    "··b@1.0.0",
+    "··c@1.0.0",
+    "··d@1.0.0",
+    "··e@1.0.0",
+    "··f@1.0.0",
+  ],
+}
+`
+
 exports[`test/pseudo/score.ts > TAP > selects packages based on their security score > exact match on overall score > must match snapshot 1`] = `
 Object {
   "edges": Array [

--- a/src/query/tap-snapshots/test/pseudo/squat.ts.test.cjs
+++ b/src/query/tap-snapshots/test/pseudo/squat.ts.test.cjs
@@ -5,6 +5,20 @@
  * Make sure to inspect the output below.  Do not ignore changes!
  */
 'use strict'
+exports[`test/pseudo/squat.ts > TAP > pseudo state form - :squat without parameters > should match any packages with squat alerts 1`] = `
+Object {
+  "edges": Array [
+    "file·.->··e@1.0.0",
+    "··d@1.0.0->··e@1.0.0",
+    "··d@1.0.0->··f@1.0.0",
+  ],
+  "nodes": Array [
+    "··e@1.0.0",
+    "··f@1.0.0",
+  ],
+}
+`
+
 exports[`test/pseudo/squat.ts > TAP > selects packages with a specific squat kind > filter out any node that does not have the squat alert > must match snapshot 1`] = `
 Object {
   "edges": Array [

--- a/src/query/test/pseudo/score.ts
+++ b/src/query/test/pseudo/score.ts
@@ -546,3 +546,46 @@ t.test('utility functions', async t => {
     )
   })
 })
+
+t.test('pseudo state form - :score without parameters', async t => {
+  const getState = (graph = getSimpleGraph()) => {
+    const ast = parse(':score')
+    const current = ast.first.first
+    const state: ParserState = {
+      comment: '',
+      current,
+      initial: {
+        edges: new Set(graph.edges.values()),
+        nodes: new Set(graph.nodes.values()),
+      },
+      partial: {
+        edges: new Set(graph.edges.values()),
+        nodes: new Set(graph.nodes.values()),
+      },
+      collect: {
+        edges: new Set(),
+        nodes: new Set(),
+      },
+      cancellable: async () => {},
+      walk: async i => i,
+      securityArchive: createTestSecurityArchive(),
+      importers: new Set(graph.importers),
+      retries: 0,
+      signal: new AbortController().signal,
+      specificity: { idCounter: 0, commonCounter: 0 },
+    }
+    return state
+  }
+
+  const state = getState()
+  const result = await score(state)
+  t.matchSnapshot(
+    {
+      nodes: [...result.partial.nodes].map(n => n.id),
+      edges: [...result.partial.edges].map(
+        e => `${e.from.id}->${e.to?.id}`,
+      ),
+    },
+    'should match any packages with score data (scanned packages)',
+  )
+})

--- a/src/query/test/pseudo/squat.ts
+++ b/src/query/test/pseudo/squat.ts
@@ -327,12 +327,10 @@ t.test('selects packages with a specific squat kind', async t => {
     )
   })
 
-  await t.test('wrong parameter', async t => {
-    await t.rejects(
-      squat(getState(':squat')),
-      { message: /Failed to parse :squat selector/ },
-      'should throw an error',
-    )
+  await t.test('pseudo state form works', async t => {
+    // :squat without parameters should now work as pseudo state
+    const result = await squat(getState(':squat'))
+    t.ok(result, 'should not throw an error for pseudo state form')
   })
 })
 
@@ -455,5 +453,113 @@ t.test('parseInternals', async t => {
       message: /Expected a valid squat kind for comparison/,
     },
     'should throw for out of range number with comparator',
+  )
+})
+
+t.test('pseudo state form - :squat without parameters', async t => {
+  const getState = (graph = getSimpleGraph()) => {
+    const ast = parse(':squat')
+    const current = ast.first.first
+    const state: ParserState = {
+      comment: '',
+      current,
+      initial: {
+        edges: new Set(graph.edges.values()),
+        nodes: new Set(graph.nodes.values()),
+      },
+      partial: {
+        edges: new Set(graph.edges.values()),
+        nodes: new Set(graph.nodes.values()),
+      },
+      collect: {
+        edges: new Set(),
+        nodes: new Set(),
+      },
+      cancellable: async () => {},
+      walk: async i => i,
+      securityArchive: asSecurityArchiveLike(
+        new Map([
+          [
+            joinDepIDTuple(['registry', '', 'e@1.0.0']),
+            {
+              id: joinDepIDTuple(['registry', '', 'e@1.0.0']),
+              alerts: [{ type: 'didYouMean' }],
+            },
+          ],
+          [
+            joinDepIDTuple(['registry', '', 'f@1.0.0']),
+            {
+              id: joinDepIDTuple(['registry', '', 'f@1.0.0']),
+              alerts: [{ type: 'gptDidYouMean' }],
+            },
+          ],
+        ]),
+      ),
+      importers: new Set(graph.importers),
+      retries: 0,
+      signal: new AbortController().signal,
+      specificity: { idCounter: 0, commonCounter: 0 },
+    }
+    return state
+  }
+
+  const state = getState()
+  const result = await squat(state)
+  t.matchSnapshot(
+    {
+      nodes: [...result.partial.nodes].map(n => n.id),
+      edges: [...result.partial.edges].map(
+        e => `${e.from.id}->${e.to?.id}`,
+      ),
+    },
+    'should match any packages with squat alerts',
+  )
+})
+
+t.test('error handling for non-query node errors', async t => {
+  // Create a state that will trigger a non-"Expected a query node" error
+  const ast = parse(':squat(invalid)')
+  const current = ast.first.first
+
+  // Create a corrupted current node that will cause parsing to fail differently
+  const corruptedCurrent = {
+    ...current,
+    nodes: [
+      {
+        type: 'function',
+        value: 'squat',
+        nodes: null, // This will cause asPostcssNodeWithChildren to fail differently
+      },
+    ],
+  }
+
+  const state: ParserState = {
+    comment: '',
+    current: corruptedCurrent as any,
+    initial: {
+      edges: new Set(),
+      nodes: new Set(),
+    },
+    partial: {
+      edges: new Set(),
+      nodes: new Set(),
+    },
+    collect: {
+      edges: new Set(),
+      nodes: new Set(),
+    },
+    cancellable: async () => {},
+    walk: async i => i,
+    securityArchive: asSecurityArchiveLike(new Map()),
+    importers: new Set(),
+    retries: 0,
+    signal: new AbortController().signal,
+    specificity: { idCounter: 0, commonCounter: 0 },
+  }
+
+  await t.rejects(
+    squat(state),
+    { message: /Failed to parse :squat selector/ },
+    'should throw error for parsing failures other than missing query node',
   )
 })

--- a/www/docs/src/content/docs/cli/selectors.mdx
+++ b/www/docs/src/content/docs/cli/selectors.mdx
@@ -174,6 +174,9 @@ e.g: `#foo` is the same as `[name=foo]`
   project.
 - `:peer` Matches peer dependencies to your current project.
 - `:link` Matches linked packages only.
+- `:outdated` Matches packages that have any newer version available
+  (equivalent to `:outdated(any)`).
+- `:scanned` Matches packages that have insight security metadata.
 
 ### Security Insights Pseudo Classes & States
 
@@ -248,6 +251,14 @@ security data needs to be fetched prior to a `Query` instantiation.
   intentionally packed to hide their behavior. This could be a sign of
   malware.
 - `:scanned` Matches packages that have insight security metadata.
+- `:squat` Matches packages with names similar to other popular
+  packages at any severity level (equivalent to `:not(:squat(none))`).
+- `:score` Matches packages that have any security score data
+  available (equivalent to `:scanned`).
+- `:license` Matches packages that have any license defined
+  (equivalent to `:not(:license(none))`).
+- `:published` Matches packages that have published metadata available
+  (useful for filtering registry packages).
 - `:score(<rate>, <kind>)` Matches packages based on their security
   score. The rate parameter is required and should be a value between
   0 and 100 (or 0 and 1). The rate parameter can be prefixed with a
@@ -263,13 +274,14 @@ security data needs to be fetched prior to a `Query` instantiation.
 - `:scripts` Matches packages that have scripts that are run when the
   package is installed. The majority of malware in npm is hidden in
   install scripts.
-- `:severity` Matches packages based of the severity level of any
-  attached CVE. The type paremeter is required and can be one of the
-  following:
+- `:severity(<level>)` Matches packages based on the severity level of
+  any attached CVE. The level parameter is required and can be one of
+  the following:
   - `critical` or `0`
   - `high` or `1`
   - `medium` or `2`
   - `low` or `3`
+  - Supports comparators: `:severity(">1")`, `:severity(">=medium")`
 - `:shell` Matches packages that accesses the system shell. Accessing
   the system shell increases the risk of executing arbitrary code.
 - `:shrinkwrap` Matches packages that contains a shrinkwrap file. This


### PR DESCRIPTION
### Features
- added `:squat` - Matches for ANY level of squat severity level
- added `:score` - Matches ANY security score data available (equivalent to `:scanned`)
- added `:license` - Matches ANY license defined (equivalent to `:not(:license(none))`)
- added `:published` - Matches packages with ANY published time metadata available (useful for filtering registry packages prior to using the pseudo method)

### Documentation
- Fixed `:severity` documentation - Now correctly shows it as `:severity(<level>)` function instead of it as a pseudo state
- Updated `:outdated` documentation - Clarified that it works both as function and pseudo state
- Added new pseudo state selectors to documentation - All new selectors are properly documented

Fixes: #1191 #1192