### PR TITLE
semver: avoid usage of instanceof

### DIFF
--- a/src/semver/src/index.ts
+++ b/src/semver/src/index.ts
@@ -10,7 +10,7 @@ export * from './version.ts'
 
 /** Return the parsed version string, or `undefined` if invalid */
 export const parse = (version: Version | string) => {
-  if (version instanceof Version) return version
+  if (!(typeof version === 'string')) return version
   try {
     return Version.parse(version)
   } catch {


### PR DESCRIPTION
Tests were breaking in a completely unrelated usage of the `parse()` method, changing to a more reliable check.