### PR TITLE
graph: fix spec version saved

### DIFF
--- a/src/graph/src/reify/update-importers-package-json.ts
+++ b/src/graph/src/reify/update-importers-package-json.ts
@@ -139,7 +139,7 @@ const addOrRemoveDeps = (
         nodeType,
         dep.spec,
         existing,
-        node.version,
+        n.version,
       )
       dependencies[name] = saveValue
       manifestChanged = manifestChanged || saveValue !== existing


### PR DESCRIPTION
Use the installed dependency version when saving to package.json

Fixes: https://github.com/vltpkg/vltpkg/issues/1326