### PR TITLE
graph: add edge names to internal hoist

### DIFF
--- a/src/graph/src/reify/internal-hoist.ts
+++ b/src/graph/src/reify/internal-hoist.ts
@@ -98,14 +98,18 @@ export const internalHoist = async (
   for (const [name, nodes] of graph.nodesByName) {
     const pickNode = pickNodeToHoist(nodes)
     if (pickNode) {
-      links.set(name, pickNode)
+      let picked = false
       if (pickNode.edgesIn.size > 0) {
         for (const edgeIn of pickNode.edgesIn) {
           const otherName = edgeIn.name
           if (otherName !== name && !links.has(otherName)) {
+            picked = true
             links.set(otherName, pickNode)
           }
         }
+      }
+      if (!picked) {
+        links.set(name, pickNode)
       }
     }
   }

--- a/src/graph/test/reify/internal-hoist.ts
+++ b/src/graph/test/reify/internal-hoist.ts
@@ -564,8 +564,7 @@ t.test('hoisting with aliased dependencies', async t => {
   const hoistDir = readdirSync(
     resolve(projectRoot, 'node_modules/.vlt/node_modules'),
   )
-  t.ok(hoistDir.includes('bar'), 'canonical name hoisted')
+  t.notOk(hoistDir.includes('bar'), 'canonical name NOT hoisted')
   t.ok(hoistDir.includes('foo'), 'alias foo hoisted')
   t.ok(hoistDir.includes('baz'), 'alias baz hoisted')
-  t.equal(hoistDir.length, 3, 'all three names hoisted')
 })


### PR DESCRIPTION
We have observed specific dependencies relying on using aliased names from the internal hoist, this changeset replaces usage of the node name with the edge names for the internal hoist symlink.

This logic change matchs the `pnpm` implementation that enables `nitro-nightly@3.0.0-20251010-091540-0e3dbc69` to work in our current install graph.