### PR TITLE
chore: update snapshots to node-22.21.0

### DIFF
--- a/src/cli-sdk/tap-snapshots/test/parse-add-remove-args.ts.test.cjs
+++ b/src/cli-sdk/tap-snapshots/test/parse-add-remove-args.ts.test.cjs
@@ -7,7 +7,7 @@
 'use strict'
 exports[`test/parse-add-remove-args.ts > TAP > parseAddArgs > define as prod if explicitly defined > should return dependency as type=prod 1`] = `
 {
-  add: AddImportersDependenciesMapImpl(1) [Map] {
+  add: AddImportersDependenciesMapImpl(1) {
     'file·.' => Map(1) { 'foo' => { spec: Spec {foo@latest}, type: 'prod' } },
     modifiedDependencies: true
   }
@@ -16,7 +16,7 @@ exports[`test/parse-add-remove-args.ts > TAP > parseAddArgs > define as prod if 
 
 exports[`test/parse-add-remove-args.ts > TAP > parseAddArgs > define dev type dep > should return dependency as type=dev 1`] = `
 {
-  add: AddImportersDependenciesMapImpl(1) [Map] {
+  add: AddImportersDependenciesMapImpl(1) {
     'file·.' => Map(1) { 'foo' => { spec: Spec {foo@latest}, type: 'dev' } },
     modifiedDependencies: true
   }
@@ -25,7 +25,7 @@ exports[`test/parse-add-remove-args.ts > TAP > parseAddArgs > define dev type de
 
 exports[`test/parse-add-remove-args.ts > TAP > parseAddArgs > define optional peer dep > should return dependency as type=peerOptional 1`] = `
 {
-  add: AddImportersDependenciesMapImpl(1) [Map] {
+  add: AddImportersDependenciesMapImpl(1) {
     'file·.' => Map(1) {
       'foo' => { spec: Spec {foo@latest}, type: 'peerOptional' }
     },
@@ -36,7 +36,7 @@ exports[`test/parse-add-remove-args.ts > TAP > parseAddArgs > define optional pe
 
 exports[`test/parse-add-remove-args.ts > TAP > parseAddArgs > define optional type dep > should return dependency as type=optional 1`] = `
 {
-  add: AddImportersDependenciesMapImpl(1) [Map] {
+  add: AddImportersDependenciesMapImpl(1) {
     'file·.' => Map(1) { 'foo' => { spec: Spec {foo@latest}, type: 'optional' } },
     modifiedDependencies: true
   }
@@ -45,7 +45,7 @@ exports[`test/parse-add-remove-args.ts > TAP > parseAddArgs > define optional ty
 
 exports[`test/parse-add-remove-args.ts > TAP > parseAddArgs > define peer dep > should return dependency as type=peer 1`] = `
 {
-  add: AddImportersDependenciesMapImpl(1) [Map] {
+  add: AddImportersDependenciesMapImpl(1) {
     'file·.' => Map(1) { 'foo' => { spec: Spec {foo@latest}, type: 'peer' } },
     modifiedDependencies: true
   }
@@ -54,7 +54,7 @@ exports[`test/parse-add-remove-args.ts > TAP > parseAddArgs > define peer dep > 
 
 exports[`test/parse-add-remove-args.ts > TAP > parseAddArgs > multiple items > should return multiple dependency items 1`] = `
 {
-  add: AddImportersDependenciesMapImpl(1) [Map] {
+  add: AddImportersDependenciesMapImpl(1) {
     'file·.' => Map(5) {
       'foo' => { spec: Spec {foo@^1}, type: 'implicit' },
       'bar' => { spec: Spec {bar@latest}, type: 'implicit' },
@@ -69,7 +69,7 @@ exports[`test/parse-add-remove-args.ts > TAP > parseAddArgs > multiple items > s
 
 exports[`test/parse-add-remove-args.ts > TAP > parseAddArgs > no item > should return no dependency items 1`] = `
 {
-  add: AddImportersDependenciesMapImpl(1) [Map] {
+  add: AddImportersDependenciesMapImpl(1) {
     'file·.' => Map(0) {},
     modifiedDependencies: false
   }
@@ -78,7 +78,7 @@ exports[`test/parse-add-remove-args.ts > TAP > parseAddArgs > no item > should r
 
 exports[`test/parse-add-remove-args.ts > TAP > parseAddArgs > single item > should return a single dependency item 1`] = `
 {
-  add: AddImportersDependenciesMapImpl(1) [Map] {
+  add: AddImportersDependenciesMapImpl(1) {
     'file·.' => Map(1) { 'foo' => { spec: Spec {foo@}, type: 'implicit' } },
     modifiedDependencies: true
   }
@@ -87,7 +87,7 @@ exports[`test/parse-add-remove-args.ts > TAP > parseAddArgs > single item > shou
 
 exports[`test/parse-add-remove-args.ts > TAP > parseAddArgs > workspaces > define multiple deps of a single workspace > should return multiple deps of a workspace 1`] = `
 {
-  add: AddImportersDependenciesMapImpl(1) [Map] {
+  add: AddImportersDependenciesMapImpl(1) {
     'workspace·utils§c' => Map(5) {
       'foo' => { spec: Spec {foo@^1}, type: 'implicit' },
       'bar' => { spec: Spec {bar@latest}, type: 'implicit' },
@@ -102,7 +102,7 @@ exports[`test/parse-add-remove-args.ts > TAP > parseAddArgs > workspaces > defin
 
 exports[`test/parse-add-remove-args.ts > TAP > parseAddArgs > workspaces > define multiple deps to multiple groups of workspaces > should return multiple deps to many groups of workspaces 1`] = `
 {
-  add: AddImportersDependenciesMapImpl(3) [Map] {
+  add: AddImportersDependenciesMapImpl(3) {
     'workspace·utils§c' => Map(5) {
       'foo' => { spec: Spec {foo@^1}, type: 'implicit' },
       'bar' => { spec: Spec {bar@latest}, type: 'implicit' },
@@ -131,7 +131,7 @@ exports[`test/parse-add-remove-args.ts > TAP > parseAddArgs > workspaces > defin
 
 exports[`test/parse-add-remove-args.ts > TAP > parseAddArgs > workspaces > define multiple deps to multiple workspaces > should return multiple deps to multiple workspaces 1`] = `
 {
-  add: AddImportersDependenciesMapImpl(3) [Map] {
+  add: AddImportersDependenciesMapImpl(3) {
     'workspace·app§b' => Map(5) {
       'foo' => { spec: Spec {foo@^1}, type: 'implicit' },
       'bar' => { spec: Spec {bar@latest}, type: 'implicit' },
@@ -160,7 +160,7 @@ exports[`test/parse-add-remove-args.ts > TAP > parseAddArgs > workspaces > defin
 
 exports[`test/parse-add-remove-args.ts > TAP > parseAddArgs > workspaces > define root dep if no workspace config defined > should return dependency of root 1`] = `
 {
-  add: AddImportersDependenciesMapImpl(1) [Map] {
+  add: AddImportersDependenciesMapImpl(1) {
     'file·.' => Map(1) { 'foo' => { spec: Spec {foo@}, type: 'implicit' } },
     modifiedDependencies: true
   }
@@ -169,7 +169,7 @@ exports[`test/parse-add-remove-args.ts > TAP > parseAddArgs > workspaces > defin
 
 exports[`test/parse-add-remove-args.ts > TAP > parseAddArgs > workspaces > define single dep of a single workspace > should return dependency of a workspace 1`] = `
 {
-  add: AddImportersDependenciesMapImpl(1) [Map] {
+  add: AddImportersDependenciesMapImpl(1) {
     'workspace·app§a' => Map(1) { 'foo' => { spec: Spec {foo@}, type: 'implicit' } },
     modifiedDependencies: true
   }
@@ -178,7 +178,7 @@ exports[`test/parse-add-remove-args.ts > TAP > parseAddArgs > workspaces > defin
 
 exports[`test/parse-add-remove-args.ts > TAP > parseAddArgs > workspaces > define single dep to a group of workspaces > should return dependency to a group of workspaces 1`] = `
 {
-  add: AddImportersDependenciesMapImpl(2) [Map] {
+  add: AddImportersDependenciesMapImpl(2) {
     'workspace·foo' => Map(1) { 'foo' => { spec: Spec {foo@}, type: 'implicit' } },
     'workspace·bar' => Map(1) { 'foo' => { spec: Spec {foo@}, type: 'implicit' } },
     modifiedDependencies: true
@@ -188,7 +188,7 @@ exports[`test/parse-add-remove-args.ts > TAP > parseAddArgs > workspaces > defin
 
 exports[`test/parse-add-remove-args.ts > TAP > parseAddArgs > workspaces > define single dep to multiple groups of workspaces > should return dependency to many groups of workspaces 1`] = `
 {
-  add: AddImportersDependenciesMapImpl(3) [Map] {
+  add: AddImportersDependenciesMapImpl(3) {
     'workspace·utils§c' => Map(1) { 'foo' => { spec: Spec {foo@}, type: 'implicit' } },
     'workspace·foo' => Map(1) { 'foo' => { spec: Spec {foo@}, type: 'implicit' } },
     'workspace·bar' => Map(1) { 'foo' => { spec: Spec {foo@}, type: 'implicit' } },
@@ -199,7 +199,7 @@ exports[`test/parse-add-remove-args.ts > TAP > parseAddArgs > workspaces > defin
 
 exports[`test/parse-add-remove-args.ts > TAP > parseRemoveArgs > multiple items > should return multiple dependency item 1`] = `
 {
-  remove: RemoveImportersDependenciesMapImpl(1) [Map] {
+  remove: RemoveImportersDependenciesMapImpl(1) {
     'file·.' => Set(3) { 'foo@^1', 'bar@latest', 'baz@1.0.0' },
     modifiedDependencies: true
   }
@@ -208,7 +208,7 @@ exports[`test/parse-add-remove-args.ts > TAP > parseRemoveArgs > multiple items 
 
 exports[`test/parse-add-remove-args.ts > TAP > parseRemoveArgs > no items > should return no items 1`] = `
 {
-  remove: RemoveImportersDependenciesMapImpl(1) [Map] {
+  remove: RemoveImportersDependenciesMapImpl(1) {
     'file·.' => Set(0) {},
     modifiedDependencies: true
   }
@@ -217,7 +217,7 @@ exports[`test/parse-add-remove-args.ts > TAP > parseRemoveArgs > no items > shou
 
 exports[`test/parse-add-remove-args.ts > TAP > parseRemoveArgs > single item > should return a single dependency item 1`] = `
 {
-  remove: RemoveImportersDependenciesMapImpl(1) [Map] {
+  remove: RemoveImportersDependenciesMapImpl(1) {
     'file·.' => Set(1) { 'foo' },
     modifiedDependencies: true
   }
@@ -226,7 +226,7 @@ exports[`test/parse-add-remove-args.ts > TAP > parseRemoveArgs > single item > s
 
 exports[`test/parse-add-remove-args.ts > TAP > parseRemoveArgs > workspaces > multiple deps from a workspace group > should remove multiple dep from a single workspace group 1`] = `
 {
-  remove: RemoveImportersDependenciesMapImpl(2) [Map] {
+  remove: RemoveImportersDependenciesMapImpl(2) {
     'workspace·app§b' => Set(2) { 'foo', 'bar' },
     'workspace·app§a' => Set(2) { 'foo', 'bar' },
     modifiedDependencies: true
@@ -236,7 +236,7 @@ exports[`test/parse-add-remove-args.ts > TAP > parseRemoveArgs > workspaces > mu
 
 exports[`test/parse-add-remove-args.ts > TAP > parseRemoveArgs > workspaces > multiple deps from multiple workspace groups > should remove multiple dep from multiple workspace groups 1`] = `
 {
-  remove: RemoveImportersDependenciesMapImpl(3) [Map] {
+  remove: RemoveImportersDependenciesMapImpl(3) {
     'workspace·utils§c' => Set(2) { 'foo', 'bar' },
     'workspace·foo' => Set(2) { 'foo', 'bar' },
     'workspace·bar' => Set(2) { 'foo', 'bar' },
@@ -247,7 +247,7 @@ exports[`test/parse-add-remove-args.ts > TAP > parseRemoveArgs > workspaces > mu
 
 exports[`test/parse-add-remove-args.ts > TAP > parseRemoveArgs > workspaces > multiple deps of a single workspace > should remove multiple deps of workspace 1`] = `
 {
-  remove: RemoveImportersDependenciesMapImpl(1) [Map] {
+  remove: RemoveImportersDependenciesMapImpl(1) {
     'workspace·utils§c' => Set(2) { 'foo', 'bar' },
     modifiedDependencies: true
   }
@@ -256,7 +256,7 @@ exports[`test/parse-add-remove-args.ts > TAP > parseRemoveArgs > workspaces > mu
 
 exports[`test/parse-add-remove-args.ts > TAP > parseRemoveArgs > workspaces > remove dep from root if no workspace defined > should remove dep from root 1`] = `
 {
-  remove: RemoveImportersDependenciesMapImpl(1) [Map] {
+  remove: RemoveImportersDependenciesMapImpl(1) {
     'file·.' => Set(1) { 'foo' },
     modifiedDependencies: true
   }
@@ -265,7 +265,7 @@ exports[`test/parse-add-remove-args.ts > TAP > parseRemoveArgs > workspaces > re
 
 exports[`test/parse-add-remove-args.ts > TAP > parseRemoveArgs > workspaces > single dep from a workspace group > should remove single dep from a single workspace group 1`] = `
 {
-  remove: RemoveImportersDependenciesMapImpl(2) [Map] {
+  remove: RemoveImportersDependenciesMapImpl(2) {
     'workspace·app§b' => Set(1) { 'foo' },
     'workspace·app§a' => Set(1) { 'foo' },
     modifiedDependencies: true
@@ -275,7 +275,7 @@ exports[`test/parse-add-remove-args.ts > TAP > parseRemoveArgs > workspaces > si
 
 exports[`test/parse-add-remove-args.ts > TAP > parseRemoveArgs > workspaces > single dep of a single workspace > should remove single dep of workspace 1`] = `
 {
-  remove: RemoveImportersDependenciesMapImpl(1) [Map] {
+  remove: RemoveImportersDependenciesMapImpl(1) {
     'workspace·app§a' => Set(1) { 'foo' },
     modifiedDependencies: true
   }

--- a/src/graph/tap-snapshots/test/ideal/get-importer-specs.ts.test.cjs
+++ b/src/graph/tap-snapshots/test/ideal/get-importer-specs.ts.test.cjs
@@ -6,7 +6,7 @@
  */
 'use strict'
 exports[`test/ideal/get-importer-specs.ts > TAP > empty graph and something to add > should result in only added specs 1`] = `
