### PR TITLE
docs: add vlt install docs

### DIFF
--- a/www/docs/src/content/docs/cli/commands/install.mdx
+++ b/www/docs/src/content/docs/cli/commands/install.mdx
@@ -98,13 +98,18 @@ $ vlt install github:user/repo#semver:^1.0
 # Full git URL
 
 $ vlt install git+ssh://git@github.com:user/repo.git
+
+# OR
+
 $ vlt install git+https://github.com/user/repo.git#main
 
-# GitLab, Bitbucket
+# GitLab
 
 $ vlt install gitlab:user/repo
-$ vlt install bitbucket:user/repo`}
-title="Terminal" lang="bash" />
+
+# Bitbucket
+
+$ vlt install bitbucket:user/repo`} title="Terminal" lang="bash" />
 
 When using `#semver:<range>`, vlt looks for matching tags/refs in the
 remote repository.


### PR DESCRIPTION
Add a more extensive documentation to the standard `vlt install` command.