### PR TITLE
chore: limit add-to-project gh action runs

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -8,6 +8,8 @@ on:
 
 jobs:
   add_to_project:
+    # should only run when the PR is from the same repository
+    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     steps:
       - name: Add to GitHub Project


### PR DESCRIPTION
The add-to-project GitHub action should only run on PRs that are open from branches directly on the repo, otherwise it doesn't have permission to actually push the item to the project board.