### PR TITLE
spec: fix missing catalog config error msg

### DIFF
--- a/src/spec/src/browser.ts
+++ b/src/spec/src/browser.ts
@@ -355,12 +355,14 @@ export class Spec implements SpecLike<Spec> {
       this.catalog = this.bareSpec.substring('catalog:'.length)
       const catalog =
         this.catalog ?
-          this.options.catalogs[this.catalog]
+          this.options.catalogs?.[this.catalog]
         : this.options.catalog
       if (!catalog) {
         throw this.#error('Named catalog not found', {
           name: this.catalog,
-          validOptions: Object.keys(this.options.catalogs),
+          validOptions:
+            this.options.catalogs &&
+            Object.keys(this.options.catalogs),
         })
       }
       const sub = catalog[this.name]

--- a/src/spec/src/types.ts
+++ b/src/spec/src/types.ts
@@ -20,7 +20,7 @@ export type SpecOptionsFilled = {
   /** registries that work like https://npm.jsr.io */
   'jsr-registries': Record<string, string>
   catalog: Record<string, string>
-  catalogs: Record<string, Record<string, string>>
+  catalogs?: Record<string, Record<string, string>>
 }
 
 export type GitSelectorParsed = {

--- a/src/spec/test/browser.ts
+++ b/src/spec/test/browser.ts
@@ -827,6 +827,23 @@ t.test('catalogs', async t => {
       spec: 'b@catalog:',
     },
   })
+  t.throws(
+    () =>
+      Spec.parse('b', 'catalog:', {
+        catalog: undefined,
+        catalogs: undefined,
+      }),
+    {
+      message: 'Named catalog not found',
+      cause: {
+        spec: 'b@catalog:',
+        name: '',
+        validOptions: undefined,
+      },
+      name: 'Error',
+    },
+    'should throw proper catalog missing when no catalogs provided',
+  )
   t.throws(() => Spec.parse('b@catalog:z', opts), {
     message: 'Named catalog not found',
     cause: {


### PR DESCRIPTION
When a `catalog:` is in use in a `package.json` file but haven't been properly configured the error message prints an helpful error message:

    Error: Named catalog not found

Instead of:

    TypeError: Cannot convert undefined or null to object