### PR TITLE
cli-sdk: add a hint to login on publish fail

### DIFF
--- a/src/cli-sdk/src/commands/publish.ts
+++ b/src/cli-sdk/src/commands/publish.ts
@@ -283,7 +283,13 @@ const commandSingle = async (
     }
 
     if (response.statusCode !== 200 && response.statusCode !== 201) {
-      throw error('Failed to publish package', {
+      let extraMsg = ''
+      // special case 404 errors to provide a better hint to the user
+      if (response.statusCode === 404) {
+        extraMsg =
+          ".\n⚠️ Make sure you're logged in and have access to publish the package."
+      }
+      throw error(`Failed to publish package${extraMsg}`, {
         url: publishUrl,
         response,
       })


### PR DESCRIPTION
When publish fails with a 404 that very likely means the user forgot to log in (ask me how I know this).

This changeset adds an extra reminder that the user may need to login in case the publish request fails with a 404 status code.