### PR TITLE
ci: drop some ci platforms

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -186,20 +186,12 @@ jobs:
           - name: macOS
             os: macos-latest
             shell: bash
-          - name: macOS Intel
-            os: macos-13
-            shell: bash
           - name: Windows
             os: windows-latest
             shell: bash
-          - name: Windows Powershell
-            os: windows-latest
-            shell: powershell
         exclude:
           - node-version: '24.x'
           - platform: ${{ fromJSON(needs.pre-check.outputs.full-matrix == 'false' && '{"name":"macOS","os":"macos-latest","shell":"bash"}') }}
-          - platform: ${{ fromJSON(needs.pre-check.outputs.full-matrix == 'false' && '{"name":"macOS Intel","os":"macos-13","shell":"bash"}') }}
-          - platform: ${{ fromJSON(needs.pre-check.outputs.full-matrix == 'false' && '{"name":"Windows Powershell","os":"windows-latest","shell":"powershell"}') }}
       fail-fast: false
 
     steps:

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -73,20 +73,12 @@ jobs:
           - name: macOS
             os: macos-latest
             shell: bash
-          - name: macOS Intel
-            os: macos-13
-            shell: bash
           - name: Windows
             os: windows-latest
             shell: bash
-          - name: Windows Powershell
-            os: windows-latest
-            shell: powershell
         exclude:
           - node-version: '24.x'
           - platform: ${{ fromJSON(needs.pre-check.outputs.full-matrix == 'false' && '{"name":"macOS","os":"macos-latest","shell":"bash"}') }}
-          - platform: ${{ fromJSON(needs.pre-check.outputs.full-matrix == 'false' && '{"name":"macOS Intel","os":"macos-13","shell":"bash"}') }}
-          - platform: ${{ fromJSON(needs.pre-check.outputs.full-matrix == 'false' && '{"name":"Windows Powershell","os":"windows-latest","shell":"powershell"}') }}
       fail-fast: false
 
     steps:


### PR DESCRIPTION
Windows Powershell is currently failing due to a dev dev prepare script in the GUI.
And macOS Intel support is just extra work.
