### PR TITLE
package-info: fix single manifest request

### DIFF
--- a/src/package-info/src/index.ts
+++ b/src/package-info/src/index.ts
@@ -354,7 +354,13 @@ export class PackageInfoClient {
       )
     }
     /* c8 ignore stop */
-    const pakuURL = new URL(`${name}/${registrySpec}`, registry)
+    const possibleLeadingChars = ['=', '^', '~', 'v']
+    const hasLeadingRange = possibleLeadingChars.some(char =>
+      registrySpec.startsWith(char),
+    )
+    const version =
+      hasLeadingRange ? registrySpec.slice(1) : registrySpec
+    const pakuURL = new URL(`${name}/${version}`, registry)
     const response = await this.registryClient.request(pakuURL, {
       headers: {
         accept: 'application/json',

--- a/src/package-info/test/index.ts
+++ b/src/package-info/test/index.ts
@@ -471,6 +471,18 @@ t.test('manifest', async t => {
   )
 })
 
+t.test('manifest strips leading semver characters', async t => {
+  // Test that leading characters (=, ^, ~, v) are stripped when using
+  // the registry manifest request shortcut for single version specs
+  for (const prefix of ['=', '^', '~', 'v']) {
+    t.strictSame(
+      await manifest(`abbrev@${prefix}2.0.0`, options),
+      pakuAbbrev.versions['2.0.0'],
+      `${prefix}2.0.0 should strip leading character`,
+    )
+  }
+})
+
 t.test('resolve', async t => {
   // do this with a consistent client so that we cover the memoizing paths
   const pi = new PackageInfoClient({


### PR DESCRIPTION
Strips possible leading characters from returned `registrySpec` values in the single manifest request method.