### PR TITLE
graph: fix missing manifests on hidden lockfile

### DIFF
--- a/src/graph/src/actual/load.ts
+++ b/src/graph/src/actual/load.ts
@@ -9,6 +9,7 @@ import {
 } from '../dependencies.ts'
 import { Graph } from '../graph.ts'
 import { loadHidden } from '../lockfile/load.ts'
+import { saveHidden } from '../lockfile/save.ts'
 import type { DepID } from '@vltpkg/dep-id'
 import type { PackageJson } from '@vltpkg/package-json'
 import type { SpecOptions } from '@vltpkg/spec'
@@ -512,6 +513,12 @@ export const load = (options: LoadOptions): Graph => {
 
     // Clean up any pending modifier entries that were never completed
     modifiers?.rollbackActiveEntries()
+
+    // caches the load result to the hidden lockfile when enabled
+    saveHidden({
+      ...options,
+      graph,
+    })
   }
 
   done()

--- a/src/graph/src/lockfile/load-nodes.ts
+++ b/src/graph/src/lockfile/load-nodes.ts
@@ -1,3 +1,4 @@
+import { error } from '@vltpkg/error-cause'
 import { splitDepID } from '@vltpkg/dep-id/browser'
 import {
   getBooleanFlagsFromNum,
@@ -13,6 +14,7 @@ export const loadNodes = (
   nodes: LockfileData['nodes'],
   options: SpecOptions,
   actual?: GraphLike,
+  throwOnMissingManifest?: boolean,
 ) => {
   const entries = Object.entries(nodes) as [DepID, LockfileNode][]
   const nodeCount = entries.length
@@ -50,6 +52,13 @@ export const loadNodes = (
     // that may be missing from the lockfile
     const referenceNode = actual?.nodes.get(id)
     const mani = manifest ?? referenceNode?.manifest
+
+    // Throw if manifest is missing and the option is enabled
+    if (!mani && throwOnMissingManifest) {
+      throw error(
+        `Missing manifest for node ${id} and no reference node found.`,
+      )
+    }
 
     // Optimize registry version extraction with caching for large graphs
     let version: string | undefined

--- a/src/graph/src/lockfile/load.ts
+++ b/src/graph/src/lockfile/load.ts
@@ -44,6 +44,10 @@ export type LoadOptions = SpecOptions & {
    * Load only importers into the graph if the modifiers have changed.
    */
   skipLoadingNodesOnModifiersChange?: boolean
+  /**
+   * Whether to throw an error if a manifest is missing when loading nodes.
+   */
+  throwOnMissingManifest?: boolean
 }
 
 const loadLockfile = (projectRoot: string, lockfilePath: string) =>
@@ -63,6 +67,8 @@ export const load = (options: LoadOptions): Graph => {
 
 export const loadHidden = (options: LoadOptions): Graph => {
   const { projectRoot } = options
+  // Ensure that missing manifests throw an error when loading hidden lockfiles
+  options.throwOnMissingManifest = true
   return loadObject(
     options,
     loadLockfile(projectRoot, 'node_modules/.vlt-lock.json'),
@@ -158,6 +164,7 @@ export const loadObject = (
       lockfileData.nodes,
       mergedOptions,
       options.actual,
+      options.throwOnMissingManifest,
     )
     loadEdges(graph, lockfileData.edges, mergedOptions)
   }

--- a/src/graph/test/install.ts
+++ b/src/graph/test/install.ts
@@ -100,10 +100,12 @@ t.test('install', async t => {
 })
 
 t.test('install with no package.json file in cwd', async t => {
-  const dir = t.testdir({})
+  const dir = t.testdir({
+    'vlt.json': JSON.stringify({}, null, 2),
+  })
   const options = {
     projectRoot: dir,
-    scurry: new PathScurry(),
+    scurry: new PathScurry(dir),
     packageJson: new PackageJson(),
     packageInfo: mockPackageInfo,
     allowScripts: ':not(*)',
@@ -143,10 +145,12 @@ t.test('install with no package.json file in cwd', async t => {
 })
 
 t.test('unknown error reading package.json', async t => {
-  const dir = t.testdir({})
+  const dir = t.testdir({
+    'vlt.json': JSON.stringify({}, null, 2),
+  })
   const options = {
     projectRoot: dir,
-    scurry: new PathScurry(),
+    scurry: new PathScurry(dir),
     packageJson: {
       read() {
         throw new Error('ERR')
@@ -198,7 +202,7 @@ t.test(
 
     const options = {
       projectRoot: dir,
-      scurry: new PathScurry(),
+      scurry: new PathScurry(dir),
       packageJson: new PackageJson(),
       packageInfo: mockPackageInfo,
       expectLockfile: true,
@@ -262,7 +266,7 @@ t.test('install with cleanInstall option (ci command)', async t => {
 
   const options = {
     projectRoot: dir,
-    scurry: new PathScurry(),
+    scurry: new PathScurry(dir),
     packageJson: new PackageJson(),
     packageInfo: mockPackageInfo,
     expectLockfile: true,
@@ -317,7 +321,7 @@ t.test(
 
     const options = {
       projectRoot: dir,
-      scurry: new PathScurry(),
+      scurry: new PathScurry(dir),
       packageJson: new PackageJson(),
       packageInfo: mockPackageInfo,
       expectLockfile: true,
@@ -369,7 +373,7 @@ t.test(
 
     const options = {
       projectRoot: dir,
-      scurry: new PathScurry(),
+      scurry: new PathScurry(dir),
       packageJson: new PackageJson(),
       packageInfo: mockPackageInfo,
       frozenLockfile: true,
@@ -425,7 +429,7 @@ t.test(
 
     const options = {
       projectRoot: dir,
-      scurry: new PathScurry(),
+      scurry: new PathScurry(dir),
       packageJson: new PackageJson(),
       packageInfo: mockPackageInfo,
       frozenLockfile: true,
@@ -469,7 +473,7 @@ t.test(
 
     const options = {
       projectRoot: dir,
-      scurry: new PathScurry(),
+      scurry: new PathScurry(dir),
       packageJson: new PackageJson(),
       packageInfo: mockPackageInfo,
       frozenLockfile: true,
@@ -545,7 +549,7 @@ t.test(
 
     const options = {
       projectRoot: dir,
-      scurry: new PathScurry(),
+      scurry: new PathScurry(dir),
       packageJson: new PackageJson(),
       packageInfo: mockPackageInfo,
       frozenLockfile: true,
@@ -616,7 +620,7 @@ t.test('install with frozenLockfile and spec changes', async t => {
 
   const options = {
     projectRoot: dir,
-    scurry: new PathScurry(),
+    scurry: new PathScurry(dir),
     packageJson: new PackageJson(),
     packageInfo: mockPackageInfo,
     frozenLockfile: true,
@@ -718,7 +722,7 @@ t.test(
 
     const options = {
       projectRoot: dir,
-      scurry: new PathScurry(),
+      scurry: new PathScurry(dir),
       packageJson: new PackageJson(),
       packageInfo: mockPackageInfo,
       frozenLockfile: true,
@@ -770,7 +774,7 @@ t.test(
 
     const options = {
       projectRoot: dir,
-      scurry: new PathScurry(),
+      scurry: new PathScurry(dir),
       packageJson: new PackageJson(),
       packageInfo: mockPackageInfo,
       expectLockfile: true,
@@ -854,7 +858,7 @@ t.test(
 
     const options = {
       projectRoot: dir,
-      scurry: new PathScurry(),
+      scurry: new PathScurry(dir),
       packageJson: new PackageJson(),
       packageInfo: mockPackageInfo,
       frozenLockfile: true,
@@ -922,11 +926,12 @@ t.test(
         nodes: {},
         edges: {},
       }),
+      'vlt.json': JSON.stringify({}, null, 2),
     })
 
     const options = {
       projectRoot: dir,
-      scurry: new PathScurry(),
+      scurry: new PathScurry(dir),
       packageJson: {
         read: () => {
           throw Object.assign(
@@ -1010,11 +1015,12 @@ t.test(
         nodes: {},
         edges: {},
       }),
+      'vlt.json': JSON.stringify({}, null, 2),
     })
 
     const options = {
       projectRoot: dir,
-      scurry: new PathScurry(),
+      scurry: new PathScurry(dir),
       packageJson: {
         read: () => {
           throw new Error('Permission denied')
@@ -1067,7 +1073,7 @@ t.test(
 
     const options = {
       projectRoot: dir,
-      scurry: new PathScurry(),
+      scurry: new PathScurry(dir),
       packageJson: new PackageJson(),
       packageInfo: mockPackageInfo,
       frozenLockfile: true,
@@ -1149,7 +1155,7 @@ t.test('install with expectLockfile but no node_modules', async t => {
 
   const options = {
     projectRoot: dir,
-    scurry: new PathScurry(),
+    scurry: new PathScurry(dir),
     packageJson: new PackageJson(),
     packageInfo: mockPackageInfo,
     expectLockfile: true,
@@ -1216,7 +1222,7 @@ t.test(
 
     const options = {
       projectRoot: dir,
-      scurry: new PathScurry(),
+      scurry: new PathScurry(dir),
       packageJson: new PackageJson(),
       packageInfo: mockPackageInfo,
       expectLockfile: true,
@@ -1289,7 +1295,7 @@ t.test('install with lockfileOnly option', async t => {
 
   const options = {
     projectRoot: dir,
-    scurry: new PathScurry(),
+    scurry: new PathScurry(dir),
     packageJson: new PackageJson(),
     packageInfo: mockPackageInfo,
     lockfileOnly: true,
@@ -1357,7 +1363,7 @@ t.test('lockfileOnly incompatible with cleanInstall', async t => {
 
   const options = {
     projectRoot: dir,
-    scurry: new PathScurry(),
+    scurry: new PathScurry(dir),
     packageJson: new PackageJson(),
     packageInfo: mockPackageInfo,
     lockfileOnly: true,
@@ -1387,7 +1393,7 @@ t.test(
 
     const options = {
       projectRoot: dir,
-      scurry: new PathScurry(),
+      scurry: new PathScurry(dir),
       packageJson: new PackageJson(),
       packageInfo: mockPackageInfo,
       lockfileOnly: true,

--- a/src/graph/test/lockfile/load-nodes.ts
+++ b/src/graph/test/lockfile/load-nodes.ts
@@ -813,3 +813,48 @@ t.test('load nodes with platform and bin', async t => {
     'should load nodes with platform and bin data',
   )
 })
+
+t.test('throwOnMissingManifest option', async t => {
+  const graph = new Graph({
+    mainManifest: {
+      name: 'my-project',
+      version: '1.0.0',
+    },
+    projectRoot: t.testdirName,
+  })
+
+  // Node with no manifest
+  const nodes = {
+    [joinDepIDTuple(['registry', '', 'no-manifest@1.0.0'])]: [
+      0,
+      'no-manifest',
+      'sha512-nomanifest==',
+      null,
+      null,
+      null, // manifest is null
+    ],
+  } as LockfileData['nodes']
+
+  // Should throw when throwOnMissingManifest is true
+  try {
+    loadNodes(graph, nodes, {}, undefined, true)
+    t.fail('should have thrown')
+  } catch (err: any) {
+    t.match(
+      err.message,
+      /Missing manifest for node.*no-manifest@1\.0\.0 and no reference node found/,
+      'should throw with correct error message',
+    )
+    t.same(
+      err,
+      /Missing manifest for node/,
+      'should have missing manifest error msg',
+    )
+  }
+
+  // Should not throw when throwOnMissingManifest is false/undefined
+  t.doesNotThrow(
+    () => loadNodes(graph, nodes, {}),
+    'should not throw when throwOnMissingManifest is not set',
+  )
+})

--- a/src/graph/test/lockfile/load.ts
+++ b/src/graph/test/lockfile/load.ts
@@ -143,18 +143,54 @@ t.test('loadHidden', async t => {
       },
     },
     nodes: {
-      [joinDepIDTuple(['file', '.'])]: [0, 'my-project'],
-      [joinDepIDTuple(['file', 'linked'])]: [0, 'linked'],
+      [joinDepIDTuple(['file', '.'])]: [
+        0,
+        'my-project',
+        // integrity
+        null,
+        // resolved
+        null,
+        // location
+        null,
+        // manifest
+        {
+          name: 'my-project',
+          version: '1.0.0',
+          // placeholder: add additional fields as needed for test
+        },
+      ],
+      [joinDepIDTuple(['file', 'linked'])]: [
+        0,
+        'linked',
+        null,
+        null,
+        null,
+        {
+          name: 'linked',
+          version: '1.0.0',
+        },
+      ],
       [joinDepIDTuple(['registry', '', 'foo@1.0.0'])]: [
         0,
         'foo',
         'sha512-6/mh1E2u2YgEsCHdY0Yx5oW+61gZU+1vXaoiHHrpKeuRNNgFvS+/jrwHiQhB5apAf5oB7UB7E19ol2R2LKH8hQ==',
+        null,
+        null,
+        {
+          name: 'foo',
+          version: '1.0.0',
+        },
       ],
       [joinDepIDTuple(['registry', '', 'bar@1.0.0'])]: [
         0,
         'bar',
         'sha512-6/deadbeef==',
         'https://registry.example.com/bar/-/bar-1.0.0.tgz',
+        null,
+        {
+          name: 'bar',
+          version: '1.0.0',
+        },
       ],
       [joinDepIDTuple(['registry', '', 'baz@1.0.0'])]: [
         0,
@@ -162,6 +198,10 @@ t.test('loadHidden', async t => {
         null,
         null,
         './node_modules/.pnpm/baz@1.0.0/node_modules/baz',
+        {
+          name: 'baz',
+          version: '1.0.0',
+        },
       ],
     } as Record<DepID, LockfileNode>,
     edges,


### PR DESCRIPTION
When loading a hidden lockfile, skips the process completely if a node is currently missing its manifest, in this case it should load data recursively from the node_modules itself.

Fixes: https://github.com/vltpkg/vltpkg/issues/1100