### PR TITLE
cli-sdk: update vlt docs default url

### DIFF
--- a/src/cli-sdk/src/commands/docs.ts
+++ b/src/cli-sdk/src/commands/docs.ts
@@ -102,9 +102,9 @@ const getUrlFromManifest = (
     }
   }
 
-  // Fallback to npmjs.com package page
+  // Fallback to vlt.io package page
   if (!url) {
-    url = `https://www.npmjs.com/package/${name}`
+    url = `https://vlt.io/explore/npm/${name}/overview`
   }
 
   return url

--- a/src/cli-sdk/test/commands/docs.ts
+++ b/src/cli-sdk/test/commands/docs.ts
@@ -269,7 +269,7 @@ t.test('git+ prefix stripped from repository url', async t => {
   t.strictSame(fromUrlCalls, ['https://github.com/user/repo'])
 })
 
-t.test('fallback to npmjs.com when no repository', async t => {
+t.test('fallback to vlt.io when no repository', async t => {
   mockManifest = {
     name: 'no-repo-pkg',
   } as Manifest
@@ -287,42 +287,47 @@ t.test('fallback to npmjs.com when no repository', async t => {
 
   const result = await Command.command(config)
 
-  t.strictSame(result, {
-    name: 'no-repo-pkg',
-    url: 'https://www.npmjs.com/package/no-repo-pkg',
-  })
-  t.equal(openedUrl, 'https://www.npmjs.com/package/no-repo-pkg')
+  t.strictSame(
+    result,
+    {
+      name: 'no-repo-pkg',
+      url: 'https://vlt.io/explore/npm/no-repo-pkg/overview',
+    },
+    'opens default vlt.io URL',
+  )
+  t.equal(
+    openedUrl,
+    'https://vlt.io/explore/npm/no-repo-pkg/overview',
+    'opens default vlt.io URL',
+  )
 })
 
-t.test(
-  'fallback to npmjs.com when hosted-git-info fails',
-  async t => {
-    mockManifest = {
-      name: 'unknown-host-pkg',
-      repository: 'https://unknown-git-host.com/user/repo',
-    } as Manifest
+t.test('fallback to vlt.io when hosted-git-info fails', async t => {
+  mockManifest = {
+    name: 'unknown-host-pkg',
+    repository: 'https://unknown-git-host.com/user/repo',
+  } as Manifest
 
-    mockFromUrlResult = null
+  mockFromUrlResult = null
 
-    const config = {
-      positionals: ['unknown-host-pkg'],
-      get: () => undefined,
-      options: {
-        projectRoot: '/test/project',
-        packageJson: {
-          read: () => ({}),
-        },
+  const config = {
+    positionals: ['unknown-host-pkg'],
+    get: () => undefined,
+    options: {
+      projectRoot: '/test/project',
+      packageJson: {
+        read: () => ({}),
       },
-    } as unknown as LoadedConfig
+    },
+  } as unknown as LoadedConfig
 
-    const result = await Command.command(config)
+  const result = await Command.command(config)
 
-    t.strictSame(result, {
-      name: 'unknown-host-pkg',
-      url: 'https://www.npmjs.com/package/unknown-host-pkg',
-    })
-  },
-)
+  t.strictSame(result, {
+    name: 'unknown-host-pkg',
+    url: 'https://vlt.io/explore/npm/unknown-host-pkg/overview',
+  })
+})
 
 t.test('error when no manifest found', async t => {
   mockManifest = undefined

--- a/www/docs/src/content/docs/cli/commands/docs.mdx
+++ b/www/docs/src/content/docs/cli/commands/docs.mdx
@@ -28,7 +28,7 @@ strategy to find the best documentation URL:
    in its `package.json`. For known git hosts (GitHub, GitLab,
    Bitbucket, etc.), generates the canonical documentation URL
 3. **Fallback** – If no repository is found or the git host is
-   unknown, falls back to the npm package page
+   unknown, falls back to the [vlt.io](https://vlt.io) package page
 
 This means you always get taken to the most relevant documentation.
 
@@ -144,17 +144,3 @@ $ vlt docs --target=":root > \*"
 # List docs for packages with build scripts
 
 $ vlt docs --target=":scripts"`} title="Terminal" lang="bash" />
-
-## Notes
-
-- The command automatically opens your default web browser for single
-  results
-- Works with any valid package specifier (names, versions, tags, etc.)
-- Does not require the package to be installed when using package
-  specifiers
-- With `--target`, it defaults to only searches packages in your
-  current dependency graph
-- Falls back gracefully to npm package pages when repository info is
-  unavailable
-- Multiple results are displayed as a formatted list instead of
-  opening URLs


### PR DESCRIPTION
Similar to https://github.com/vltpkg/vltpkg/pull/1310 the fallback url should point to vlt.io