### PR TITLE
registry-client: increase swr factor

### DIFF
--- a/src/registry-client/src/index.ts
+++ b/src/registry-client/src/index.ts
@@ -209,7 +209,7 @@ export class RegistryClient {
       'fetch-retries': maxRetries = 3,
       identity = '',
       'stale-while-revalidate-factor':
-        staleWhileRevalidateFactor = 60,
+        staleWhileRevalidateFactor = 576, // 48h for a 5min cache
     } = options
     this.identity = identity
     this.staleWhileRevalidateFactor = staleWhileRevalidateFactor


### PR DESCRIPTION
Increase the state-while-revalidate factor to amount to 48h for the default 5min cache duration of registry metadata.