### PR TITLE
query: fix remove edges helper

### DIFF
--- a/src/query/src/pseudo/helpers.ts
+++ b/src/query/src/pseudo/helpers.ts
@@ -17,7 +17,7 @@ export const removeNode = (state: ParserState, node: NodeLike) => {
  */
 export const removeEdge = (state: ParserState, edge: EdgeLike) => {
   state.partial.edges.delete(edge)
-  if (edge.to) {
+  if (edge.to && edge.to.edgesIn.size === 1) {
     state.partial.nodes.delete(edge.to)
   }
 }
@@ -37,10 +37,13 @@ export const removeDanglingEdges = (state: ParserState) => {
  * Removes any nodes that have no incoming edges from the results.
  */
 export const removeUnlinkedNodes = (state: ParserState) => {
-  for (const node of state.partial.nodes) {
-    if (node.edgesIn.size === 0) {
-      state.partial.nodes.delete(node)
+  nodeLoop: for (const node of state.partial.nodes) {
+    for (const edge of state.partial.edges) {
+      if (edge.to === node) {
+        continue nodeLoop
+      }
     }
+    state.partial.nodes.delete(node)
   }
 }
 


### PR DESCRIPTION
Some selectors like `:peer` were omitting results due to the `removeEdge` helper function greedly removing the node from an edge, despite the fact that node could be fulfilling other edges.

This changeset fixes it by properly limitting the ability of `removeEdge` to only remove a node in case that specific edge is the only edge that links into that node and comparing all edges for usage in the `removeUnlinkedNodes` helper function.