### PR TITLE
add a `vlt build` command

### DIFF
--- a/src/cli-sdk/src/commands/build.ts
+++ b/src/cli-sdk/src/commands/build.ts
@@ -1,0 +1,204 @@
+import { build, skip, actual, GraphModifier } from '@vltpkg/graph'
+import { error } from '@vltpkg/error-cause'
+import { Query } from '@vltpkg/query'
+import { SecurityArchive } from '@vltpkg/security-archive'
+import { commandUsage } from '../config/usage.ts'
+import { createHostContextsMap } from '../query-host-contexts.ts'
+import type { Node, Graph } from '@vltpkg/graph'
+import type { DepID } from '@vltpkg/dep-id'
+import type { NodeLike } from '@vltpkg/types'
+import type { CommandFn, CommandUsage } from '../index.ts'
+import type { LoadedConfig } from '../config/index.ts'
+import type { Views } from '../view.ts'
+import { isErrorWithCause } from '@vltpkg/types'
+
+export const views = {
+  human: (_, __, conf) => {
+    const sub = conf.positionals[0]
+    return sub === 'skip' ?
+        'Skip completed successfully.'
+      : 'Build completed successfully.'
+  },
+  json: (_, __, conf) => {
+    const sub = conf.positionals[0]
+    return sub === 'skip' ?
+        {
+          success: true,
+          message: 'Skip completed successfully.',
+        }
+      : {
+          success: true,
+          message: 'Build completed successfully.',
+        }
+  },
+} as const satisfies Views
+
+export const usage: CommandUsage = () =>
+  commandUsage({
+    command: 'build',
+    usage: '[skip] [--scope=<query>]',
+    description: `Build the project based on the current dependency graph.
+
+    This command processes the installed packages in node_modules and runs
+    any necessary build steps, such as lifecycle scripts and binary linking.
+    
+    The build process is idempotent and will only perform work that is
+    actually needed based on the current state of the dependency graph.
+    
+    Use --scope option to filter packages using DSS query language syntax.`,
+    subcommands: {
+      skip: {
+        usage: '[--scope=<query>]',
+        description:
+          'Skip building queued packages and update lockfile',
+      },
+    },
+    options: {
+      scope: {
+        value: '<query>',
+        description:
+          'Query selector to filter packages using DSS syntax.',
+      },
+    },
+  })
+
+const isGraphRunError = (
+  error: unknown,
+): error is Error & { code: string; node: Node } =>
+  typeof error === 'object' &&
+  error !== null &&
+  'code' in error &&
+  error.code === 'GRAPHRUN_TRAVERSAL' &&
+  'node' in error
+
+/**
+ * Helper function to get filtered nodes based on scope query
+ */
+const getFilteredNodes = async (
+  conf: LoadedConfig,
+  graph: Graph | undefined,
+): Promise<DepID[] | undefined> => {
+  const queryString = conf.get('scope')
+  /* c8 ignore next */
+  if (!queryString || !graph) return undefined
+
+  const hostContexts = await createHostContextsMap(conf)
+  /* c8 ignore start */
+  const securityArchive =
+    Query.hasSecuritySelectors(queryString) ?
+      await SecurityArchive.start({
+        nodes: [...graph.nodes.values()],
+      })
+    : undefined
+  /* c8 ignore stop */
+
+  const edges = graph.edges
+  const nodes = new Set<NodeLike>(graph.nodes.values())
+  const importers = graph.importers
+
+  const query = new Query({
+    edges,
+    nodes,
+    importers,
+    securityArchive,
+    hostContexts,
+  })
+
+  const { nodes: resultNodes } = await query.search(queryString, {
+    signal: new AbortController().signal,
+  })
+
+  return resultNodes.map(node => node.id)
+}
+
+/**
+ * Build command implementation. Runs any required "postinstall"
+ * lifecycle scripts and binary linking.
+ */
+export const command: CommandFn = async (conf: LoadedConfig) => {
+  const { options, projectRoot } = conf
+  const sub = conf.positionals[0]
+
+  try {
+    // Handle skip subcommand
+    if (sub === 'skip') {
+      // For skip, we need to load the graph to potentially filter by scope
+      let queryFilteredNodes: DepID[] | undefined
+
+      if (conf.get('scope')) {
+        const modifiers = GraphModifier.maybeLoad(options)
+        const mainManifest =
+          options.packageJson.maybeRead(projectRoot)
+        let graph: Graph | undefined
+
+        if (mainManifest) {
+          graph = actual.load({
+            ...options,
+            mainManifest,
+            modifiers,
+            monorepo: options.monorepo,
+            loadManifests: false,
+          })
+        }
+
+        queryFilteredNodes = await getFilteredNodes(conf, graph)
+      }
+
+      await skip({
+        ...options,
+        projectRoot,
+        packageJson: options.packageJson,
+        monorepo: options.monorepo,
+        scurry: options.scurry,
+        queryFilteredNodes,
+      })
+
+      return { success: true }
+    }
+
+    // Handle default build command
+    let queryFilteredNodes: DepID[] | undefined
+
+    if (conf.get('scope')) {
+      const modifiers = GraphModifier.maybeLoad(options)
+      const mainManifest = options.packageJson.maybeRead(projectRoot)
+      let graph: Graph | undefined
+
+      if (mainManifest) {
+        graph = actual.load({
+          ...options,
+          mainManifest,
+          modifiers,
+          monorepo: options.monorepo,
+          loadManifests: false,
+        })
+      }
+
+      queryFilteredNodes = await getFilteredNodes(conf, graph)
+    }
+
+    // Run the build process using the graph build function
+    await build({
+      ...options,
+      projectRoot,
+      packageJson: options.packageJson,
+      monorepo: options.monorepo,
+      scurry: options.scurry,
+      queryFilteredNodes,
+    })
+
+    return { success: true }
+  } catch (cause) {
+    let errorMsg = sub === 'skip' ? 'Skip failed' : 'Build failed'
+    const graphRunError =
+      isErrorWithCause(cause) && isGraphRunError(cause.cause) ?
+        cause.cause
+      : undefined
+    if (graphRunError?.code === 'GRAPHRUN_TRAVERSAL') {
+      errorMsg +=
+        ':\n  Failed to build package: ' +
+        `${graphRunError.node.name}@${graphRunError.node.version}`
+    }
+    throw error(errorMsg, { cause })
+  }
+}

--- a/src/cli-sdk/src/commands/ci.ts
+++ b/src/cli-sdk/src/commands/ci.ts
@@ -1,9 +1,11 @@
-import type { Graph } from '@vltpkg/graph'
-import { commandUsage } from '../config/usage.ts'
-import type { CommandFn, CommandUsage } from '../index.ts'
 import { install } from '@vltpkg/graph'
-import type { Views } from '../view.ts'
+import { commandUsage } from '../config/usage.ts'
 import { InstallReporter } from './install/reporter.ts'
+import type { CommandFn, CommandUsage } from '../index.ts'
+import type { Views } from '../view.ts'
+import type { InstallResult } from './install.ts'
+
+export type CIResult = Omit<InstallResult, 'buildQueue'>
 
 export const usage: CommandUsage = () =>
   commandUsage({
@@ -19,18 +21,20 @@ export const usage: CommandUsage = () =>
   })
 
 export const views = {
-  json: g => g.toJSON(),
+  json: i => i.graph.toJSON(),
   human: InstallReporter,
-} as const satisfies Views<Graph>
+} as const satisfies Views<CIResult>
 
-export const command: CommandFn<Graph> = async conf => {
+export const command: CommandFn<CIResult> = async conf => {
   const ciOptions = {
     ...conf.options,
+    // include scripts by default on ci
+    includeScripts: conf.options['install-scripts'] ?? true,
     expectLockfile: true,
     frozenLockfile: true,
     cleanInstall: true,
   }
 
   const { graph } = await install(ciOptions)
-  return graph
+  return { graph }
 }

--- a/src/cli-sdk/src/commands/install.ts
+++ b/src/cli-sdk/src/commands/install.ts
@@ -1,10 +1,25 @@
-import type { Graph } from '@vltpkg/graph'
 import { commandUsage } from '../config/usage.ts'
-import type { CommandFn, CommandUsage } from '../index.ts'
 import { install } from '@vltpkg/graph'
 import { parseAddArgs } from '../parse-add-remove-args.ts'
-import type { Views } from '../view.ts'
 import { InstallReporter } from './install/reporter.ts'
+import type { DepID } from '@vltpkg/dep-id'
+import type { Graph } from '@vltpkg/graph'
+import type { CommandFn, CommandUsage } from '../index.ts'
+import type { Views } from '../view.ts'
+
+/**
+ * The resulting object of an install operation. To be used by the view impl.
+ */
+export type InstallResult = {
+  /**
+   * A queue of package IDs that need to be built after the install is complete.
+   */
+  buildQueue?: DepID[]
+  /**
+   * The resulting graph structure at the end of an install.
+   */
+  graph: Graph
+}
 
 export const usage: CommandUsage = () =>
   commandUsage({
@@ -15,22 +30,34 @@ export const usage: CommandUsage = () =>
   })
 
 export const views = {
-  json: g => g.toJSON(),
+  json: i => ({
+    ...(i.buildQueue?.length ?
+      {
+        buildQueue: i.buildQueue,
+        message: `${i.buildQueue.length} packages that will need to be built, run "vlt build" to complete the install.`,
+      }
+    : null),
+    graph: i.graph.toJSON(),
+  }),
   human: InstallReporter,
-} as const satisfies Views<Graph>
+} as const satisfies Views<InstallResult>
 