-AddImportersDependenciesMapImpl(1) [Map] {
+AddImportersDependenciesMapImpl(1) {
   'file·.' => Map(2) {
     'bar' => { spec: Spec {bar@custom:bar@^1.1.1}, type: 'dev' },
     'foo' => { spec: Spec {foo@^1.1.1}, type: 'prod' }
@@ -20,7 +20,7 @@ AddImportersDependenciesMapImpl {}
 `
 
 exports[`test/ideal/get-importer-specs.ts > TAP > graph specs and new things to add > should have root specs along with the added ones 1`] = `
-AddImportersDependenciesMapImpl(1) [Map] {
+AddImportersDependenciesMapImpl(1) {
   'file·.' => Map(3) {
     'foo' => { spec: Spec {foo@^1.0.0}, type: 'prod' },
     'bar' => { spec: Spec {bar@^1.0.0}, type: 'dev' },
@@ -31,7 +31,7 @@ AddImportersDependenciesMapImpl(1) [Map] {
 `
 
 exports[`test/ideal/get-importer-specs.ts > TAP > graph specs and nothing to add > should have root specs added only 1`] = `
-AddImportersDependenciesMapImpl(1) [Map] {
+AddImportersDependenciesMapImpl(1) {
   'file·.' => Map(2) {
     'foo' => { spec: Spec {foo@^1.0.0}, type: 'prod' },
     'bar' => { spec: Spec {bar@^1.0.0}, type: 'dev' }
@@ -42,10 +42,8 @@ AddImportersDependenciesMapImpl(1) [Map] {
 
 exports[`test/ideal/get-importer-specs.ts > TAP > graph specs and something to remove > should removed entries missing from manifest file 1`] = `
 {
-  add: AddImportersDependenciesMapImpl(0) [Map] {
-    modifiedDependencies: false
-  },
-  remove: RemoveImportersDependenciesMapImpl(1) [Map] {
+  add: AddImportersDependenciesMapImpl(0) { modifiedDependencies: false },
+  remove: RemoveImportersDependenciesMapImpl(1) {
     'file·.' => Set(1) { 'foo' },
     modifiedDependencies: true
   }
@@ -53,14 +51,14 @@ exports[`test/ideal/get-importer-specs.ts > TAP > graph specs and something to r
 `
 
 exports[`test/ideal/get-importer-specs.ts > TAP > graph specs and something to update > should have the updated root spec 1`] = `
-AddImportersDependenciesMapImpl(1) [Map] {
+AddImportersDependenciesMapImpl(1) {
   'file·.' => Map(1) { 'foo' => { spec: Spec {foo@^2.0.0}, type: 'prod' } },
   modifiedDependencies: true
 }
 `
 
 exports[`test/ideal/get-importer-specs.ts > TAP > graph specs with workspaces and something to add > should have root and workspaces nodes with specs to add 1`] = `
-AddImportersDependenciesMapImpl(3) [Map] {
+AddImportersDependenciesMapImpl(3) {
   'file·.' => Map(2) {
     'foo' => { spec: Spec {foo@^1.0.0}, type: 'prod' },
     'bar' => { spec: Spec {bar@^2.0.0}, type: 'prod' }
@@ -79,10 +77,8 @@ AddImportersDependenciesMapImpl(3) [Map] {
 
 exports[`test/ideal/get-importer-specs.ts > TAP > graph specs with workspaces and somethings to remove > should have root and workspaces nodes with specs to remove 1`] = `
 {
-  add: AddImportersDependenciesMapImpl(0) [Map] {
-    modifiedDependencies: false
-  },
-  remove: RemoveImportersDependenciesMapImpl(2) [Map] {
+  add: AddImportersDependenciesMapImpl(0) { modifiedDependencies: false },
+  remove: RemoveImportersDependenciesMapImpl(2) {
     'workspace·packages§a' => Set(1) { 'bar' },
     'workspace·packages§b' => Set(1) { 'a' },
     modifiedDependencies: true
@@ -92,12 +88,10 @@ exports[`test/ideal/get-importer-specs.ts > TAP > graph specs with workspaces an
 
 exports[`test/ideal/get-importer-specs.ts > TAP > installing over a dangling edge > should add the missing dep 1`] = `
 {
-  add: AddImportersDependenciesMapImpl(1) [Map] {
+  add: AddImportersDependenciesMapImpl(1) {
     'file·.' => Map(1) { 'foo' => { spec: Spec {foo@^1.0.0}, type: 'prod' } },
     modifiedDependencies: true
   },
-  remove: RemoveImportersDependenciesMapImpl(0) [Map] {
-    modifiedDependencies: false
-  }
+  remove: RemoveImportersDependenciesMapImpl(0) { modifiedDependencies: false }
 }
 `


### PR DESCRIPTION
Some snapshots are no longer matching after updating to node 22.21.0