### PR TITLE
cli-sdk: fix json formatting on vlt pack

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -535,6 +535,9 @@ importers:
       path-scurry:
         specifier: 'catalog:'
         version: 2.0.0
+      polite-json:
+        specifier: 'catalog:'
+        version: 5.0.0
       pretty-bytes:
         specifier: ^7.0.1
         version: 7.0.1

--- a/src/cli-sdk/package.json
+++ b/src/cli-sdk/package.json
@@ -57,6 +57,7 @@
     "minimatch": "catalog:",
     "package-json-from-dist": "catalog:",
     "path-scurry": "catalog:",
+    "polite-json": "catalog:",
     "pretty-bytes": "^7.0.1",
     "react": "^19.1.1",
     "react-devtools-core": "^4.28.5",

--- a/src/cli-sdk/src/pack-tarball.ts
+++ b/src/cli-sdk/src/pack-tarball.ts
@@ -8,6 +8,7 @@ import { existsSync, statSync } from 'node:fs'
 import { Spec } from '@vltpkg/spec'
 import type { LoadedConfig } from './config/index.ts'
 import { join } from 'node:path'
+import { parse, stringify } from 'polite-json'
 
 export type PackTarballResult = {
   name: string
@@ -31,8 +32,9 @@ const replaceWorkspaceAndCatalogSpecs = (
   manifest_: NormalizedManifest,
   config: LoadedConfig,
 ): NormalizedManifest => {
-  // Create a deep copy of the manifest to avoid modifying the original
-  const manifest = structuredClone(manifest_)
+  // Create a json copy of the manifest to avoid modifying the original
+  // preserves original formatting symbols from polite-json
+  const manifest = parse(stringify(manifest_)) as NormalizedManifest
 
   // Get workspace and catalog configuration from config
   const { monorepo, catalog = {}, catalogs = {} } = config.options


### PR DESCRIPTION
Fixes the ability of retaining the original json formatting when running vlt pack and/or publish.