### PR TITLE
[bugfixes] gui: improve performance in `selected-item` and `external-info`

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1095,6 +1095,9 @@ importers:
 
   src/gui:
     dependencies:
+      '@effect/platform':
+        specifier: ^0.93.6
+        version: 0.93.6(effect@3.19.9)
       '@radix-ui/react-accordion':
         specifier: ^1.2.12
         version: 1.2.12(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -1200,6 +1203,9 @@ importers:
       date-fns:
         specifier: ^4.1.0
         version: 4.1.0
+      effect:
+        specifier: ^3.19.9
+        version: 3.19.9
       framer-motion:
         specifier: ^12.23.12
         version: 12.23.24(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -3230,6 +3236,11 @@ packages:
   '@drizzle-team/brocli@0.10.2':
     resolution: {integrity: sha512-z33Il7l5dKjUgGULTqBsQBQwckHh5AbIuxhdsIxDDiZAzBOrZO6q9ogcWC65kU382AfynTfgNumVcNIjuIua6w==}
 
+  '@effect/platform@0.93.6':
+    resolution: {integrity: sha512-I5lBGQWzWXP4zlIdPs7z7WHmEFVBQhn+74emr/h16GZX96EEJ6I1rjGaKyZF7mtukbMuo9wEckDPssM8vskZ/w==}
+    peerDependencies:
+      effect: ^3.19.8
+
   '@emmetio/abbreviation@2.3.3':
     resolution: {integrity: sha512-mgv58UrU3rh4YgbE/TzgLQwJ3pFsHHhCLqY20aJq+9comytTXUDNGG/SMtSeMJdkpxgXSXunBGLD8Boka3JyVA==}
 
@@ -4461,6 +4472,36 @@ packages:
 
   '@mdx-js/mdx@3.1.1':
     resolution: {integrity: sha512-f6ZO2ifpwAQIpzGWaBQT2TXxPv6z3RBzQKpVftEWN78Vl/YweF1uwussDx8ECAXVtr3Rs89fKyG9YlzUs9DyGQ==}
+
+  '@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.3':
+    resolution: {integrity: sha512-QZHtlVgbAdy2zAqNA9Gu1UpIuI8Xvsd1v8ic6B2pZmeFnFcMWiPLfWXh7TVw4eGEZ/C9TH281KwhVoeQUKbyjw==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@msgpackr-extract/msgpackr-extract-darwin-x64@3.0.3':
+    resolution: {integrity: sha512-mdzd3AVzYKuUmiWOQ8GNhl64/IoFGol569zNRdkLReh6LRLHOXxU4U8eq0JwaD8iFHdVGqSy4IjFL4reoWCDFw==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@msgpackr-extract/msgpackr-extract-linux-arm64@3.0.3':
+    resolution: {integrity: sha512-YxQL+ax0XqBJDZiKimS2XQaf+2wDGVa1enVRGzEvLLVFeqa5kx2bWbtcSXgsxjQB7nRqqIGFIcLteF/sHeVtQg==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@msgpackr-extract/msgpackr-extract-linux-arm@3.0.3':
+    resolution: {integrity: sha512-fg0uy/dG/nZEXfYilKoRe7yALaNmHoYeIoJuJ7KJ+YyU2bvY8vPv27f7UKhGRpY6euFYqEVhxCFZgAUNQBM3nw==}
+    cpu: [arm]
+    os: [linux]
+
+  '@msgpackr-extract/msgpackr-extract-linux-x64@3.0.3':
+    resolution: {integrity: sha512-cvwNfbP07pKUfq1uH+S6KJ7dT9K8WOE4ZiAcsrSes+UY55E/0jLYc+vq+DO7jlmqRb5zAggExKm0H7O/CBaesg==}
+    cpu: [x64]
+    os: [linux]
+
+  '@msgpackr-extract/msgpackr-extract-win32-x64@3.0.3':
+    resolution: {integrity: sha512-x0fWaQtYp4E6sktbsdAqnehxDgEc/VwM7uLsRCYWaiGu0ykYdZPiS8zCWdnjHwyiumousxfBm4SO31eXqwEZhQ==}
+    cpu: [x64]
+    os: [win32]
 
   '@mswjs/interceptors@0.40.0':
     resolution: {integrity: sha512-EFd6cVbHsgLa6wa4RljGj6Wk75qoHxUSyc5asLyyPSyuhIcdS2Q3Phw6ImS1q+CkALthJRShiYfKANcQMuMqsQ==}
@@ -6154,6 +6195,9 @@ packages:
 
   '@speed-highlight/core@1.2.7':
     resolution: {integrity: sha512-0dxmVj4gxg3Jg879kvFS/msl4s9F3T9UXC1InxgOf7t5NvcPD97u/WTA5vL/IxWHMn7qSxBozqrnnE2wvl1m8g==}
+
+  '@standard-schema/spec@1.0.0':
+    resolution: {integrity: sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==}
 
   '@swc/helpers@0.5.17':
     resolution: {integrity: sha512-5IKx/Y13RsYd+sauPb2x+U/xZikHjolzfuDgTAl/Tdf3Q8rslRvC19NKDLgAJQ6wsqADk10ntlv08nPFw/gO/A==}
@@ -8152,6 +8196,9 @@ packages:
   eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
 
+  effect@3.19.9:
+    resolution: {integrity: sha512-taMXnfG/p+j7AmMOHHQaCHvjqwu9QBO3cxuZqL2dMG/yWcEMw0ZHruHe9B49OxtfKH/vKKDDKRhZ+1GJ2p5R5w==}
+
   electron-to-chromium@1.5.211:
     resolution: {integrity: sha512-IGBvimJkotaLzFnwIVgW9/UD/AOJ2tByUmeOrtqBfACSbAw5b1G0XpvdaieKyc7ULmbwXVx+4e4Be8pOPBrYkw==}
 
@@ -8468,6 +8515,10 @@ packages:
   extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
 
+  fast-check@3.23.2:
+    resolution: {integrity: sha512-h5+1OzzfCC3Ef7VbtKdcv7zsstUQwUDlYpUTvjeUsJAssPgLn7QzbboPtL5ro04Mq0rPOsMzl7q5hIbRs2wD1A==}
+    engines: {node: '>=8.0.0'}
+
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
@@ -8535,6 +8586,9 @@ packages:
   fill-range@7.1.1:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
     engines: {node: '>=8'}
+
+  find-my-way-ts@0.1.6:
+    resolution: {integrity: sha512-a85L9ZoXtNAey3Y6Z+eBWW658kO/MwR7zIafkIUPUMf3isZG0NCs2pjW2wtjxAKuJPxMAsHUIP4ZPGv0o5gyTA==}
 
   find-up-simple@1.0.1:
     resolution: {integrity: sha512-afd4O7zpqHeRyg4PfDQsXmlDe2PfdHtJt6Akt8jOWaApLOZk5JXs6VMR29lz03pRe9mpykrRCYIYxaJYcfpncQ==}
@@ -10045,6 +10099,13 @@ packages:
     resolution: {integrity: sha512-WC/Eo7NzFrOV/RRrTaI0fxKVbNCzEy76j2VqNV8SxDf9D69gSE2Lh0QwYvDlhiYmheBYExAvEAxVf5NoN0cj2A==}
     engines: {node: '>=20'}
 
+  msgpackr-extract@3.0.3:
+    resolution: {integrity: sha512-P0efT1C9jIdVRefqjzOQ9Xml57zpOXnIuS+csaB4MdZbTdmGDLo8XhzBG1N7aO11gKDDkJvBLULeFTo46wwreA==}
+    hasBin: true
+
+  msgpackr@1.11.5:
+    resolution: {integrity: sha512-UjkUHN0yqp9RWKy0Lplhh+wlpdt9oQBYgULZOiFhV3VclSF1JnSQWZ5r9gORQlNYaUKQoR8itv7g7z1xDDuACA==}
+
   msw@2.12.3:
     resolution: {integrity: sha512-/5rpGC0eK8LlFqsHaBmL19/PVKxu/CCt8pO1vzp9X6SDLsRDh/Ccudkf3Ur5lyaKxJz9ndAx+LaThdv0ySqB6A==}
     engines: {node: '>=18'}
@@ -10057,6 +10118,9 @@ packages:
 
   muggle-string@0.4.1:
     resolution: {integrity: sha512-VNTrAak/KhO2i8dqqnqnAHOa3cYBwXEZe9h+D5h/1ZqFSTEFHdM65lR7RoIqq3tBBYavsOXV84NoHXZ0AkPyqQ==}
+
+  multipasta@0.2.7:
+    resolution: {integrity: sha512-KPA58d68KgGil15oDqXjkUBEBYc00XvbPj5/X+dyzeo/lWm9Nc25pQRlf1D+gv4OpK7NM0J1odrbu9JNNGvynA==}
 
   mute-stream@2.0.0:
     resolution: {integrity: sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==}
@@ -10156,6 +10220,10 @@ packages:
   node-fetch@3.3.2:
     resolution: {integrity: sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  node-gyp-build-optional-packages@5.2.2:
+    resolution: {integrity: sha512-s+w+rBWnpTMwSFbaE0UXsRlg7hU4FjekKU4eyAih5T8nJuNZT1nNsskXpxmeqSK9UzkBl6UgRlnKc8hz8IEqOw==}
+    hasBin: true
 
   node-gyp-build@4.8.4:
     resolution: {integrity: sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==}
@@ -10824,6 +10892,9 @@ packages:
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
+
+  pure-rand@6.1.0:
+    resolution: {integrity: sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==}
 
   quansync@0.2.11:
     resolution: {integrity: sha512-AifT7QEbW9Nri4tAwR5M/uzpBuqfZf+zwaEM/QkzEjj7NBuFD2rBuy0K3dE+8wltbezDV7JMA0WfnCPYRSYbXA==}
@@ -13495,6 +13566,13 @@ snapshots:
 
   '@drizzle-team/brocli@0.10.2': {}
 
+  '@effect/platform@0.93.6(effect@3.19.9)':
+    dependencies:
+      effect: 3.19.9
+      find-my-way-ts: 0.1.6
+      msgpackr: 1.11.5
+      multipasta: 0.2.7
+
   '@emmetio/abbreviation@2.3.3':
     dependencies:
       '@emmetio/scanner': 1.0.4
@@ -14520,6 +14598,24 @@ snapshots:
       vfile: 6.0.3
     transitivePeerDependencies:
       - supports-color
+
+  '@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.3':
+    optional: true
+
+  '@msgpackr-extract/msgpackr-extract-darwin-x64@3.0.3':
+    optional: true
+
+  '@msgpackr-extract/msgpackr-extract-linux-arm64@3.0.3':
+    optional: true
+
+  '@msgpackr-extract/msgpackr-extract-linux-arm@3.0.3':
+    optional: true
+
+  '@msgpackr-extract/msgpackr-extract-linux-x64@3.0.3':
+    optional: true
+
+  '@msgpackr-extract/msgpackr-extract-win32-x64@3.0.3':
+    optional: true
 
   '@mswjs/interceptors@0.40.0':
     dependencies:
@@ -16375,6 +16471,8 @@ snapshots:
   '@sindresorhus/merge-streams@4.0.0': {}
 
   '@speed-highlight/core@1.2.7': {}
+
+  '@standard-schema/spec@1.0.0': {}
 
   '@swc/helpers@0.5.17':
     dependencies:
@@ -18928,6 +19026,11 @@ snapshots:
 
   eastasianwidth@0.2.0: {}
 
+  effect@3.19.9:
+    dependencies:
+      '@standard-schema/spec': 1.0.0
+      fast-check: 3.23.2
+
   electron-to-chromium@1.5.211: {}
 
   emmet@2.4.11:
@@ -19496,6 +19599,10 @@ snapshots:
 
   extend@3.0.2: {}
 
+  fast-check@3.23.2:
+    dependencies:
+      pure-rand: 6.1.0
+
   fast-deep-equal@3.1.3: {}
 
   fast-equals@5.2.2: {}
@@ -19556,6 +19663,8 @@ snapshots:
   fill-range@7.1.1:
     dependencies:
       to-regex-range: 5.0.1
+
+  find-my-way-ts@0.1.6: {}
 
   find-up-simple@1.0.1: {}
 
@@ -21630,6 +21739,22 @@ snapshots:
 
   ms@4.0.0-nightly.202508271359: {}
 
+  msgpackr-extract@3.0.3:
+    dependencies:
+      node-gyp-build-optional-packages: 5.2.2
+    optionalDependencies:
+      '@msgpackr-extract/msgpackr-extract-darwin-arm64': 3.0.3
+      '@msgpackr-extract/msgpackr-extract-darwin-x64': 3.0.3
+      '@msgpackr-extract/msgpackr-extract-linux-arm': 3.0.3
+      '@msgpackr-extract/msgpackr-extract-linux-arm64': 3.0.3
+      '@msgpackr-extract/msgpackr-extract-linux-x64': 3.0.3
+      '@msgpackr-extract/msgpackr-extract-win32-x64': 3.0.3
+    optional: true
+
+  msgpackr@1.11.5:
+    optionalDependencies:
+      msgpackr-extract: 3.0.3
+
   msw@2.12.3(@types/node@22.18.0)(typescript@5.7.3):
     dependencies:
       '@inquirer/confirm': 5.0.1(@types/node@22.18.0)
@@ -21656,6 +21781,8 @@ snapshots:
       - '@types/node'
 
   muggle-string@0.4.1: {}
+
+  multipasta@0.2.7: {}
 
   mute-stream@2.0.0: {}
 
@@ -21766,6 +21893,11 @@ snapshots:
       data-uri-to-buffer: 4.0.1
       fetch-blob: 3.2.0
       formdata-polyfill: 4.0.10
+
+  node-gyp-build-optional-packages@5.2.2:
+    dependencies:
+      detect-libc: 2.1.2
+    optional: true
 
   node-gyp-build@4.8.4: {}
 
@@ -22519,6 +22651,8 @@ snapshots:
   punycode.js@2.3.1: {}
 
   punycode@2.3.1: {}
+
+  pure-rand@6.1.0: {}
 
   quansync@0.2.11: {}
 

--- a/src/gui/package.json
+++ b/src/gui/package.json
@@ -9,6 +9,7 @@
   },
   "author": "vlt technology inc. <support@vlt.sh> (http://vlt.sh)",
   "dependencies": {
+    "@effect/platform": "^0.93.6",
     "@radix-ui/react-accordion": "^1.2.12",
     "@radix-ui/react-alert-dialog": "^1.1.14",
     "@radix-ui/react-avatar": "^1.1.10",
@@ -44,6 +45,7 @@
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",
     "date-fns": "^4.1.0",
+    "effect": "^3.19.9",
     "framer-motion": "^12.23.12",
     "lucide-react": "^0.503.0",
     "lz-string": "catalog:",

--- a/src/gui/src/components/explorer-grid/index.tsx
+++ b/src/gui/src/components/explorer-grid/index.tsx
@@ -186,7 +186,10 @@ export const ExplorerGrid = ({
       breadcrumbs: undefined,
     }
 
-    return <SelectedItem item={externalItem} />
+    // Key forces remount to reset loading state when navigating between packages
+    return (
+      <SelectedItem key={externalPackageSpec} item={externalItem} />
+    )
   }
 
   const items = getItemsData(edges, nodes, query)
@@ -205,7 +208,8 @@ export const ExplorerGrid = ({
   }
 
   if (items.length === 1 && items[0]) {
-    return <SelectedItem item={items[0]} />
+    // Key forces remount to reset loading state when navigating between items
+    return <SelectedItem key={items[0].id} item={items[0]} />
   }
 
   // Show Results component for both empty and populated results

--- a/src/gui/src/components/explorer-grid/selected-item/aside/aside-contributors.tsx
+++ b/src/gui/src/components/explorer-grid/selected-item/aside/aside-contributors.tsx
@@ -23,7 +23,7 @@ export const AsideContributors = () => {
   if (!contributors || contributors.length === 0) return null
 
   const [firstContributors, restContributors] = splitArray(
-    contributors,
+    [...contributors],
     10,
   )
 

--- a/src/gui/src/components/explorer-grid/selected-item/aside/aside-repo.tsx
+++ b/src/gui/src/components/explorer-grid/selected-item/aside/aside-repo.tsx
@@ -60,7 +60,7 @@ export const AsideRepo = () => {
       <AsideItem count={openIssue} icon={CircleDot}>
         Issues
       </AsideItem>
-      {(starGazers ?? 0) > 0 && (
+      {Number(starGazers ?? 0) > 0 && (
         <AsideItem count={String(starGazers)} icon={Star}>
           Stars
         </AsideItem>

--- a/src/gui/src/components/explorer-grid/selected-item/item-header.tsx
+++ b/src/gui/src/components/explorer-grid/selected-item/item-header.tsx
@@ -320,11 +320,12 @@ export const Publisher = ({ className }: { className?: string }) => {
     state => state.downloadsPerVersion,
   )
 
-  const downloadCount = toHumanNumber(
-    (currentVersion?.version &&
-      downloads?.[currentVersion.version]) ??
-      0,
-  )
+  // Use currentVersion.version if available, fallback to manifest.version for external packages
+  const versionKey = currentVersion?.version ?? manifest?.version
+  const rawDownloadCount =
+    (versionKey && downloads?.[versionKey]) || 0
+  const downloadCount =
+    rawDownloadCount > 0 ? toHumanNumber(rawDownloadCount) : null
 
   const authorNameShort =
     publisher?.name ? publisher.name.substring(0, 2) : '?'

--- a/src/gui/src/components/explorer-grid/selected-item/item.tsx
+++ b/src/gui/src/components/explorer-grid/selected-item/item.tsx
@@ -3,6 +3,8 @@ import { Outlet } from 'react-router'
 import { AnimatePresence, motion } from 'framer-motion'
 import { ChevronRight, ChevronLeft } from 'lucide-react'
 import { Button } from '@/components/ui/button.tsx'
+import { JellyTriangleSpinner } from '@/components/ui/jelly-spinner.tsx'
+import { PartialErrorsIndicator } from '@/components/explorer-grid/selected-item/partial-errors-indicator.tsx'
 import {
   SelectedItemProvider,
   useTabNavigation,
@@ -51,28 +53,53 @@ Section.displayName = 'Section'
 export const Item = ({ item, className }: ItemProps) => {
   return (
     <SelectedItemProvider key={item.id} selectedItem={item}>
-      <section
-        className={cn(
-          'bg-foreground/6 flex min-w-0 flex-col gap-[1px] rounded',
-          className,
-        )}>
-        <Section>
-          <ItemBreadcrumbs />
-        </Section>
-        <Section className="py-4">
-          <PackageImageSpec />
-        </Section>
-        <Section>
-          <Publisher className="flex-col items-start lg:flex-row" />
-        </Section>
-        <Section className="p-0">
-          <SelectedItemTabs />
-        </Section>
-        <Section className="h-full p-0">
-          <SelectedItemView />
-        </Section>
-      </section>
+      <ItemContent className={className} />
     </SelectedItemProvider>
+  )
+}
+
+const ItemContent = ({ className }: { className?: string }) => {
+  const isLoadingDetails = useSelectedItemStore(
+    state => state.isLoadingDetails,
+  )
+
+  return (
+    <section
+      className={cn(
+        'bg-foreground/6 relative flex min-w-0 flex-col gap-px rounded',
+        className,
+      )}>
+      <AnimatePresence initial={false}>
+        {isLoadingDetails && (
+          <motion.div
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            transition={{ duration: 0.2 }}
+            className="bg-background/80 absolute inset-0 z-11 flex items-center justify-center rounded backdrop-blur-sm">
+            <JellyTriangleSpinner size={40} />
+          </motion.div>
+        )}
+      </AnimatePresence>
+
+      <PartialErrorsIndicator />
+
+      <Section>
+        <ItemBreadcrumbs />
+      </Section>
+      <Section className="py-4">
+        <PackageImageSpec />
+      </Section>
+      <Section>
+        <Publisher className="flex-col items-start lg:flex-row" />
+      </Section>
+      <Section className="p-0">
+        <SelectedItemTabs />
+      </Section>
+      <Section className="h-full p-0">
+        <SelectedItemView />
+      </Section>
+    </section>
   )
 }
 
@@ -220,7 +247,7 @@ const ScrollHelper = forwardRef<
       ref={ref}
       variant="ghost"
       className={cn(
-        'bg-background/50 absolute z-[10] flex aspect-square h-full items-center justify-center rounded backdrop-blur-sm [&_svg]:size-4',
+        'bg-background/50 absolute z-10 flex aspect-square h-full items-center justify-center rounded backdrop-blur-sm [&_svg]:size-4',
         align === 'start' && 'top-0 left-0',
         align === 'end' && 'top-0 right-0',
         className,

--- a/src/gui/src/components/explorer-grid/selected-item/partial-errors-indicator.tsx
+++ b/src/gui/src/components/explorer-grid/selected-item/partial-errors-indicator.tsx
@@ -1,0 +1,82 @@
+import { motion } from 'framer-motion'
+import { AlertTriangle } from 'lucide-react'
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@/components/ui/tooltip.tsx'
+import { useSelectedItemStore } from '@/components/explorer-grid/selected-item/context.tsx'
+import { cn } from '@/lib/utils.ts'
+
+import type { PartialError } from '@/lib/external-info.ts'
+
+/** Friendly names for data sources */
+const dataSourceLabels: Record<string, string> = {
+  'npm-packument': 'npm package info',
+  'npm-manifest': 'npm manifest',
+  'npm-downloads': 'download stats',
+  'npm-downloads-versions': 'version downloads',
+  'github-repo': 'GitHub repository',
+  'github-issues': 'GitHub issues',
+  'github-prs': 'GitHub pull requests',
+  readme: 'README',
+  contributors: 'contributors',
+}
+
+interface PartialErrorsIndicatorProps {
+  className?: string
+}
+
+export const PartialErrorsIndicator = ({
+  className,
+}: PartialErrorsIndicatorProps) => {
+  const isLoadingDetails = useSelectedItemStore(
+    state => state.isLoadingDetails,
+  )
+  const partialErrors = useSelectedItemStore(
+    state => state.partialErrors,
+  )
+
+  const hasPartialErrors =
+    !isLoadingDetails && partialErrors && partialErrors.length > 0
+
+  if (!hasPartialErrors) return null
+
+  return (
+    <TooltipProvider>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <motion.div
+            initial={{ opacity: 0, scale: 0.8 }}
+            animate={{ opacity: 1, scale: 1 }}
+            className={cn(
+              'absolute top-2 right-2 z-10 cursor-help',
+              className,
+            )}>
+            <div className="bg-warning/20 flex items-center gap-1.5 rounded-full px-2 py-1 text-amber-500">
+              <AlertTriangle className="h-3.5 w-3.5" />
+              <span className="text-xs font-medium">
+                {partialErrors.length} failed
+              </span>
+            </div>
+          </motion.div>
+        </TooltipTrigger>
+        <TooltipContent side="left" className="max-w-xs">
+          <p className="mb-2 text-xs font-medium">
+            Some data sources failed to load:
+          </p>
+          <ul className="space-y-1">
+            {partialErrors.map((error: PartialError, idx: number) => (
+              <li key={idx} className="text-muted-foreground text-xs">
+                <span className="font-medium">
+                  {dataSourceLabels[error.source] || error.source}
+                </span>
+              </li>
+            ))}
+          </ul>
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  )
+}

--- a/src/gui/src/components/explorer-grid/selected-item/tabs-versions.tsx
+++ b/src/gui/src/components/explorer-grid/selected-item/tabs-versions.tsx
@@ -571,10 +571,10 @@ export const VersionsTabContent = () => {
   const processedVersions = useMemo(() => {
     if (!versions) return []
 
-    // Apply all filters in sequence
+    // Apply all filters in sequence (spread to create mutable copy)
     const filteredAllVersions = filterFunctions.reduce(
       (versions, filter) => filter(versions),
-      versions,
+      [...versions],
     )
 
     // Add downloads data to each version

--- a/src/gui/src/components/hooks/use-query-navigation.tsx
+++ b/src/gui/src/components/hooks/use-query-navigation.tsx
@@ -12,11 +12,7 @@ import {
 export const useQueryNavigation = () => {
   const location = useLocation()
   const navigate = useNavigate()
-  const {
-    query: encodedQueryURL,
-    tab,
-    subTab,
-  } = useParams<{ query: string; tab: string; subTab?: string }>()
+  const { query: encodedQueryURL } = useParams<{ query: string }>()
 
   const query = useGraphStore(state => state.query)
   const updateQuery = useGraphStore(state => state.updateQuery)
@@ -74,7 +70,8 @@ export const useQueryNavigation = () => {
     if (query) {
       const encodedQuery = encodeCompressedQuery(query)
       if (encodedQuery !== encodedQueryURL) {
-        void navigate(`/explore/${encodedQuery}`, {
+        // Always navigate to 'overview' when query changes (navigating to new item)
+        void navigate(`/explore/${encodedQuery}/overview`, {
           relative: 'path',
         })
       }
@@ -83,8 +80,6 @@ export const useQueryNavigation = () => {
     query,
     navigate,
     location.pathname,
-    tab,
-    subTab,
     encodedQueryURL,
     isNpmRoute,
   ])

--- a/src/gui/src/utils/parse-aria-label-from-svg.ts
+++ b/src/gui/src/utils/parse-aria-label-from-svg.ts
@@ -1,0 +1,28 @@
+/**
+ * Parses an aria-label from an SVG
+ * Used by external-info to get gh stars and issue counts
+ *
+ * [\d.]+
+ * Matches with one or more digits or dots, intentionally loose to match:
+ * '1', '12.5', '3.14.15.9' (not enforcing proper decimals)
+ *
+ * \s
+ * Allows any amount of whitespace or none
+ *
+ * [kmb]?
+ * Shorthand for "thousands", "millions" or "billions"
+ * An optional letter of: k, m or b. Case-insensitive so it also matches
+ * K, M, B
+ */
+export const parseAriaLabelFromSVG = (
+  svg: string,
+): string | undefined => {
+  const parser = new DOMParser()
+  const svgDoc = parser.parseFromString(svg, 'image/svg+xml')
+  const ariaLabel = svgDoc
+    .querySelector('svg')
+    ?.getAttribute('aria-label')
+  if (!ariaLabel) return undefined
+  const match = /[\d.]+\s*[kmb]?/i.exec(ariaLabel)
+  return match?.[0].trim()
+}

--- a/src/gui/src/utils/retrieve-gravatar.ts
+++ b/src/gui/src/utils/retrieve-gravatar.ts
@@ -1,0 +1,14 @@
+export const retrieveGravatar = async (
+  email: string,
+): Promise<string> => {
+  const cleaned = email.trim().toLowerCase()
+  const encoder = new TextEncoder()
+  const data = encoder.encode(cleaned)
+  const compute = await window.crypto.subtle.digest('SHA-256', data)
+  const hashArray = Array.from(new Uint8Array(compute))
+  const hash = hashArray
+    .map(b => b.toString(16).padStart(2, '0'))
+    .join('')
+
+  return `https://gravatar.com/avatar/${hash}?d=retro`
+}

--- a/src/gui/test/components/explorer-grid/selected-item/__fixtures__/item.ts
+++ b/src/gui/test/components/explorer-grid/selected-item/__fixtures__/item.ts
@@ -141,3 +141,13 @@ export const SELECTED_ITEM_DETAILS: DetailsInfo = {
     alt: 'John Doe',
   },
 }
+
+/**
+ * Default loading state properties for tests.
+ * Add these to mockState to satisfy SelectedItemStore type.
+ */
+export const MOCK_LOADING_STATE = {
+  isLoadingDetails: false,
+  isLoadingDependencies: false,
+  dependenciesError: null,
+}

--- a/src/gui/test/components/explorer-grid/selected-item/__snapshots__/item.tsx.snap
+++ b/src/gui/test/components/explorer-grid/selected-item/__snapshots__/item.tsx.snap
@@ -3,7 +3,16 @@
 exports[`Item renders with the default structure 1`] = `
 
 <gui-selected-item-provider selecteditem="[object Object]">
-  <section class="bg-foreground/6 flex min-w-0 flex-col gap-[1px] rounded">
+  <section class="bg-foreground/6 relative flex min-w-0 flex-col gap-px rounded">
+    <div
+      class="bg-background/80 absolute inset-0 z-11 flex items-center justify-center rounded backdrop-blur-sm"
+      style="opacity: 1;"
+    >
+      <gui-jelly-triangle-spinner size="40">
+      </gui-jelly-triangle-spinner>
+    </div>
+    <gui-partial-errors-indicator>
+    </gui-partial-errors-indicator>
     <div class="bg-background w-full rounded px-6 py-2 empty:hidden">
       <gui-item-breadcrumbs>
       </gui-item-breadcrumbs>
@@ -80,7 +89,7 @@ exports[`Item renders with the default structure 1`] = `
         </gui-navigation-list>
         <button
           data-slot="button"
-          class="cursor-pointer gap-2 whitespace-nowrap text-sm font-medium transition-all disabled:cursor-not-allowed disabled:opacity-50 [&amp;_svg]:pointer-events-none [&amp;_svg:not([class*='size-'])]:size-4 shrink-0 [&amp;_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50 px-4 py-2 has-[>svg]:px-3 bg-background/50 absolute z-[10] flex aspect-square h-full items-center justify-center rounded backdrop-blur-sm [&amp;_svg]:size-4 top-0 right-0"
+          class="cursor-pointer gap-2 whitespace-nowrap text-sm font-medium transition-all disabled:cursor-not-allowed disabled:opacity-50 [&amp;_svg]:pointer-events-none [&amp;_svg:not([class*='size-'])]:size-4 shrink-0 [&amp;_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50 px-4 py-2 has-[>svg]:px-3 bg-background/50 absolute z-10 flex aspect-square h-full items-center justify-center rounded backdrop-blur-sm [&amp;_svg]:size-4 top-0 right-0"
           style="opacity: 0; filter: blur(2px);"
         >
           <gui-chevron-right-icon>

--- a/src/gui/test/components/explorer-grid/selected-item/focused-view/__snapshots__/index.tsx.snap
+++ b/src/gui/test/components/explorer-grid/selected-item/focused-view/__snapshots__/index.tsx.snap
@@ -11,9 +11,11 @@ exports[`FocusedView renders default 1`] = `
     uninstalleddependencies
   >
     <div class="bg-background relative">
+      <gui-partial-errors-indicator>
+      </gui-partial-errors-indicator>
       <div class="bg-foreground/6">
         <div class="grid-cols-[4fr_1fr] lg:grid">
-          <div class="flex w-full flex-col gap-[1px] p-[0.5px] pl-[0px] pt-[0px]">
+          <div class="flex w-full flex-col gap-px p-[0.5px] pl-0 pt-0">
             <div class="bg-background w-full rounded px-6 py-4">
               <gui-package-image-spec>
               </gui-package-image-spec>
@@ -29,7 +31,7 @@ exports[`FocusedView renders default 1`] = `
         <div class="bg-background pattern-hatch h-9 w-full rounded lg:hidden">
         </div>
         <div class="grid-cols-[4fr_1fr] lg:grid">
-          <div class="flex w-full p-[0.5px] pl-[0px]">
+          <div class="flex w-full p-[0.5px] pl-0">
             <div class="bg-background w-full rounded">
               <gui-navigation>
                 <gui-navigation-list>
@@ -94,7 +96,7 @@ exports[`FocusedView renders default 1`] = `
           </div>
         </div>
         <div class="h-full min-w-0 grid-cols-[4fr_1fr] lg:grid lg:min-h-[calc(100svh-64px-96.5px-45px-1px)]">
-          <div class="flex w-full min-w-0 p-[0.5px] pl-[0px]">
+          <div class="flex w-full min-w-0 p-[0.5px] pl-0">
             <div class="bg-background w-full min-w-0 rounded">
               <gui-router-outlet>
               </gui-router-outlet>
@@ -103,7 +105,7 @@ exports[`FocusedView renders default 1`] = `
           <div class="bg-background pattern-hatch h-9 w-full rounded lg:hidden">
           </div>
           <div class="flex w-full min-w-0 rounded p-[0.5px]">
-            <div class="flex h-full w-full min-w-0 flex-col gap-[1px] rounded **:data-[slot=aside-section]:last-of-type:h-full [&amp;>aside]:h-full **:data-[slot=aside-section]:last-of-type:[&amp;>div]:h-full">
+            <div class="flex h-full w-full min-w-0 flex-col gap-px rounded **:data-[slot=aside-section]:last-of-type:h-full [&amp;>aside]:h-full **:data-[slot=aside-section]:last-of-type:[&amp;>div]:h-full">
               <gui-install-helper>
               </gui-install-helper>
               <gui-aside-overview-empty-state>

--- a/src/gui/test/components/explorer-grid/selected-item/focused-view/index.tsx
+++ b/src/gui/test/components/explorer-grid/selected-item/focused-view/index.tsx
@@ -50,6 +50,17 @@ vi.mock(
   }),
 )
 
+vi.mock('@/components/ui/jelly-spinner.tsx', () => ({
+  JellyTriangleSpinner: 'gui-jelly-triangle-spinner',
+}))
+
+vi.mock(
+  '@/components/explorer-grid/selected-item/partial-errors-indicator.tsx',
+  () => ({
+    PartialErrorsIndicator: 'gui-partial-errors-indicator',
+  }),
+)
+
 vi.mock(
   '@/components/explorer-grid/dependency-sidebar/filter.tsx',
   () => ({

--- a/src/gui/test/components/explorer-grid/selected-item/index.tsx
+++ b/src/gui/test/components/explorer-grid/selected-item/index.tsx
@@ -28,6 +28,17 @@ vi.mock(
   }),
 )
 
+vi.mock('@/components/ui/jelly-spinner.tsx', () => ({
+  JellyTriangleSpinner: 'gui-jelly-triangle-spinner',
+}))
+
+vi.mock(
+  '@/components/explorer-grid/selected-item/partial-errors-indicator.tsx',
+  () => ({
+    PartialErrorsIndicator: 'gui-partial-errors-indicator',
+  }),
+)
+
 vi.mock(
   '@/components/explorer-grid/overview-sidebar/index.tsx',
   () => ({

--- a/src/gui/test/components/explorer-grid/selected-item/item-header.tsx
+++ b/src/gui/test/components/explorer-grid/selected-item/item-header.tsx
@@ -13,6 +13,7 @@ import {
   specOptions,
   SELECTED_ITEM,
   SELECTED_ITEM_DETAILS,
+  MOCK_LOADING_STATE,
 } from './__fixtures__/item.ts'
 import type { SelectedItemStore } from '@/components/explorer-grid/selected-item/context.tsx'
 
@@ -104,8 +105,6 @@ test('ItemBreadcrumbs renders with breadcrumbs', () => {
       ...SELECTED_ITEM,
       breadcrumbs: mockBreadcrumbs,
     },
-    manifest: null,
-    rawManifest: null,
     packageScore: undefined,
     insights: undefined,
     author: undefined,
@@ -125,6 +124,9 @@ test('ItemBreadcrumbs renders with breadcrumbs', () => {
     depFunding: undefined,
     setDepFunding: vi.fn(),
     ...SELECTED_ITEM_DETAILS,
+    ...MOCK_LOADING_STATE,
+    manifest: null,
+    rawManifest: null,
   } satisfies SelectedItemStore
 
   vi.mocked(useSelectedItemStore).mockImplementation(selector =>
@@ -141,8 +143,6 @@ test('ItemBreadcrumbs renders null when no breadcrumbs', () => {
       ...SELECTED_ITEM,
       breadcrumbs: undefined,
     },
-    manifest: null,
-    rawManifest: null,
     packageScore: undefined,
     insights: undefined,
     author: undefined,
@@ -162,6 +162,9 @@ test('ItemBreadcrumbs renders null when no breadcrumbs', () => {
     depFunding: undefined,
     setDepFunding: vi.fn(),
     ...SELECTED_ITEM_DETAILS,
+    ...MOCK_LOADING_STATE,
+    manifest: null,
+    rawManifest: null,
   } satisfies SelectedItemStore
 
   vi.mocked(useSelectedItemStore).mockImplementation(selector =>
@@ -175,8 +178,6 @@ test('ItemBreadcrumbs renders null when no breadcrumbs', () => {
 test('PackageImageSpec renders with default item', () => {
   const mockState = {
     selectedItem: SELECTED_ITEM,
-    manifest: null,
-    rawManifest: null,
     packageScore: undefined,
     insights: undefined,
     author: undefined,
@@ -197,6 +198,9 @@ test('PackageImageSpec renders with default item', () => {
     setDepFunding: vi.fn(),
     favicon: SELECTED_ITEM_DETAILS.favicon,
     ...SELECTED_ITEM_DETAILS,
+    ...MOCK_LOADING_STATE,
+    manifest: null,
+    rawManifest: null,
   } satisfies SelectedItemStore
 
   vi.mocked(useSelectedItemStore).mockImplementation(selector =>
@@ -228,8 +232,6 @@ test('PackageImageSpec renders with package score', () => {
 
   const mockState = {
     selectedItem: SELECTED_ITEM,
-    manifest: null,
-    rawManifest: null,
     packageScore: mockPackageScore,
     insights: undefined,
     author: undefined,
@@ -250,6 +252,9 @@ test('PackageImageSpec renders with package score', () => {
     setDepFunding: vi.fn(),
     favicon: SELECTED_ITEM_DETAILS.favicon,
     ...SELECTED_ITEM_DETAILS,
+    ...MOCK_LOADING_STATE,
+    manifest: null,
+    rawManifest: null,
   } satisfies SelectedItemStore
 
   vi.mocked(useSelectedItemStore).mockImplementation(selector =>
@@ -288,12 +293,10 @@ test('Publisher renders with publisher information', () => {
 
   const mockManifest = {
     version: '1.0.0',
-  } satisfies SelectedItemStore['manifest']
+  } as SelectedItemStore['manifest']
 
   const mockState = {
     selectedItem: SELECTED_ITEM,
-    manifest: mockManifest,
-    rawManifest: null,
     packageScore: undefined,
     insights: undefined,
     author: undefined,
@@ -316,6 +319,9 @@ test('Publisher renders with publisher information', () => {
     publisherAvatar: SELECTED_ITEM_DETAILS.publisherAvatar,
     downloadsPerVersion: SELECTED_ITEM_DETAILS.downloadsPerVersion,
     ...SELECTED_ITEM_DETAILS,
+    ...MOCK_LOADING_STATE,
+    manifest: mockManifest,
+    rawManifest: null,
   } satisfies SelectedItemStore
 
   vi.mocked(useSelectedItemStore).mockImplementation(selector =>
@@ -329,8 +335,6 @@ test('Publisher renders with publisher information', () => {
 test('Publisher renders null when no publisher', () => {
   const mockState = {
     selectedItem: SELECTED_ITEM,
-    manifest: null,
-    rawManifest: null,
     packageScore: undefined,
     insights: undefined,
     author: undefined,
@@ -350,9 +354,12 @@ test('Publisher renders null when no publisher', () => {
     depFunding: undefined,
     setDepFunding: vi.fn(),
     ...SELECTED_ITEM_DETAILS,
+    ...MOCK_LOADING_STATE,
     publisher: undefined,
     publisherAvatar: undefined,
     downloadsPerVersion: undefined,
+    manifest: null,
+    rawManifest: null,
   } satisfies SelectedItemStore
 
   vi.mocked(useSelectedItemStore).mockImplementation(selector =>

--- a/src/gui/test/components/explorer-grid/selected-item/item.tsx
+++ b/src/gui/test/components/explorer-grid/selected-item/item.tsx
@@ -5,7 +5,10 @@ import { useGraphStore as useStore } from '@/state/index.ts'
 import { Item } from '@/components/explorer-grid/selected-item/item.tsx'
 import type { SelectedItemStore } from '@/components/explorer-grid/selected-item/context.tsx'
 import { useSelectedItemStore } from '@/components/explorer-grid/selected-item/context.tsx'
-import { SELECTED_ITEM } from './__fixtures__/item.ts'
+import {
+  SELECTED_ITEM,
+  MOCK_LOADING_STATE,
+} from './__fixtures__/item.ts'
 
 global.ResizeObserver = vi.fn().mockImplementation(() => ({
   observe: vi.fn(),
@@ -49,6 +52,17 @@ vi.mock(
     NavigationButton: 'gui-navigation-button',
     NavigationList: 'gui-navigation-list',
     NavigationListItem: 'gui-navigation-list-item',
+  }),
+)
+
+vi.mock('@/components/ui/jelly-spinner.tsx', () => ({
+  JellyTriangleSpinner: 'gui-jelly-triangle-spinner',
+}))
+
+vi.mock(
+  '@/components/explorer-grid/selected-item/partial-errors-indicator.tsx',
+  () => ({
+    PartialErrorsIndicator: 'gui-partial-errors-indicator',
   }),
 )
 
@@ -141,6 +155,7 @@ test('Item renders with the default structure', () => {
     setDuplicatedDeps: vi.fn(),
     depFunding: undefined,
     setDepFunding: vi.fn(),
+    ...MOCK_LOADING_STATE,
   } satisfies SelectedItemStore)
 
   const Container = () => {

--- a/src/gui/test/components/explorer-grid/selected-item/tabs-contributors.tsx
+++ b/src/gui/test/components/explorer-grid/selected-item/tabs-contributors.tsx
@@ -7,6 +7,7 @@ import { ContributorTabContent } from '@/components/explorer-grid/selected-item/
 import {
   SELECTED_ITEM,
   SELECTED_ITEM_DETAILS,
+  MOCK_LOADING_STATE,
 } from './__fixtures__/item.ts'
 
 import type { SelectedItemStore } from '@/components/explorer-grid/selected-item/context.tsx'
@@ -144,6 +145,7 @@ test('ContributorTabContent renders with contributors', () => {
     setDuplicatedDeps: vi.fn(),
     depFunding: undefined,
     setDepFunding: vi.fn(),
+    ...MOCK_LOADING_STATE,
   } satisfies SelectedItemStore
 
   vi.mocked(useSelectedItemStore).mockImplementation(selector =>
@@ -179,6 +181,7 @@ test('ContributorTabContent renders with no contributors', () => {
     setDuplicatedDeps: vi.fn(),
     depFunding: undefined,
     setDepFunding: vi.fn(),
+    ...MOCK_LOADING_STATE,
   } satisfies SelectedItemStore
 
   vi.mocked(useSelectedItemStore).mockImplementation(selector =>

--- a/src/gui/test/components/explorer-grid/selected-item/tabs-dependencies/index.tsx
+++ b/src/gui/test/components/explorer-grid/selected-item/tabs-dependencies/index.tsx
@@ -3,7 +3,10 @@ import { cleanup, render } from '@testing-library/react'
 import html from 'diffable-html'
 import { useGraphStore as useStore } from '@/state/index.ts'
 import { useSelectedItemStore } from '@/components/explorer-grid/selected-item/context.tsx'
-import { SELECTED_ITEM } from '../__fixtures__/item.ts'
+import {
+  SELECTED_ITEM,
+  MOCK_LOADING_STATE,
+} from '../__fixtures__/item.ts'
 import { DependenciesTabContent } from '@/components/explorer-grid/selected-item/tabs-dependencies/index.tsx'
 
 vi.mock('react-router', () => ({
@@ -104,6 +107,7 @@ test('DependenciesTabContent renders default', () => {
       setDuplicatedDeps: vi.fn(),
       depFunding: undefined,
       setDepFunding: vi.fn(),
+      ...MOCK_LOADING_STATE,
     }),
   )
 
@@ -142,6 +146,7 @@ test('DependenciesTabContent renders an empty state', () => {
       setDuplicatedDeps: vi.fn(),
       depFunding: undefined,
       setDepFunding: vi.fn(),
+      ...MOCK_LOADING_STATE,
     }),
   )
 

--- a/src/gui/test/components/explorer-grid/selected-item/tabs-dependencies/tabs-duplicates.tsx
+++ b/src/gui/test/components/explorer-grid/selected-item/tabs-dependencies/tabs-duplicates.tsx
@@ -3,7 +3,10 @@ import { cleanup, render } from '@testing-library/react'
 import html from 'diffable-html'
 import { useGraphStore as useStore } from '@/state/index.ts'
 import { useSelectedItemStore } from '@/components/explorer-grid/selected-item/context.tsx'
-import { SELECTED_ITEM } from '../__fixtures__/item.ts'
+import {
+  SELECTED_ITEM,
+  MOCK_LOADING_STATE,
+} from '../__fixtures__/item.ts'
 import { DuplicatesTabContent } from '@/components/explorer-grid/selected-item/tabs-dependencies/tabs-duplicates.tsx'
 
 import type { DuplicatedDeps } from '@/components/explorer-grid/selected-item/context.tsx'
@@ -104,6 +107,7 @@ test('DuplicatesTabContent renders with an empty state', () => {
       setDuplicatedDeps: vi.fn(),
       depFunding: undefined,
       setDepFunding: vi.fn(),
+      ...MOCK_LOADING_STATE,
     }),
   )
 
@@ -143,6 +147,7 @@ test('DuplicatesTabContent renders with duplicated deps', () => {
       setDuplicatedDeps: vi.fn(),
       depFunding: undefined,
       setDepFunding: vi.fn(),
+      ...MOCK_LOADING_STATE,
     }),
   )
 

--- a/src/gui/test/components/explorer-grid/selected-item/tabs-dependencies/tabs-funding.tsx
+++ b/src/gui/test/components/explorer-grid/selected-item/tabs-dependencies/tabs-funding.tsx
@@ -3,7 +3,10 @@ import { cleanup, render } from '@testing-library/react'
 import html from 'diffable-html'
 import { useGraphStore as useStore } from '@/state/index.ts'
 import { useSelectedItemStore } from '@/components/explorer-grid/selected-item/context.tsx'
-import { SELECTED_ITEM } from '../__fixtures__/item.ts'
+import {
+  SELECTED_ITEM,
+  MOCK_LOADING_STATE,
+} from '../__fixtures__/item.ts'
 import { FundingTabContent } from '@/components/explorer-grid/selected-item/tabs-dependencies/tabs-funding.tsx'
 
 import type { DepFunding } from '@/components/explorer-grid/selected-item/context.tsx'
@@ -124,6 +127,7 @@ test('FundingTabContent renders with an empty state ', () => {
       setDepFunding: vi.fn(),
       duplicatedDeps: undefined,
       setDuplicatedDeps: vi.fn(),
+      ...MOCK_LOADING_STATE,
     }),
   )
 
@@ -163,6 +167,7 @@ test('FundingTabContent renders with an funding', () => {
       setDepFunding: vi.fn(),
       duplicatedDeps: undefined,
       setDuplicatedDeps: vi.fn(),
+      ...MOCK_LOADING_STATE,
     }),
   )
 

--- a/src/gui/test/components/explorer-grid/selected-item/tabs-dependencies/tabs-insights.tsx
+++ b/src/gui/test/components/explorer-grid/selected-item/tabs-dependencies/tabs-insights.tsx
@@ -3,7 +3,10 @@ import { cleanup, render } from '@testing-library/react'
 import html from 'diffable-html'
 import { useGraphStore as useStore } from '@/state/index.ts'
 import { useSelectedItemStore } from '@/components/explorer-grid/selected-item/context.tsx'
-import { SELECTED_ITEM } from '../__fixtures__/item.ts'
+import {
+  SELECTED_ITEM,
+  MOCK_LOADING_STATE,
+} from '../__fixtures__/item.ts'
 import { InsightsTabContent } from '@/components/explorer-grid/selected-item/tabs-dependencies/tabs-insights.tsx'
 
 import type { DepWarning } from '@/components/explorer-grid/selected-item/context.tsx'
@@ -160,6 +163,7 @@ test('InsightsTabContent renders with an empty state', () => {
       setDuplicatedDeps: vi.fn(),
       depFunding: undefined,
       setDepFunding: vi.fn(),
+      ...MOCK_LOADING_STATE,
     }),
   )
 
@@ -199,6 +203,7 @@ test('InsightsTabContent renders with insights', () => {
       setDuplicatedDeps: vi.fn(),
       depFunding: undefined,
       setDepFunding: vi.fn(),
+      ...MOCK_LOADING_STATE,
     }),
   )
 
@@ -238,6 +243,7 @@ test('InsightsTabContent renders with a warning for unscanned deps', () => {
       setDuplicatedDeps: vi.fn(),
       depFunding: undefined,
       setDepFunding: vi.fn(),
+      ...MOCK_LOADING_STATE,
     }),
   )
 

--- a/src/gui/test/components/explorer-grid/selected-item/tabs-dependencies/tabs-licenses.tsx
+++ b/src/gui/test/components/explorer-grid/selected-item/tabs-dependencies/tabs-licenses.tsx
@@ -6,7 +6,10 @@ import {
   getLicenseSeverity,
   useSelectedItemStore,
 } from '@/components/explorer-grid/selected-item/context.tsx'
-import { SELECTED_ITEM } from '../__fixtures__/item.ts'
+import {
+  SELECTED_ITEM,
+  MOCK_LOADING_STATE,
+} from '../__fixtures__/item.ts'
 import { LicensesTabContent } from '@/components/explorer-grid/selected-item/tabs-dependencies/tabs-licenses.tsx'
 
 import type { DepLicenses } from '@/components/explorer-grid/selected-item/context.tsx'
@@ -172,6 +175,7 @@ test('LicensesTabContent renders with an empty state', () => {
       setDuplicatedDeps: vi.fn(),
       depFunding: undefined,
       setDepFunding: vi.fn(),
+      ...MOCK_LOADING_STATE,
     }),
   )
 
@@ -211,6 +215,7 @@ test('LicensesTabContent renders with licenses', () => {
       setDuplicatedDeps: vi.fn(),
       depFunding: undefined,
       setDepFunding: vi.fn(),
+      ...MOCK_LOADING_STATE,
     }),
   )
 

--- a/src/gui/test/components/explorer-grid/selected-item/tabs-insight.tsx
+++ b/src/gui/test/components/explorer-grid/selected-item/tabs-insight.tsx
@@ -7,6 +7,7 @@ import { InsightTabContent } from '@/components/explorer-grid/selected-item/tabs
 import {
   SELECTED_ITEM,
   SELECTED_ITEM_DETAILS,
+  MOCK_LOADING_STATE,
 } from './__fixtures__/item.ts'
 
 import type { PackageScore } from '@vltpkg/security-archive'
@@ -125,6 +126,7 @@ test('InsightTabContent renders an empty state', () => {
     setDuplicatedDeps: vi.fn(),
     depFunding: undefined,
     setDepFunding: vi.fn(),
+    ...MOCK_LOADING_STATE,
   } satisfies SelectedItemStore
 
   vi.mocked(useSelectedItemStore).mockImplementation(selector =>
@@ -160,6 +162,7 @@ test('InsightTabContent renders with insights', () => {
     setDuplicatedDeps: vi.fn(),
     depFunding: undefined,
     setDepFunding: vi.fn(),
+    ...MOCK_LOADING_STATE,
   } satisfies SelectedItemStore
 
   vi.mocked(useSelectedItemStore).mockImplementation(selector =>
@@ -196,6 +199,7 @@ test('InsightTabContent renders with no insights but a package score', () => {
     setDuplicatedDeps: vi.fn(),
     depFunding: undefined,
     setDepFunding: vi.fn(),
+    ...MOCK_LOADING_STATE,
   } satisfies SelectedItemStore
 
   vi.mocked(useSelectedItemStore).mockImplementation(selector =>

--- a/src/gui/test/components/explorer-grid/selected-item/tabs-json.tsx
+++ b/src/gui/test/components/explorer-grid/selected-item/tabs-json.tsx
@@ -8,6 +8,7 @@ import { TabsJsonContent } from '@/components/explorer-grid/selected-item/tabs-j
 import {
   SELECTED_ITEM,
   SELECTED_ITEM_DETAILS,
+  MOCK_LOADING_STATE,
 } from './__fixtures__/item.ts'
 
 import type { SelectedItemStore } from '@/components/explorer-grid/selected-item/context.tsx'
@@ -86,6 +87,7 @@ test('TabsManifestContent renders with a json object', () => {
     setDuplicatedDeps: vi.fn(),
     depFunding: undefined,
     setDepFunding: vi.fn(),
+    ...MOCK_LOADING_STATE,
   } satisfies SelectedItemStore
 
   vi.mocked(useSelectedItemStore).mockImplementation(selector =>

--- a/src/gui/test/components/explorer-grid/selected-item/tabs-overview.tsx
+++ b/src/gui/test/components/explorer-grid/selected-item/tabs-overview.tsx
@@ -7,6 +7,7 @@ import { OverviewTabContent } from '@/components/explorer-grid/selected-item/tab
 import {
   SELECTED_ITEM,
   SELECTED_ITEM_DETAILS,
+  MOCK_LOADING_STATE,
 } from './__fixtures__/item.ts'
 
 import type { SelectedItemStore } from '@/components/explorer-grid/selected-item/context.tsx'
@@ -111,6 +112,7 @@ test('OverviewTabContent renders with an empty state', () => {
     setDuplicatedDeps: vi.fn(),
     depFunding: undefined,
     setDepFunding: vi.fn(),
+    ...MOCK_LOADING_STATE,
   } satisfies SelectedItemStore
 
   vi.mocked(useSelectedItemStore).mockImplementation(selector =>
@@ -150,6 +152,7 @@ test('OverviewTabContent renders with content', () => {
     setDuplicatedDeps: vi.fn(),
     depFunding: undefined,
     setDepFunding: vi.fn(),
+    ...MOCK_LOADING_STATE,
   } satisfies SelectedItemStore
 
   vi.mocked(useSelectedItemStore).mockImplementation(selector =>

--- a/src/gui/test/components/explorer-grid/selected-item/tabs-versions.tsx
+++ b/src/gui/test/components/explorer-grid/selected-item/tabs-versions.tsx
@@ -7,6 +7,7 @@ import { VersionsTabContent } from '@/components/explorer-grid/selected-item/tab
 import {
   SELECTED_ITEM,
   SELECTED_ITEM_DETAILS,
+  MOCK_LOADING_STATE,
 } from './__fixtures__/item.ts'
 
 import type { Version } from '@/lib/external-info.ts'
@@ -175,6 +176,7 @@ test('VersionsTabContent renders with versions', () => {
     setDuplicatedDeps: vi.fn(),
     depFunding: undefined,
     setDepFunding: vi.fn(),
+    ...MOCK_LOADING_STATE,
   } satisfies SelectedItemStore
 
   vi.mocked(useSelectedItemStore).mockImplementation(selector =>
@@ -208,6 +210,7 @@ test('VersionsTabContent renders an empty state', () => {
     setDuplicatedDeps: vi.fn(),
     depFunding: undefined,
     setDepFunding: vi.fn(),
+    ...MOCK_LOADING_STATE,
   } satisfies SelectedItemStore
 
   vi.mocked(useSelectedItemStore).mockImplementation(selector =>
@@ -241,6 +244,7 @@ test('VersionsTabContent filters versions', () => {
     setDuplicatedDeps: vi.fn(),
     depFunding: undefined,
     setDepFunding: vi.fn(),
+    ...MOCK_LOADING_STATE,
   } satisfies SelectedItemStore
 
   vi.mocked(useSelectedItemStore).mockImplementation(selector =>
@@ -280,6 +284,7 @@ test('VersionsTabContent toggles pre-releases', () => {
     setDuplicatedDeps: vi.fn(),
     depFunding: undefined,
     setDepFunding: vi.fn(),
+    ...MOCK_LOADING_STATE,
   } satisfies SelectedItemStore
 
   vi.mocked(useSelectedItemStore).mockImplementation(selector =>
@@ -319,6 +324,7 @@ test('VersionsTabContent filters pre-releases', () => {
     setDuplicatedDeps: vi.fn(),
     depFunding: undefined,
     setDepFunding: vi.fn(),
+    ...MOCK_LOADING_STATE,
   } satisfies SelectedItemStore
 
   vi.mocked(useSelectedItemStore).mockImplementation(selector =>
@@ -362,6 +368,7 @@ test('VersionsTabContent filters newer versions', () => {
     setDuplicatedDeps: vi.fn(),
     depFunding: undefined,
     setDepFunding: vi.fn(),
+    ...MOCK_LOADING_STATE,
   } satisfies SelectedItemStore
 
   vi.mocked(useSelectedItemStore).mockImplementation(selector =>
@@ -405,6 +412,7 @@ test('VersionsTabContent handles missing manifest version', () => {
     setDuplicatedDeps: vi.fn(),
     depFunding: undefined,
     setDepFunding: vi.fn(),
+    ...MOCK_LOADING_STATE,
   } satisfies SelectedItemStore
 
   vi.mocked(useSelectedItemStore).mockImplementation(selector =>


### PR DESCRIPTION
# Overview

This PR addresses a lot of performance improvements in the GUI in relation to the `selected-item` component and the `external-info` module.

## Improvements

Before | After | Improvement
-- | -- | --
~20+ re-renders per selected item | 2 re-renders per selected item | ~90% reduction
Duplicate packument fetches, duplicate publisher logic | Each API called exactly once | Eliminated duplicates
Streaming updates could show stale data if user changed selection mid-stream | Single atomic update eliminates race conditions
UI flickered as partial data streamed in | Clean single update with complete data
Multiple layout shifts as content populated | One layout adjustment when data arrives

## Before and Afters

### Before
https://github.com/user-attachments/assets/ff327844-c5a8-4977-9d79-932d9be16193

### After
https://github.com/user-attachments/assets/2eb40119-5437-4d8b-bc2a-185122d93687

## What were the issues?

In our original implementation of the GUI, we prioritized getting data back to the UI as quickly as possible, so the UI can at least present something while the rest of the data was being loaded / fetched. We did this by streaming UI updates directly into the state in the `selected-item/context` tree. With all the race conditions and state updates, this produces layout thrashing and popcorning in the UI as data was loaded in incrementally.

### [Seven Setters](https://github.com/vltpkg/vltpkg/blob/f98fabece724d6257a7186c807e9fefc0aeadf6d/src/gui/src/components/explorer-grid/selected-item/context.tsx#L389-L410)

```ts
  } finally {
    const {
      depLicenses,
      scannedDeps,
      averageScore,
      depWarnings,
      totalDepCount,
      duplicatedDeps,
      depFunding,
    } = counters


    setDepLicenses(depLicenses)
    setScannedDeps(scannedDeps)
    setDepsAverageScore(
      Math.floor((averageScore.score / averageScore.count) * 100),
    )
    setDepWarnings(Array.from(depWarnings.values()))
    setDepCount(totalDepCount || undefined)
    setDuplicatedDeps(duplicatedDeps)
    setDepFunding(depFunding)
  }
}
```

React does its best at batching state updates, but zustand updates synchronously. So we were forcing each component to "wake up" and check their state 7 times in a row within a single update.

### `lib/external-info.ts`

Previously, we were streaming updates directly into state as they came in. 

#### `selected-item/context`
```ts
for await (const d of fetchDetails(
            manifestHydratedSpec ?? finalSpec,
            abortController.signal,
            manifest ?? undefined,
          )) {
            store.setState(state => ({
              ...state,
              ...d,
            }))
          }
```

#### `lib/external-info`
```ts
while (true) {
    // when we reach the end of the promises queue, we have this extra logic
    // here to ensure that we yield all final results, including edge cases
    // such as when multiple promises fulfill at the same time.
    if (promisesQueue.length === 0) {
      let res: DetailsInfo = {}
      for (const p of await Promise.all(fulfilledPromises)) {
        for (const key of Object.keys(p)) {
          res = { ...res, [key]: p[key as keyof DetailsInfo] }
        }
      }
      yield res
      break
    }
    // yield results as soon as they're ready
    yield await Promise.race(promisesQueue)
  }
```

Therefore if `fetchDetails` yields 5 times (stars, licenses, manifest, readme etc) then the UI 'pops' 5 times, if on React `strictMode` this increases to 10

This is the module that got the biggest improvement. The previous logic was intense and hard to maintain with the callbacks, by leveraging [Effect](https://www.effect.website) we could break apart each meaningful operation into composable Effects, each operation (i.e. `fetchGithubStars`, `fetchGithubRepo`, `fetchReadme`, `fetchDownloadsLastYear`) could be modelled as an effect, with a wrapper for error tracking. By modelling each parallel fetch as an effect and combining them all, we could guarantee that the combined effect only succeeds once with a complete, aggregated data structure solving the layout thrashing issue by enforcing a single atomic update.

By introducing Effect, we have access to a type signature with a possible error / exception on the Effects, and then use them to display an 'indicator' in the UI when one or many fetches failed to happen.

And by removing the streaming we also remove the 'popcorning' and layout thrashing.