-export const command: CommandFn<Graph> = async conf => {
+export const command: CommandFn<InstallResult> = async conf => {
+  // TODO: we should probably throw an error if the user
+  // tries to install using either view=mermaid or view=gui
   const monorepo = conf.options.monorepo
   const { add } = parseAddArgs(conf, monorepo)
   const frozenLockfile = conf.options['frozen-lockfile']
   const expectLockfile = conf.options['expect-lockfile']
-  const { graph } = await install(
+  const includeScripts = conf.options['install-scripts']
+  const { buildQueue, graph } = await install(
     {
       ...conf.options,
       frozenLockfile,
       expectLockfile,
+      includeScripts,
     },
     add,
   )
-  return graph
+  return { buildQueue, graph }
 }

--- a/src/cli-sdk/src/commands/install/reporter.ts
+++ b/src/cli-sdk/src/commands/install/reporter.ts
@@ -11,6 +11,7 @@ import {
 } from 'react'
 import { ViewClass } from '../../view.ts'
 import { asError } from '@vltpkg/types'
+import type { InstallResult } from '../install.ts'
 
 type Step = {
   state: 'waiting' | 'in_progress' | 'completed'
@@ -98,8 +99,19 @@ export class InstallReporter extends ViewClass {
     this.#instance = render($(App))
   }
 
-  async done(_result: unknown, { time }: { time: number }) {
-    this.#instance?.rerender($(App, { trailer: `Done in ${time}ms` }))
+  async done(_result: InstallResult, { time }: { time: number }) {
+    let out = `Done in ${time}ms`
+
+    // prints a very complete message explaining users the next steps
+    // in case there are packages to be built
+    if (_result.buildQueue?.length) {
+      out += `\n\nℹ️ ${_result.buildQueue.length} packages have install scripts/bins defined & were not fully built\n`
+      out += '🔎 Run `vlt query :scripts` to list them\n'
+      out +=
+        '🔨 Run `vlt build` to run all required scripts to build installed packages.\n'
+      out += '💡 Learn more: `vlt build --help`\n'
+    }
+    this.#instance?.rerender($(App, { trailer: out }))
     return undefined
   }
 

--- a/src/cli-sdk/src/commands/uninstall.ts
+++ b/src/cli-sdk/src/commands/uninstall.ts
@@ -6,6 +6,13 @@ import { parseRemoveArgs } from '../parse-add-remove-args.ts'
 import { InstallReporter } from './install/reporter.ts'
 import type { Views } from '../view.ts'
 
+export type UninstallResult = {
+  /**
+   * The resulting graph structure at the end of an uninstall.
+   */
+  graph: Graph
+}
+
 export const usage: CommandUsage = () =>
   commandUsage({
     command: 'uninstall',
@@ -15,13 +22,13 @@ export const usage: CommandUsage = () =>
   })
 
 export const views = {
-  json: g => g.toJSON(),
+  json: i => i.graph.toJSON(),
   human: InstallReporter,
-} as const satisfies Views<Graph>
+} as const satisfies Views<UninstallResult>
 
-export const command: CommandFn<Graph> = async conf => {
+export const command: CommandFn<UninstallResult> = async conf => {
   const monorepo = conf.options.monorepo
   const { remove } = parseRemoveArgs(conf, monorepo)
   const { graph } = await uninstall(conf.options, remove)
-  return graph
+  return { graph }
 }

--- a/src/cli-sdk/src/commands/update.ts
+++ b/src/cli-sdk/src/commands/update.ts
@@ -1,10 +1,10 @@
 import { update } from '@vltpkg/graph'
 import { error } from '@vltpkg/error-cause'
-import type { Graph } from '@vltpkg/graph'
 import { commandUsage } from '../config/usage.ts'
 import type { CommandFn, CommandUsage } from '../index.ts'
 import { InstallReporter } from './install/reporter.ts'
 import type { Views } from '../view.ts'
+import type { InstallResult } from './install.ts'
 
 export const usage: CommandUsage = () =>
   commandUsage({
@@ -15,11 +15,19 @@ export const usage: CommandUsage = () =>
   })
 
 export const views = {
-  json: g => g.toJSON(),
+  json: i => ({
+    ...(i.buildQueue?.length ?
+      {
+        buildQueue: i.buildQueue,
+        message: `${i.buildQueue.length} packages that will need to be built, run "vlt build" to complete the update.`,
+      }
+    : null),
+    graph: i.graph.toJSON(),
+  }),
   human: InstallReporter,
-} as const satisfies Views<Graph>
+} as const satisfies Views<InstallResult>
 
-export const command: CommandFn<Graph> = async conf => {
+export const command: CommandFn<InstallResult> = async conf => {
   // Throw error if any arguments are provided
   if (conf.positionals.length > 0) {
     throw error('Arguments are not yet supported for vlt update', {
@@ -27,6 +35,6 @@ export const command: CommandFn<Graph> = async conf => {
     })
   }
 
-  const { graph } = await update(conf.options)
-  return graph
+  const { buildQueue, graph } = await update(conf.options)
+  return { buildQueue, graph }
 }

--- a/src/cli-sdk/src/config/definition.ts
+++ b/src/cli-sdk/src/config/definition.ts
@@ -19,6 +19,7 @@ export const defaultEditor = () =>
   : 'vi')
 
 const canonicalCommands = {
+  build: 'build',
   cache: 'cache',
   ci: 'ci',
   config: 'config',
@@ -630,6 +631,10 @@ export const definition = j
     'frozen-lockfile': {
       description:
         'Fail if lockfile is missing or out of sync with package.json. Prevents any lockfile modifications.',
+    },
+    'install-scripts': {
+      description:
+        'Include lifecycle scripts when installing packages',
     },
   })
   .opt({

--- a/src/cli-sdk/tap-snapshots/test/commands/build.ts.test.cjs
+++ b/src/cli-sdk/tap-snapshots/test/commands/build.ts.test.cjs
@@ -1,0 +1,67 @@
+/* IMPORTANT
+ * This snapshot file is auto-generated, but designed for humans.
+ * It should be checked into source control and tracked carefully.
+ * Re-generate by setting TAP_SNAPSHOT=1 and running tests.
+ * Make sure to inspect the output below.  Do not ignore changes!
+ */
+'use strict'
+exports[`test/commands/build.ts > TAP > command execution > successful build > should format human output for successful build 1`] = `
+Build completed successfully.
+`
+
+exports[`test/commands/build.ts > TAP > command execution > successful build > should format json output for successful build 1`] = `
+Object {
+  "message": "Build completed successfully.",
+  "success": true,
+}
+`
+
+exports[`test/commands/build.ts > TAP > usage > should return usage information 1`] = `
+Usage:
+  vlt build [skip] [--scope=<query>]
+
+Build the project based on the current dependency graph.
+
+This command processes the installed packages in node_modules and runs any
+necessary build steps, such as lifecycle scripts and binary linking.
+The build process is idempotent and will only perform work that is actually
+needed based on the current state of the dependency graph.
+Use --scope option to filter packages using DSS query language syntax.
+
+  Subcommands
+
+    skip
+      Skip building queued packages and update lockfile
+
+      ​vlt build skip [--scope=<query>]
+
+  Options
+
+    scope
+      Query selector to filter packages using DSS syntax.
+
+      ​--scope=<query>
+
+`
+
+exports[`test/commands/build.ts > TAP > views > human view - build > should return human-readable success message for build 1`] = `
+Build completed successfully.
+`
+
+exports[`test/commands/build.ts > TAP > views > human view - skip > should return human-readable success message for skip 1`] = `
+Skip completed successfully.
+`
+
+exports[`test/commands/build.ts > TAP > views > json view - build > should return json success object for build 1`] = `
+Object {
+  "message": "Build completed successfully.",
+  "success": true,
+}
+`
+
+exports[`test/commands/build.ts > TAP > views > json view - skip > should return json success object for skip 1`] = `
+Object {
+  "message": "Skip completed successfully.",
+  "success": true,
+}
+`

--- a/src/cli-sdk/tap-snapshots/test/config/definition.ts.test.cjs
+++ b/src/cli-sdk/tap-snapshots/test/config/definition.ts.test.cjs
@@ -9,6 +9,7 @@ exports[`test/config/definition.ts > TAP > commands 1`] = `
 Object {
   "?": "help",
   "add": "install",
+  "build": "build",
   "cache": "cache",
   "ci": "ci",
   "conf": "config",
@@ -141,6 +142,7 @@ Object {
     "hint": "command",
     "type": "string",
     "validOptions": Array [
+      "build",
       "cache",
       "ci",
       "config",
@@ -253,6 +255,10 @@ Object {
       This will default to true if --scope, --workspace,
       --workspace-group, or --recursive is set. Otherwise, it will default to false.
     ),
+    "type": "boolean",
+  },
+  "install-scripts": Object {
+    "description": "Include lifecycle scripts when installing packages",
     "type": "boolean",
   },
   "jsr-registries": Object {
@@ -505,6 +511,7 @@ Array [
   "--help",
   "--identity=<name>",
   "--if-present",
+  "--install-scripts",
   "--jsr-registries=<name=url>",
   "--no-bail",
   "--no-color",
@@ -562,6 +569,7 @@ Array [
   "help",
   "identity",
   "if-present",
+  "install-scripts",
   "jsr-registries",
   "no-bail",
   "no-color",

--- a/src/cli-sdk/tap-snapshots/test/index.ts.test.cjs
+++ b/src/cli-sdk/tap-snapshots/test/index.ts.test.cjs
@@ -58,6 +58,7 @@ Unknown option '--unknown'. To specify a positional argument starting with a '-'
     --help
     --identity=<name>
     --if-present
+    --install-scripts
     --jsr-registries=<name=url>
     --no-bail
     --no-color
@@ -118,6 +119,7 @@ Unknown config option: asdf
     help
     identity
     if-present
+    install-scripts
     jsr-registries
     no-bail
     no-color

--- a/src/cli-sdk/test/commands/build.ts
+++ b/src/cli-sdk/test/commands/build.ts
@@ -1,0 +1,459 @@
+import t from 'tap'
+import type { LoadedConfig } from '../../src/config/index.ts'
+import type { Node } from '@vltpkg/graph'
+
+let buildCalled = false
+let buildOptions: any = null
+let skipCalled = false
+let skipOptions: any = null
+let actualLoadCalled = false
+let _actualLoadOptions: any = null
+let queryCalled = false
+let _queryOptions: any = null
+let mockError: Error | null = null
+
+// Reset state before each test
+t.beforeEach(() => {
+  buildCalled = false
+  buildOptions = null
+  skipCalled = false
+  skipOptions = null
+  actualLoadCalled = false
+  _actualLoadOptions = null
+  queryCalled = false
+  _queryOptions = null
+  mockError = null
+})
+
+const mockGraph = {
+  nodes: new Map([['dep1', { id: 'dep1' }]]),
+  edges: new Set(),
+  importers: new Set(),
+}
+
+const Command = await t.mockImport<
+  typeof import('../../src/commands/build.ts')
+>('../../src/commands/build.ts', {
+  '@vltpkg/graph': {
+    build: async (options: any) => {
+      buildCalled = true
+      buildOptions = options
+      if (mockError) throw mockError
+    },
+    skip: async (options: any) => {
+      skipCalled = true
+      skipOptions = options
+      if (mockError) throw mockError
+    },
+    actual: {
+      load: (options: any) => {
+        actualLoadCalled = true
+        _actualLoadOptions = options
+        return mockGraph
+      },
+    },
+    GraphModifier: {
+      maybeLoad: () => null,
+    },
+    // Common graph exports that other modules may import
+    asDependency: (obj: unknown) => obj,
+    install: async () => ({ graph: mockGraph, buildQueue: [] }),
+    uninstall: async () => ({ graph: mockGraph }),
+    update: async () => ({ graph: mockGraph, buildQueue: [] }),
+    createVirtualRoot: () => ({
+      name: 'virtual-root',
+      version: '0.0.0',
+    }),
+    reify: async () => ({
+      diff: { nodes: new Map(), edges: new Map() },
+      buildQueue: [],
+    }),
+    lockfile: {
+      load: () => mockGraph,
+      save: () => {},
+      loadEdges: () => new Set(),
+      loadNodes: () => new Map(),
+    },
+    ideal: {
+      build: () => mockGraph,
+    },
+    Graph: class MockGraph {
+      nodes = new Map()
+    },
+    Node: class MockNode {
+      id = 'mock-node'
+    },
+    Edge: class MockEdge {
+      spec = null
+    },
+    Diff: class MockDiff {
+      nodes = new Map()
+    },
+  },
+  '@vltpkg/query': {
+    Query: class MockQuery {
+      constructor(options: any) {
+        _queryOptions = options
+      }
+      static hasSecuritySelectors = () => false
+      async search() {
+        queryCalled = true
+        return { nodes: [{ id: 'dep1' }] }
+      }
+    },
+  },
+  '@vltpkg/security-archive': {
+    SecurityArchive: {
+      start: () => undefined,
+    },
+  },
+  '../query-host-contexts.ts': {
+    createHostContextsMap: async () => ({}),
+  },
+})
+
+const makeTestConfig = (
+  options = {},
+  values = {},
+  positionals: string[] = [],
+): LoadedConfig =>
+  ({
+    projectRoot: '/test/project',
+    options: {
+      packageJson: {},
+      monorepo: null,
+      scurry: {
+        cwd: {
+          resolve: (path: string) => ({ fullpath: () => path }),
+        },
+        lstat: async (path: string) => ({
+          isDirectory: () => true,
+          fullpath: () => path,
+        }),
+      },
+      ...options,
+    },
+    values,
+    positionals,
+    get: (key: string) => (values as any)[key],
+  }) as unknown as LoadedConfig
+
+t.test('usage', async t => {
+  t.matchSnapshot(
+    Command.usage().usage(),
+    'should return usage information',
+  )
+})
+
+t.test('views', async t => {
+  t.test('human view - build', async t => {
+    const config = makeTestConfig()
+    const output = Command.views.human({}, {}, config)
+    t.matchSnapshot(
+      output,
+      'should return human-readable success message for build',
+    )
+  })
+
+  t.test('json view - build', async t => {
+    const config = makeTestConfig()
+    const output = Command.views.json({}, {}, config)
+    t.matchSnapshot(
+      output,
+      'should return json success object for build',
+    )
+  })
+
+  t.test('human view - skip', async t => {
+    const config = makeTestConfig({}, {}, ['skip'])
+    const output = Command.views.human({}, {}, config)
+    t.matchSnapshot(
+      output,
+      'should return human-readable success message for skip',
+    )
+  })
+
+  t.test('json view - skip', async t => {
+    const config = makeTestConfig({}, {}, ['skip'])
+    const output = Command.views.json({}, {}, config)
+    t.matchSnapshot(
+      output,
+      'should return json success object for skip',
+    )
+  })
+})
+
+t.test('command execution', async t => {
+  t.test('successful build', async t => {
+    const config = makeTestConfig({
+      packageJson: { name: 'test-package' },
+      monorepo: { name: 'test-mono' },
+      scurry: { name: 'test-scurry' },
+    })
+
+    const result = await Command.command(config)
+
+    t.ok(buildCalled, 'should call build function')
+    t.strictSame(
+      result,
+      { success: true },
+      'should return success result',
+    )
+    t.strictSame(
+      buildOptions,
+      {
+        packageJson: { name: 'test-package' },
+        monorepo: { name: 'test-mono' },
+        scurry: { name: 'test-scurry' },
+        projectRoot: '/test/project',
+        queryFilteredNodes: undefined,
+      },
+      'should pass correct options to build function',
+    )
+
+    // Test views with the actual result
+    t.matchSnapshot(
+      Command.views.human({}, {}, config),
+      'should format human output for successful build',
+    )
+    t.matchSnapshot(
+      Command.views.json({}, {}, config),
+      'should format json output for successful build',
+    )
+  })
+
+  t.test('build fails with GRAPHRUN_TRAVERSAL error', async t => {
+    const mockNode = {
+      name: 'failing-package',
+      version: '1.2.3',
+    } as Node
+
+    const graphRunError = Object.assign(
+      new Error('Graph traversal failed'),
+      {
+        code: 'GRAPHRUN_TRAVERSAL',
+        node: mockNode,
+        cause: new Error('Inner error'),
+      },
+    )
+
+    const buildError = Object.assign(
+      new Error('Build process failed'),
+      {
+        cause: graphRunError,
+      },
+    )
+
+    mockError = buildError
+
+    const config = makeTestConfig()
+
+    await t.rejects(
+      Command.command(config),
+      {
+        message:
+          'Build failed:\n  Failed to build package: failing-package@1.2.3',
+        cause: {
+          cause: buildError,
+        },
+      },
+      'should throw error with specific package information',
+    )
+  })
+
+  t.test('build fails with generic error', async t => {
+    const buildError = new Error('Generic build failure')
+    mockError = buildError
+
+    const config = makeTestConfig()
+
+    await t.rejects(
+      Command.command(config),
+      {
+        message: 'Build failed',
+        cause: {
+          cause: buildError,
+        },
+      },
+      'should throw generic build failed error',
+    )
+  })
+
+  t.test('build fails with nested error without node', async t => {
+    const innerError = Object.assign(new Error('Some other error'), {
+      code: 'SOME_OTHER_ERROR',
+    })
+
+    const buildError = Object.assign(
+      new Error('Build process failed'),
+      {
+        cause: innerError,
+      },
+    )
+
+    mockError = buildError
+
+    const config = makeTestConfig()
+
+    await t.rejects(
+      Command.command(config),
+      {
+        message: 'Build failed',
+        cause: {
+          cause: buildError,
+        },
+      },
+      'should throw generic build failed error for non-GRAPHRUN_TRAVERSAL errors',
+    )
+  })
+
+  t.test(
+    'build fails with malformed GRAPHRUN_TRAVERSAL error',
+    async t => {
+      const graphRunError = Object.assign(
+        new Error('Graph traversal failed'),
+        {
+          code: 'GRAPHRUN_TRAVERSAL',
+          // Missing node property
+        },
+      )
+
+      const buildError = Object.assign(
+        new Error('Build process failed'),
+        {
+          cause: graphRunError,
+        },
+      )
+
+      mockError = buildError
+
+      const config = makeTestConfig()
+
+      await t.rejects(
+        Command.command(config),
+        {
+          message: 'Build failed',
+          cause: {
+            cause: buildError,
+          },
+        },
+        'should throw generic error for malformed GRAPHRUN_TRAVERSAL error',
+      )
+    },
+  )
+
+  t.test('build with --scope option', async t => {
+    const config = makeTestConfig(
+      {
+        packageJson: {
+          maybeRead: () => ({ name: 'test-package' }),
+        },
+      },
+      { scope: '#dep1' },
+    )
+
+    const result = await Command.command(config)
+
+    t.ok(buildCalled, 'should call build function')
+    t.ok(
+      actualLoadCalled,
+      'should load actual graph for scope filtering',
+    )
+    t.ok(queryCalled, 'should execute query search')
+    t.strictSame(
+      result,
+      { success: true },
+      'should return success result',
+    )
+    t.ok(
+      buildOptions.queryFilteredNodes,
+      'should pass queryFilteredNodes to build',
+    )
+    t.strictSame(
+      buildOptions.queryFilteredNodes,
+      ['dep1'],
+      'should pass filtered node IDs',
+    )
+  })
+
+  t.test('skip subcommand', async t => {
+    const config = makeTestConfig(
+      {
+        packageJson: { name: 'test-package' },
+        monorepo: { name: 'test-mono' },
+        scurry: { name: 'test-scurry' },
+      },
+      {},
+      ['skip'],
+    )
+
+    const result = await Command.command(config)
+
+    t.ok(skipCalled, 'should call skip function')
+    t.strictSame(
+      result,
+      { success: true },
+      'should return success result',
+    )
+    t.strictSame(
+      skipOptions,
+      {
+        packageJson: { name: 'test-package' },
+        monorepo: { name: 'test-mono' },
+        scurry: { name: 'test-scurry' },
+        projectRoot: '/test/project',
+        queryFilteredNodes: undefined,
+      },
+      'should pass correct options to skip function',
+    )
+  })
+
+  t.test('skip subcommand with --scope option', async t => {
+    const config = makeTestConfig(
+      {
+        packageJson: {
+          maybeRead: () => ({ name: 'test-package' }),
+        },
+      },
+      { scope: '#dep1' },
+      ['skip'],
+    )
+
+    const result = await Command.command(config)
+
+    t.ok(skipCalled, 'should call skip function')
+    t.ok(queryCalled, 'should execute query search')
+    t.strictSame(
+      result,
+      { success: true },
+      'should return success result',
+    )
+    t.ok(
+      skipOptions.queryFilteredNodes,
+      'should pass queryFilteredNodes to skip',
+    )
+    t.strictSame(
+      skipOptions.queryFilteredNodes,
+      ['dep1'],
+      'should pass filtered node IDs',
+    )
+  })
+
+  t.test('skip fails with error', async t => {
+    const skipError = new Error('Skip failure')
+    mockError = skipError
+
+    const config = makeTestConfig({}, {}, ['skip'])
+
+    await t.rejects(
+      Command.command(config),
+      {
+        message: 'Skip failed',
+        cause: {
+          cause: skipError,
+        },
+      },
+      'should throw skip failed error',
+    )
+  })
+})

--- a/src/cli-sdk/test/commands/ci.ts
+++ b/src/cli-sdk/test/commands/ci.ts
@@ -1,6 +1,6 @@
 import t from 'tap'
 import type { LoadedConfig } from '../../src/config/index.ts'
-import type { Graph } from '@vltpkg/graph'
+import type { CIResult } from '../../src/commands/ci.ts'
 
 const options = {}
 let log = ''
@@ -41,8 +41,10 @@ t.test('views', t => {
   // Test json view
   t.strictSame(
     Command.views.json({
-      toJSON: () => ({ ci: true }),
-    } as unknown as Graph),
+      graph: {
+        toJSON: () => ({ ci: true }),
+      },
+    } as unknown as CIResult),
     { ci: true },
     'json view returns graph.toJSON()',
   )

--- a/src/cli-sdk/test/commands/install.ts
+++ b/src/cli-sdk/test/commands/install.ts
@@ -1,6 +1,5 @@
 import t from 'tap'
 import type { LoadedConfig } from '../../src/config/index.ts'
-import type { Graph } from '@vltpkg/graph'
 
 const options = {}
 let log = ''
@@ -13,7 +12,9 @@ const Command = await t.mockImport<
     async install() {
       log += 'install\n'
       return {
-        graph: {},
+        graph: {
+          toJSON: () => ({}),
+        },
       }
     },
   },
@@ -52,9 +53,60 @@ t.matchSnapshot(log, 'should install adding a new dependency')
 
 t.strictSame(
   Command.views.json({
-    toJSON: () => ({ install: true }),
-  } as unknown as Graph),
-  { install: true },
+    graph: {
+      toJSON: () => ({
+        lockfileVersion: 0,
+        options: {},
+        nodes: {},
+        edges: {},
+      }),
+    } as any,
+  }),
+  {
+    graph: { lockfileVersion: 0, options: {}, nodes: {}, edges: {} },
+  },
+  'json view without buildQueue should only include graph',
+)
+
+// Test JSON view with buildQueue
+t.strictSame(
+  Command.views.json({
+    buildQueue: ['··foo@1.0.0' as any, '··bar@2.0.0' as any],
+    graph: {
+      toJSON: () => ({
+        lockfileVersion: 0,
+        options: {},
+        nodes: {},
+        edges: {},
+      }),
+    } as any,
+  }),
+  {
+    buildQueue: ['··foo@1.0.0', '··bar@2.0.0'],
+    message:
+      '2 packages that will need to be built, run "vlt build" to complete the install.',
+    graph: { lockfileVersion: 0, options: {}, nodes: {}, edges: {} },
+  },
+  'json view with buildQueue should include buildQueue, message, and graph',
+)
+
+// Test JSON view with empty buildQueue (should not include buildQueue or message)
+t.strictSame(
+  Command.views.json({
+    buildQueue: [],
+    graph: {
+      toJSON: () => ({
+        lockfileVersion: 0,
+        options: {},
+        nodes: {},
+        edges: {},
+      }),
+    } as any,
+  }),
+  {
+    graph: { lockfileVersion: 0, options: {}, nodes: {}, edges: {} },
+  },
+  'json view with empty buildQueue should only include graph',
 )
 
 t.test('frozen-lockfile flag', async t => {
@@ -87,7 +139,9 @@ t.test('frozen-lockfile flag', async t => {
           log += `add packages: ${add.size}\n`
         }
         return {
-          graph: {},
+          graph: {
+            toJSON: () => ({}),
+          },
         }
       },
       asDependency: (dep: any) => dep,

--- a/src/cli-sdk/test/commands/uninstall.ts
+++ b/src/cli-sdk/test/commands/uninstall.ts
@@ -1,6 +1,6 @@
 import t from 'tap'
 import type { LoadedConfig } from '../../src/config/index.ts'
-import type { Graph } from '@vltpkg/graph'
+import type { UninstallResult } from '../../src/commands/uninstall.ts'
 
 const options = {}
 let log = ''
@@ -44,7 +44,9 @@ t.matchSnapshot(log, 'should uninstall a dependency')
 
 t.strictSame(
   Command.views.json({
-    toJSON: () => ({ install: true }),
-  } as unknown as Graph),
+    graph: {
+      toJSON: () => ({ install: true }),
+    },
+  } as unknown as UninstallResult),
   { install: true },
 )

--- a/src/cli-sdk/test/commands/update.ts
+++ b/src/cli-sdk/test/commands/update.ts
@@ -1,6 +1,6 @@
 import t from 'tap'
 import type { LoadedConfig } from '../../src/config/index.ts'
-import type { Graph } from '@vltpkg/graph'
+import type { InstallResult } from '../../src/commands/install.ts'
 
 const options = {}
 let log = ''
@@ -64,10 +64,15 @@ t.test('update with multiple arguments throws error', async t => {
 
 t.test('views.json returns graph toJSON', t => {
   const mockGraph = {
-    toJSON: () => ({ updated: true }),
-  } as unknown as Graph
+    buildQueue: [],
+    graph: {
+      toJSON: () => ({ updated: true }),
+    },
+  } as unknown as InstallResult
 
-  t.strictSame(Command.views.json(mockGraph), { updated: true })
+  t.strictSame(Command.views.json(mockGraph), {
+    graph: { updated: true },
+  })
   t.end()
 })
 
@@ -76,3 +81,25 @@ t.test('views.human uses InstallReporter', t => {
   t.type(Command.views.human, 'function')
   t.end()
 })
+
+// Test JSON view with buildQueue
+t.strictSame(
+  Command.views.json({
+    buildQueue: ['··foo@1.0.0' as any, '··bar@2.0.0' as any],
+    graph: {
+      toJSON: () => ({
+        lockfileVersion: 0,
+        options: {},
+        nodes: {},
+        edges: {},
+      }),
+    } as any,
+  }),
+  {
+    buildQueue: ['··foo@1.0.0', '··bar@2.0.0'],
+    message:
+      '2 packages that will need to be built, run "vlt build" to complete the update.',
+    graph: { lockfileVersion: 0, options: {}, nodes: {}, edges: {} },
+  },
+  'json view with buildQueue should include buildQueue, message, and graph',
+)

--- a/src/graph/src/build.ts
+++ b/src/graph/src/build.ts
@@ -1,0 +1,413 @@
+import {
+  readFileSync,
+  existsSync,
+  unlinkSync,
+  writeFileSync,
+} from 'node:fs'
+import { resolve } from 'node:path'
+import { Monorepo } from '@vltpkg/workspaces'
+import { splitDepID } from '@vltpkg/dep-id'
+import { load as loadActual } from './actual/load.ts'
+import { build as reifyBuild } from './reify/build.ts'
+import { Diff } from './diff.ts'
+import { Graph } from './graph.ts'
+import type { BuildData } from './reify/save-build.ts'
+import type { LoadOptions } from './actual/load.ts'
+import type { LockfileData } from './lockfile/types.ts'
+import type { DepID } from '@vltpkg/dep-id'
+import { saveData } from './lockfile/save.ts'
+
+/**
+ * Options for the build process
+ */
+export interface BuildOptions extends LoadOptions {
+  /**
+   * Optional monorepo configuration. If not provided, will attempt to load from project.
+   */
+  monorepo?: Monorepo
+  /**
+   * Optional array of DepIDs to filter nodes for building. If provided,
+   * only nodes with IDs in this array will be built.
+   */
+  queryFilteredNodes?: DepID[]
+}
+
+/**
+ * Options for the skip process
+ */
+export interface SkipOptions extends LoadOptions {
+  /**
+   * Optional monorepo configuration. If not provided, will attempt to load from project.
+   */
+  monorepo?: Monorepo
+  /**
+   * Optional array of DepIDs to filter nodes for skipping. If provided,
+   * only nodes with IDs in this array will be skipped.
+   */
+  queryFilteredNodes?: DepID[]
+}
+
+/**
+ * Load BuildData from .vlt-build.json file if it exists
+ */
+const loadBuildData = (
+  projectRoot: string,
+): BuildData | undefined => {
+  const buildFilePath = resolve(
+    projectRoot,
+    'node_modules/.vlt-build.json',
+  )
+
+  if (!existsSync(buildFilePath)) {
+    return
+  }
+
+  try {
+    const content = readFileSync(buildFilePath, 'utf8')
+    return JSON.parse(content) as BuildData
+  } catch {
+    // If file is corrupted or unreadable, treat as if it doesn't exist
+    return
+  }
+}
+
+/**
+ * Load lockfile data from vlt-lock.json if it exists
+ */
+const loadLockfileBuildData = (
+  projectRoot: string,
+): LockfileData | undefined => {
+  const lockfilePath = resolve(projectRoot, 'vlt-lock.json')
+
+  if (!existsSync(lockfilePath)) {
+    return
+  }
+
+  try {
+    const content = readFileSync(lockfilePath, 'utf8')
+    return JSON.parse(content) as LockfileData
+  } catch {
+    // If file is corrupted or unreadable, treat as if it doesn't exist
+    return
+  }
+}
+
+/**
+ * Update or remove the BuildData file after successful build completion
+ * If queryFilteredNodes was provided, only remove the built nodes from the queue
+ * If no queryFilteredNodes was provided, remove the entire file
+ */
+const cleanupBuildData = (
+  projectRoot: string,
+  builtEntries: [string, string[]][],
+  actualGraph: Graph,
+  queryFilteredNodes?: DepID[],
+): void => {
+  const buildFilePath = resolve(
+    projectRoot,
+    'node_modules/.vlt-build.json',
+  )
+
+  if (!existsSync(buildFilePath)) return
+
+  // If no query filtering was used, remove entire file as before
+  if (!queryFilteredNodes) {
+    unlinkSync(buildFilePath)
+    return
+  }
+
+  // Load current build data
+  const currentData = loadBuildData(projectRoot)
+  /* c8 ignore next */
+  if (!currentData) return
+
+  // Create a set of built DepIDs from builtEntries and actualGraph
+  const builtDepIDs = new Set<DepID>()
+
+  // Add all nodes that were actually built based on the build results
+  for (const [registry, names] of builtEntries) {
+    for (const name of names) {
+      // Find nodes in the actual graph that match this registry and name
+      for (const [depId, node] of actualGraph.nodes) {
+        if (
+          node.name === name &&
+          node.registry === registry &&
+          typeof node.name === 'string' &&
+          typeof node.registry === 'string'
+        ) {
+          builtDepIDs.add(depId)
+        }
+      }
+    }
+  }
+
+  // Filter out built nodes from the queue
+  const updatedQueue = currentData.queue.filter(
+    id => !builtDepIDs.has(id),
+  )
+
+  try {
+    // If no items left in queue, remove the file
+    if (updatedQueue.length === 0) {
+      unlinkSync(buildFilePath)
+    } else {
+      // Update the file with remaining queue items
+      const updatedData: BuildData = { queue: updatedQueue }
+      writeFileSync(buildFilePath, JSON.stringify(updatedData))
+    }
+
+    /* c8 ignore start */
+  } catch {
+    // If cleanup fails, it's not critical - just continue
+    // The file will be overwritten on next build if needed
+  }
+  /* c8 ignore stop */
+}
+
+/**
+ * Build the project based on actual graph state and cached build data
+ *
+ * This function:
+ * 1. Loads the actual graph from node_modules
+ * 2. Loads build data from lockfile and transfers it to the actual graph
+ * 3. Optionally loads cached build data from .vlt-build.json
+ * 4. Constructs a Diff object representing what needs to be built
+ * 5. Calls the reify build process with the constructed diff
+ * 6. Persists build results to lockfile
+ * 7. Cleans up the build data file after successful completion
+ */
+export const build = async (options: BuildOptions): Promise<void> => {
+  const {
+    projectRoot,
+    packageJson,
+    monorepo = Monorepo.maybeLoad(projectRoot),
+    scurry,
+    mainManifest = packageJson.read(projectRoot),
+    queryFilteredNodes,
+    ...loadOptions
+  } = options
+
+  // Load lockfile data to get build information
+  const lockfileDataObj = loadLockfileBuildData(projectRoot)
+
+  // Load the actual graph from node_modules
+  const actualGraph = loadActual({
+    ...loadOptions,
+    projectRoot,
+    packageJson,
+    monorepo,
+    scurry,
+    loadManifests: true,
+  })
+
+  // Transfer build data from lockfile to actual graph
+  if (lockfileDataObj?.build) {
+    actualGraph.build = lockfileDataObj.build
+  }
+
+  // Create a total diff including the actual graph as 'to'
+  const diff = new Diff(
+    new Graph({
+      ...options,
+      projectRoot,
+      monorepo,
+      mainManifest,
+    }),
+    actualGraph,
+  )
+
+  // Load cached build data if available
+  const { queue } = loadBuildData(projectRoot) ?? {}
+
+  // Now tweak the diff object to only include the nodes that need to be built
+  // as part of `diff.nodes.add` since this is the only thing that reifyBuild cares about
+  diff.nodes.add = new Set(
+    [...diff.nodes.add].filter(node => {
+      // First filter by queue (existing logic)
+      const inQueue = queue?.includes(node.id)
+
+      // Then filter by queryFilteredNodes if provided
+      const inQueryFilter =
+        queryFilteredNodes ?
+          queryFilteredNodes.includes(node.id)
+        : true
+
+      return inQueue && inQueryFilter
+    }),
+  )
+
+  // Call the reify build process with the constructed diff
+  // this will only build the nodes that need to be built
+  // as part of `diff.nodes.add`
+  const buildResults = await reifyBuild(
+    diff,
+    packageJson,
+    scurry,
+    true,
+  )
+
+  // Merge build results into the lockfile data
+  const builtEntries = Object.entries(buildResults)
+  if (lockfileDataObj && builtEntries.length) {
+    for (const [registry, names] of builtEntries) {
+      const prevAllowed =
+        lockfileDataObj.build.allowed[registry] ?? []
+      if (names.length) {
+        lockfileDataObj.build.allowed[registry] = [
+          ...new Set([...prevAllowed, ...names]),
+        ]
+      }
+    }
+  }
+
+  // Save updated lockfile
+  if (lockfileDataObj) {
+    saveData(
+      lockfileDataObj,
+      resolve(projectRoot, 'vlt-lock.json'),
+      false,
+    )
+  }
+
+  // Clean up the build data file after successful completion
+  // since it's no longer needed after the build is complete
+  cleanupBuildData(
+    projectRoot,
+    builtEntries,
+    actualGraph,
+    queryFilteredNodes,
+  )
+}
+
+/**
+ * Skip building queued packages and update lockfile to mark them as blocked
+ *
+ * This function:
+ * 1. Loads the actual graph from node_modules
+ * 2. Loads build data from lockfile and .vlt-build.json
+ * 3. Determines which packages to skip based on queue and optional query filtering
+ * 4. Updates the lockfile to mark skipped packages as blocked
+ * 5. Updates or removes .vlt-build.json based on remaining items
+ */
+export const skip = async (options: SkipOptions): Promise<void> => {
+  const {
+    projectRoot,
+    packageJson,
+    monorepo = Monorepo.maybeLoad(projectRoot),
+    scurry,
+    mainManifest: _mainManifest = packageJson.read(projectRoot),
+    queryFilteredNodes,
+    ...loadOptions
+  } = options
+
+  // Load lockfile data to get build information
+  const lockfileDataObj = loadLockfileBuildData(projectRoot)
+
+  // Load the actual graph from node_modules
+  const actualGraph = loadActual({
+    ...loadOptions,
+    projectRoot,
+    packageJson,
+    monorepo,
+    scurry,
+    loadManifests: false,
+  })
+
+  // Transfer build data from lockfile to actual graph
+  if (lockfileDataObj?.build) {
+    actualGraph.build = lockfileDataObj.build
+  }
+
+  // Load cached build data if available
+  const buildData = loadBuildData(projectRoot)
+  const { queue } = buildData ?? {}
+
+  if (!queue || queue.length === 0) {
+    // No queued items to skip
+    return
+  }
+
+  // Determine which nodes to skip based on queue and optional query filtering
+  const nodesToSkip = queue.filter(depId => {
+    // If queryFilteredNodes is provided, only skip nodes that match the query
+    return queryFilteredNodes ?
+        queryFilteredNodes.includes(depId)
+      : true
+  })
+
+  if (nodesToSkip.length === 0) {
+    // No nodes to skip based on filtering
+    return
+  }
+
+  // Update lockfile to mark skipped packages as blocked
+  const skippedByRegistry: Record<string, string[]> = {}
+
+  for (const depId of nodesToSkip) {
+    const node = actualGraph.nodes.get(depId)
+    if (node?.name) {
+    /* c8 ignore next */
+      const registry = node.registry || splitDepID(node.id)[0]
+      const name = node.name
+      skippedByRegistry[registry] ??= []
+      skippedByRegistry[registry].push(name)
+    }
+  }
+
+  if (lockfileDataObj) {
+    // Merge skipped entries into blocked section of lockfile
+    for (const [registry, names] of Object.entries(
+      skippedByRegistry,
+    )) {
+      const prevBlocked =
+        lockfileDataObj.build.blocked[registry] ?? []
+      if (names.length) {
+        lockfileDataObj.build.blocked[registry] = [
+          ...new Set([...prevBlocked, ...names]),
+        ]
+      }
+    }
+
+    // Save updated lockfile
+    saveData(
+      lockfileDataObj,
+      resolve(projectRoot, 'vlt-lock.json'),
+      false,
+    )
+  }
+
+  // Update build data file - remove skipped nodes from queue
+  const buildFilePath = resolve(
+    projectRoot,
+    'node_modules/.vlt-build.json',
+  )
+  if (existsSync(buildFilePath) && buildData) {
+    const remainingQueue = buildData.queue.filter(
+      id => !nodesToSkip.includes(id),
+    )
+
+    if (remainingQueue.length === 0) {
+      // Remove file if no items remain
+      try {
+        unlinkSync(buildFilePath)
+        /* c8 ignore start */
+      } catch {
+        // If cleanup fails, it's not critical
+      }
+      /* c8 ignore stop */
+    } else {
+      // Update file with remaining items
+      const updatedData: BuildData = { queue: remainingQueue }
+      try {
+        writeFileSync(
+          buildFilePath,
+          JSON.stringify(updatedData, null, 2),
+        )
+        /* c8 ignore start */
+      } catch {
+        // If update fails, it's not critical
+      }
+      /* c8 ignore stop */
+    }
+  }
+}

--- a/src/graph/src/diff.ts
+++ b/src/graph/src/diff.ts
@@ -155,4 +155,17 @@ ${lines
       this.edges.delete.size > 0
     )
   }
+
+  toJSON() {
+    return {
+      nodes: {
+        add: [...this.nodes.add].map(node => node.toJSON()),
+        delete: [...this.nodes.delete].map(node => node.toJSON()),
+      },
+      edges: {
+        add: [...this.edges.add].map(edge => edge.toJSON()),
+        delete: [...this.edges.delete].map(edge => edge.toJSON()),
+      },
+    }
+  }
 }

--- a/src/graph/src/edge.ts
+++ b/src/graph/src/edge.ts
@@ -93,4 +93,13 @@ export class Edge implements EdgeLike {
           this.from.projectRoot,
         )
   }
+
+  toJSON() {
+    return {
+      from: this.from.id,
+      to: this.to?.id,
+      type: this.type,
+      spec: String(this.spec),
+    }
+  }
 }

--- a/src/graph/src/graph.ts
+++ b/src/graph/src/graph.ts
@@ -9,6 +9,7 @@ import type {
   NodeLike,
   NormalizedManifest,
   DependencySaveType,
+  LockfileBuildData,
 } from '@vltpkg/types'
 import type { Monorepo } from '@vltpkg/workspaces'
 import { inspect } from 'node:util'
@@ -139,6 +140,11 @@ export class Graph implements GraphLike {
    * The root of the project this graph represents
    */
   projectRoot: string
+
+  /**
+   * The lockfile build data related to this graph if any is available.
+   */
+  build: LockfileBuildData | undefined
 
   constructor(options: GraphOptions) {
     const { mainManifest, monorepo } = options

--- a/src/graph/src/index.ts
+++ b/src/graph/src/index.ts
@@ -1,3 +1,4 @@
+export * from './build.ts'
 export * from './edge.ts'
 export * from './graph.ts'
 export * from './node.ts'
@@ -37,5 +38,6 @@ import { build } from './ideal/build.ts'
 import type { BuildIdealOptions } from './ideal/build.ts'
 export type { BuildIdealOptions }
 export const ideal = { build }
+
 export { reify } from './reify/index.ts'
 export type { ReifyOptions } from './reify/index.ts'

--- a/src/graph/src/install.ts
+++ b/src/graph/src/install.ts
@@ -23,6 +23,7 @@ import { getImporterSpecs } from './ideal/get-importer-specs.ts'
 export type InstallOptions = LoadOptions & {
   packageInfo: PackageInfoClient
   cleanInstall?: boolean // Only set by ci command for clean install
+  includeScripts?: boolean
 }
 
 export const install = async (
@@ -184,7 +185,7 @@ export const install = async (
       loadManifests: true,
       modifiers,
     })
-    const diff = await reify({
+    const { diff, buildQueue } = await reify({
       ...options,
       add,
       actual: act,
@@ -193,7 +194,7 @@ export const install = async (
       modifiers,
     })
 
-    return { graph, diff }
+    return { buildQueue, graph, diff }
   } catch (err) {
     /* c8 ignore next */
     await remover.rollback().catch(() => {})

--- a/src/graph/src/lockfile/load.ts
+++ b/src/graph/src/lockfile/load.ts
@@ -71,8 +71,13 @@ export const loadHidden = (options: LoadOptions): Graph => {
 
 export const loadObject = (
   options: LoadOptions,
-  lockfileData: Omit<LockfileData, 'options' | 'lockfileVersion'> &
-    Partial<Pick<LockfileData, 'options' | 'lockfileVersion'>>,
+  lockfileData: Omit<
+    LockfileData,
+    'options' | 'lockfileVersion' | 'build'
+  > &
+    Partial<
+      Pick<LockfileData, 'options' | 'lockfileVersion' | 'build'>
+    >,
 ) => {
   const {
     mainManifest,
@@ -93,6 +98,7 @@ export const loadObject = (
     registries,
     'git-hosts': gitHosts,
     'git-host-archives': gitHostArchives,
+    /* c8 ignore next */
   } = lockfileData.options ?? {}
 
   // Optimize options merging - only create new objects when needed
@@ -123,6 +129,9 @@ export const loadObject = (
     mainManifest,
     monorepo,
   })
+
+  // Extract build data with default to empty objects
+  graph.build = lockfileData.build ?? { allowed: {}, blocked: {} }
 
   // When using the skipLoadingNodesOnModifiersChange option, we should skip loading
   // dependencies in case the modifiers have changed since we'll need to

--- a/src/graph/src/lockfile/save.ts
+++ b/src/graph/src/lockfile/save.ts
@@ -26,6 +26,7 @@ import type {
   LockfileNode,
   LockfilePlatform,
 } from './types.ts'
+import type { LockfileBuildData } from '@vltpkg/types'
 import type { GraphModifier } from '../modifiers.ts'
 
 export type SaveOptions = SpecOptions & {
@@ -41,6 +42,11 @@ export type SaveOptions = SpecOptions & {
    * Should it save manifest data in the lockfile?
    */
   saveManifests?: boolean
+  /**
+   * Build data indicating what dependencies are auto-build
+   * and what should be auto-skipped during an install.
+   */
+  build?: LockfileBuildData
 }
 
 const formatNodes = (
@@ -137,6 +143,7 @@ const removeDefaultItems = (
 
 export const lockfileData = ({
   graph,
+  build,
   catalog,
   catalogs,
   'git-hosts': gitHosts,
@@ -201,6 +208,7 @@ export const lockfileData = ({
         { 'git-host-archives': cleanGitHostArchives }
       : undefined),
     },
+    build: build ?? { allowed: {}, blocked: {} },
     nodes: formatNodes(graph.nodes.values(), saveManifests, registry),
     edges: formatEdges(graph.edges),
   }

--- a/src/graph/src/lockfile/types.ts
+++ b/src/graph/src/lockfile/types.ts
@@ -4,6 +4,7 @@ import type {
   Integrity,
   NormalizedManifest,
   DependencyTypeShort,
+  LockfileBuildData,
 } from '@vltpkg/types'
 import type { Graph } from '../graph.ts'
 
@@ -28,6 +29,7 @@ export type LockfileData = {
   options: SpecOptions & {
     modifiers?: Record<string, string> | undefined
   }
+  build: LockfileBuildData
   nodes: Record<DepID, LockfileNode>
   edges: LockfileEdges
 }

--- a/src/graph/src/node.ts
+++ b/src/graph/src/node.ts
@@ -195,6 +195,11 @@ export class Node implements NodeLike {
   }
 
   /**
+   * True if this node has been built as part of the reify step.
+   */
+  built = false
+
+  /**
    * The file system location for this node.
    */
   get location(): string {

--- a/src/graph/src/reify/build.ts
+++ b/src/graph/src/reify/build.ts
@@ -13,16 +13,47 @@ import type { Node } from '../node.ts'
 import { nonEmptyList } from '../non-empty-list.ts'
 import { binPaths } from './bin-paths.ts'
 import { optionalFail } from './optional-fail.ts'
+import { splitDepID } from '@vltpkg/dep-id'
+
+/**
+ * Returns an object mapping registries to the names of the packages built.
+ */
+export type BuildResult = Record<string, string[]>
 
 export const build = async (
   diff: Diff,
   packageJson: PackageJson,
   scurry: PathScurry,
-) => {
+  includeScripts?: boolean,
+): Promise<BuildResult> => {
   const graph = diff.to
   const nodes = nonEmptyList([...graph.importers])
+  const res: BuildResult = {}
+
+  // determine if we should run scripts on a given node
+  const isRunScriptBlocked = (node: Node): boolean =>
+    !!(
+      (node.registry &&
+        graph.build?.blocked[node.registry]?.includes(node.name)) ||
+      /* c8 ignore next */
+      graph.build?.blocked[splitDepID(node.id)[0]]?.includes(
+        node.name,
+      )
+    )
+  const shouldRunScripts = (node: Node): boolean => {
+    if (includeScripts) return true
+    const includedRegistryNode =
+      node.registry &&
+      graph.build?.allowed[node.registry]?.includes(node.name)
+    const includedDepIDNode = graph.build?.allowed[
+      splitDepID(node.id)[0]
+      /* c8 ignore next */
+    ]?.includes(node.name)
+    return !!(includedRegistryNode || includedDepIDNode)
+  }
+
   /* c8 ignore next - all graphs have at least one importer */
-  if (!nodes) return
+  if (!nodes) return {}
 
   await graphRun<Node, unknown>({
     graph: nodes,
@@ -33,12 +64,24 @@ export const build = async (
       // most recent build.
       // For now, just always build all importers, because we don't
       // track all that other stuff.
-      if (!node.importer && !diff.nodes.add.has(node)) return
+
+      // exit early if this run script has been blocked
+      if (isRunScriptBlocked(node)) return
+
+      if (
+        !node.importer &&
+        (!diff.nodes.add.has(node) || !shouldRunScripts(node))
+      )
+        return
 
       await visit(packageJson, scurry, node, signal, path).then(
         x => x,
         optionalFail(diff, node),
       )
+
+      const registry = node.registry || splitDepID(node.id)[0]
+      const arr = res[registry] ?? (res[registry] = [])
+      arr.push(node.name)
     },
 
     getDeps: node => {
@@ -50,6 +93,8 @@ export const build = async (
       return deps
     },
   })
+
+  return res
 }
 
 const visit = async (
@@ -84,6 +129,7 @@ const visit = async (
       projectRoot: node.projectRoot,
       manifest,
     })
+    node.built = true
   }
 
   // if it's an importer or git, run prepare
@@ -102,6 +148,7 @@ const visit = async (
       projectRoot: node.projectRoot,
       manifest,
     })
+    node.built = true
   }
 
   const chmods: Promise<unknown>[] = []

--- a/src/graph/src/reify/index.ts
+++ b/src/graph/src/reify/index.ts
@@ -3,6 +3,7 @@ import type { PackageInfoClient } from '@vltpkg/package-info'
 import { RollbackRemove } from '@vltpkg/rollback-remove'
 import { availableParallelism } from 'node:os'
 import { callLimit } from 'promise-call-limit'
+import type { DepID } from '@vltpkg/dep-id'
 import type { LoadOptions } from '../actual/load.ts'
 import { load as loadActual } from '../actual/load.ts'
 import type {
@@ -11,7 +12,6 @@ import type {
 } from '../dependencies.ts'
 import { Diff } from '../diff.ts'
 import type { Graph } from '../graph.ts'
-import { lockfile } from '../index.ts'
 import type { GraphModifier } from '../modifiers.ts'
 import {
   lockfileData,
@@ -22,11 +22,13 @@ import { addEdges } from './add-edges.ts'
 import { addNodes } from './add-nodes.ts'
 import { build } from './build.ts'
 import { deleteEdges } from './delete-edges.ts'
+import { saveBuild } from './save-build.ts'
 import { deleteNodes } from './delete-nodes.ts'
 import { internalHoist } from './internal-hoist.ts'
 import { rollback } from './rollback.ts'
 import { updatePackageJson } from './update-importers-package-json.ts'
-import { copyFileSync } from 'node:fs'
+import { copyFileSync, unlinkSync } from 'node:fs'
+import { resolve } from 'node:path'
 
 const limit = Math.max(availableParallelism() - 1, 1) * 8
 
@@ -35,6 +37,7 @@ const limit = Math.max(availableParallelism() - 1, 1) * 8
 
 export type ReifyOptions = LoadOptions & {
   add?: AddImportersDependenciesMap
+  includeScripts?: boolean
   remove?: RemoveImportersDependenciesMap
   graph: Graph
   actual?: Graph
@@ -42,11 +45,36 @@ export type ReifyOptions = LoadOptions & {
   modifiers?: GraphModifier
 }
 
+export type ReifyResult = {
+  /**
+   * The diff object that was used to reify the project.
+   */
+  diff: Diff
+  /**
+   * Optional queue of DepIDs that requires building (running lifecycle scripts
+   * and binary linking) after the reification is complete.
+   */
+  buildQueue?: DepID[]
+}
+
 /**
  * Make the current project match the supplied graph.
  */
-export const reify = async (options: ReifyOptions) => {
+export const reify = async (
+  options: ReifyOptions,
+): Promise<ReifyResult> => {
   const done = graphStep('reify')
+
+  // Remove any existing build file before proceeding
+  try {
+    const buildFilePath = resolve(
+      options.projectRoot,
+      'node_modules/.vlt-build.json',
+    )
+    unlinkSync(buildFilePath)
+  } catch {
+    // Ignore any errors - file might not exist or be unreadable
+  }
 
   const { graph, scurry } = options
 
@@ -60,18 +88,20 @@ export const reify = async (options: ReifyOptions) => {
   const diff = new Diff(actual, graph)
   const skipOptionalOnly =
     !options.add?.modifiedDependencies && diff.optionalOnly
+  const res: ReifyResult = { diff }
   if (!diff.hasChanges() || skipOptionalOnly) {
     // nothing to do, so just return the diff
     done()
-    return diff
+    return res
   }
 
   const remover = new RollbackRemove()
   let success = false
   try {
-    await reify_(options, diff, remover)
+    const { buildQueue } = await reify_(options, diff, remover)
     remover.confirm()
     success = true
+    res.buildQueue = buildQueue
   } finally {
     /* c8 ignore start */
     if (!success) {
@@ -82,15 +112,17 @@ export const reify = async (options: ReifyOptions) => {
 
   done()
 
-  return diff
+  return res
 }
 
 const reify_ = async (
   options: ReifyOptions,
   diff: Diff,
   remover: RollbackRemove,
-) => {
-  const { add, remove, packageInfo, packageJson, scurry } = options
+): Promise<Omit<ReifyResult, 'diff'>> => {
+  const res: Omit<ReifyResult, 'diff'> = {}
+  const { add, graph, remove, packageInfo, packageJson, scurry } =
+    options
   const saveImportersPackageJson =
     /* c8 ignore next */
     add?.modifiedDependencies || remove?.modifiedDependencies ?
@@ -129,11 +161,34 @@ const reify_ = async (
 
   await internalHoist(diff.to, options, remover)
 
-  // run lifecycles and chmod bins
-  await build(diff, packageJson, scurry)
+  // run install lifecycle scripts and link any binary files
+  const built = await build(
+    diff,
+    packageJson,
+    scurry,
+    options.includeScripts,
+  )
 
-  // save the lockfile
-  lockfile.save(options)
+  // add any allowed build dependency to the lockfile data
+  const builtEntries = Object.entries(built)
+  if (builtEntries.length) {
+    for (const [registry, names] of builtEntries) {
+      /* c8 ignore next */
+      const prevAllowed = graph.build?.allowed[registry] ?? []
+      if (names.length) {
+        lfData.build.allowed[registry] = [
+          ...new Set([...prevAllowed, ...names]),
+        ]
+      }
+    }
+  }
+
+  // save any remaining build data for potential future builds
+  const { queue } = saveBuild({
+    diff,
+    projectRoot: options.projectRoot,
+  })
+  res.buildQueue = queue
 
   // if we had to change the actual graph along the way,
   // make sure we do not leave behind any unreachable nodes
@@ -169,4 +224,7 @@ const reify_ = async (
       scurry.resolve('node_modules/.vlt/vlt.json'),
     )
   }
+
+  // returns the result object
+  return res
 }

--- a/src/graph/src/reify/save-build.ts
+++ b/src/graph/src/reify/save-build.ts
@@ -1,0 +1,106 @@
+import { writeFileSync, mkdirSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import type { DepID } from '@vltpkg/dep-id'
+import type { Diff } from '../diff.ts'
+import type { Node } from '../node.ts'
+import { binPaths } from './bin-paths.ts'
+
+/**
+ * Build data that gets saved to .vlt-build.json
+ */
+export type BuildData = {
+  queue: DepID[]
+}
+
+/**
+ * Options for saving build data
+ */
+export type SaveBuildOptions = {
+  /**
+   * The diff object to serialize and save
+   */
+  diff: Diff
+  /**
+   * The project root path where node_modules/.vlt-build.json should be created
+   */
+  projectRoot: string
+  /**
+   * Optional queue of DepIDs from a previously saved store that should be combined
+   * with the new nodes being added. Defaults to empty array.
+   */
+  queue?: DepID[]
+}
+
+/**
+ * Checks if a node needs to be built based on the conditions from build.ts:
+ * 1. Has install lifecycle scripts (install, preinstall, postinstall)
+ * 2. Is an importer or git dependency with prepare scripts (prepare, preprepare, postprepare)
+ * 3. Has binary files that need to be linked
+ */
+const nodeNeedsBuild = (node: Node): boolean => {
+  // If the node has already been built during reify, no need to build again
+  if (node.built) return false
+
+  const { manifest } = node
+  /* c8 ignore next */
+  if (!manifest) return false
+
+  const { scripts = {} } = manifest
+
+  // Check for install lifecycle scripts
+  const runInstall = !!(
+    scripts.install ||
+    scripts.preinstall ||
+    scripts.postinstall
+  )
+  if (runInstall) return true
+
+  // Check for prepare scripts on importers or git dependencies
+  const prepable =
+    node.id.startsWith('git') || node.importer || !node.inVltStore()
+  const runPrepare =
+    !!(
+      (scripts.prepare || scripts.preprepare || scripts.postprepare)
+      /* c8 ignore next 2 */
+    ) && prepable
+  if (runPrepare) return true
+
+  // Check if the package has binary files
+  const hasBins = Object.values(binPaths(manifest)).length > 0
+  if (hasBins) return true
+
+  return false
+}
+
+/**
+ * Save build data to node_modules/.vlt-build.json
+ * This file contains the DepIDs of the nodes that need
+ * to run install lifecycle scripts as part of `vlt build`
+ * @returns {BuildData} The BuildData object that was saved
+ */
+export const saveBuild = (options: SaveBuildOptions): BuildData => {
+  const { diff, projectRoot, queue = [] } = options
+
+  // Filter nodes to only include those that actually need to be built
+  const nodesToBuild = [...diff.nodes.add].filter(nodeNeedsBuild)
+
+  const buildData: BuildData = {
+    queue: [
+      ...new Set([...queue, ...nodesToBuild.map(node => node.id)]),
+    ],
+  }
+
+  const fileName = resolve(
+    projectRoot,
+    'node_modules/.vlt-build.json',
+  )
+
+  // Ensure the node_modules directory exists
+  mkdirSync(dirname(fileName), { recursive: true })
+
+  // Save the build data as formatted JSON
+  const json = JSON.stringify(buildData, null, 2)
+  writeFileSync(fileName, json, 'utf8')
+
+  return buildData
+}

--- a/src/graph/src/transfer-data/load.ts
+++ b/src/graph/src/transfer-data/load.ts
@@ -247,6 +247,10 @@ export const load = (transfered: TransferData): LoadResult => {
   // populate nodes and edges from loaded data
   const graph = maybeGraph as GraphLike
   const specOptions = loadSpecOptions(transfered.lockfile)
+
+  // Set build data on the graph
+  graph.build = transfered.lockfile.build
+
   loadNodes(graph, transfered.lockfile.nodes, specOptions, graph)
   loadEdges(graph, transfered.lockfile.edges, specOptions)
 

--- a/src/graph/src/update.ts
+++ b/src/graph/src/update.ts
@@ -47,7 +47,7 @@ export const update = async (options: UpdateOptions) => {
     loadManifests: true,
   })
 
-  const diff = await reify({
+  const { buildQueue, diff } = await reify({
     ...options,
     actual: act,
     graph,
@@ -55,5 +55,5 @@ export const update = async (options: UpdateOptions) => {
     modifiers,
   })
 
-  return { graph, diff }
+  return { buildQueue, graph, diff }
 }

--- a/src/graph/tap-snapshots/test/graph.ts.test.cjs
+++ b/src/graph/tap-snapshots/test/graph.ts.test.cjs
@@ -6,13 +6,20 @@
  */
 'use strict'
 exports[`test/graph.ts > TAP > Graph > should print with special tag name 1`] = `
-@vltpkg/graph.Graph { lockfileVersion: 0, options: [Object], nodes: {}, edges: {} }
+@vltpkg/graph.Graph {
+  lockfileVersion: 0,
+  options: [Object],
+  build: [Object],
+  nodes: {},
+  edges: {}
+}
 `
 
 exports[`test/graph.ts > TAP > using placePackage > should add a type=git package 1`] = `
 @vltpkg/graph.Graph {
   lockfileVersion: 0,
   options: { registries: {} },
+  build: { allowed: {}, blocked: {} },
   nodes: {
     '··bar@1.0.0': [
       0,
@@ -37,6 +44,7 @@ exports[`test/graph.ts > TAP > using placePackage > should find and fix nameless
 @vltpkg/graph.Graph {
   lockfileVersion: 0,
   options: { registries: {} },
+  build: { allowed: {}, blocked: {} },
   nodes: {
     '··bar@1.0.0': [
       0,
@@ -60,6 +68,7 @@ exports[`test/graph.ts > TAP > using placePackage > should have removed baz from
 @vltpkg/graph.Graph {
   lockfileVersion: 0,
   options: { registries: {} },
+  build: { allowed: {}, blocked: {} },
   nodes: {
     '··bar@1.0.0': [
       0,
@@ -81,6 +90,7 @@ exports[`test/graph.ts > TAP > using placePackage > the graph 1`] = `
 @vltpkg/graph.Graph {
   lockfileVersion: 0,
   options: { registries: {} },
+  build: { allowed: {}, blocked: {} },
   nodes: {
     '··bar@1.0.0': [
       0,
@@ -109,6 +119,7 @@ exports[`test/graph.ts > TAP > using placePackage > the graph 1`] = `
 exports[`test/graph.ts > TAP > workspaces > should have root and workspaces as importers 1`] = `
 Set {
   &ref_1 Node {
+    "built": false,
     "confused": false,
     "edgesIn": Set {},
     "edgesOut": Map {},
@@ -221,6 +232,7 @@ Set {
           "workspaceSpec": "*",
         },
         "to": Node {
+          "built": false,
           "confused": false,
           "edgesIn": Set {},
           "edgesOut": Map {},
@@ -338,6 +350,7 @@ Set {
           "workspaceSpec": "*",
         },
         "to": Node {
+          "built": false,
           "confused": false,
           "edgesIn": Set {},
           "edgesOut": Map {},
@@ -365,6 +378,7 @@ Set {
     },
   },
   Node {
+    "built": false,
     "confused": false,
     "edgesIn": Set {},
     "edgesOut": Map {},
@@ -388,6 +402,7 @@ Set {
     "workspaces": undefined,
   },
   Node {
+    "built": false,
     "confused": false,
     "edgesIn": Set {},
     "edgesOut": Map {},

--- a/src/graph/tap-snapshots/test/ideal/append-nodes.ts.test.cjs
+++ b/src/graph/tap-snapshots/test/ideal/append-nodes.ts.test.cjs
@@ -42,6 +42,7 @@ exports[`test/ideal/append-nodes.ts > TAP > append different type of dependencie
 @vltpkg/graph.Graph {
   lockfileVersion: 0,
   options: { registries: {} },
+  build: { allowed: {}, blocked: {} },
   nodes: {
     '··bar@1.0.0': [ 1, 'bar', <3 empty items>, { name: 'bar', version: '1.0.0' } ],
     '··foo@1.0.0': [
@@ -98,6 +99,7 @@ exports[`test/ideal/append-nodes.ts > TAP > resolve against the correct registri
   options: {
     registries: { a: 'https://a.example.com/', b: 'https://b.example.com/' }
   },
+  build: { allowed: {}, blocked: {} },
   nodes: {
     '·a·bar@1.2.3': [
       0,

--- a/src/graph/tap-snapshots/test/ideal/remove-nodes.ts.test.cjs
+++ b/src/graph/tap-snapshots/test/ideal/remove-nodes.ts.test.cjs
@@ -7,6 +7,10 @@
 'use strict'
 exports[`test/ideal/remove-nodes.ts > TAP > removeNodes > should remove the node and edge from the graph 1`] = `
 Object {
+  "build": Object {
+    "allowed": Object {},
+    "blocked": Object {},
+  },
   "edges": Object {},
   "lockfileVersion": 0,
   "nodes": Object {},

--- a/src/graph/tap-snapshots/test/lockfile/load.ts.test.cjs
+++ b/src/graph/tap-snapshots/test/lockfile/load.ts.test.cjs
@@ -38,6 +38,26 @@ exports[`test/lockfile/load.ts > TAP > load > must match snapshot 1`] = `
 ]
 `
 
+exports[`test/lockfile/load.ts > TAP > load build data > load with build data provided > graph loaded with build data 1`] = `
+[ Node { id: 'file·.', location: '.', importer: true } ]
+`
+
+exports[`test/lockfile/load.ts > TAP > load build data > load with empty build data > graph loaded with empty build data 1`] = `
+[ Node { id: 'file·.', location: '.', importer: true } ]
+`
+
+exports[`test/lockfile/load.ts > TAP > load build data > load without build data (defaults) > graph loaded without build data 1`] = `
+[ Node { id: 'file·.', location: '.', importer: true } ]
+`
+
+exports[`test/lockfile/load.ts > TAP > load build data > load() and loadHidden() with build data files > load() with build data 1`] = `
+[ Node { id: 'file·.', location: '.', importer: true } ]
+`
+
+exports[`test/lockfile/load.ts > TAP > load build data > load() and loadHidden() with build data files > loadHidden() with build data 1`] = `
+[ Node { id: 'file·.', location: '.', importer: true } ]
+`
+
 exports[`test/lockfile/load.ts > TAP > load with custom git hosts > should build specs with custom git hosts 1`] = `
 Spec {
   "bareSpec": "example:foo/bar",
@@ -283,6 +303,10 @@ exports[`test/lockfile/load.ts > TAP > missing options object > should be able t
       "example": "http://foo"
     }
   },
+  "build": {
+    "allowed": {},
+    "blocked": {}
+  },
   "nodes": {},
   "edges": {}
 }
@@ -297,6 +321,10 @@ exports[`test/lockfile/load.ts > TAP > option-defined values should overwrite lo
       "example": "http://bar",
       "lorem": "http://lorem"
     }
+  },
+  "build": {
+    "allowed": {},
+    "blocked": {}
   },
   "nodes": {},
   "edges": {}

--- a/src/graph/tap-snapshots/test/lockfile/save.ts.test.cjs
+++ b/src/graph/tap-snapshots/test/lockfile/save.ts.test.cjs
@@ -13,6 +13,10 @@ exports[`test/lockfile/save.ts > TAP > confused manifest > should save lockfile 
       "custom": "http://example.com"
     }
   },
+  "build": {
+    "allowed": {},
+    "blocked": {}
+  },
   "nodes": {
     "··foo@1.0.0": [
       0,
@@ -55,6 +59,10 @@ exports[`test/lockfile/save.ts > TAP > custom git hosts and catalogs > must matc
       "example": "https://example.com/$1/$2/archive/$3.tar.gz"
     }
   },
+  "build": {
+    "allowed": {},
+    "blocked": {}
+  },
   "nodes": {
     "git·example%3Afoo§bar·": [
       0,
@@ -74,6 +82,10 @@ exports[`test/lockfile/save.ts > TAP > jsr-registries > must match snapshot 1`] 
     "scope-registries": {
       "@myscope": "https://example.com/"
     }
+  },
+  "build": {
+    "allowed": {},
+    "blocked": {}
   },
   "nodes": {
     "··foo@1.0.0": [
@@ -95,6 +107,10 @@ exports[`test/lockfile/save.ts > TAP > jsr-registries > must match snapshot 2`] 
       "intl": "https://jsr.example.com/"
     }
   },
+  "build": {
+    "allowed": {},
+    "blocked": {}
+  },
   "nodes": {
     "·https%3A§§jsr.example.com§·@foo§bar@1.0.0": [
       0,
@@ -113,6 +129,10 @@ exports[`test/lockfile/save.ts > TAP > missing registries > must match snapshot 
   "options": {
     "registry": "http://example.com"
   },
+  "build": {
+    "allowed": {},
+    "blocked": {}
+  },
   "nodes": {},
   "edges": {}
 }
@@ -127,6 +147,10 @@ exports[`test/lockfile/save.ts > TAP > overrides default registries > must match
       "npm": "http://example.com"
     }
   },
+  "build": {
+    "allowed": {},
+    "blocked": {}
+  },
   "nodes": {},
   "edges": {}
 }
@@ -139,6 +163,10 @@ exports[`test/lockfile/save.ts > TAP > save > must match snapshot 1`] = `
     "registries": {
       "custom": "http://example.com"
     }
+  },
+  "build": {
+    "allowed": {},
+    "blocked": {}
   },
   "nodes": {
     "··bar@1.0.0": [3,"bar"],
@@ -161,6 +189,10 @@ exports[`test/lockfile/save.ts > TAP > save > save hidden (yes manifests) > must
     "registries": {
       "custom": "http://example.com"
     }
+  },
+  "build": {
+    "allowed": {},
+    "blocked": {}
   },
   "nodes": {
     "··bar@1.0.0": [
@@ -219,6 +251,10 @@ exports[`test/lockfile/save.ts > TAP > save > save normal (no manifests) > must 
       "custom": "http://example.com"
     }
   },
+  "build": {
+    "allowed": {},
+    "blocked": {}
+  },
   "nodes": {
     "··bar@1.0.0": [3,"bar"],
     "··foo@1.0.0": [2,"foo","sha512-6/mh1E2u2YgEsCHdY0Yx5oW+61gZU+1vXaoiHHrpKeuRNNgFvS+/jrwHiQhB5apAf5oB7UB7E19ol2R2LKH8hQ==",null,"node_modules/.pnpm/foo@1.0.0/node_modules/foo"],
@@ -233,6 +269,158 @@ exports[`test/lockfile/save.ts > TAP > save > save normal (no manifests) > must 
 
 `
 
+exports[`test/lockfile/save.ts > TAP > save build data > save build data undefined > lockfile with undefined build data 1`] = `
+{
+  "lockfileVersion": 0,
+  "options": {
+    "registries": {
+      "custom": "http://example.com"
+    }
+  },
+  "build": {
+    "allowed": {},
+    "blocked": {}
+  },
+  "nodes": {},
+  "edges": {}
+}
+`
+
+exports[`test/lockfile/save.ts > TAP > save build data > save empty build data > lockfile with empty build data 1`] = `
+{
+  "lockfileVersion": 0,
+  "options": {
+    "registries": {
+      "custom": "http://example.com"
+    }
+  },
+  "build": {
+    "allowed": {},
+    "blocked": {}
+  },
+  "nodes": {},
+  "edges": {}
+}
+`
+
+exports[`test/lockfile/save.ts > TAP > save build data > save with build data provided > lockfile with build data provided 1`] = `
+{
+  "lockfileVersion": 0,
+  "options": {
+    "registries": {
+      "custom": "http://example.com"
+    }
+  },
+  "build": {
+    "allowed": {
+      "https://registry.npmjs.org/": [
+        "foo",
+        "bar"
+      ]
+    },
+    "blocked": {
+      "https://registry.npmjs.org/": [
+        "baz"
+      ]
+    }
+  },
+  "nodes": {},
+  "edges": {}
+}
+`
+
+exports[`test/lockfile/save.ts > TAP > save build data > save without build data (defaults) > lockfile with no build data 1`] = `
+{
+  "lockfileVersion": 0,
+  "options": {
+    "registries": {
+      "custom": "http://example.com"
+    }
+  },
+  "build": {
+    "allowed": {},
+    "blocked": {}
+  },
+  "nodes": {},
+  "edges": {}
+}
+`
+
+exports[`test/lockfile/save.ts > TAP > save build data > save() and saveHidden() functions with build data > save() with build data 1`] = `
+{
+  "lockfileVersion": 0,
+  "options": {
+    "registries": {
+      "custom": "http://example.com"
+    }
+  },
+  "build": {
+    "allowed": {
+      "https://registry.npmjs.org/": [
+        "foo"
+      ]
+    },
+    "blocked": {
+      "https://registry.npmjs.org/": [
+        "blocked"
+      ]
+    }
+  },
+  "nodes": {
+    "··foo@1.0.0": [
+      0,
+      "foo",
+      "sha512-6/mh1E2u2YgEsCHdY0Yx5oW+61gZU+1vXaoiHHrpKeuRNNgFvS+/jrwHiQhB5apAf5oB7UB7E19ol2R2LKH8hQ=="
+    ]
+  },
+  "edges": {
+    "file·. foo": "prod ^1.0.0 ··foo@1.0.0"
+  }
+}
+`
+
+exports[`test/lockfile/save.ts > TAP > save build data > save() and saveHidden() functions with build data > saveHidden() with build data 1`] = `
+{
+  "lockfileVersion": 0,
+  "options": {
+    "registries": {
+      "custom": "http://example.com"
+    }
+  },
+  "build": {
+    "allowed": {
+      "https://registry.npmjs.org/": [
+        "foo"
+      ]
+    },
+    "blocked": {
+      "https://registry.npmjs.org/": [
+        "blocked"
+      ]
+    }
+  },
+  "nodes": {
+    "··foo@1.0.0": [
+      0,
+      "foo",
+      "sha512-6/mh1E2u2YgEsCHdY0Yx5oW+61gZU+1vXaoiHHrpKeuRNNgFvS+/jrwHiQhB5apAf5oB7UB7E19ol2R2LKH8hQ==",
+      null,
+      null,
+      {
+        "name": "foo",
+        "version": "1.0.0",
+        "dist": {
+          "integrity": "sha512-6/mh1E2u2YgEsCHdY0Yx5oW+61gZU+1vXaoiHHrpKeuRNNgFvS+/jrwHiQhB5apAf5oB7UB7E19ol2R2LKH8hQ=="
+        }
+      }
+    ]
+  },
+  "edges": {
+    "file·. foo": "prod ^1.0.0 ··foo@1.0.0"
+  }
+}
+`
+
 exports[`test/lockfile/save.ts > TAP > save platform data for optional dependencies > lockfile with platform data for optional dependencies 1`] = `
 {
   "lockfileVersion": 0,
@@ -240,6 +428,10 @@ exports[`test/lockfile/save.ts > TAP > save platform data for optional dependenc
     "registries": {
       "custom": "http://example.com"
     }
+  },
+  "build": {
+    "allowed": {},
+    "blocked": {}
   },
   "nodes": {
     "··bar@1.0.0": [
@@ -289,6 +481,10 @@ exports[`test/lockfile/save.ts > TAP > saveManifests with normalized author and 
       "custom": "http://example.com"
     }
   },
+  "build": {
+    "allowed": {},
+    "blocked": {}
+  },
   "nodes": {
     "··foo@1.0.0": [
       0,
@@ -333,6 +529,10 @@ exports[`test/lockfile/save.ts > TAP > saveManifests with normalized author and 
 
 exports[`test/lockfile/save.ts > TAP > store modifiers > with empty modifiers config > should save lockfile without modifiers when config is empty 1`] = `
 Object {
+  "build": Object {
+    "allowed": Object {},
+    "blocked": Object {},
+  },
   "edges": Object {
     "file·. foo": "prod ^1.0.0 ··foo@1.0.0",
   },
@@ -354,6 +554,10 @@ Object {
 
 exports[`test/lockfile/save.ts > TAP > store modifiers > with invalid scope registries > should save lockfile without scope registries when invalid type 1`] = `
 Object {
+  "build": Object {
+    "allowed": Object {},
+    "blocked": Object {},
+  },
   "edges": Object {
     "file·. foo": "prod ^1.0.0 ··foo@1.0.0",
   },
@@ -375,6 +579,10 @@ Object {
 
 exports[`test/lockfile/save.ts > TAP > store modifiers > with missing modifiers > should save lockfile without modifiers when undefined 1`] = `
 Object {
+  "build": Object {
+    "allowed": Object {},
+    "blocked": Object {},
+  },
   "edges": Object {
     "file·. foo": "prod ^1.0.0 ··foo@1.0.0",
   },
@@ -396,6 +604,10 @@ Object {
 
 exports[`test/lockfile/save.ts > TAP > store modifiers > with undefined scope registries > should save lockfile without scope registries when undefined 1`] = `
 Object {
+  "build": Object {
+    "allowed": Object {},
+    "blocked": Object {},
+  },
   "edges": Object {
     "file·. foo": "prod ^1.0.0 ··foo@1.0.0",
   },
@@ -426,6 +638,10 @@ exports[`test/lockfile/save.ts > TAP > store modifiers > with valid modifiers > 
       "custom": "http://example.com"
     }
   },
+  "build": {
+    "allowed": {},
+    "blocked": {}
+  },
   "nodes": {
     "··foo@2.0.0·%3Aroot%20%3E%20%23foo": [0,"foo","sha512-6/mh1E2u2YgEsCHdY0Yx5oW+61gZU+1vXaoiHHrpKeuRNNgFvS+/jrwHiQhB5apAf5oB7UB7E19ol2R2LKH8hQ=="]
   },
@@ -444,6 +660,10 @@ exports[`test/lockfile/save.ts > TAP > workspaces > save manifests > must match 
       "custom": "http://example.com"
     }
   },
+  "build": {
+    "allowed": {},
+    "blocked": {}
+  },
   "nodes": {
     "··c@1.0.0": [0,"c","sha512-6/mh1E2u2YgEsCHdY0Yx5oW+61gZU+1vXaoiHHrpKeuRNNgFvS+/jrwHiQhB5apAf5oB7UB7E19ol2R2LKH8hQ=="]
   },
@@ -461,6 +681,10 @@ exports[`test/lockfile/save.ts > TAP > workspaces > should save lockfile with wo
     "registries": {
       "custom": "http://example.com"
     }
+  },
+  "build": {
+    "allowed": {},
+    "blocked": {}
   },
   "nodes": {
     "··c@1.0.0": [0,"c","sha512-6/mh1E2u2YgEsCHdY0Yx5oW+61gZU+1vXaoiHHrpKeuRNNgFvS+/jrwHiQhB5apAf5oB7UB7E19ol2R2LKH8hQ=="]

--- a/src/graph/tap-snapshots/test/node.ts.test.cjs
+++ b/src/graph/tap-snapshots/test/node.ts.test.cjs
@@ -22,7 +22,8 @@ Node [@vltpkg/graph.Node] {
   modifier: undefined,
   version: '1.0.0',
   resolved: undefined,
-  platform: undefined
+  platform: undefined,
+  built: false
 }
 `
 

--- a/src/graph/tap-snapshots/test/reify/optional-fail.ts.test.cjs
+++ b/src/graph/tap-snapshots/test/reify/optional-fail.ts.test.cjs
@@ -7,6 +7,10 @@
 'use strict'
 exports[`test/reify/optional-fail.ts > TAP > register and optional node failure > must match snapshot 1`] = `
 Object {
+  "build": Object {
+    "allowed": Object {},
+    "blocked": Object {},
+  },
   "edges": Object {
     "··foo@1.2.3 bar": "prod * MISSING",
     "file·. foo": "optional * ··foo@1.2.3",

--- a/src/graph/test/build.ts
+++ b/src/graph/test/build.ts
@@ -1,0 +1,1608 @@
+import { existsSync, readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import t from 'tap'
+import { joinDepIDTuple } from '@vltpkg/dep-id'
+import { build, skip } from '../src/build.ts'
+import type { BuildData } from '../src/reify/save-build.ts'
+import { PackageJson } from '@vltpkg/package-json'
+import { PathScurry } from 'path-scurry'
+
+const scurry = new PathScurry(t.testdirName)
+const packageJson = new PackageJson()
+
+t.test('build function', async t => {
+  t.test('builds from cached build data when available', async t => {
+    const dir = t.testdir({
+      'package.json': JSON.stringify({
+        name: 'test-project',
+        version: '1.0.0',
+        dependencies: {},
+      }),
+      'vlt.json': JSON.stringify({}),
+      node_modules: {
+        '.vlt-build.json': JSON.stringify({
+          queue: [],
+        } satisfies BuildData),
+        '.vlt-lock.json': JSON.stringify({
+          lockfileVersion: 0,
+          options: {
+            registries: {
+              npm: 'https://registry.npmjs.org/',
+            },
+          },
+          build: {
+            allowed: {},
+            blocked: {},
+          },
+          nodes: {
+            [joinDepIDTuple(['file', '.'])]: [0, 'test-project'],
+          },
+          edges: {},
+        }),
+      },
+    })
+
+    // Call build function
+    await build({
+      projectRoot: dir,
+      packageJson,
+      scurry,
+    })
+
+    // Verify the build file was cleaned up after successful completion
+    const buildFilePath = resolve(dir, 'node_modules/.vlt-build.json')
+    t.notOk(
+      existsSync(buildFilePath),
+      'build file should be removed after successful build',
+    )
+
+    // The function should complete without errors
+    // This test primarily validates that the function can load cached build data
+    // and call the reify build process without throwing errors
+    t.pass('build completed successfully with cached build data')
+  })
+
+  t.test(
+    'builds everything when no cached build data exists',
+    async t => {
+      const dir = t.testdir({
+        'package.json': JSON.stringify({
+          name: 'test-project',
+          version: '1.0.0',
+          dependencies: {
+            lodash: '4',
+          },
+        }),
+        'vlt.json': JSON.stringify({}),
+        node_modules: {
+          lodash: {
+            'package.json': JSON.stringify({
+              name: 'lodash',
+              version: '4.17.21',
+            }),
+          },
+          '.vlt-lock.json': JSON.stringify({
+            lockfileVersion: 0,
+            options: {
+              registries: {
+                npm: 'https://registry.npmjs.org/',
+              },
+            },
+            build: {
+              allowed: {},
+              blocked: {},
+            },
+            nodes: {
+              [joinDepIDTuple(['file', '.'])]: [0, 'test-project'],
+              [joinDepIDTuple(['registry', '', 'lodash@4.17.21'])]: [
+                0,
+                'lodash',
+                'sha512-lodashintegrity==',
+              ],
+            },
+            edges: {
+              [`${joinDepIDTuple(['file', '.'])} lodash`]: `prod 4 ${joinDepIDTuple(['registry', '', 'lodash@4.17.21'])}`,
+            },
+          }),
+        },
+      })
+
+      // Ensure no build file exists
+      const buildFilePath = resolve(
+        dir,
+        'node_modules/.vlt-build.json',
+      )
+      t.notOk(
+        existsSync(buildFilePath),
+        'build file should not exist initially',
+      )
+
+      // Call build function
+      await build({
+        projectRoot: dir,
+        packageJson,
+        scurry,
+      })
+
+      // The function should complete without errors
+      // This test validates that the function can build everything when no cached data exists
+      t.pass('build completed successfully without cached build data')
+    },
+  )
+
+  t.test('handles corrupted build file gracefully', async t => {
+    const dir = t.testdir({
+      'package.json': JSON.stringify({
+        name: 'test-project',
+        version: '1.0.0',
+        dependencies: {
+          lodash: '4',
+        },
+      }),
+      'vlt.json': JSON.stringify({}),
+      node_modules: {
+        '.vlt-build.json': 'invalid json content',
+        lodash: {
+          'package.json': JSON.stringify({
+            name: 'lodash',
+            version: '4.17.21',
+          }),
+        },
+        '.vlt-lock.json': JSON.stringify({
+          lockfileVersion: 0,
+          options: {
+            registries: {
+              npm: 'https://registry.npmjs.org/',
+            },
+          },
+          build: {
+            allowed: {},
+            blocked: {},
+          },
+          nodes: {
+            [joinDepIDTuple(['file', '.'])]: [0, 'test-project'],
+            [joinDepIDTuple(['registry', '', 'lodash@4.17.21'])]: [
+              0,
+              'lodash',
+              'sha512-lodashintegrity==',
+            ],
+          },
+          edges: {
+            [`${joinDepIDTuple(['file', '.'])} lodash`]: `prod 4 ${joinDepIDTuple(['registry', '', 'lodash@4.17.21'])}`,
+          },
+        }),
+      },
+    })
+
+    // Call build function - should handle corrupted file gracefully
+    await build({
+      projectRoot: dir,
+      packageJson,
+      scurry,
+    })
+
+    // Verify the corrupted build file was cleaned up after successful completion
+    const buildFilePath = resolve(dir, 'node_modules/.vlt-build.json')
+    t.notOk(
+      existsSync(buildFilePath),
+      'corrupted build file should be removed after successful build',
+    )
+
+    // The function should complete without errors even with corrupted build file
+    t.pass('build handled corrupted build file gracefully')
+  })
+
+  t.test('handles missing node_modules directory', async t => {
+    const dir = t.testdir({
+      'package.json': JSON.stringify({
+        name: 'test-project',
+        version: '1.0.0',
+        dependencies: {
+          lodash: '4',
+        },
+      }),
+      'vlt.json': JSON.stringify({}),
+    })
+
+    // Call build function - should handle missing node_modules
+    await build({
+      projectRoot: dir,
+      packageJson,
+      scurry,
+    })
+
+    // The function should complete without errors even without node_modules
+    t.pass('build handled missing node_modules directory gracefully')
+  })
+
+  t.test('uses provided options correctly', async t => {
+    const dir = t.testdir({
+      'package.json': JSON.stringify({
+        name: 'test-project',
+        version: '1.0.0',
+        dependencies: {
+          lodash: '4',
+        },
+      }),
+      'vlt.json': JSON.stringify({}),
+      node_modules: {
+        '.vlt-lock.json': JSON.stringify({
+          lockfileVersion: 0,
+          options: {
+            registries: {
+              npm: 'https://registry.npmjs.org/',
+            },
+          },
+          build: {
+            allowed: {},
+            blocked: {},
+          },
+          nodes: {
+            [joinDepIDTuple(['file', '.'])]: [0, 'test-project'],
+          },
+          edges: {},
+        }),
+      },
+    })
+
+    // Call build function with custom options
+    await build({
+      projectRoot: dir,
+      packageJson,
+      scurry,
+    })
+
+    // The function should complete without errors
+    t.pass('build completed successfully with custom options')
+  })
+
+  t.test('cleans up build file after successful build', async t => {
+    const dir = t.testdir({
+      'package.json': JSON.stringify({
+        name: 'test-project',
+        version: '1.0.0',
+        dependencies: {},
+      }),
+      'vlt.json': JSON.stringify({}),
+      node_modules: {
+        '.vlt-build.json': JSON.stringify({
+          queue: [],
+        } satisfies BuildData),
+        '.vlt-lock.json': JSON.stringify({
+          lockfileVersion: 0,
+          options: {
+            registries: {
+              npm: 'https://registry.npmjs.org/',
+            },
+          },
+          build: {
+            allowed: {},
+            blocked: {},
+          },
+          nodes: {
+            [joinDepIDTuple(['file', '.'])]: [0, 'test-project'],
+          },
+          edges: {},
+        }),
+      },
+    })
+
+    const buildFilePath = resolve(dir, 'node_modules/.vlt-build.json')
+
+    // Verify the build file exists before the build
+    t.ok(
+      existsSync(buildFilePath),
+      'build file should exist before build',
+    )
+
+    // Call build function
+    await build({
+      projectRoot: dir,
+      packageJson,
+      scurry,
+    })
+
+    // Verify the build file was cleaned up
+    t.notOk(
+      existsSync(buildFilePath),
+      'build file should be removed after successful build',
+    )
+  })
+
+  t.test(
+    'loads build data from lockfile and transfers to graph',
+    async t => {
+      const dir = t.testdir({
+        'package.json': JSON.stringify({
+          name: 'test-project',
+          version: '1.0.0',
+          dependencies: {
+            'test-pkg': '1.0.0',
+          },
+        }),
+        'vlt-lock.json': JSON.stringify({
+          lockfileVersion: 0,
+          options: {
+            registry: 'https://registry.npmjs.org/',
+          },
+          build: {
+            allowed: {
+              'https://registry.npmjs.org/': ['test-pkg'],
+            },
+            blocked: {
+              'https://registry.npmjs.org/': ['blocked-pkg'],
+            },
+          },
+          nodes: {
+            [joinDepIDTuple(['file', '.'])]: [0, 'test-project'],
+            [joinDepIDTuple([
+              'registry',
+              'https://registry.npmjs.org/',
+              'test-pkg@1.0.0',
+            ])]: [0, 'test-pkg', 'sha512-testpkgintegrity=='],
+          },
+          edges: {
+            [`${joinDepIDTuple(['file', '.'])} test-pkg`]: `prod 1.0.0 ${joinDepIDTuple(['registry', 'https://registry.npmjs.org/', 'test-pkg@1.0.0'])}`,
+          },
+        }),
+        node_modules: {
+          'test-pkg': {
+            'package.json': JSON.stringify({
+              name: 'test-pkg',
+              version: '1.0.0',
+              scripts: {
+                install: 'echo "building"',
+              },
+            }),
+          },
+          '.vlt-lock.json': JSON.stringify({
+            lockfileVersion: 0,
+            options: {
+              registry: 'https://registry.npmjs.org/',
+            },
+            build: {
+              allowed: {},
+              blocked: {},
+            },
+            nodes: {
+              [joinDepIDTuple(['file', '.'])]: [0, 'test-project'],
+              [joinDepIDTuple([
+                'registry',
+                'https://registry.npmjs.org/',
+                'test-pkg@1.0.0',
+              ])]: [0, 'test-pkg', 'sha512-testpkgintegrity=='],
+            },
+            edges: {
+              [`${joinDepIDTuple(['file', '.'])} test-pkg`]: `prod 1.0.0 ${joinDepIDTuple(['registry', 'https://registry.npmjs.org/', 'test-pkg@1.0.0'])}`,
+            },
+          }),
+        },
+      })
+
+      // Call build function
+      await build({
+        projectRoot: dir,
+        packageJson,
+        scurry,
+      })
+
+      // Verify lockfile was updated with build data
+      const lockfilePath = resolve(dir, 'vlt-lock.json')
+      t.ok(
+        existsSync(lockfilePath),
+        'lockfile should exist after build',
+      )
+
+      const lockfileContent = JSON.parse(
+        readFileSync(lockfilePath, 'utf8'),
+      )
+      t.ok(
+        lockfileContent.build,
+        'lockfile should contain build data',
+      )
+      t.ok(
+        lockfileContent.build.allowed,
+        'lockfile should contain allowed build data',
+      )
+
+      t.pass(
+        'build loaded and applied lockfile build data successfully',
+      )
+    },
+  )
+
+  t.test('persists build results to lockfile', async t => {
+    const testPkgId = joinDepIDTuple([
+      'registry',
+      'https://registry.npmjs.org/',
+      'test-build-pkg@1.0.0',
+    ])
+
+    const dir = t.testdir({
+      'package.json': JSON.stringify({
+        name: 'test-project',
+        version: '1.0.0',
+        dependencies: {
+          'test-build-pkg': '1.0.0',
+        },
+      }),
+      'vlt-lock.json': JSON.stringify({
+        lockfileVersion: 0,
+        options: {
+          registry: 'https://registry.npmjs.org/',
+        },
+        build: {
+          allowed: {},
+          blocked: {},
+        },
+        nodes: {
+          [joinDepIDTuple(['file', '.'])]: [0, 'test-project'],
+          [testPkgId]: [
+            0,
+            'test-build-pkg',
+            'sha512-testintegrity==',
+          ],
+        },
+        edges: {
+          [`${joinDepIDTuple(['file', '.'])} test-build-pkg`]: `prod 1.0.0 ${testPkgId}`,
+        },
+      }),
+      node_modules: {
+        '.vlt-build.json': JSON.stringify({
+          queue: [testPkgId],
+        } satisfies BuildData),
+        'test-build-pkg': {
+          'package.json': JSON.stringify({
+            name: 'test-build-pkg',
+            version: '1.0.0',
+          }),
+        },
+        '.vlt-lock.json': JSON.stringify({
+          lockfileVersion: 0,
+          options: {
+            registry: 'https://registry.npmjs.org/',
+          },
+          build: {
+            allowed: {},
+            blocked: {},
+          },
+          nodes: {
+            [joinDepIDTuple(['file', '.'])]: [0, 'test-project'],
+            [testPkgId]: [
+              0,
+              'test-build-pkg',
+              'sha512-testintegrity==',
+              null,
+              null,
+              {
+                name: 'test-build-pkg',
+                version: '1.0.0',
+              },
+            ],
+          },
+          edges: {
+            [`${joinDepIDTuple(['file', '.'])} test-build-pkg`]: `prod 1.0.0 ${testPkgId}`,
+          },
+        }),
+      },
+    })
+
+    // Call build function
+    await build({
+      projectRoot: dir,
+      packageJson,
+      scurry,
+    })
+
+    // Verify lockfile was updated with build results
+    const lockfilePath = resolve(dir, 'vlt-lock.json')
+    t.ok(
+      existsSync(lockfilePath),
+      'lockfile should exist after build',
+    )
+
+    const lockfileContent = JSON.parse(
+      readFileSync(lockfilePath, 'utf8'),
+    )
+
+    // Verify build data is persisted
+    t.ok(lockfileContent.build, 'lockfile should contain build data')
+    t.ok(
+      lockfileContent.build.allowed,
+      'lockfile should contain allowed build data',
+    )
+
+    t.pass('build results were persisted to lockfile successfully')
+  })
+
+  t.test(
+    'handles corrupted lockfile build data gracefully',
+    async t => {
+      const dir = t.testdir({
+        'package.json': JSON.stringify({
+          name: 'test-project',
+          version: '1.0.0',
+          dependencies: {},
+        }),
+        'vlt-lock.json': 'invalid json content',
+        node_modules: {
+          '.vlt-lock.json': JSON.stringify({
+            lockfileVersion: 0,
+            options: {
+              registry: 'https://registry.npmjs.org/',
+            },
+            build: {
+              allowed: {},
+              blocked: {},
+            },
+            nodes: {
+              [joinDepIDTuple(['file', '.'])]: [0, 'test-project'],
+            },
+            edges: {},
+          }),
+        },
+      })
+
+      // Call build function - should handle corrupted lockfile gracefully
+      await build({
+        projectRoot: dir,
+        packageJson,
+        scurry,
+      })
+
+      // The function should complete without errors even with corrupted lockfile
+      t.pass('build handled corrupted lockfile gracefully')
+    },
+  )
+
+  t.test(
+    'works when both lockfile and build cache exist',
+    async t => {
+      const testPkgId = joinDepIDTuple([
+        'registry',
+        'https://registry.npmjs.org/',
+        'cached-pkg@1.0.0',
+      ])
+
+      const dir = t.testdir({
+        'package.json': JSON.stringify({
+          name: 'test-project',
+          version: '1.0.0',
+          dependencies: {
+            'cached-pkg': '1.0.0',
+          },
+        }),
+        'vlt-lock.json': JSON.stringify({
+          lockfileVersion: 0,
+          options: {
+            registry: 'https://registry.npmjs.org/',
+          },
+          build: {
+            allowed: {
+              'https://registry.npmjs.org/': ['existing-pkg'],
+            },
+            blocked: {},
+          },
+          nodes: {
+            [joinDepIDTuple(['file', '.'])]: [0, 'test-project'],
+            [testPkgId]: [
+              0,
+              'cached-pkg',
+              'sha512-cachedintegrity==',
+            ],
+          },
+          edges: {
+            [`${joinDepIDTuple(['file', '.'])} cached-pkg`]: `prod 1.0.0 ${testPkgId}`,
+          },
+        }),
+        node_modules: {
+          '.vlt-build.json': JSON.stringify({
+            queue: [testPkgId],
+          } satisfies BuildData),
+          'cached-pkg': {
+            'package.json': JSON.stringify({
+              name: 'cached-pkg',
+              version: '1.0.0',
+            }),
+          },
+          '.vlt-lock.json': JSON.stringify({
+            lockfileVersion: 0,
+            options: {
+              registry: 'https://registry.npmjs.org/',
+            },
+            build: {
+              allowed: {},
+              blocked: {},
+            },
+            nodes: {
+              [joinDepIDTuple(['file', '.'])]: [0, 'test-project'],
+              [testPkgId]: [
+                0,
+                'cached-pkg',
+                'sha512-cachedintegrity==',
+                null,
+                null,
+                {
+                  name: 'cached-pkg',
+                  version: '1.0.0',
+                },
+              ],
+            },
+            edges: {
+              [`${joinDepIDTuple(['file', '.'])} cached-pkg`]: `prod 1.0.0 ${testPkgId}`,
+            },
+          }),
+        },
+      })
+
+      // Call build function
+      await build({
+        projectRoot: dir,
+        packageJson,
+        scurry,
+      })
+
+      // Verify both lockfile build data and build cache were processed
+      const lockfilePath = resolve(dir, 'vlt-lock.json')
+      t.ok(
+        existsSync(lockfilePath),
+        'lockfile should exist after build',
+      )
+
+      const buildFilePath = resolve(
+        dir,
+        'node_modules/.vlt-build.json',
+      )
+      t.notOk(
+        existsSync(buildFilePath),
+        'build cache file should be cleaned up',
+      )
+
+      const lockfileContent = JSON.parse(
+        readFileSync(lockfilePath, 'utf8'),
+      )
+
+      t.ok(
+        lockfileContent.build,
+        'lockfile should contain build data',
+      )
+
+      t.pass(
+        'build handled both lockfile and build cache successfully',
+      )
+    },
+  )
+
+  t.test('build with queryFilteredNodes parameter', async t => {
+    const testPkgId1 = joinDepIDTuple([
+      'registry',
+      'https://registry.npmjs.org/',
+      'test-pkg-1',
+      '1.0.0',
+    ])
+    const testPkgId2 = joinDepIDTuple([
+      'registry',
+      'https://registry.npmjs.org/',
+      'test-pkg-2',
+      '1.0.0',
+    ])
+
+    const dir = t.testdir({
+      'package.json': JSON.stringify({
+        name: 'test-project',
+        version: '1.0.0',
+        dependencies: {
+          'test-pkg-1': '1.0.0',
+          'test-pkg-2': '1.0.0',
+        },
+      }),
+      'vlt.json': JSON.stringify({}),
+      node_modules: {
+        '.vlt-build.json': JSON.stringify({
+          queue: [testPkgId1, testPkgId2],
+        } satisfies BuildData),
+        'test-pkg-1': {
+          'package.json': JSON.stringify({
+            name: 'test-pkg-1',
+            version: '1.0.0',
+          }),
+        },
+        'test-pkg-2': {
+          'package.json': JSON.stringify({
+            name: 'test-pkg-2',
+            version: '1.0.0',
+          }),
+        },
+        '.vlt-lock.json': JSON.stringify({
+          lockfileVersion: 0,
+          options: {
+            registry: 'https://registry.npmjs.org/',
+          },
+          build: {
+            allowed: {},
+            blocked: {},
+          },
+          nodes: {
+            [joinDepIDTuple(['file', '.'])]: [0, 'test-project'],
+            [testPkgId1]: [
+              0,
+              'test-pkg-1',
+              'sha512-testintegrity==',
+              null,
+              null,
+              {
+                name: 'test-pkg-1',
+                version: '1.0.0',
+              },
+            ],
+            [testPkgId2]: [
+              0,
+              'test-pkg-2',
+              'sha512-testintegrity==',
+              null,
+              null,
+              {
+                name: 'test-pkg-2',
+                version: '1.0.0',
+              },
+            ],
+          },
+          edges: {
+            [`${joinDepIDTuple(['file', '.'])} test-pkg-1`]: `prod 1.0.0 ${testPkgId1}`,
+            [`${joinDepIDTuple(['file', '.'])} test-pkg-2`]: `prod 1.0.0 ${testPkgId2}`,
+          },
+        }),
+      },
+    })
+
+    // Call build with queryFilteredNodes - only build test-pkg-1
+    await build({
+      projectRoot: dir,
+      packageJson,
+      scurry,
+      queryFilteredNodes: [testPkgId1],
+    })
+
+    // Verify build data was partially updated (test-pkg-2 should remain in queue)
+    const buildFilePath = resolve(dir, 'node_modules/.vlt-build.json')
+
+    if (existsSync(buildFilePath)) {
+      const updatedBuildData = JSON.parse(
+        readFileSync(buildFilePath, 'utf8'),
+      )
+      t.strictSame(
+        updatedBuildData.queue,
+        [testPkgId2],
+        'should remove only built packages from queue',
+      )
+    }
+
+    t.pass('build with queryFilteredNodes completed')
+  })
+
+  t.test('build function with no lockfile data', async t => {
+    const dir = t.testdir({
+      'package.json': JSON.stringify({
+        name: 'test-project',
+        version: '1.0.0',
+        dependencies: {
+          'test-pkg': '1.0.0',
+        },
+      }),
+      node_modules: {
+        '.vlt-build.json': JSON.stringify({
+          queue: [],
+        } satisfies BuildData),
+        'test-pkg': {
+          'package.json': JSON.stringify({
+            name: 'test-pkg',
+            version: '1.0.0',
+          }),
+        },
+        '.vlt-lock.json': JSON.stringify({
+          lockfileVersion: 0,
+          options: {
+            registries: {
+              npm: 'https://registry.npmjs.org/',
+            },
+          },
+          build: {
+            allowed: {},
+            blocked: {},
+          },
+          nodes: {
+            [joinDepIDTuple(['file', '.'])]: [0, 'test-project'],
+            [joinDepIDTuple(['registry', '', 'test-pkg@1.0.0'])]: [
+              0,
+              'test-pkg',
+              'sha512-testintegrity==',
+              null,
+              null,
+              {
+                name: 'test-pkg',
+                version: '1.0.0',
+              },
+            ],
+          },
+          edges: {
+            [`${joinDepIDTuple(['file', '.'])} test-pkg`]: `prod 1.0.0 ${joinDepIDTuple(['registry', '', 'test-pkg@1.0.0'])}`,
+          },
+        }),
+      },
+    })
+
+    // Call build function - should handle missing lockfile gracefully
+    await build({
+      projectRoot: dir,
+      packageJson,
+      scurry,
+    })
+
+    // Verify the build file was cleaned up after successful completion
+    const buildFilePath = resolve(dir, 'node_modules/.vlt-build.json')
+    t.notOk(
+      existsSync(buildFilePath),
+      'build file should be removed after successful build',
+    )
+
+    // Since there's no vlt-lock.json file at the project root,
+    // build results won't be persisted to a lockfile
+    const lockfilePath = resolve(dir, 'vlt-lock.json')
+    t.notOk(
+      existsSync(lockfilePath),
+      'no lockfile should be created when none existed initially',
+    )
+
+    t.pass('build handled missing lockfile data gracefully')
+  })
+
+  t.test(
+    'build function removes build file when queue becomes empty after filtering',
+    async t => {
+      const testPkgId = joinDepIDTuple(['registry', '', 'test-pkg@1.0.0'])
+
+      const dir = t.testdir({
+        'package.json': JSON.stringify({
+          name: 'test-project',
+          version: '1.0.0',
+          dependencies: {
+            'test-pkg': '^1.0.0',
+          },
+        }),
+        'vlt-lock.json': JSON.stringify({
+          lockfileVersion: 0,
+          options: {
+            registry: 'https://registry.npmjs.org/',
+          },
+          build: {
+            allowed: {},
+            blocked: {},
+          },
+          nodes: {
+            [joinDepIDTuple(['file', '.'])]: [0, 'test-project'],
+            [testPkgId]: [
+              0,
+              'test-pkg',
+              'sha512-testintegrity==',
+              null,
+              null,
+              {
+                name: 'test-pkg',
+                version: '1.0.0',
+              },
+            ],
+          },
+          edges: {
+            [`${joinDepIDTuple(['file', '.'])} test-pkg`]: `prod ^1.0.0 ${testPkgId}`,
+          },
+        }),
+        'vlt.json': JSON.stringify({}),
+        node_modules: {
+          '.vlt-build.json': JSON.stringify({
+            queue: [testPkgId], // test-pkg DepID in queue
+          } satisfies BuildData),
+          'test-pkg': {
+            'package.json': JSON.stringify({
+              name: 'test-pkg',
+              version: '1.0.0',
+            }),
+          },
+          '.vlt-lock.json': JSON.stringify({
+            lockfileVersion: 0,
+            options: {
+              registry: 'https://registry.npmjs.org/',
+            },
+            build: {
+              allowed: {},
+              blocked: {},
+            },
+            nodes: {
+              [joinDepIDTuple(['file', '.'])]: [0, 'test-project'],
+              [testPkgId]: [
+                0,
+                'test-pkg',
+                'sha512-testintegrity==',
+                null,
+                null,
+                {
+                  name: 'test-pkg',
+                  version: '1.0.0',
+                },
+              ],
+            },
+            edges: {
+              [`${joinDepIDTuple(['file', '.'])} test-pkg`]: `prod ^1.0.0 ${testPkgId}`,
+            },
+          }),
+        },
+      })
+
+      const buildFilePath = resolve(
+        dir,
+        'node_modules/.vlt-build.json',
+      )
+
+      // Verify the build file exists before the build
+      t.ok(
+        existsSync(buildFilePath),
+        'build file should exist before build',
+      )
+
+      // Call build function with queryFilteredNodes to trigger conditional cleanup path
+      // This will cause the build to process the test-pkg, removing it from the queue
+      // When the queue becomes empty after filtering, it should trigger remove the
+      // temporary build queue data file
+      await build({
+        projectRoot: dir,
+        packageJson,
+        scurry,
+        queryFilteredNodes: [testPkgId],
+      })
+
+      // Verify the build file was completely removed after build
+      t.notOk(
+        existsSync(buildFilePath),
+        'build file should be completely removed when queue becomes empty after filtering',
+      )
+
+      // Verify lockfile still exists
+      const lockfilePath = resolve(dir, 'vlt-lock.json')
+      t.ok(
+        existsSync(lockfilePath),
+        'lockfile should still exist after build',
+      )
+
+      t.pass(
+        'build cleanup correctly removed build file when queue became empty after filtering',
+      )
+    },
+  )
+
+  t.end()
+})
+
+t.test('skip function', async t => {
+  t.test('skip packages and update lockfile', async t => {
+    const testPkgId1 = joinDepIDTuple([
+      'registry',
+      'https://registry.npmjs.org/',
+      'test-pkg-1',
+      '1.0.0',
+    ])
+    const testPkgId2 = joinDepIDTuple([
+      'registry',
+      'https://registry.npmjs.org/',
+      'test-pkg-2',
+      '1.0.0',
+    ])
+
+    const dir = t.testdir({
+      'package.json': JSON.stringify({
+        name: 'test-project',
+        version: '1.0.0',
+        dependencies: {
+          'test-pkg-1': '1.0.0',
+          'test-pkg-2': '1.0.0',
+        },
+      }),
+      'vlt-lock.json': JSON.stringify({
+        lockfileVersion: 0,
+        options: {
+          registry: 'https://registry.npmjs.org/',
+        },
+        build: {
+          allowed: {},
+          blocked: {},
+        },
+        nodes: {
+          [joinDepIDTuple(['file', '.'])]: [0, 'test-project'],
+          [testPkgId1]: [0, 'test-pkg-1', 'sha512-testintegrity=='],
+          [testPkgId2]: [0, 'test-pkg-2', 'sha512-testintegrity=='],
+        },
+        edges: {
+          [`${joinDepIDTuple(['file', '.'])} test-pkg-1`]: `prod 1.0.0 ${testPkgId1}`,
+          [`${joinDepIDTuple(['file', '.'])} test-pkg-2`]: `prod 1.0.0 ${testPkgId2}`,
+        },
+      }),
+      'vlt.json': JSON.stringify({}),
+      node_modules: {
+        '.vlt-build.json': JSON.stringify({
+          queue: [testPkgId1, testPkgId2],
+        } satisfies BuildData),
+        'test-pkg-1': {
+          'package.json': JSON.stringify({
+            name: 'test-pkg-1',
+            version: '1.0.0',
+          }),
+        },
+        'test-pkg-2': {
+          'package.json': JSON.stringify({
+            name: 'test-pkg-2',
+            version: '1.0.0',
+          }),
+        },
+        '.vlt-lock.json': JSON.stringify({
+          lockfileVersion: 0,
+          options: {
+            registry: 'https://registry.npmjs.org/',
+          },
+          build: {
+            allowed: {},
+            blocked: {},
+          },
+          nodes: {
+            [joinDepIDTuple(['file', '.'])]: [0, 'test-project'],
+            [testPkgId1]: [
+              0,
+              'test-pkg-1',
+              'sha512-testintegrity==',
+              null,
+              null,
+              {
+                name: 'test-pkg-1',
+                version: '1.0.0',
+              },
+            ],
+            [testPkgId2]: [
+              0,
+              'test-pkg-2',
+              'sha512-testintegrity==',
+              null,
+              null,
+              {
+                name: 'test-pkg-2',
+                version: '1.0.0',
+              },
+            ],
+          },
+          edges: {
+            [`${joinDepIDTuple(['file', '.'])} test-pkg-1`]: `prod 1.0.0 ${testPkgId1}`,
+            [`${joinDepIDTuple(['file', '.'])} test-pkg-2`]: `prod 1.0.0 ${testPkgId2}`,
+          },
+        }),
+      },
+    })
+
+    // Call skip function
+    await skip({
+      projectRoot: dir,
+      packageJson,
+      scurry,
+    })
+
+    // Verify lockfile was updated with blocked packages
+    const lockfilePath = resolve(dir, 'vlt-lock.json')
+    t.ok(existsSync(lockfilePath), 'lockfile should exist after skip')
+
+    const lockfileContent = JSON.parse(
+      readFileSync(lockfilePath, 'utf8'),
+    )
+
+    t.ok(lockfileContent.build, 'lockfile should contain build data')
+    t.ok(
+      lockfileContent.build.blocked,
+      'lockfile should contain blocked build data',
+    )
+
+    // Verify build data file was removed (no items remain)
+    const buildFilePath = resolve(dir, 'node_modules/.vlt-build.json')
+    t.notOk(
+      existsSync(buildFilePath),
+      'build data file should be removed after skipping all items',
+    )
+
+    t.pass('skip completed successfully')
+  })
+
+  t.test('skip with queryFilteredNodes parameter', async t => {
+    const testPkgId1 = joinDepIDTuple([
+      'registry',
+      'https://registry.npmjs.org/',
+      'test-pkg-1',
+      '1.0.0',
+    ])
+    const testPkgId2 = joinDepIDTuple([
+      'registry',
+      'https://registry.npmjs.org/',
+      'test-pkg-2',
+      '1.0.0',
+    ])
+
+    const dir = t.testdir({
+      'package.json': JSON.stringify({
+        name: 'test-project',
+        version: '1.0.0',
+        dependencies: {
+          'test-pkg-1': '1.0.0',
+          'test-pkg-2': '1.0.0',
+        },
+      }),
+      'vlt.json': JSON.stringify({}),
+      node_modules: {
+        '.vlt-build.json': JSON.stringify({
+          queue: [testPkgId1, testPkgId2],
+        } satisfies BuildData),
+        'test-pkg-1': {
+          'package.json': JSON.stringify({
+            name: 'test-pkg-1',
+            version: '1.0.0',
+          }),
+        },
+        'test-pkg-2': {
+          'package.json': JSON.stringify({
+            name: 'test-pkg-2',
+            version: '1.0.0',
+          }),
+        },
+        '.vlt-lock.json': JSON.stringify({
+          lockfileVersion: 0,
+          options: {
+            registry: 'https://registry.npmjs.org/',
+          },
+          build: {
+            allowed: {},
+            blocked: {},
+          },
+          nodes: {
+            [joinDepIDTuple(['file', '.'])]: [0, 'test-project'],
+            [testPkgId1]: [
+              0,
+              'test-pkg-1',
+              'sha512-testintegrity==',
+              null,
+              null,
+              {
+                name: 'test-pkg-1',
+                version: '1.0.0',
+              },
+            ],
+            [testPkgId2]: [
+              0,
+              'test-pkg-2',
+              'sha512-testintegrity==',
+              null,
+              null,
+              {
+                name: 'test-pkg-2',
+                version: '1.0.0',
+              },
+            ],
+          },
+          edges: {
+            [`${joinDepIDTuple(['file', '.'])} test-pkg-1`]: `prod 1.0.0 ${testPkgId1}`,
+            [`${joinDepIDTuple(['file', '.'])} test-pkg-2`]: `prod 1.0.0 ${testPkgId2}`,
+          },
+        }),
+      },
+    })
+
+    // Call skip with queryFilteredNodes - only skip test-pkg-1
+    await skip({
+      projectRoot: dir,
+      packageJson,
+      scurry,
+      queryFilteredNodes: [testPkgId1],
+    })
+
+    // Verify build data was partially updated (test-pkg-2 should remain in queue)
+    const buildFilePath = resolve(dir, 'node_modules/.vlt-build.json')
+    t.ok(
+      existsSync(buildFilePath),
+      'build data file should still exist',
+    )
+
+    const updatedBuildData = JSON.parse(
+      readFileSync(buildFilePath, 'utf8'),
+    )
+    t.strictSame(
+      updatedBuildData.queue,
+      [testPkgId2],
+      'should remove only skipped packages from queue',
+    )
+
+    t.pass('skip with queryFilteredNodes completed')
+  })
+
+  t.test('skip with no lockfile', async t => {
+    const dir = t.testdir({
+      'package.json': JSON.stringify({
+        name: 'test-project',
+        version: '1.0.0',
+      }),
+      'vlt.json': JSON.stringify({}),
+    })
+
+    // Call skip function - should return early with no lockfile
+    await skip({
+      projectRoot: dir,
+      packageJson,
+      scurry,
+    })
+
+    t.pass('skip with no lockfile completed without error')
+  })
+
+  t.test('skip with no queued items', async t => {
+    const dir = t.testdir({
+      'package.json': JSON.stringify({
+        name: 'test-project',
+        version: '1.0.0',
+      }),
+      'vlt.json': JSON.stringify({}),
+      node_modules: {
+        '.vlt-lock.json': JSON.stringify({
+          lockfileVersion: 0,
+          options: {
+            registry: 'https://registry.npmjs.org/',
+          },
+          build: {
+            allowed: {},
+            blocked: {},
+          },
+          nodes: {
+            [joinDepIDTuple(['file', '.'])]: [0, 'test-project'],
+          },
+          edges: {},
+        }),
+      },
+    })
+
+    // Call skip function - should return early with no queue
+    await skip({
+      projectRoot: dir,
+      packageJson,
+      scurry,
+    })
+
+    t.pass('skip with no queued items completed without error')
+  })
+
+  t.test(
+    'skip function with existing lockfile build data',
+    async t => {
+      const testPkgId1 = joinDepIDTuple([
+        'registry',
+        'https://registry.npmjs.org/',
+        'skip-pkg-1',
+        '1.0.0',
+      ])
+      const testPkgId2 = joinDepIDTuple([
+        'registry',
+        'https://registry.npmjs.org/',
+        'skip-pkg-2',
+        '1.0.0',
+      ])
+
+      const dir = t.testdir({
+        'package.json': JSON.stringify({
+          name: 'test-project',
+          version: '1.0.0',
+          dependencies: {
+            'skip-pkg-1': '1.0.0',
+            'skip-pkg-2': '1.0.0',
+          },
+        }),
+        'vlt-lock.json': JSON.stringify({
+          lockfileVersion: 0,
+          options: {
+            registry: 'https://registry.npmjs.org/',
+          },
+          build: {
+            allowed: {
+              'https://registry.npmjs.org/': ['existing-allowed-pkg'],
+            },
+            blocked: {
+              'https://registry.npmjs.org/': ['existing-blocked-pkg'],
+            },
+          },
+          nodes: {
+            [joinDepIDTuple(['file', '.'])]: [0, 'test-project'],
+            [testPkgId1]: [0, 'skip-pkg-1', 'sha512-skipintegrity=='],
+            [testPkgId2]: [0, 'skip-pkg-2', 'sha512-skipintegrity=='],
+          },
+          edges: {
+            [`${joinDepIDTuple(['file', '.'])} skip-pkg-1`]: `prod 1.0.0 ${testPkgId1}`,
+            [`${joinDepIDTuple(['file', '.'])} skip-pkg-2`]: `prod 1.0.0 ${testPkgId2}`,
+          },
+        }),
+        'vlt.json': JSON.stringify({}),
+        node_modules: {
+          '.vlt-build.json': JSON.stringify({
+            queue: [testPkgId1, testPkgId2],
+          } satisfies BuildData),
+          'skip-pkg-1': {
+            'package.json': JSON.stringify({
+              name: 'skip-pkg-1',
+              version: '1.0.0',
+            }),
+          },
+          'skip-pkg-2': {
+            'package.json': JSON.stringify({
+              name: 'skip-pkg-2',
+              version: '1.0.0',
+            }),
+          },
+          '.vlt-lock.json': JSON.stringify({
+            lockfileVersion: 0,
+            options: {
+              registry: 'https://registry.npmjs.org/',
+            },
+            build: {
+              allowed: {},
+              blocked: {},
+            },
+            nodes: {
+              [joinDepIDTuple(['file', '.'])]: [0, 'test-project'],
+              [testPkgId1]: [
+                0,
+                'skip-pkg-1',
+                'sha512-skipintegrity==',
+              ],
+              [testPkgId2]: [
+                0,
+                'skip-pkg-2',
+                'sha512-skipintegrity==',
+              ],
+            },
+            edges: {
+              [`${joinDepIDTuple(['file', '.'])} skip-pkg-1`]: `prod 1.0.0 ${testPkgId1}`,
+              [`${joinDepIDTuple(['file', '.'])} skip-pkg-2`]: `prod 1.0.0 ${testPkgId2}`,
+            },
+          }),
+        },
+      })
+
+      // Call skip function
+      await skip({
+        projectRoot: dir,
+        packageJson,
+        scurry,
+      })
+
+      // Verify lockfile was updated with blocked packages while preserving existing data
+      const lockfilePath = resolve(dir, 'vlt-lock.json')
+      t.ok(
+        existsSync(lockfilePath),
+        'lockfile should exist after skip',
+      )
+
+      const lockfileContent = JSON.parse(
+        readFileSync(lockfilePath, 'utf8'),
+      )
+
+      t.ok(
+        lockfileContent.build,
+        'lockfile should contain build data',
+      )
+      t.ok(
+        lockfileContent.build.blocked,
+        'lockfile should contain blocked build data',
+      )
+      t.ok(
+        lockfileContent.build.allowed,
+        'lockfile should contain allowed build data',
+      )
+
+      // Check that existing build data is preserved
+      t.strictSame(
+        lockfileContent.build.allowed,
+        { 'https://registry.npmjs.org/': ['existing-allowed-pkg'] },
+        'existing allowed packages should be preserved',
+      )
+
+      // Check that skipped packages are added to blocked list alongside existing blocked packages
+      t.strictSame(
+        lockfileContent.build.blocked[
+          'https://registry.npmjs.org/'
+        ].sort(),
+        ['existing-blocked-pkg', 'skip-pkg-1', 'skip-pkg-2'].sort(),
+        'skipped packages should be added to blocked list with existing packages',
+      )
+
+      // Verify build data file was removed (no items remain)
+      const buildFilePath = resolve(
+        dir,
+        'node_modules/.vlt-build.json',
+      )
+      t.notOk(
+        existsSync(buildFilePath),
+        'build data file should be removed after skipping all items',
+      )
+
+      t.pass(
+        'skip with existing lockfile build data completed successfully',
+      )
+    },
+  )
+
+  t.test(
+    'skip function with no nodes to skip after filtering',
+    async t => {
+      const testPkgId1 = joinDepIDTuple([
+        'registry',
+        'https://registry.npmjs.org/',
+        'queued-pkg-1',
+        '1.0.0',
+      ])
+      const testPkgId2 = joinDepIDTuple([
+        'registry',
+        'https://registry.npmjs.org/',
+        'queued-pkg-2',
+        '1.0.0',
+      ])
+      const testPkgId3 = joinDepIDTuple([
+        'registry',
+        'https://registry.npmjs.org/',
+        'filtered-pkg',
+        '1.0.0',
+      ])
+
+      const dir = t.testdir({
+        'package.json': JSON.stringify({
+          name: 'test-project',
+          version: '1.0.0',
+          dependencies: {
+            'queued-pkg-1': '1.0.0',
+            'queued-pkg-2': '1.0.0',
+            'filtered-pkg': '1.0.0',
+          },
+        }),
+        'vlt-lock.json': JSON.stringify({
+          lockfileVersion: 0,
+          options: {
+            registry: 'https://registry.npmjs.org/',
+          },
+          build: {
+            allowed: {},
+            blocked: {},
+          },
+          nodes: {
+            [joinDepIDTuple(['file', '.'])]: [0, 'test-project'],
+            [testPkgId1]: [
+              0,
+              'queued-pkg-1',
+              'sha512-queuedintegrity==',
+            ],
+            [testPkgId2]: [
+              0,
+              'queued-pkg-2',
+              'sha512-queuedintegrity==',
+            ],
+            [testPkgId3]: [
+              0,
+              'filtered-pkg',
+              'sha512-filteredintegrity==',
+            ],
+          },
+          edges: {
+            [`${joinDepIDTuple(['file', '.'])} queued-pkg-1`]: `prod 1.0.0 ${testPkgId1}`,
+            [`${joinDepIDTuple(['file', '.'])} queued-pkg-2`]: `prod 1.0.0 ${testPkgId2}`,
+            [`${joinDepIDTuple(['file', '.'])} filtered-pkg`]: `prod 1.0.0 ${testPkgId3}`,
+          },
+        }),
+        'vlt.json': JSON.stringify({}),
+        node_modules: {
+          '.vlt-build.json': JSON.stringify({
+            queue: [testPkgId1, testPkgId2], // testPkgId3 is NOT in queue, so it won't be skipped
+          } satisfies BuildData),
+          'queued-pkg-1': {
+            'package.json': JSON.stringify({
+              name: 'queued-pkg-1',
+              version: '1.0.0',
+            }),
+          },
+          'queued-pkg-2': {
+            'package.json': JSON.stringify({
+              name: 'queued-pkg-2',
+              version: '1.0.0',
+            }),
+          },
+          'filtered-pkg': {
+            'package.json': JSON.stringify({
+              name: 'filtered-pkg',
+              version: '1.0.0',
+            }),
+          },
+          '.vlt-lock.json': JSON.stringify({
+            lockfileVersion: 0,
+            options: {
+              registry: 'https://registry.npmjs.org/',
+            },
+            build: {
+              allowed: {},
+              blocked: {},
+            },
+            nodes: {
+              [joinDepIDTuple(['file', '.'])]: [0, 'test-project'],
+              [testPkgId1]: [
+                0,
+                'queued-pkg-1',
+                'sha512-queuedintegrity==',
+              ],
+              [testPkgId2]: [
+                0,
+                'queued-pkg-2',
+                'sha512-queuedintegrity==',
+              ],
+              [testPkgId3]: [
+                0,
+                'filtered-pkg',
+                'sha512-filteredintegrity==',
+              ],
+            },
+            edges: {
+              [`${joinDepIDTuple(['file', '.'])} queued-pkg-1`]: `prod 1.0.0 ${testPkgId1}`,
+              [`${joinDepIDTuple(['file', '.'])} queued-pkg-2`]: `prod 1.0.0 ${testPkgId2}`,
+              [`${joinDepIDTuple(['file', '.'])} filtered-pkg`]: `prod 1.0.0 ${testPkgId3}`,
+            },
+          }),
+        },
+      })
+
+      // Call skip function with queryFilteredNodes that don't match anything in the queue
+      // This should result in no nodes being skipped due to filtering
+      await skip({
+        projectRoot: dir,
+        packageJson,
+        scurry,
+        queryFilteredNodes: [testPkgId3], // This package is NOT in the build queue
+      })
+
+      // Verify lockfile was NOT modified since no nodes were actually skipped
+      const lockfilePath = resolve(dir, 'vlt-lock.json')
+      const lockfileContent = JSON.parse(
+        readFileSync(lockfilePath, 'utf8'),
+      )
+
+      // Build data should remain empty since no packages were skipped
+      t.strictSame(
+        lockfileContent.build.blocked,
+        {},
+        'no packages should be blocked since none were skipped',
+      )
+
+      // Verify build data file still exists with original queue
+      const buildFilePath = resolve(
+        dir,
+        'node_modules/.vlt-build.json',
+      )
+      t.ok(
+        existsSync(buildFilePath),
+        'build data file should still exist since no items were skipped',
+      )
+
+      const buildData = JSON.parse(
+        readFileSync(buildFilePath, 'utf8'),
+      )
+      t.strictSame(
+        buildData.queue.sort(),
+        [testPkgId1, testPkgId2].sort(),
+        'build queue should remain unchanged',
+      )
+
+      t.pass(
+        'skip with no nodes to skip after filtering completed without changes',
+      )
+    },
+  )
+})

--- a/src/graph/test/edge.ts
+++ b/src/graph/test/edge.ts
@@ -77,4 +77,54 @@ t.test('Edge', async t => {
   const pdmEdge = new Edge('peerOptional', Spec.parse('foo@*'), pdm)
   t.equal(pdmEdge.peer, true)
   t.equal(pdmEdge.peerOptional, true)
+
+  // Test toJSON() method
+  t.test('toJSON', t => {
+    const edgeWithTo = new Edge(
+      'prod',
+      Spec.parse('child@^1.0.0'),
+      root,
+      child,
+    )
+    const edgeJSON = edgeWithTo.toJSON()
+    t.match(edgeJSON, {
+      from: root.id,
+      to: child.id,
+      type: 'prod',
+      spec: 'child@^1.0.0',
+    })
+    t.type(edgeJSON.from, 'string')
+    t.type(edgeJSON.to, 'string')
+    t.type(edgeJSON.type, 'string')
+    t.type(edgeJSON.spec, 'string')
+
+    // Test dangling edge (no to node)
+    const danglingEdgeJSON = dangling.toJSON()
+    t.match(danglingEdgeJSON, {
+      from: child.id,
+      to: undefined,
+      type: 'prod',
+      spec: 'missing@latest',
+    })
+    t.type(danglingEdgeJSON.from, 'string')
+    t.equal(danglingEdgeJSON.to, undefined)
+
+    // Test different dependency types
+    const devEdge = new Edge(
+      'dev',
+      Spec.parse('dev-dep@1.0.0'),
+      root,
+      child,
+    )
+    const devJSON = devEdge.toJSON()
+    t.equal(devJSON.type, 'dev')
+
+    const optionalJSON = optional.toJSON()
+    t.equal(optionalJSON.type, 'optional')
+
+    const peerOptionalJSON = pdmEdge.toJSON()
+    t.equal(peerOptionalJSON.type, 'peerOptional')
+
+    t.end()
+  })
 })

--- a/src/graph/test/ideal/build-ideal-from-starting-graph.ts.bak3
+++ b/src/graph/test/ideal/build-ideal-from-starting-graph.ts.bak3
@@ -86,10 +86,6 @@ t.test('build from a virtual graph', async t => {
         custom: 'https://registry.example.com',
       },
     },
-    build: {
-      allowed: {},
-      blocked: {},
-    },
     nodes: {
       [joinDepIDTuple(['file', '.'])]: [0, 'my-project'],
       [joinDepIDTuple(['file', 'linked'])]: [0, 'linked'],
@@ -190,10 +186,6 @@ t.test('add from manifest file only', async t => {
         custom: 'https://registry.example.com',
       },
     },
-    build: {
-      allowed: {},
-      blocked: {},
-    },
     nodes: {
       [joinDepIDTuple(['file', '.'])]: [0, 'my-project'],
     } as Record<DepID, LockfileNode>,
@@ -240,10 +232,6 @@ t.test('remove from manifest file only', async t => {
         npm: 'https://registry.npmjs.org/',
         custom: 'https://registry.example.com',
       },
-    },
-    build: {
-      allowed: {},
-      blocked: {},
     },
     nodes: {
       [joinDepIDTuple(['file', '.'])]: [0, 'my-project'],

--- a/src/graph/test/install.ts
+++ b/src/graph/test/install.ts
@@ -59,6 +59,7 @@ t.test('install', async t => {
     '../src/reify/index.ts': {
       reify: async () => {
         log += 'reify\n'
+        return { buildQueue: [], diff: {} }
       },
     },
     '../src/modifiers.ts': {
@@ -109,7 +110,9 @@ t.test('install with no package.json file in cwd', async t => {
     typeof import('../src/install.ts')
   >('../src/install.ts', {
     '../src/reify/index.ts': {
-      reify: async () => {},
+      reify: async () => {
+        return { buildQueue: [], diff: {} }
+      },
     },
   })
 
@@ -153,7 +156,9 @@ t.test('unknown error reading package.json', async t => {
     typeof import('../src/install.ts')
   >('../src/install.ts', {
     '../src/reify/index.ts': {
-      reify: async () => {},
+      reify: async () => {
+        return { buildQueue: [], diff: {} }
+      },
     },
   })
 
@@ -267,7 +272,7 @@ t.test('install with cleanInstall option (ci command)', async t => {
     typeof import('../src/install.ts')
   >('../src/install.ts', {
     '../src/reify/index.ts': {
-      reify: async () => ({ diff: {} }),
+      reify: async () => ({ buildQueue: {}, diff: {} }),
     },
     '@vltpkg/rollback-remove': {
       RollbackRemove: class MockRollbackRemove {
@@ -317,7 +322,7 @@ t.test(
       typeof import('../src/install.ts')
     >('../src/install.ts', {
       '../src/reify/index.ts': {
-        reify: async () => ({ diff: {} }),
+        reify: async () => ({ buildQueue: {}, diff: {} }),
       },
     })
 
@@ -368,7 +373,7 @@ t.test(
       typeof import('../src/install.ts')
     >('../src/install.ts', {
       '../src/reify/index.ts': {
-        reify: async () => ({ diff: {} }),
+        reify: async () => ({ buildQueue: {}, diff: {} }),
       },
       '../src/ideal/get-importer-specs.ts': {
         getImporterSpecs: () => ({
@@ -423,7 +428,7 @@ t.test(
       typeof import('../src/install.ts')
     >('../src/install.ts', {
       '../src/reify/index.ts': {
-        reify: async () => ({ diff: {} }),
+        reify: async () => ({ buildQueue: {}, diff: {} }),
       },
     })
 
@@ -472,7 +477,7 @@ t.test(
       typeof import('../src/install.ts')
     >('../src/install.ts', {
       '../src/reify/index.ts': {
-        reify: async () => ({ diff: {} }),
+        reify: async () => ({ buildQueue: {}, diff: {} }),
       },
       '../src/ideal/get-importer-specs.ts': {
         getImporterSpecs: () => ({
@@ -544,7 +549,7 @@ t.test(
       typeof import('../src/install.ts')
     >('../src/install.ts', {
       '../src/reify/index.ts': {
-        reify: async () => ({ diff: {} }),
+        reify: async () => ({ buildQueue: {}, diff: {} }),
       },
       '../src/ideal/get-importer-specs.ts': {
         getImporterSpecs: () => ({
@@ -611,7 +616,7 @@ t.test('install with frozenLockfile and spec changes', async t => {
     typeof import('../src/install.ts')
   >('../src/install.ts', {
     '../src/reify/index.ts': {
-      reify: async () => ({ diff: {} }),
+      reify: async () => ({ buildQueue: {}, diff: {} }),
     },
     '../src/ideal/get-importer-specs.ts': {
       getImporterSpecs: () => ({
@@ -712,7 +717,7 @@ t.test(
       typeof import('../src/install.ts')
     >('../src/install.ts', {
       '../src/reify/index.ts': {
-        reify: async () => ({ diff: {} }),
+        reify: async () => ({ buildQueue: {}, diff: {} }),
       },
     })
 
@@ -770,7 +775,7 @@ t.test(
       typeof import('../src/install.ts')
     >('../src/install.ts', {
       '../src/reify/index.ts': {
-        reify: async () => ({ diff: {} }),
+        reify: async () => ({ buildQueue: {}, diff: {} }),
       },
       '../src/ideal/get-importer-specs.ts': {
         getImporterSpecs: () => ({
@@ -853,7 +858,7 @@ t.test(
       typeof import('../src/install.ts')
     >('../src/install.ts', {
       '../src/reify/index.ts': {
-        reify: async () => ({ diff: {} }),
+        reify: async () => ({ buildQueue: {}, diff: {} }),
       },
       '../src/ideal/get-importer-specs.ts': {
         getImporterSpecs: () => ({
@@ -932,7 +937,7 @@ t.test(
         },
       },
       '../src/reify/index.ts': {
-        reify: async () => ({ diff: {} }),
+        reify: async () => ({ buildQueue: {}, diff: {} }),
       },
       '../src/ideal/get-importer-specs.ts': {
         getImporterSpecs: () => ({
@@ -1013,7 +1018,7 @@ t.test(
         },
       },
       '../src/reify/index.ts': {
-        reify: async () => ({ diff: {} }),
+        reify: async () => ({ buildQueue: {}, diff: {} }),
       },
     })
 
@@ -1064,7 +1069,7 @@ t.test(
       typeof import('../src/install.ts')
     >('../src/install.ts', {
       '../src/reify/index.ts': {
-        reify: async () => ({ diff: {} }),
+        reify: async () => ({ buildQueue: {}, diff: {} }),
       },
       '../src/ideal/get-importer-specs.ts': {
         getImporterSpecs: () => ({
@@ -1140,7 +1145,7 @@ t.test('install with expectLockfile but no node_modules', async t => {
     typeof import('../src/install.ts')
   >('../src/install.ts', {
     '../src/reify/index.ts': {
-      reify: async () => ({ diff: {} }),
+      reify: async () => ({ buildQueue: {}, diff: {} }),
     },
     '@vltpkg/rollback-remove': {
       RollbackRemove: class MockRollbackRemove {
@@ -1213,7 +1218,7 @@ t.test(
         },
       },
       '../src/reify/index.ts': {
-        reify: async () => ({ diff: {} }),
+        reify: async () => ({ buildQueue: {}, diff: {} }),
       },
       '@vltpkg/rollback-remove': {
         RollbackRemove: class MockRollbackRemove {

--- a/src/graph/test/lockfile/load.ts
+++ b/src/graph/test/lockfile/load.ts
@@ -73,6 +73,10 @@ t.test('load', async t => {
         custom: 'https://registry.example.com',
       },
     },
+    build: {
+      allowed: {},
+      blocked: {},
+    },
     nodes: {
       [joinDepIDTuple(['file', '.'])]: [0, 'my-project'],
       [joinDepIDTuple(['file', 'linked'])]: [0, 'linked'],
@@ -142,6 +146,10 @@ t.test('loadHidden', async t => {
         custom: 'https://registry.example.com',
       },
     },
+    build: {
+      allowed: {},
+      blocked: {},
+    },
     nodes: {
       [joinDepIDTuple(['file', '.'])]: [0, 'my-project'],
       [joinDepIDTuple(['file', 'linked'])]: [0, 'linked'],
@@ -190,6 +198,10 @@ t.test('workspaces', async t => {
       registries: {
         custom: 'http://example.com',
       },
+    },
+    build: {
+      allowed: {},
+      blocked: {},
     },
     nodes: {
       [joinDepIDTuple(['file', '.'])]: [0, 'my-project'],
@@ -246,6 +258,10 @@ t.test('unknown dep type', async t => {
   const lockfileData: LockfileData = {
     lockfileVersion: 0,
     options: {},
+    build: {
+      allowed: {},
+      blocked: {},
+    },
     nodes: {
       [joinDepIDTuple(['file', '.'])]: [0, 'my-project'],
       [joinDepIDTuple(['registry', '', 'foo@1.0.0'])]: [
@@ -283,6 +299,10 @@ t.test('invalid dep id in edge', async t => {
   const lockfileData: LockfileData = {
     lockfileVersion: 0,
     options: {},
+    build: {
+      allowed: {},
+      blocked: {},
+    },
     nodes: {
       [joinDepIDTuple(['file', '.'])]: [0, 'my-project'],
       [joinDepIDTuple(['registry', '', 'foo@1.0.0'])]: [
@@ -321,6 +341,10 @@ t.test('missing edge `from`', async t => {
   const lockfileData: LockfileData = {
     lockfileVersion: 0,
     options: {},
+    build: {
+      allowed: {},
+      blocked: {},
+    },
     nodes: {
       [joinDepIDTuple(['file', '.'])]: [0, 'my-project'],
       [joinDepIDTuple(['registry', '', 'foo@1.0.0'])]: [
@@ -365,6 +389,10 @@ t.test('load with custom git hosts', async t => {
         example: 'git+ssh://example.com/$1/$2/archive/$3.tar.gz',
       },
     },
+    build: {
+      allowed: {},
+      blocked: {},
+    },
     nodes: {
       [joinDepIDTuple(['git', 'example:foo/bar', ''])]: [0, 'foo'],
     } as Record<DepID, LockfileNode>,
@@ -404,6 +432,10 @@ t.test('load with custom scope registry', async t => {
       'scope-registries': {
         '@myscope': 'http://example.com',
       },
+    },
+    build: {
+      allowed: {},
+      blocked: {},
     },
     nodes: {
       [joinDepIDTuple(['registry', '', '@myscope/foo@1.0.0'])]: [
@@ -464,6 +496,7 @@ t.test(
         },
       },
       nodes: {},
+      build: { allowed: {}, blocked: {} },
       edges: {},
     }
     t.matchSnapshot(
@@ -486,7 +519,10 @@ t.test('missing options object', async t => {
     projectRoot,
   }
   const lockfileData = {
+    lockfileVersion: 0,
+    options: {},
     nodes: {},
+    build: { allowed: {}, blocked: {} },
     edges: {},
   } as LockfileData
   t.matchSnapshot(
@@ -508,6 +544,10 @@ t.test('skipLoadingNodesOnModifiersChange behavior', async t => {
     lockfileVersion: 0,
     options: {
       modifiers: modifiersConfig,
+    },
+    build: {
+      allowed: {},
+      blocked: {},
     },
     nodes: {
       [joinDepIDTuple(['file', '.'])]: [0, 'test-project'],
@@ -982,6 +1022,10 @@ t.test('load with optimization path for large graphs', async t => {
   const lockfileData: LockfileData = {
     lockfileVersion: 0,
     options: { registry: 'https://registry.npmjs.org/' },
+    build: {
+      allowed: {},
+      blocked: {},
+    },
     nodes,
     edges,
   }
@@ -1085,6 +1129,10 @@ t.test('load platform data for optional dependencies', async t => {
   const lockfileData: LockfileData = {
     lockfileVersion: 0,
     options: configData,
+    build: {
+      allowed: {},
+      blocked: {},
+    },
     nodes: {
       [joinDepIDTuple(['registry', '', 'foo@1.0.0'])]: [
         0,
@@ -1183,4 +1231,237 @@ t.test('load platform data for optional dependencies', async t => {
     'baz platform data is loaded correctly',
   )
   t.equal(baz?.optional, true, 'baz is optional')
+})
+
+t.test('load build data', async t => {
+  const projectRoot = t.testdir({
+    'vlt.json': '{}',
+  })
+  t.chdir(projectRoot)
+  unload('project')
+
+  await t.test('load with build data provided', async t => {
+    const buildData = {
+      allowed: {
+        'https://registry.npmjs.org/': ['foo', 'bar'],
+      },
+      blocked: {
+        'https://registry.npmjs.org/': ['baz'],
+      },
+    }
+
+    const lockfileData: LockfileData = {
+      lockfileVersion: 0,
+      options: {},
+      build: buildData,
+      nodes: {},
+      edges: {},
+    }
+
+    const graph = loadObject(
+      {
+        ...configData,
+        projectRoot,
+        mainManifest,
+      },
+      lockfileData,
+    )
+
+    t.ok(graph, 'graph should be created')
+    t.same(
+      graph.build,
+      buildData,
+      'build data should be preserved on graph',
+    )
+    t.matchSnapshot(
+      objectLikeOutput(graph),
+      'graph loaded with build data',
+    )
+  })
+
+  await t.test('load without build data (defaults)', async t => {
+    const lockfileData: LockfileData = {
+      lockfileVersion: 0,
+      options: {},
+      nodes: {},
+      edges: {},
+      // build property is missing - will default to empty objects
+    } as LockfileData
+
+    const graph = loadObject(
+      {
+        ...configData,
+        projectRoot,
+        mainManifest,
+      },
+      lockfileData,
+    )
+
+    t.ok(graph, 'graph should be created even without build data')
+    t.same(
+      graph.build,
+      { allowed: {}, blocked: {} },
+      'build should default to empty objects',
+    )
+    t.matchSnapshot(
+      objectLikeOutput(graph),
+      'graph loaded without build data',
+    )
+  })
+
+  await t.test('load with empty build data', async t => {
+    const buildData = {
+      allowed: {},
+      blocked: {},
+    }
+
+    const lockfileData: LockfileData = {
+      lockfileVersion: 0,
+      options: {},
+      build: buildData,
+      nodes: {},
+      edges: {},
+    }
+
+    const graph = loadObject(
+      {
+        ...configData,
+        projectRoot,
+        mainManifest,
+      },
+      lockfileData,
+    )
+
+    t.ok(graph, 'graph should be created with empty build data')
+    t.same(
+      graph.build,
+      buildData,
+      'empty build data should be preserved on graph',
+    )
+    t.matchSnapshot(
+      objectLikeOutput(graph),
+      'graph loaded with empty build data',
+    )
+  })
+
+  await t.test(
+    'load() and loadHidden() with build data files',
+    async t => {
+      const buildData = {
+        allowed: {
+          'https://registry.npmjs.org/': ['foo'],
+        },
+        blocked: {
+          'https://registry.npmjs.org/': ['blocked'],
+        },
+      }
+
+      const lockfileContent = {
+        lockfileVersion: 0,
+        options: {
+          registry: 'https://registry.npmjs.org/',
+        },
+        build: buildData,
+        nodes: {},
+        edges: {},
+      }
+
+      // Create vlt-lock.json file
+      const testDir = t.testdir({
+        'vlt.json': '{}',
+        'vlt-lock.json': JSON.stringify(lockfileContent, null, 2),
+        node_modules: {
+          '.vlt-lock.json': JSON.stringify(lockfileContent, null, 2),
+        },
+      })
+      t.chdir(testDir)
+      unload('project')
+
+      // Test load()
+      const graph1 = load({
+        ...configData,
+        projectRoot: testDir,
+        mainManifest,
+      })
+      t.ok(graph1, 'load() should work with build data in lockfile')
+      t.same(
+        graph1.build,
+        buildData,
+        'build data should be loaded correctly from lockfile',
+      )
+      t.matchSnapshot(
+        objectLikeOutput(graph1),
+        'load() with build data',
+      )
+
+      // Test loadHidden()
+      const graph2 = loadHidden({
+        ...configData,
+        projectRoot: testDir,
+        mainManifest,
+      })
+      t.ok(
+        graph2,
+        'loadHidden() should work with build data in hidden lockfile',
+      )
+      t.same(
+        graph2.build,
+        buildData,
+        'build data should be loaded correctly from hidden lockfile',
+      )
+      t.matchSnapshot(
+        objectLikeOutput(graph2),
+        'loadHidden() with build data',
+      )
+    },
+  )
+
+  await t.test('load with malformed build data', async t => {
+    // Test various edge cases with malformed/missing build data
+    const lockfileDataWithUndefinedBuild: any = {
+      lockfileVersion: 0,
+      options: {},
+      build: undefined,
+      nodes: {},
+      edges: {},
+    }
+
+    const graph1 = loadObject(
+      {
+        ...configData,
+        projectRoot,
+        mainManifest,
+      },
+      lockfileDataWithUndefinedBuild,
+    )
+    t.ok(graph1, 'should handle undefined build data gracefully')
+    t.same(
+      graph1.build,
+      { allowed: {}, blocked: {} },
+      'undefined build should default to empty objects',
+    )
+
+    const lockfileDataWithNullBuild: any = {
+      lockfileVersion: 0,
+      options: {},
+      build: null,
+      nodes: {},
+      edges: {},
+    }
+
+    const graph2 = loadObject(
+      {
+        ...configData,
+        projectRoot,
+        mainManifest,
+      },
+      lockfileDataWithNullBuild,
+    )
+    t.ok(graph2, 'should handle null build data gracefully')
+    t.same(
+      graph2.build,
+      { allowed: {}, blocked: {} },
+      'null build should default to empty objects',
+    )
+  })
 })

--- a/src/graph/test/lockfile/save.ts
+++ b/src/graph/test/lockfile/save.ts
@@ -831,3 +831,152 @@ t.test('save platform data for optional dependencies', async t => {
     'lockfile with platform data for optional dependencies',
   )
 })
+
+t.test('save build data', async t => {
+  const mainManifest = {
+    name: 'my-project',
+    version: '1.0.0',
+    dependencies: {
+      foo: '^1.0.0',
+    },
+  }
+  const projectRoot = t.testdir({ 'vlt.json': '{}' })
+  t.chdir(projectRoot)
+  unload('project')
+  const graph = new Graph({
+    ...configData,
+    projectRoot,
+    mainManifest,
+  })
+
+  await t.test('save with build data provided', async t => {
+    const buildData = {
+      allowed: {
+        'https://registry.npmjs.org/': ['foo', 'bar'],
+      },
+      blocked: {
+        'https://registry.npmjs.org/': ['baz'],
+      },
+    }
+
+    const lockfile = lockfileData({
+      ...configData,
+      graph,
+      build: buildData,
+    })
+    t.same(
+      lockfile.build,
+      buildData,
+      'build data should be preserved when provided',
+    )
+    t.matchSnapshot(
+      JSON.stringify(lockfile, null, 2),
+      'lockfile with build data provided',
+    )
+  })
+
+  await t.test('save without build data (defaults)', async t => {
+    const lockfile = lockfileData({ ...configData, graph })
+    t.same(
+      lockfile.build,
+      {
+        allowed: {},
+        blocked: {},
+      },
+      'build property should have empty allowed and blocked records by default',
+    )
+    t.matchSnapshot(
+      JSON.stringify(lockfile, null, 2),
+      'lockfile with no build data',
+    )
+  })
+
+  await t.test('save empty build data', async t => {
+    const buildData = {
+      allowed: {},
+      blocked: {},
+    }
+
+    const lockfile = lockfileData({
+      ...configData,
+      graph,
+      build: buildData,
+    })
+    t.same(
+      lockfile.build,
+      buildData,
+      'empty build data should be preserved when explicitly provided',
+    )
+    t.matchSnapshot(
+      JSON.stringify(lockfile, null, 2),
+      'lockfile with empty build data',
+    )
+  })
+
+  await t.test(
+    'save() and saveHidden() functions with build data',
+    async t => {
+      const foo = graph.placePackage(
+        graph.mainImporter,
+        'prod',
+        Spec.parse('foo@^1.0.0'),
+        {
+          name: 'foo',
+          version: '1.0.0',
+          dist: {
+            integrity:
+              'sha512-6/mh1E2u2YgEsCHdY0Yx5oW+61gZU+1vXaoiHHrpKeuRNNgFvS+/jrwHiQhB5apAf5oB7UB7E19ol2R2LKH8hQ==',
+          },
+        },
+      )
+      if (!foo) throw new Error('Missing foo package')
+      foo.setResolved()
+
+      const buildData = {
+        allowed: {
+          'https://registry.npmjs.org/': ['foo'],
+        },
+        blocked: {
+          'https://registry.npmjs.org/': ['blocked'],
+        },
+      }
+
+      // Test save() with build data
+      save({ ...configData, graph, build: buildData })
+      const savedContent = JSON.parse(
+        readFileSync(resolve(projectRoot, 'vlt-lock.json'), {
+          encoding: 'utf8',
+        }),
+      )
+      t.same(
+        savedContent.build,
+        buildData,
+        'save() should include build data in lockfile',
+      )
+      t.matchSnapshot(
+        JSON.stringify(savedContent, null, 2),
+        'save() with build data',
+      )
+
+      // Test saveHidden() with build data
+      saveHidden({ ...configData, graph, build: buildData })
+      const hiddenContent = JSON.parse(
+        readFileSync(
+          resolve(projectRoot, 'node_modules/.vlt-lock.json'),
+          {
+            encoding: 'utf8',
+          },
+        ),
+      )
+      t.same(
+        hiddenContent.build,
+        buildData,
+        'saveHidden() should include build data in hidden lockfile',
+      )
+      t.matchSnapshot(
+        JSON.stringify(hiddenContent, null, 2),
+        'saveHidden() with build data',
+      )
+    },
+  )
+})

--- a/src/graph/test/lockfile/types.ts
+++ b/src/graph/test/lockfile/types.ts
@@ -23,18 +23,29 @@ t.test('lockfile type checks', t => {
   //@ts-expect-error - missing required properties
   let ld: LockfileData = {}
   ld
-  //@ts-expect-error - options must be an object
-  ld = { options: null, nodes: {}, edges: {} }
+  ld = {
+    //@ts-expect-error - options must be an object
+    options: null,
+    nodes: {},
+    build: { allowed: {}, blocked: {} },
+    edges: {},
+  }
   //@ts-expect-error - nodes must be a record
   ld = { options: {}, nodes: null, edges: {} }
-  //@ts-expect-error - edges must be a record
-  ld = { options: {}, nodes: {}, edges: null }
+  ld = {
+    options: {},
+    nodes: {},
+    build: { allowed: {}, blocked: {} },
+    //@ts-expect-error - edges must be a record
+    edges: null,
+  }
 
   // Valid LockfileData
   ld = {
     lockfileVersion: 0,
     options: {},
     nodes: {},
+    build: { allowed: {}, blocked: {} },
     edges: {},
   }
 
@@ -53,6 +64,10 @@ t.test('lockfile type checks', t => {
     options: {
       registries: { npm: 'https://registry.npmjs.org/' },
       modifiers: { ':root > #foo': '2.0.0' },
+    },
+    build: {
+      allowed: {},
+      blocked: {},
     },
     nodes: {
       [validDepId]: [
@@ -311,6 +326,7 @@ t.test('lockfile type constraints', t => {
       },
     },
     nodes: {},
+    build: { allowed: {}, blocked: {} },
     edges: {},
   }
   t.ok(
@@ -331,6 +347,7 @@ t.test('lockfile type constraints', t => {
       modifiers: undefined,
     },
     nodes: {},
+    build: { allowed: {}, blocked: {} },
     edges: {},
   }
   t.equal(

--- a/src/graph/test/reify/build.ts
+++ b/src/graph/test/reify/build.ts
@@ -157,20 +157,66 @@ t.test(
     before.removeNode(by)
     const diff = new Diff(before, after)
 
-    await build(diff, new PackageJson(), new PathScurry(projectRoot))
-    t.match(
-      new Set(runs),
-      new Set([
-        {
-          arg0: 'install',
-          cwd: resolve(
-            projectRoot,
-            `./node_modules/.vlt/${yid}/node_modules/y`,
-          ),
-        },
-        { arg0: 'prepare', cwd: resolve(projectRoot, `./src/app`) },
-      ]),
+    const result = await build(
+      diff,
+      new PackageJson(),
+      new PathScurry(projectRoot),
+      true,
     )
+
+    // Check that we got the expected build result
+    t.match(result, {
+      'https://registry.npmjs.org/': ['x', 'y'],
+      file: ['project'],
+      workspace: ['app'],
+    })
+
+    // Check the runs - now including all the additional parameters
+    t.equal(runs.length, 2, 'should have 2 runs')
+
+    // Find the install run and prepare run
+    const installRun = runs.find(r => r.arg0 === 'install')
+    const prepareRun = runs.find(r => r.arg0 === 'prepare')
+
+    t.ok(installRun, 'should have install run')
+    t.ok(prepareRun, 'should have prepare run')
+
+    if (installRun) {
+      t.equal(
+        installRun.cwd,
+        resolve(
+          projectRoot,
+          `./node_modules/.vlt/${yid}/node_modules/y`,
+        ),
+        'install run should have correct cwd',
+      )
+      t.equal(
+        installRun.ignoreMissing,
+        true,
+        'install run should ignore missing',
+      )
+      t.ok(
+        installRun.signal instanceof AbortSignal,
+        'install run should have signal',
+      )
+    }
+
+    if (prepareRun) {
+      t.equal(
+        prepareRun.cwd,
+        resolve(projectRoot, `./src/app`),
+        'prepare run should have correct cwd',
+      )
+      t.equal(
+        prepareRun.ignoreMissing,
+        true,
+        'prepare run should ignore missing',
+      )
+      t.ok(
+        prepareRun.signal instanceof AbortSignal,
+        'prepare run should have signal',
+      )
+    }
     t.match(
       new Set(chmods),
       new Set([
@@ -280,7 +326,13 @@ t.test('should handle missing bin files gracefully', async t => {
   const diff = new Diff(before, after)
 
   // This should not throw an error even though the bin file doesn't exist
-  await build(diff, new PackageJson(), new PathScurry(projectRoot))
+  // Pass includeScripts: true to ensure the visit function is called
+  await build(
+    diff,
+    new PackageJson(),
+    new PathScurry(projectRoot),
+    true,
+  )
 
   // Verify the existsSync was called for the missing bin file
   t.ok(
@@ -294,3 +346,500 @@ t.test('should handle missing bin files gracefully', async t => {
     'chmod should not be called for missing bin files',
   )
 })
+
+t.test(
+  'build scripts filtering based on build.allowed and build.blocked',
+  async t => {
+    await t.test(
+      'includeScripts=false with package in build.allowed[registry] and another not allowed',
+      async t => {
+        const aid = joinDepIDTuple([
+          'registry',
+          '',
+          'allowed-pkg@1.0.0',
+        ])
+        const nid = joinDepIDTuple([
+          'registry',
+          '',
+          'not-allowed@1.0.0',
+        ])
+
+        const projectRoot = t.testdir({
+          'package.json': JSON.stringify({
+            name: 'project',
+            version: '1.0.0',
+            dependencies: {
+              'allowed-pkg': '1.0.0',
+              'not-allowed': '1.0.0',
+            },
+          }),
+          node_modules: {
+            'allowed-pkg': t.fixture(
+              'symlink',
+              './.vlt/' + aid + '/node_modules/allowed-pkg',
+            ),
+            'not-allowed': t.fixture(
+              'symlink',
+              './.vlt/' + nid + '/node_modules/not-allowed',
+            ),
+            '.vlt': {
+              [aid]: {
+                node_modules: {
+                  'allowed-pkg': {
+                    'package.json': JSON.stringify({
+                      name: 'allowed-pkg',
+                      version: '1.0.0',
+                      scripts: {
+                        install: 'echo "allowed pkg install"',
+                      },
+                    }),
+                  },
+                },
+              },
+              [nid]: {
+                node_modules: {
+                  'not-allowed': {
+                    'package.json': JSON.stringify({
+                      name: 'not-allowed',
+                      version: '1.0.0',
+                      scripts: {
+                        install: 'echo "not allowed pkg install"',
+                      },
+                    }),
+                  },
+                },
+              },
+            },
+          },
+        })
+
+        // Load the "after" state with both packages
+        const after = actual.load({
+          monorepo: Monorepo.maybeLoad(projectRoot),
+          packageJson: new PackageJson(),
+          scurry: new PathScurry(projectRoot),
+          projectRoot,
+          loadManifests: true,
+        })
+
+        // Configure build.allowed to only include 'allowed-pkg'
+        after.build = {
+          allowed: {
+            'https://registry.npmjs.org/': ['allowed-pkg'],
+          },
+          blocked: {},
+        }
+
+        // Load the "before" state without packages
+        const before = actual.load({
+          projectRoot,
+          monorepo: Monorepo.maybeLoad(projectRoot),
+          packageJson: new PackageJson(),
+          scurry: new PathScurry(projectRoot),
+          loadManifests: true,
+        })
+        const aNode = before.nodes.get(aid)
+        const nNode = before.nodes.get(nid)
+        if (!aNode) throw new Error('no allowed-pkg node in before??')
+        if (!nNode) throw new Error('no not-allowed node in before??')
+        before.removeNode(aNode)
+        before.removeNode(nNode)
+        const diff = new Diff(before, after)
+
+        // Call build with includeScripts=false
+        const result = await build(
+          diff,
+          new PackageJson(),
+          new PathScurry(projectRoot),
+          false, // includeScripts=false
+        )
+
+        // Should only build the allowed package
+        t.match(result, {
+          'https://registry.npmjs.org/': ['allowed-pkg'],
+        })
+        // Should not contain the not-allowed package
+        t.notMatch(result['https://registry.npmjs.org/'] ?? [], [
+          'not-allowed',
+        ])
+
+        // Verify runs - only the allowed package should run its install script
+        const allowedRuns = runs.filter(r =>
+          r.cwd.includes('/allowed-pkg'),
+        )
+        const notAllowedRuns = runs.filter(r =>
+          r.cwd.includes('/not-allowed'),
+        )
+
+        t.equal(
+          allowedRuns.length,
+          1,
+          'allowed package should have install run',
+        )
+        t.equal(
+          notAllowedRuns.length,
+          0,
+          'not-allowed package should not have install run',
+        )
+      },
+    )
+
+    await t.test(
+      'includeScripts=false with package in build.blocked[registry] and another not blocked',
+      async t => {
+        const bid = joinDepIDTuple([
+          'registry',
+          '',
+          'blocked-pkg@1.0.0',
+        ])
+        const uid = joinDepIDTuple([
+          'registry',
+          '',
+          'unblocked@1.0.0',
+        ])
+
+        const projectRoot = t.testdir({
+          'package.json': JSON.stringify({
+            name: 'project',
+            version: '1.0.0',
+            dependencies: {
+              'blocked-pkg': '1.0.0',
+              unblocked: '1.0.0',
+            },
+          }),
+          node_modules: {
+            'blocked-pkg': t.fixture(
+              'symlink',
+              './.vlt/' + bid + '/node_modules/blocked-pkg',
+            ),
+            unblocked: t.fixture(
+              'symlink',
+              './.vlt/' + uid + '/node_modules/unblocked',
+            ),
+            '.vlt': {
+              [bid]: {
+                node_modules: {
+                  'blocked-pkg': {
+                    'package.json': JSON.stringify({
+                      name: 'blocked-pkg',
+                      version: '1.0.0',
+                      scripts: {
+                        install: 'echo "blocked pkg install"',
+                      },
+                    }),
+                  },
+                },
+              },
+              [uid]: {
+                node_modules: {
+                  unblocked: {
+                    'package.json': JSON.stringify({
+                      name: 'unblocked',
+                      version: '1.0.0',
+                      scripts: {
+                        install: 'echo "unblocked pkg install"',
+                      },
+                    }),
+                  },
+                },
+              },
+            },
+          },
+        })
+
+        // Load the "after" state with both packages
+        const after = actual.load({
+          monorepo: Monorepo.maybeLoad(projectRoot),
+          packageJson: new PackageJson(),
+          scurry: new PathScurry(projectRoot),
+          projectRoot,
+          loadManifests: true,
+        })
+
+        // Configure build.blocked to block 'blocked-pkg'
+        after.build = {
+          allowed: {},
+          blocked: {
+            'https://registry.npmjs.org/': ['blocked-pkg'],
+          },
+        }
+
+        // Load the "before" state without packages
+        const before = actual.load({
+          projectRoot,
+          monorepo: Monorepo.maybeLoad(projectRoot),
+          packageJson: new PackageJson(),
+          scurry: new PathScurry(projectRoot),
+          loadManifests: true,
+        })
+        const bNode = before.nodes.get(bid)
+        const uNode = before.nodes.get(uid)
+        if (!bNode) throw new Error('no blocked-pkg node in before??')
+        if (!uNode) throw new Error('no unblocked node in before??')
+        before.removeNode(bNode)
+        before.removeNode(uNode)
+        const diff = new Diff(before, after)
+
+        // Call build with includeScripts=false
+        const result = await build(
+          diff,
+          new PackageJson(),
+          new PathScurry(projectRoot),
+          false, // includeScripts=false
+        )
+
+        // Should only build the unblocked package (because blocked is excluded and with includeScripts=false, only allowed packages run)
+        // Actually, with includeScripts=false and no allowed packages, none should run
+        t.match(result, {})
+
+        // Verify runs - no packages should run (blocked is blocked, unblocked is not in allowed list)
+        const blockedRuns = runs.filter(r =>
+          r.cwd.includes('/blocked-pkg'),
+        )
+        const unblockedRuns = runs.filter(r =>
+          r.cwd.includes('/unblocked'),
+        )
+
+        t.equal(
+          blockedRuns.length,
+          0,
+          'blocked package should not have install run',
+        )
+        t.equal(
+          unblockedRuns.length,
+          0,
+          'unblocked package should not have install run when not in allowed list',
+        )
+      },
+    )
+
+    await t.test(
+      'includeScripts=false with package in both build.allowed[registry] and build.blocked[registry]',
+      async t => {
+        const cid = joinDepIDTuple([
+          'registry',
+          '',
+          'conflicted@1.0.0',
+        ])
+
+        const projectRoot = t.testdir({
+          'package.json': JSON.stringify({
+            name: 'project',
+            version: '1.0.0',
+            dependencies: {
+              conflicted: '1.0.0',
+            },
+          }),
+          node_modules: {
+            conflicted: t.fixture(
+              'symlink',
+              './.vlt/' + cid + '/node_modules/conflicted',
+            ),
+            '.vlt': {
+              [cid]: {
+                node_modules: {
+                  conflicted: {
+                    'package.json': JSON.stringify({
+                      name: 'conflicted',
+                      version: '1.0.0',
+                      scripts: {
+                        install: 'echo "conflicted pkg install"',
+                      },
+                    }),
+                  },
+                },
+              },
+            },
+          },
+        })
+
+        // Load the "after" state with the package
+        const after = actual.load({
+          monorepo: Monorepo.maybeLoad(projectRoot),
+          packageJson: new PackageJson(),
+          scurry: new PathScurry(projectRoot),
+          projectRoot,
+          loadManifests: true,
+        })
+
+        // Configure build to have the package in both allowed and blocked
+        after.build = {
+          allowed: {
+            'https://registry.npmjs.org/': ['conflicted'],
+          },
+          blocked: {
+            'https://registry.npmjs.org/': ['conflicted'],
+          },
+        }
+
+        // Load the "before" state without packages
+        const before = actual.load({
+          projectRoot,
+          monorepo: Monorepo.maybeLoad(projectRoot),
+          packageJson: new PackageJson(),
+          scurry: new PathScurry(projectRoot),
+          loadManifests: true,
+        })
+        const cNode = before.nodes.get(cid)
+        if (!cNode) throw new Error('no conflicted node in before??')
+        before.removeNode(cNode)
+        const diff = new Diff(before, after)
+
+        // Call build with includeScripts=false
+        const result = await build(
+          diff,
+          new PackageJson(),
+          new PathScurry(projectRoot),
+          false, // includeScripts=false
+        )
+
+        // Blocked should take precedence over allowed, so no builds should occur
+        t.match(result, {})
+
+        // Verify runs - the package should not run (blocked takes precedence)
+        const conflictedRuns = runs.filter(r =>
+          r.cwd.includes('/conflicted'),
+        )
+        t.equal(
+          conflictedRuns.length,
+          0,
+          'conflicted package should not run when blocked, even if also allowed',
+        )
+      },
+    )
+
+    await t.test(
+      'includeScripts=true with package in build.blocked[registry]',
+      async t => {
+        const bid = joinDepIDTuple([
+          'registry',
+          '',
+          'blocked-pkg@1.0.0',
+        ])
+        const rid = joinDepIDTuple([
+          'registry',
+          '',
+          'regular-pkg@1.0.0',
+        ])
+
+        const projectRoot = t.testdir({
+          'package.json': JSON.stringify({
+            name: 'project',
+            version: '1.0.0',
+            dependencies: {
+              'blocked-pkg': '1.0.0',
+              'regular-pkg': '1.0.0',
+            },
+          }),
+          node_modules: {
+            'blocked-pkg': t.fixture(
+              'symlink',
+              './.vlt/' + bid + '/node_modules/blocked-pkg',
+            ),
+            'regular-pkg': t.fixture(
+              'symlink',
+              './.vlt/' + rid + '/node_modules/regular-pkg',
+            ),
+            '.vlt': {
+              [bid]: {
+                node_modules: {
+                  'blocked-pkg': {
+                    'package.json': JSON.stringify({
+                      name: 'blocked-pkg',
+                      version: '1.0.0',
+                      scripts: {
+                        install: 'echo "blocked pkg install"',
+                      },
+                    }),
+                  },
+                },
+              },
+              [rid]: {
+                node_modules: {
+                  'regular-pkg': {
+                    'package.json': JSON.stringify({
+                      name: 'regular-pkg',
+                      version: '1.0.0',
+                      scripts: {
+                        install: 'echo "regular pkg install"',
+                      },
+                    }),
+                  },
+                },
+              },
+            },
+          },
+        })
+
+        // Load the "after" state with both packages
+        const after = actual.load({
+          monorepo: Monorepo.maybeLoad(projectRoot),
+          packageJson: new PackageJson(),
+          scurry: new PathScurry(projectRoot),
+          projectRoot,
+          loadManifests: true,
+        })
+
+        // Configure build.blocked to block 'blocked-pkg'
+        after.build = {
+          allowed: {},
+          blocked: {
+            'https://registry.npmjs.org/': ['blocked-pkg'],
+          },
+        }
+
+        // Load the "before" state without packages
+        const before = actual.load({
+          projectRoot,
+          monorepo: Monorepo.maybeLoad(projectRoot),
+          packageJson: new PackageJson(),
+          scurry: new PathScurry(projectRoot),
+          loadManifests: true,
+        })
+        const bNode = before.nodes.get(bid)
+        const rNode = before.nodes.get(rid)
+        if (!bNode) throw new Error('no blocked-pkg node in before??')
+        if (!rNode) throw new Error('no regular-pkg node in before??')
+        before.removeNode(bNode)
+        before.removeNode(rNode)
+        const diff = new Diff(before, after)
+
+        // Call build with includeScripts=true
+        const result = await build(
+          diff,
+          new PackageJson(),
+          new PathScurry(projectRoot),
+          true, // includeScripts=true
+        )
+
+        // Should build only the regular package (blocked package should be excluded even with includeScripts=true)
+        t.match(result, {
+          'https://registry.npmjs.org/': ['regular-pkg'],
+        })
+        // Should not contain the blocked package
+        t.notMatch(result['https://registry.npmjs.org/'] ?? [], [
+          'blocked-pkg',
+        ])
+
+        // Verify runs - only the regular package should run
+        const blockedRuns = runs.filter(r =>
+          r.cwd.includes('/blocked-pkg'),
+        )
+        const regularRuns = runs.filter(r =>
+          r.cwd.includes('/regular-pkg'),
+        )
+
+        t.equal(
+          blockedRuns.length,
+          0,
+          'blocked package should not have install run even with includeScripts=true',
+        )
+        t.equal(
+          regularRuns.length,
+          1,
+          'regular package should have install run with includeScripts=true',
+        )
+      },
+    )
+  },
+)

--- a/src/graph/test/reify/index.ts
+++ b/src/graph/test/reify/index.ts
@@ -82,7 +82,7 @@ t.test('super basic reification', async t => {
 
   t.strictSame(
     new Set(readdirSync(projectRoot + '/node_modules')),
-    new Set(['.vlt', '.vlt-lock.json', 'lodash']),
+    new Set(['.vlt', '.vlt-build.json', '.vlt-lock.json', 'lodash']),
   )
 
   t.strictSame(
@@ -95,6 +95,10 @@ t.test('super basic reification', async t => {
   const expectLockfileData: LockfileData = {
     lockfileVersion: 0,
     options: {},
+    build: {
+      allowed: { file: ['x'] },
+      blocked: {},
+    },
     nodes: {
       [joinDepIDTuple(['registry', '', 'lodash@4.17.21'])]: [
         0,
@@ -126,11 +130,14 @@ t.test('super basic reification', async t => {
     graph.mainImporter.manifest.dependencies.underscore = '1'
   }
   graph.mainImporter.edgesOut.delete('lodash')
-  graph.removeNode(
-    graph.nodes.get(
-      joinDepIDTuple(['registry', '', 'lodash@4.17.21']),
-    )!,
+  const ldNode = graph.nodes.get(
+    joinDepIDTuple(['registry', '', 'lodash@4.17.21']),
   )
+  if (!ldNode) {
+    throw new Error('expected lodash node to be present')
+  }
+
+  graph.removeNode(ldNode)
   graph.addNode(
     joinDepIDTuple(['registry', '', 'underscore@1.13.7']),
     fixtureManifest('underscore-1.13.7'),
@@ -327,6 +334,7 @@ t.test('failure rolls back', async t => {
       projectRoot,
       packageInfo: mockPackageInfo,
       graph,
+      includeScripts: true,
       packageJson: new PackageJson(),
       scurry: new PathScurry(projectRoot),
     }),
@@ -515,8 +523,9 @@ t.test('early termination when no changes are needed', async t => {
   })
 
   // Verify early termination behavior
-  t.ok(result, 'reify should return a diff object')
-  t.equal(result.hasChanges(), false, 'diff should have no changes')
+  const { diff } = result
+  t.ok(diff, 'reify should return a diff object')
+  t.equal(diff.hasChanges(), false, 'diff should have no changes')
 
   // Verify that no reification work was performed
   t.equal(
@@ -545,3 +554,198 @@ t.test('early termination when no changes are needed', async t => {
     'deleteNodes should not be called when no changes',
   )
 })
+
+t.test('saveBuild is called during reification', async t => {
+  // Use the same test setup as the basic reification test
+  const dir = t.testdir({
+    project: {
+      'vlt.json': JSON.stringify({
+        monorepo: {
+          packages: [],
+        },
+      }),
+      'package.json': JSON.stringify({
+        name: 'x',
+        version: '1.0.0',
+        dependencies: {
+          lodash: '4',
+        },
+      }),
+    },
+  })
+  const projectRoot = resolve(dir, 'project')
+  const packageJson = new PackageJson()
+  const graph = await ideal.build({
+    projectRoot,
+    packageInfo: mockPackageInfo,
+    monorepo: Monorepo.maybeLoad(projectRoot),
+    scurry: new PathScurry(projectRoot),
+    packageJson,
+  })
+
+  await reify({
+    projectRoot,
+    packageInfo: mockPackageInfo,
+    monorepo: Monorepo.maybeLoad(projectRoot),
+    scurry: new PathScurry(projectRoot),
+    packageJson: new PackageJson(),
+    graph: graph,
+  })
+
+  // Verify .vlt-build.json file was created (this proves saveBuild was called)
+  const buildFilePath = resolve(
+    projectRoot,
+    'node_modules/.vlt-build.json',
+  )
+  t.ok(
+    statSync(buildFilePath, { throwIfNoEntry: false }),
+    'build file should be created, proving saveBuild was called',
+  )
+
+  // Basic structure verification
+  if (statSync(buildFilePath, { throwIfNoEntry: false })) {
+    const buildContent = readFileSync(buildFilePath, 'utf8')
+    const buildData = JSON.parse(buildContent)
+    t.type(buildData, 'object', 'build data should be an object')
+    t.ok(
+      'queue' in buildData,
+      'build data should have queue property',
+    )
+  }
+})
+
+t.test('reify removes existing .vlt-build.json file', async t => {
+  const dir = t.testdir({
+    project: {
+      'vlt.json': JSON.stringify({
+        monorepo: {
+          packages: [],
+        },
+      }),
+      'package.json': JSON.stringify({
+        name: 'test-project',
+        version: '1.0.0',
+        dependencies: {
+          lodash: '4',
+        },
+      }),
+      node_modules: {
+        '.vlt-build.json': JSON.stringify({
+          diff: {
+            nodes: { add: [], delete: [] },
+            edges: { add: [], delete: [] },
+          },
+        }),
+      },
+    },
+  })
+  const projectRoot = resolve(dir, 'project')
+  const packageJson = new PackageJson()
+
+  // Verify the build file exists before reify
+  const buildFilePath = resolve(
+    projectRoot,
+    'node_modules/.vlt-build.json',
+  )
+  t.ok(
+    statSync(buildFilePath, { throwIfNoEntry: false }),
+    'build file should exist before reify',
+  )
+
+  const graph = await ideal.build({
+    projectRoot,
+    packageInfo: mockPackageInfo,
+    monorepo: Monorepo.maybeLoad(projectRoot),
+    scurry: new PathScurry(projectRoot),
+    packageJson,
+  })
+
+  await reify({
+    projectRoot,
+    packageInfo: mockPackageInfo,
+    monorepo: Monorepo.maybeLoad(projectRoot),
+    scurry: new PathScurry(projectRoot),
+    packageJson: new PackageJson(),
+    graph: graph,
+  })
+
+  // The old build file should have been removed and a new one created
+  // We can verify this worked by checking that the file exists (new one was created by saveBuild)
+  // and contains the expected structure from the current reify operation
+  t.ok(
+    statSync(buildFilePath, { throwIfNoEntry: false }),
+    'build file should exist after reify (new one created)',
+  )
+
+  const buildContent = readFileSync(buildFilePath, 'utf8')
+  const buildData = JSON.parse(buildContent)
+  t.type(buildData, 'object', 'new build data should be an object')
+  t.ok(
+    'queue' in buildData,
+    'new build data should have queue property',
+  )
+})
+
+t.test(
+  'saveBuild is called when includeScripts is undefined',
+  async t => {
+    const dir = t.testdir({
+      cache: {},
+      project: {
+        'vlt.json': JSON.stringify({
+          cache: resolve(t.testdirName, 'cache'),
+        }),
+        'package.json': JSON.stringify({
+          name: 'test-project',
+          version: '1.0.0',
+          dependencies: {
+            lodash: '4',
+          },
+        }),
+      },
+    })
+    const projectRoot = resolve(dir, 'project')
+    const packageJson = new PackageJson()
+
+    const graph = await ideal.build({
+      projectRoot,
+      packageInfo: mockPackageInfo,
+      monorepo: Monorepo.maybeLoad(projectRoot),
+      scurry: new PathScurry(projectRoot),
+      packageJson,
+    })
+
+    // Call reify without includeScripts (should be undefined)
+    await reify({
+      projectRoot,
+      packageInfo: mockPackageInfo,
+      monorepo: Monorepo.maybeLoad(projectRoot),
+      scurry: new PathScurry(projectRoot),
+      packageJson: new PackageJson(),
+      graph,
+      // Explicitly not setting includeScripts (undefined)
+    })
+
+    // Verify .vlt-build.json file was created (this proves saveBuild was called)
+    const buildFilePath = resolve(
+      projectRoot,
+      'node_modules/.vlt-build.json',
+    )
+    t.ok(
+      statSync(buildFilePath, { throwIfNoEntry: false }),
+      'build file should be created when includeScripts is undefined, proving saveBuild was called',
+    )
+
+    // Verify the build file contains expected structure
+    if (statSync(buildFilePath, { throwIfNoEntry: false })) {
+      const buildContent = readFileSync(buildFilePath, 'utf8')
+      const buildData = JSON.parse(buildContent)
+      t.type(buildData, 'object', 'build data should be an object')
+      t.ok(
+        'queue' in buildData,
+        'build data should have queue property',
+      )
+      t.type(buildData.queue, Array, 'queue should be an array')
+    }
+  },
+)

--- a/src/graph/test/reify/save-build.ts
+++ b/src/graph/test/reify/save-build.ts
@@ -1,0 +1,742 @@
+import { readFileSync, existsSync } from 'node:fs'
+import { resolve } from 'node:path'
+import t from 'tap'
+import { joinDepIDTuple } from '@vltpkg/dep-id'
+import { Diff } from '../../src/diff.ts'
+import { Graph } from '../../src/graph.ts'
+import { saveBuild } from '../../src/reify/save-build.ts'
+
+// Helper to create a mock node for testing
+const createMockNode = (
+  id: string,
+  manifest?: any,
+  importer = false,
+  gitDep = false,
+): any => {
+  const node = {
+    id: gitDep ? `git:${id}` : id,
+    manifest: manifest || undefined,
+    importer,
+    inVltStore: () => !importer && !gitDep, // importers and git deps are not in store
+  }
+  return node
+}
+
+// Local implementation of nodeNeedsBuild logic for testing
+const nodeNeedsBuild = (node: any): boolean => {
+  // If the node has already been built during reify, no need to build again
+  if (node.built) return false
+
+  const { manifest } = node
+  if (!manifest) return false
+
+  const { scripts = {} } = manifest
+
+  // Check for install lifecycle scripts
+  const runInstall = !!(
+    scripts.install ||
+    scripts.preinstall ||
+    scripts.postinstall
+  )
+  if (runInstall) return true
+
+  // Check for prepare scripts on importers or git dependencies
+  const prepable =
+    node.id.startsWith('git') || node.importer || !node.inVltStore()
+  const runPrepare =
+    !!(
+      scripts.prepare ||
+      scripts.preprepare ||
+      scripts.postprepare
+    ) && prepable
+  if (runPrepare) return true
+
+  // Check if the package has binary files
+  const { bin } = manifest
+  if (bin) {
+    if (typeof bin === 'string') return true
+    if (typeof bin === 'object' && Object.keys(bin).length > 0)
+      return true
+  }
+
+  return false
+}
+
+t.test('nodeNeedsBuild', async t => {
+  t.test('includes nodes with install scripts', async t => {
+    const nodeWithPreinstall = createMockNode('test@1.0.0', {
+      name: 'test',
+      version: '1.0.0',
+      scripts: { preinstall: 'echo pre' },
+    })
+    t.ok(
+      nodeNeedsBuild(nodeWithPreinstall),
+      'should include node with preinstall script',
+    )
+
+    const nodeWithInstall = createMockNode('test@1.0.0', {
+      name: 'test',
+      version: '1.0.0',
+      scripts: { install: 'echo install' },
+    })
+    t.ok(
+      nodeNeedsBuild(nodeWithInstall),
+      'should include node with install script',
+    )
+
+    const nodeWithPostinstall = createMockNode('test@1.0.0', {
+      name: 'test',
+      version: '1.0.0',
+      scripts: { postinstall: 'echo post' },
+    })
+    t.ok(
+      nodeNeedsBuild(nodeWithPostinstall),
+      'should include node with postinstall script',
+    )
+
+    t.end()
+  })
+
+  t.test('includes nodes with binary files', async t => {
+    const nodeWithStringBin = createMockNode('test@1.0.0', {
+      name: 'test',
+      version: '1.0.0',
+      bin: './bin/test',
+    })
+    t.ok(
+      nodeNeedsBuild(nodeWithStringBin),
+      'should include node with string bin',
+    )
+
+    const nodeWithObjectBin = createMockNode('test@1.0.0', {
+      name: 'test',
+      version: '1.0.0',
+      bin: { test: './bin/test', other: './bin/other' },
+    })
+    t.ok(
+      nodeNeedsBuild(nodeWithObjectBin),
+      'should include node with object bin',
+    )
+
+    t.end()
+  })
+
+  t.test('includes importers with prepare scripts', async t => {
+    const importerWithPrepare = createMockNode(
+      'test@1.0.0',
+      {
+        name: 'test',
+        version: '1.0.0',
+        scripts: { prepare: 'npm run build' },
+      },
+      true,
+    ) // importer = true
+    t.ok(
+      nodeNeedsBuild(importerWithPrepare),
+      'should include importer with prepare script',
+    )
+
+    const importerWithPreprepare = createMockNode(
+      'test@1.0.0',
+      {
+        name: 'test',
+        version: '1.0.0',
+        scripts: { preprepare: 'echo preparing' },
+      },
+      true,
+    ) // importer = true
+    t.ok(
+      nodeNeedsBuild(importerWithPreprepare),
+      'should include importer with preprepare script',
+    )
+
+    const importerWithPostprepare = createMockNode(
+      'test@1.0.0',
+      {
+        name: 'test',
+        version: '1.0.0',
+        scripts: { postprepare: 'echo done' },
+      },
+      true,
+    ) // importer = true
+    t.ok(
+      nodeNeedsBuild(importerWithPostprepare),
+      'should include importer with postprepare script',
+    )
+
+    t.end()
+  })
+
+  t.test(
+    'includes git dependencies with prepare scripts',
+    async t => {
+      const gitDepWithPrepare = createMockNode(
+        'test@1.0.0',
+        {
+          name: 'test',
+          version: '1.0.0',
+          scripts: { prepare: 'npm run build' },
+        },
+        false,
+        true,
+      ) // gitDep = true
+      t.ok(
+        nodeNeedsBuild(gitDepWithPrepare),
+        'should include git dependency with prepare script',
+      )
+
+      t.end()
+    },
+  )
+
+  t.test('excludes registry nodes with prepare scripts', async t => {
+    const registryNodeWithPrepare = createMockNode(
+      joinDepIDTuple(['registry', '', 'test@1.0.0']),
+      {
+        name: 'test',
+        version: '1.0.0',
+        scripts: { prepare: 'npm run build' },
+      },
+    )
+    t.notOk(
+      nodeNeedsBuild(registryNodeWithPrepare),
+      'should exclude registry node with prepare script',
+    )
+
+    t.end()
+  })
+
+  t.test('excludes nodes without manifests', async t => {
+    const nodeWithoutManifest = createMockNode('test@1.0.0')
+    t.notOk(
+      nodeNeedsBuild(nodeWithoutManifest),
+      'should exclude node without manifest',
+    )
+
+    t.end()
+  })
+
+  t.test('excludes nodes without build requirements', async t => {
+    const plainNode = createMockNode('test@1.0.0', {
+      name: 'test',
+      version: '1.0.0',
+    })
+    t.notOk(
+      nodeNeedsBuild(plainNode),
+      'should exclude node with no build requirements',
+    )
+
+    const nodeWithIrrelevantScripts = createMockNode('test@1.0.0', {
+      name: 'test',
+      version: '1.0.0',
+      scripts: { test: 'echo test', start: 'node index.js' },
+    })
+    t.notOk(
+      nodeNeedsBuild(nodeWithIrrelevantScripts),
+      'should exclude node with irrelevant scripts',
+    )
+
+    t.end()
+  })
+
+  t.end()
+})
+
+t.test(
+  'nodeNeedsBuild - excludes nodes that have already been built',
+  async t => {
+    t.test(
+      'excludes nodes with built=true even when they have install scripts',
+      async t => {
+        const builtNodeWithInstall = createMockNode(
+          'built-pkg@1.0.0',
+          {
+            name: 'built-pkg',
+            version: '1.0.0',
+            scripts: { install: 'echo installing' },
+          },
+        )
+        builtNodeWithInstall.built = true
+
+        t.notOk(
+          nodeNeedsBuild(builtNodeWithInstall),
+          'should exclude node with built=true even with install script',
+        )
+
+        // Compare with similar node that hasn't been built
+        const unbuiltNodeWithInstall = createMockNode(
+          'unbuilt-pkg@1.0.0',
+          {
+            name: 'unbuilt-pkg',
+            version: '1.0.0',
+            scripts: { install: 'echo installing' },
+          },
+        )
+        // Built should default to false, but let's be explicit
+        unbuiltNodeWithInstall.built = false
+
+        t.ok(
+          nodeNeedsBuild(unbuiltNodeWithInstall),
+          'should include node with built=false and install script',
+        )
+
+        t.end()
+      },
+    )
+
+    t.test(
+      'excludes nodes with built=true even when they have prepare scripts as importers',
+      async t => {
+        const builtImporterWithPrepare = createMockNode(
+          'built-importer@1.0.0',
+          {
+            name: 'built-importer',
+            version: '1.0.0',
+            scripts: { prepare: 'npm run build' },
+          },
+          true, // importer = true
+        )
+        builtImporterWithPrepare.built = true
+
+        t.notOk(
+          nodeNeedsBuild(builtImporterWithPrepare),
+          'should exclude built importer even with prepare script',
+        )
+
+        // Compare with similar node that hasn't been built
+        const unbuiltImporterWithPrepare = createMockNode(
+          'unbuilt-importer@1.0.0',
+          {
+            name: 'unbuilt-importer',
+            version: '1.0.0',
+            scripts: { prepare: 'npm run build' },
+          },
+          true, // importer = true
+        )
+        unbuiltImporterWithPrepare.built = false
+
+        t.ok(
+          nodeNeedsBuild(unbuiltImporterWithPrepare),
+          'should include unbuilt importer with prepare script',
+        )
+
+        t.end()
+      },
+    )
+
+    t.test(
+      'excludes nodes with built=true even when they have binary files',
+      async t => {
+        const builtNodeWithBin = createMockNode(
+          'built-bin-pkg@1.0.0',
+          {
+            name: 'built-bin-pkg',
+            version: '1.0.0',
+            bin: './bin/tool',
+          },
+        )
+        builtNodeWithBin.built = true
+
+        t.notOk(
+          nodeNeedsBuild(builtNodeWithBin),
+          'should exclude node with built=true even with binary',
+        )
+
+        // Compare with similar node that hasn't been built
+        const unbuiltNodeWithBin = createMockNode(
+          'unbuilt-bin-pkg@1.0.0',
+          {
+            name: 'unbuilt-bin-pkg',
+            version: '1.0.0',
+            bin: './bin/tool',
+          },
+        )
+        unbuiltNodeWithBin.built = false
+
+        t.ok(
+          nodeNeedsBuild(unbuiltNodeWithBin),
+          'should include node with built=false and binary',
+        )
+
+        t.end()
+      },
+    )
+
+    t.test(
+      'excludes nodes with built=true even when they are git dependencies with prepare scripts',
+      async t => {
+        const builtGitDepWithPrepare = createMockNode(
+          'built-git-pkg@1.0.0',
+          {
+            name: 'built-git-pkg',
+            version: '1.0.0',
+            scripts: { prepare: 'npm run build' },
+          },
+          false,
+          true, // gitDep = true
+        )
+        builtGitDepWithPrepare.built = true
+
+        t.notOk(
+          nodeNeedsBuild(builtGitDepWithPrepare),
+          'should exclude built git dependency even with prepare script',
+        )
+
+        // Compare with similar node that hasn't been built
+        const unbuiltGitDepWithPrepare = createMockNode(
+          'unbuilt-git-pkg@1.0.0',
+          {
+            name: 'unbuilt-git-pkg',
+            version: '1.0.0',
+            scripts: { prepare: 'npm run build' },
+          },
+          false,
+          true, // gitDep = true
+        )
+        unbuiltGitDepWithPrepare.built = false
+
+        t.ok(
+          nodeNeedsBuild(unbuiltGitDepWithPrepare),
+          'should include unbuilt git dependency with prepare script',
+        )
+
+        t.end()
+      },
+    )
+
+    t.end()
+  },
+)
+
+t.test('saveBuild integration', async t => {
+  t.test('creates and saves build data file', async t => {
+    const projectRoot = t.testdir({})
+
+    // Create a simple graph with one importer
+    const graph1 = new Graph({
+      projectRoot,
+      mainManifest: { name: 'test-project', version: '1.0.0' },
+      registry: 'https://registry.npmjs.org/',
+    })
+
+    const graph2 = new Graph({
+      projectRoot,
+      mainManifest: { name: 'test-project', version: '1.0.0' },
+      registry: 'https://registry.npmjs.org/',
+    })
+
+    const diff = new Diff(graph1, graph2)
+    const buildData = saveBuild({ diff, projectRoot })
+
+    // Verify function returns BuildData
+    t.type(buildData, 'object', 'should return BuildData object')
+    t.ok('queue' in buildData, 'should have queue property')
+
+    // Verify file was created
+    const filePath = resolve(
+      projectRoot,
+      'node_modules/.vlt-build.json',
+    )
+    t.ok(existsSync(filePath), 'build file should be created')
+
+    // Verify file content
+    const content = readFileSync(filePath, 'utf8')
+    const fileData = JSON.parse(content)
+    t.strictSame(
+      buildData,
+      fileData,
+      'returned data should match file data',
+    )
+
+    // Should have empty queue since no nodes need building
+    t.type(fileData.queue, Array, 'queue should be an array')
+    t.equal(
+      fileData.queue.length,
+      0,
+      'should have empty queue with no nodes to build',
+    )
+
+    t.end()
+  })
+
+  t.test(
+    'excludes built nodes from build queue even with build requirements',
+    async t => {
+      const projectRoot = t.testdir({})
+
+      // Create graphs with nodes that have different built states
+      const graph1 = new Graph({
+        projectRoot,
+        mainManifest: { name: 'test-project', version: '1.0.0' },
+        registry: 'https://registry.npmjs.org/',
+      })
+
+      const graph2 = new Graph({
+        projectRoot,
+        mainManifest: { name: 'test-project', version: '1.0.0' },
+        registry: 'https://registry.npmjs.org/',
+      })
+
+      // Add a node with install script that has already been built
+      const builtInstallNode = graph2.addNode(
+        joinDepIDTuple(['registry', '', 'built-install-pkg@1.0.0']),
+        {
+          name: 'built-install-pkg',
+          version: '1.0.0',
+          scripts: { install: 'echo installing' },
+        },
+      )
+      builtInstallNode.manifest = {
+        name: 'built-install-pkg',
+        version: '1.0.0',
+        scripts: { install: 'echo installing' },
+      }
+      builtInstallNode.built = true // Mark as already built
+
+      // Add a node with install script that hasn't been built
+      const unbuiltInstallNode = graph2.addNode(
+        joinDepIDTuple(['registry', '', 'unbuilt-install-pkg@1.0.0']),
+        {
+          name: 'unbuilt-install-pkg',
+          version: '1.0.0',
+          scripts: { install: 'echo installing' },
+        },
+      )
+      unbuiltInstallNode.manifest = {
+        name: 'unbuilt-install-pkg',
+        version: '1.0.0',
+        scripts: { install: 'echo installing' },
+      }
+      unbuiltInstallNode.built = false // Explicitly mark as not built
+
+      // Add a node with binary that has already been built
+      const builtBinNode = graph2.addNode(
+        joinDepIDTuple(['registry', '', 'built-bin-pkg@1.0.0']),
+        {
+          name: 'built-bin-pkg',
+          version: '1.0.0',
+          bin: './bin/tool',
+        },
+      )
+      builtBinNode.manifest = {
+        name: 'built-bin-pkg',
+        version: '1.0.0',
+        bin: './bin/tool',
+      }
+      builtBinNode.built = true
+
+      const diff = new Diff(graph1, graph2)
+      const buildData = saveBuild({ diff, projectRoot })
+
+      // Verify function returns BuildData
+      t.type(buildData, 'object', 'should return BuildData object')
+      t.ok('queue' in buildData, 'should have queue property')
+
+      // Verify file was created
+      const filePath = resolve(
+        projectRoot,
+        'node_modules/.vlt-build.json',
+      )
+      t.ok(existsSync(filePath), 'build file should be created')
+
+      // Verify file content
+      const content = readFileSync(filePath, 'utf8')
+      const fileData = JSON.parse(content)
+      t.strictSame(
+        buildData,
+        fileData,
+        'returned data should match file data',
+      )
+
+      // Should include only the unbuilt install node, exclude built nodes
+      t.type(fileData.queue, Array, 'queue should be an array')
+      t.equal(
+        fileData.queue.length,
+        1,
+        'should have 1 node needing build',
+      )
+
+      t.ok(
+        fileData.queue.includes(
+          joinDepIDTuple([
+            'registry',
+            '',
+            'unbuilt-install-pkg@1.0.0',
+          ]),
+        ),
+        'should include unbuilt node with install script',
+      )
+
+      t.notOk(
+        fileData.queue.includes(
+          joinDepIDTuple(['registry', '', 'built-install-pkg@1.0.0']),
+        ),
+        'should exclude built node even with install script',
+      )
+
+      t.notOk(
+        fileData.queue.includes(
+          joinDepIDTuple(['registry', '', 'built-bin-pkg@1.0.0']),
+        ),
+        'should exclude built node even with binary',
+      )
+
+      t.end()
+    },
+  )
+
+  t.test(
+    'filters nodes and handles existing queue with deduplication',
+    async t => {
+      const projectRoot = t.testdir({})
+
+      // Create graphs with actual differences to test filtering
+      const graph1 = new Graph({
+        projectRoot,
+        mainManifest: { name: 'test-project', version: '1.0.0' },
+        registry: 'https://registry.npmjs.org/',
+      })
+
+      const graph2 = new Graph({
+        projectRoot,
+        mainManifest: { name: 'test-project', version: '1.0.0' },
+        registry: 'https://registry.npmjs.org/',
+      })
+
+      // Add nodes with different build requirements to graph2
+      const installScriptNode = graph2.addNode(
+        joinDepIDTuple(['registry', '', 'install-pkg@1.0.0']),
+        {
+          name: 'install-pkg',
+          version: '1.0.0',
+          scripts: { install: 'echo installing' },
+        },
+      )
+      installScriptNode.manifest = {
+        name: 'install-pkg',
+        version: '1.0.0',
+        scripts: { install: 'echo installing' },
+      }
+
+      const binNode = graph2.addNode(
+        joinDepIDTuple(['registry', '', 'bin-pkg@1.0.0']),
+        { name: 'bin-pkg', version: '1.0.0', bin: './bin/tool' },
+      )
+      binNode.manifest = {
+        name: 'bin-pkg',
+        version: '1.0.0',
+        bin: './bin/tool',
+      }
+
+      const plainNode = graph2.addNode(
+        joinDepIDTuple(['registry', '', 'plain-pkg@1.0.0']),
+        { name: 'plain-pkg', version: '1.0.0' },
+      )
+      plainNode.manifest = { name: 'plain-pkg', version: '1.0.0' }
+
+      const prepareNode = graph2.addNode(
+        joinDepIDTuple(['registry', '', 'prepare-pkg@1.0.0']),
+        {
+          name: 'prepare-pkg',
+          version: '1.0.0',
+          scripts: { prepare: 'npm run build' },
+        },
+      )
+      prepareNode.manifest = {
+        name: 'prepare-pkg',
+        version: '1.0.0',
+        scripts: { prepare: 'npm run build' },
+      }
+
+      const diff = new Diff(graph1, graph2)
+
+      // Test with existing queue containing some duplicates
+      const existingQueue = [
+        joinDepIDTuple(['registry', '', 'existing@1.0.0']),
+        joinDepIDTuple(['registry', '', 'install-pkg@1.0.0']), // This should be deduplicated
+      ]
+
+      const buildData = saveBuild({
+        diff,
+        projectRoot,
+        queue: existingQueue,
+      })
+
+      // Verify function returns BuildData
+      t.type(buildData, 'object', 'should return BuildData object')
+      t.ok('queue' in buildData, 'should have queue property')
+
+      // Verify file was created
+      const filePath = resolve(
+        projectRoot,
+        'node_modules/.vlt-build.json',
+      )
+      t.ok(existsSync(filePath), 'build file should be created')
+
+      // Verify file content
+      const content = readFileSync(filePath, 'utf8')
+      const fileData = JSON.parse(content)
+      t.strictSame(
+        buildData,
+        fileData,
+        'returned data should match file data',
+      )
+
+      // Should include:
+      // - existing@1.0.0 (from existing queue)
+      // - install-pkg@1.0.0 (has install script, deduplicated)
+      // - bin-pkg@1.0.0 (has binary)
+      // Should exclude:
+      // - plain-pkg@1.0.0 (no build requirements)
+      // - prepare-pkg@1.0.0 (registry node with prepare script - not importer/git)
+      t.type(fileData.queue, Array, 'queue should be an array')
+      t.equal(fileData.queue.length, 3, 'should have 3 unique nodes')
+
+      // Verify specific inclusions
+      t.ok(
+        fileData.queue.includes(
+          joinDepIDTuple(['registry', '', 'existing@1.0.0']),
+        ),
+        'should include existing queue item',
+      )
+      t.ok(
+        fileData.queue.includes(
+          joinDepIDTuple(['registry', '', 'install-pkg@1.0.0']),
+        ),
+        'should include node with install script',
+      )
+      t.ok(
+        fileData.queue.includes(
+          joinDepIDTuple(['registry', '', 'bin-pkg@1.0.0']),
+        ),
+        'should include node with binary',
+      )
+
+      // Verify exclusions
+      t.notOk(
+        fileData.queue.includes(
+          joinDepIDTuple(['registry', '', 'plain-pkg@1.0.0']),
+        ),
+        'should exclude plain node without build requirements',
+      )
+      t.notOk(
+        fileData.queue.includes(
+          joinDepIDTuple(['registry', '', 'prepare-pkg@1.0.0']),
+        ),
+        'should exclude registry node with prepare script',
+      )
+
+      // Verify deduplication worked (no duplicates)
+      const uniqueIds = new Set(fileData.queue)
+      t.equal(
+        uniqueIds.size,
+        fileData.queue.length,
+        'should not have duplicate DepIDs',
+      )
+
+      t.end()
+    },
+  )
+
+  t.end()
+})

--- a/src/graph/test/transfer-data/load.ts
+++ b/src/graph/test/transfer-data/load.ts
@@ -36,6 +36,10 @@ const transferData: TransferData = {
         custom: 'http://example.com',
       },
     },
+    build: {
+      allowed: {},
+      blocked: {},
+    },
     nodes: {
       '··bar@1.0.0': [
         3,

--- a/src/graph/test/update.ts
+++ b/src/graph/test/update.ts
@@ -44,6 +44,7 @@ t.test('update', async t => {
     '../src/reify/index.ts': {
       reify: async () => {
         log += 'reify\n'
+        return { buildQueue: [], diff: {} }
       },
     },
     '../src/modifiers.ts': {
@@ -92,7 +93,7 @@ t.test(
         },
       },
       '../src/reify/index.ts': {
-        reify: async () => ({ diff: {} }),
+        reify: async () => ({ buildQueue: [], diff: {} }),
       },
     })
 
@@ -163,7 +164,7 @@ t.test(
       typeof import('../src/update.ts')
     >('../src/update.ts', {
       '../src/reify/index.ts': {
-        reify: async () => ({ diff: {} }),
+        reify: async () => ({ buildQueue: [], diff: {} }),
       },
     })
 
@@ -215,7 +216,7 @@ t.test(
     >('../src/update.ts', {
       // Avoid making any file system changes
       '../src/reify/index.ts': {
-        reify: async () => ({ diff: {} }),
+        reify: async () => ({ buildQueue: [], diff: {} }),
       },
     })
 

--- a/src/query/src/pseudo/scripts.ts
+++ b/src/query/src/pseudo/scripts.ts
@@ -1,9 +1,54 @@
-import { createSecuritySelectorFilter } from './helpers.ts'
+import type { NodeLike } from '@vltpkg/types'
+import type { ParserState } from '../types.ts'
+import { removeNode, removeDanglingEdges } from './helpers.ts'
 
 /**
- * Filters out any node that does not have an **installScripts** report alert.
+ * Checks if a node needs to be built based on the conditions from the reify build process:
+ * 1. Has install lifecycle scripts (install, preinstall, postinstall)
+ * 2. Is an importer or git dependency with prepare scripts (prepare, preprepare, postprepare)
  */
-export const scripts = createSecuritySelectorFilter(
-  'scripts',
-  'installScripts',
-)
+const nodeNeedsBuild = (node: NodeLike): boolean => {
+  const { manifest } = node
+  /* c8 ignore next */
+  if (!manifest) return false
+
+  const { scripts = {} } = manifest
+
+  // Check for install lifecycle scripts
+  const runInstall = !!(
+    scripts.install ||
+    scripts.preinstall ||
+    scripts.postinstall
+  )
+  if (runInstall) return true
+
+  // Check for prepare scripts on importers or git dependencies
+  const prepable = node.id.startsWith('git') || node.importer
+  const runPrepare =
+    !!(
+      (scripts.prepare || scripts.preprepare || scripts.postprepare)
+      /* c8 ignore next 2 */
+    ) && prepable
+  if (runPrepare) return true
+
+  return false
+}
+
+/**
+ * :scripts Pseudo-Selector filters nodes based on whether they need to be built.
+ *
+ * A node needs to be built if it has:
+ * - Install lifecycle scripts (install, preinstall, postinstall)
+ * - Prepare scripts on importers or git dependencies (prepare, preprepare, postprepare)
+ */
+export const scripts = async (state: ParserState) => {
+  for (const node of state.partial.nodes) {
+    if (!nodeNeedsBuild(node)) {
+      removeNode(state, node)
+    }
+  }
+
+  removeDanglingEdges(state)
+
+  return state
+}

--- a/src/query/tap-snapshots/test/pseudo/scripts.ts.test.cjs
+++ b/src/query/tap-snapshots/test/pseudo/scripts.ts.test.cjs
@@ -5,14 +5,67 @@
  * Make sure to inspect the output below.  Do not ignore changes!
  */
 'use strict'
-exports[`test/pseudo/scripts.ts > TAP > selects packages with an installScripts alert > filter out any node that does not have the alert > must match snapshot 1`] = `
+exports[`test/pseudo/scripts.ts > TAP > selects packages that need to be built > filters out nodes without build requirements > must match snapshot 1`] = `
 Object {
-  "edges": Array [
-    "e",
-    "e",
-  ],
+  "edges": Array [],
+  "nodes": Array [],
+}
+`
+
+exports[`test/pseudo/scripts.ts > TAP > selects packages that need to be built > handles empty partial state > must match snapshot 1`] = `
+Object {
+  "edges": Array [],
+  "nodes": Array [],
+}
+`
+
+exports[`test/pseudo/scripts.ts > TAP > selects packages that need to be built > handles mixed scenarios correctly > must match snapshot 1`] = `
+Object {
+  "edges": Array [],
   "nodes": Array [
-    "e",
+    "build-pkg1",
+    "build-pkg2",
+  ],
+}
+`
+
+exports[`test/pseudo/scripts.ts > TAP > selects packages that need to be built > selects git dependencies with prepare scripts > must match snapshot 1`] = `
+Object {
+  "edges": Array [],
+  "nodes": Array [
+    "git-pkg",
+    "git-postprepare-pkg",
+    "git-preprepare-pkg",
+  ],
+}
+`
+
+exports[`test/pseudo/scripts.ts > TAP > selects packages that need to be built > selects importer nodes with prepare scripts > must match snapshot 1`] = `
+Object {
+  "edges": Array [],
+  "nodes": Array [
+    "importer-pkg",
+  ],
+}
+`
+
+exports[`test/pseudo/scripts.ts > TAP > selects packages that need to be built > selects nodes with binary files > must match snapshot 1`] = `
+Object {
+  "edges": Array [],
+  "nodes": Array [
+    "object-bin-pkg",
+    "string-bin-pkg",
+  ],
+}
+`
+
+exports[`test/pseudo/scripts.ts > TAP > selects packages that need to be built > selects nodes with install lifecycle scripts > must match snapshot 1`] = `
+Object {
+  "edges": Array [],
+  "nodes": Array [
+    "install-pkg",
+    "postinstall-pkg",
+    "preinstall-pkg",
   ],
 }
 `

--- a/src/query/test/pseudo/scripts.ts
+++ b/src/query/test/pseudo/scripts.ts
@@ -1,25 +1,33 @@
 import t from 'tap'
+import postcssSelectorParser from 'postcss-selector-parser'
 import { joinDepIDTuple } from '@vltpkg/dep-id'
-import { asSecurityArchiveLike } from '@vltpkg/security-archive'
-import { getSimpleGraph } from '../fixtures/graph.ts'
+import { normalizeManifest } from '@vltpkg/types'
 import type { ParserState } from '../../src/types.ts'
 import { scripts } from '../../src/pseudo/scripts.ts'
-import { parse } from '../../src/parser.ts'
+import { newGraph, newNode } from '../fixtures/graph.ts'
+import type { NodeLike } from '@vltpkg/types'
 
-t.test('selects packages with an installScripts alert', async t => {
-  const getState = (query: string, graph = getSimpleGraph()) => {
-    const ast = parse(query)
+t.test('selects packages that need to be built', async t => {
+  const getState = (query: string, nodes: NodeLike[] = []) => {
+    const ast = postcssSelectorParser().astSync(query)
     const current = ast.first.first
+
+    // Create a minimal graph with our test nodes
+    const graph = newGraph('test-project')
+    nodes.forEach(node => {
+      graph.nodes.set(node.id, node)
+    })
+
     const state: ParserState = {
       comment: '',
       current,
       initial: {
         edges: new Set(graph.edges.values()),
-        nodes: new Set(graph.nodes.values()),
+        nodes: new Set(nodes),
       },
       partial: {
         edges: new Set(graph.edges.values()),
-        nodes: new Set(graph.nodes.values()),
+        nodes: new Set(nodes),
       },
       collect: {
         edges: new Set(),
@@ -27,72 +35,260 @@ t.test('selects packages with an installScripts alert', async t => {
       },
       cancellable: async () => {},
       walk: async i => i,
-      securityArchive: asSecurityArchiveLike(
-        new Map([
-          [
-            joinDepIDTuple(['registry', '', 'e@1.0.0']),
-            { alerts: [{ type: 'installScripts' }] },
-          ],
-        ]),
-      ),
-      importers: new Set(graph.importers),
       retries: 0,
+      securityArchive: undefined,
+      importers: new Set(graph.importers),
       signal: new AbortController().signal,
       specificity: { idCounter: 0, commonCounter: 0 },
     }
     return state
+  }
+
+  const createTestNode = (name: string, manifest: any): NodeLike => {
+    const graph = newGraph('test')
+    const addNode = newNode(graph)
+    const node = addNode(name)
+    node.manifest = normalizeManifest({
+      name,
+      version: '1.0.0',
+      ...manifest,
+    })
+    return node
   }
 
   await t.test(
-    'filter out any node that does not have the alert',
+    'selects nodes with install lifecycle scripts',
     async t => {
-      const res = await scripts(getState(':scripts'))
+      const nodeWithInstall = createTestNode('install-pkg', {
+        scripts: { install: 'echo installing' },
+      })
+      const nodeWithPreinstall = createTestNode('preinstall-pkg', {
+        scripts: { preinstall: 'echo pre installing' },
+      })
+      const nodeWithPostinstall = createTestNode('postinstall-pkg', {
+        scripts: { postinstall: 'echo post installing' },
+      })
+      const nodeWithoutScripts = createTestNode('no-scripts-pkg', {})
+
+      const res = await scripts(
+        getState(':scripts', [
+          nodeWithInstall,
+          nodeWithPreinstall,
+          nodeWithPostinstall,
+          nodeWithoutScripts,
+        ]),
+      )
+
       t.strictSame(
-        [...res.partial.nodes].map(n => n.name),
-        ['e'],
-        'should select only scripts packages',
+        [...res.partial.nodes].map(n => n.name).sort(),
+        ['install-pkg', 'postinstall-pkg', 'preinstall-pkg'],
+        'should select packages with install lifecycle scripts',
       )
       t.matchSnapshot({
-        nodes: [...res.partial.nodes].map(n => n.name),
-        edges: [...res.partial.edges].map(e => e.name),
+        nodes: [...res.partial.nodes].map(n => n.name).sort(),
+        edges: [...res.partial.edges].map(e => e.name).sort(),
       })
     },
   )
-})
 
-t.test('missing security archive', async t => {
-  const getState = (query: string) => {
-    const ast = parse(query)
-    const current = ast.first.first
-    const state: ParserState = {
-      comment: '',
-      current,
-      initial: {
-        edges: new Set(),
-        nodes: new Set(),
-      },
-      partial: {
-        edges: new Set(),
-        nodes: new Set(),
-      },
-      collect: {
-        edges: new Set(),
-        nodes: new Set(),
-      },
-      cancellable: async () => {},
-      walk: async i => i,
-      securityArchive: undefined,
-      importers: new Set(),
-      retries: 0,
-      signal: new AbortController().signal,
-      specificity: { idCounter: 0, commonCounter: 0 },
-    }
-    return state
-  }
+  await t.test(
+    'selects git dependencies with prepare scripts',
+    async t => {
+      const gitNodeWithPrepare = createTestNode('git-pkg', {
+        scripts: { prepare: 'npm run build' },
+      })
+      gitNodeWithPrepare.id = joinDepIDTuple([
+        'git',
+        'github.com/user/repo.git',
+        'git-pkg@1.0.0',
+      ])
 
-  await t.rejects(
-    scripts(getState(':scripts')),
-    { message: /Missing security archive/ },
-    'should throw an error',
+      const gitNodeWithPreprepare = createTestNode(
+        'git-preprepare-pkg',
+        {
+          scripts: { preprepare: 'npm run setup' },
+        },
+      )
+      gitNodeWithPreprepare.id = joinDepIDTuple([
+        'git',
+        'github.com/user/repo2.git',
+        'git-preprepare-pkg@1.0.0',
+      ])
+
+      const gitNodeWithPostprepare = createTestNode(
+        'git-postprepare-pkg',
+        {
+          scripts: { postprepare: 'npm run cleanup' },
+        },
+      )
+      gitNodeWithPostprepare.id = joinDepIDTuple([
+        'git',
+        'github.com/user/repo3.git',
+        'git-postprepare-pkg@1.0.0',
+      ])
+
+      const gitNodeWithoutPrepare = createTestNode(
+        'git-no-prepare-pkg',
+        {},
+      )
+      gitNodeWithoutPrepare.id = joinDepIDTuple([
+        'git',
+        'github.com/user/repo4.git',
+        'git-no-prepare-pkg@1.0.0',
+      ])
+
+      const res = await scripts(
+        getState(':scripts', [
+          gitNodeWithPrepare,
+          gitNodeWithPreprepare,
+          gitNodeWithPostprepare,
+          gitNodeWithoutPrepare,
+        ]),
+      )
+
+      t.strictSame(
+        [...res.partial.nodes].map(n => n.name).sort(),
+        ['git-pkg', 'git-postprepare-pkg', 'git-preprepare-pkg'],
+        'should select git packages with prepare scripts',
+      )
+      t.matchSnapshot({
+        nodes: [...res.partial.nodes].map(n => n.name).sort(),
+        edges: [...res.partial.edges].map(e => e.name).sort(),
+      })
+    },
   )
+
+  await t.test(
+    'selects importer nodes with prepare scripts',
+    async t => {
+      const importerNodeWithPrepare = createTestNode('importer-pkg', {
+        scripts: { prepare: 'npm run build' },
+      })
+      importerNodeWithPrepare.importer = true
+
+      const importerNodeWithoutPrepare = createTestNode(
+        'importer-no-prepare-pkg',
+        {},
+      )
+      importerNodeWithoutPrepare.importer = true
+
+      const regularNodeWithPrepare = createTestNode('regular-pkg', {
+        scripts: { prepare: 'npm run build' },
+      })
+      // Add mock inVltStore method that returns true for regular nodes
+      ;(regularNodeWithPrepare as any).inVltStore = () => true
+
+      const res = await scripts(
+        getState(':scripts', [
+          importerNodeWithPrepare,
+          importerNodeWithoutPrepare,
+          regularNodeWithPrepare,
+        ]),
+      )
+
+      t.strictSame(
+        [...res.partial.nodes].map(n => n.name).sort(),
+        ['importer-pkg'],
+        'should select importer packages with prepare scripts but not regular packages in vlt store',
+      )
+      t.matchSnapshot({
+        nodes: [...res.partial.nodes].map(n => n.name).sort(),
+        edges: [...res.partial.edges].map(e => e.name).sort(),
+      })
+    },
+  )
+
+  await t.test(
+    'filters out nodes without build requirements',
+    async t => {
+      const nodeWithoutManifest = createTestNode(
+        'no-manifest-pkg',
+        {},
+      )
+      delete nodeWithoutManifest.manifest
+
+      const nodeWithEmptyManifest = createTestNode(
+        'empty-manifest-pkg',
+        {},
+      )
+
+      const nodeWithOnlyDevScripts = createTestNode(
+        'dev-scripts-pkg',
+        {
+          scripts: {
+            dev: 'webpack serve',
+            test: 'jest',
+          },
+        },
+      )
+
+      const res = await scripts(
+        getState(':scripts', [
+          nodeWithoutManifest,
+          nodeWithEmptyManifest,
+          nodeWithOnlyDevScripts,
+        ]),
+      )
+
+      t.strictSame(
+        [...res.partial.nodes].map(n => n.name).sort(),
+        [],
+        'should filter out packages that do not need building',
+      )
+      t.matchSnapshot({
+        nodes: [...res.partial.nodes].map(n => n.name).sort(),
+        edges: [...res.partial.edges].map(e => e.name).sort(),
+      })
+    },
+  )
+
+  await t.test('handles mixed scenarios correctly', async t => {
+    const nodeNeedingBuild1 = createTestNode('build-pkg1', {
+      scripts: { install: 'make install' },
+    })
+
+    const nodeNeedingBuild2 = createTestNode('build-pkg2', {
+      scripts: { prepare: 'npm run compile' },
+    })
+    nodeNeedingBuild2.importer = true
+
+    const nodeNotNeedingBuild = createTestNode('no-build-pkg', {
+      scripts: { start: 'node server.js' },
+    })
+
+    const res = await scripts(
+      getState(':scripts', [
+        nodeNeedingBuild1,
+        nodeNeedingBuild2,
+        nodeNotNeedingBuild,
+      ]),
+    )
+
+    t.strictSame(
+      [...res.partial.nodes].map(n => n.name).sort(),
+      ['build-pkg1', 'build-pkg2'],
+      'should correctly handle mixed build scenarios',
+    )
+    t.matchSnapshot({
+      nodes: [...res.partial.nodes].map(n => n.name).sort(),
+      edges: [...res.partial.edges].map(e => e.name).sort(),
+    })
+  })
+
+  await t.test('handles empty partial state', async t => {
+    const state = getState(':scripts')
+    state.partial.nodes.clear()
+    state.partial.edges.clear()
+
+    const res = await scripts(state)
+    t.strictSame(
+      [...res.partial.nodes].map(n => n.name),
+      [],
+      'should return empty array when starting with empty partial state',
+    )
+    t.matchSnapshot({
+      nodes: [...res.partial.nodes].map(n => n.name),
+      edges: [...res.partial.edges].map(e => e.name),
+    })
+  })
 })

--- a/src/types/src/index.ts
+++ b/src/types/src/index.ts
@@ -3,6 +3,12 @@ import { Version } from '@vltpkg/semver'
 import type { DepID } from '@vltpkg/dep-id'
 import type { Spec, SpecLikeBase, SpecOptions } from '@vltpkg/spec'
 
+// Forward declare LockfileBuildData to avoid circular dependency
+export type LockfileBuildData = {
+  allowed: Record<string, string[]>
+  blocked: Record<string, string[]>
+}
+
 /**
  * Utility type that overrides specific properties of type T with new types
  * from R. Constrains override values to exclude undefined, ensuring that
@@ -1394,6 +1400,7 @@ export type GraphLike = {
   nodes: Map<DepID, NodeLike>
   nodesByName: Map<string, Set<NodeLike>>
   edges: Set<EdgeLike>
+  build?: LockfileBuildData
   addEdge: (
     type: DependencyTypeShort,
     spec: Spec,
@@ -1435,6 +1442,8 @@ export type NodeLike = {
     os?: string[] | string
     cpu?: string[] | string
   }
+  buildAllowed?: boolean
+  buildBlocked?: boolean
   options: SpecOptions
   toJSON: () => Pick<
     NodeLike,
@@ -1451,6 +1460,8 @@ export type NodeLike = {
     | 'optional'
     | 'confused'
     | 'platform'
+    | 'buildAllowed'
+    | 'buildBlocked'
   > & {
     rawManifest?: NodeLike['manifest']
   }

--- a/src/vlx/src/install.ts
+++ b/src/vlx/src/install.ts
@@ -81,6 +81,8 @@ export const vlxInstall = async (
     projectRoot: dir,
     monorepo: undefined,
     scurry: new PathScurry(dir),
+    // vlx always run lifecycle scripts
+    includeScripts: true,
   })
 
   return vlxInfo(dir, options, manifest)

--- a/www/docs/src/content/docs/cli/commands/build.mdx
+++ b/www/docs/src/content/docs/cli/commands/build.mdx
@@ -1,0 +1,204 @@
+---
+title: vlt build
+sidebar:
+  label: build
+---
+
+import { Code } from '@astrojs/starlight/components'
+
+Usage:
+
+<Code code="$ vlt build [options]" title="Terminal" lang="bash" />
+
+The `vlt build` command represents a fundamental shift in how JavaScript package managers handle post-installation tasks. By separating the build phase from installation, `vlt` gives you unprecedented control over which packages run lifecycle scripts in your project.
+
+## Breaking the Traditional Model
+
+Traditional package managers conflate installation with building – when you run `npm install` or `yarn install`, packages are downloaded, extracted, and their lifecycle scripts run automatically. This monolithic approach has several drawbacks:
+
+- **Security risks**: Malicious packages can execute arbitrary code during installation
+- **Performance overhead**: Every install triggers all lifecycle scripts, even when unnecessary
+- **Limited control**: You can't selectively enable or disable scripts for specific packages
+
+With `vlt`, we've reimagined this process as two distinct phases:
+
+1. **`vlt install`** – Downloads and extracts packages into `node_modules`
+2. **`vlt build`** – Runs lifecycle scripts and performs binary linking
+
+This separation leverages the full power of our Dependency Selector Syntax (DSS) query language, allowing you to precisely control which packages are allowed to execute scripts.
+
+## Basic Usage
+
+The simplest workflow mirrors traditional package managers but with explicit steps:
+
+<Code
+  code={`# Step 1: Install packages (no scripts run)
+$ vlt install
+
+# Step 2: Build all packages that need building
+$ vlt build`}
+  title="Terminal"
+  lang="bash"
+/>
+
+The build process is idempotent – it only performs work that's actually needed based on the current state of your dependency graph. If a package has already been built, `vlt build` skips it automatically.
+
+## Selective Building with DSS Queries
+
+The real power of `vlt build` comes from its integration with our query language. You can use any DSS selector to target specific packages:
+
+<Code
+  code={`# Build only packages matching a specific scope
+$ vlt build --scope="#esbuild"
+
+# Build all packages except those marked as dev dependencies
+$ vlt build --scope=":not(:dev)"`}
+  title="Terminal"
+  lang="bash"
+/>
+
+## Skipping Problematic Packages
+
+Sometimes you need to prevent certain packages from running scripts. The `vlt build skip` command lets you mark packages that should never be built:
+
+<Code
+  code={`# Skip building a specific package
+$ vlt build skip --scope="#problematic-package"
+
+# Skip all packages from a specific registry
+$ vlt build skip --scope="[registry~=suspicious-registry.com]"`}
+  title="Terminal"
+  lang="bash"
+/>
+
+These skip rules are persisted in your project configuration, so future `vlt build` commands will respect them automatically.
+
+## Real-World Examples
+
+### Example 1: Security-First Installation
+
+Imagine you're installing dependencies in a security-sensitive environment. You want to inspect packages before allowing them to run scripts:
+
+<Code
+  code={`# Install without running any scripts
+$ vlt install
+
+# Check for packages flagged as malware
+$ vlt query ":malware"
+
+# If malware is detected, skip building those packages
+$ vlt build skip --scope=":malware"
+
+# Build everything else
+$ vlt build`}
+  title="Terminal"
+  lang="bash"
+/>
+
+### Example 2: Selective Trust
+
+Maybe you only trust certain critical build tools to run scripts, while treating everything else with caution:
+
+<Code
+  code={`# Install packages
+$ vlt install
+
+# Only build the specific tools you trust
+$ vlt build --scope="#esbuild"
+$ vlt build --scope="#typescript"
+
+# Mark everything else as skip for future installs
+$ vlt build skip`}
+  title="Terminal"
+  lang="bash"
+/>
+
+### Example 3: Performance Optimization
+
+For CI/CD pipelines where you know certain packages don't need rebuilding:
+
+<Code
+  code={`# Install packages
+$ vlt install
+
+# Skip building packages that are platform-specific for other platforms
+$ vlt build skip --scope="[os~=darwin]" # On a Linux CI server
+
+# Build only what's needed
+$ vlt build`}
+  title="Terminal"
+  lang="bash"
+/>
+
+## Options
+
+### `--scope`
+
+The `--scope` option accepts any valid DSS query to filter which packages to build:
+
+<Code
+  code={`# Build only direct dependencies
+$ vlt build --scope=":root > *"
+
+# Build only packages with native bindings
+$ vlt build --scope=":has-binary"`}
+  title="Terminal"
+  lang="bash"
+/>
+
+### Build State Persistence
+
+The build state is tracked in a `.vlt-build.json` file in your project root. This file records which packages have been built and which have been marked to skip. The state is also reflected in your lockfile under the `build` section:
+
+<Code
+  code={`{
+  "build": {
+    "allowed": {
+      "esbuild": true,
+      "typescript": true
+    },
+    "blocked": {
+      "suspicious-package": true
+    }
+  }
+}`}
+  title="vlt-lock.json"
+  lang="json"
+/>
+
+## Best Practices
+
+1. **Start with `vlt install`** – Always install first, then decide what to build
+2. **Use queries for precision** – Target specific packages or patterns rather than building everything
+3. **Persist your choices** – Use `vlt build skip` to codify security decisions
+4. **Review regularly** – Periodically audit which packages are allowed to run scripts
+
+## Migration from Traditional Package Managers
+
+If you're coming from npm, yarn, or pnpm, here's a quick translation guide:
+
+<Code
+  code={`# Traditional approach
+$ npm install        # Downloads AND builds everything
+
+# vlt approach
+$ vlt install        # Just downloads
+$ vlt build          # Explicitly builds what you allow`}
+  title="Terminal"
+  lang="bash"
+/>
+
+For projects that need to maintain compatibility, you can use the `--install-scripts` flag with `vlt install` to get traditional behavior:
+
+<Code
+  code={`# Traditional-style installation (not recommended)
+$ vlt install --install-scripts`}
+  title="Terminal"
+  lang="bash"
+/>
+
+## What's Next?
+
+The `vlt build` command is part of our broader vision for secure, performant JavaScript development. By giving developers fine-grained control over the build process, we're putting security and performance back in your hands.
+
+Try out `vlt build` in your projects and let us know how it changes your workflow. Join our [Discord community](https://discord.gg/vltpkg) to share your experiences and help shape the future of JavaScript package management.


### PR DESCRIPTION
This changeset fundamentally changes how install works in the vlt cli by breaking installs into two distinct steps:
- Install step that resolves a graph data structure from parsing `package.json` files retrieved and extracts tarball data into the `node_modules` folder.
- A build step that runs the lifecycle scripts on packages that requires it.

Our design principle here is that by separating the install into these distinctive two steps we can grant the user power to control what lifecycle scripts they want to run and most importantly the ability to block unwanted ones.

To improve the UX around this, an install will persist the choice of allowed or blocked packages to the lockfile so that the user will only need to make that decision once for a given package in the same registry and also allowing that decision to be shared with a team by checking in the lockfile to a version control system.

How it works:
- Running `vlt install` no longer run lifecycle scripts
- Running `vlt query :scripts` allows the user to inspect what packages currently installed in their system rely on post install lifecycle scripts
- Running `vlt build --scope=<query>` allows the user to run lifecycle scripts to only the matching packages from the given query and adds these packages to an allowed list in the lockfile
- Running `vlt build skip --scope=<query>` skips the lifecycle sciprts of the matching packages using the given query and adds these packages to a block list in the lockfile.
- Running `vlt build` with no parameters will run lifecycle scripts to all packages on the previous install
- Running `vlt build skip` with no parameters will block lifecycle scripts of all packages on the previous install

Running `vlt install && vlt build` is the functional equivalent of the prior `vlt install` behavior.