### PR TITLE
chore: add tailwind to allow-scripts

### DIFF
--- a/.github/workflows/vlt.yml
+++ b/.github/workflows/vlt.yml
@@ -25,8 +25,8 @@ jobs:
           node-version: '^22.14.0'
           check-latest: true
 
-      - name: Boostrap
-        run: npx vlt install --view=json
+      - name: Bootstrap
+        run: npx vlt install --view=json --allow-scripts="#tailwindcss"
 
       - name: Build vlt
         run: node --run build:bundle
@@ -35,7 +35,7 @@ jobs:
         run: echo "$GITHUB_WORKSPACE/scripts/bins/bundle" >> $GITHUB_PATH
       
       - name: Install Dependencies
-        run: vlt install --view=json
+        run: vlt install --view=json --allow-scripts="#tailwindcss"
 
       - name: Formatting
         id: format
@@ -117,7 +117,7 @@ jobs:
           check-latest: true
 
       - name: Boostrap
-        run: npx vlt install --view=json
+        run: npx vlt install --view=json --allow-scripts="#tailwindcss"
 
       - name: Build vlt
         run: node --run build:bundle
@@ -126,7 +126,7 @@ jobs:
         run: echo "$GITHUB_WORKSPACE/scripts/bins/bundle" >> $GITHUB_PATH
       
       - name: Install Dependencies
-        run: vlt install --view=json
+        run: vlt install --view=json --allow-scripts="#tailwindcss"
 
       - name: Run Typecheck
         continue-on-error: true


### PR DESCRIPTION
In the `vlt` lint and test CI targets we use the `vlt` cli to install our own dependencies. This needs to now include the new `--allow-scripts` option to allow for `tailwindcss` to run its build step in order to generate its `tailwind` binary.