### PR TITLE
package-info: add remote integrity checks

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -139,7 +139,7 @@ importers:
         version: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.34.0(jiti@2.6.1))
       eslint-plugin-import:
         specifier: ^2.32.0
-        version: 2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.34.0(jiti@2.6.1))
+        version: 2.32.0(@typescript-eslint/parser@8.41.0(eslint@9.34.0(jiti@2.6.1))(typescript@5.7.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.34.0(jiti@2.6.1))
       eslint-plugin-jsdoc:
         specifier: ^54.1.1
         version: 54.7.0(eslint@9.34.0(jiti@2.6.1))
@@ -1495,6 +1495,9 @@ importers:
       '@vltpkg/xdg':
         specifier: workspace:*
         version: link:../xdg
+      ssri:
+        specifier: 'catalog:'
+        version: 12.0.0
       tar:
         specifier: 'catalog:'
         version: 7.5.1
@@ -17378,10 +17381,10 @@ snapshots:
     dependencies:
       '@types/node': 22.18.0
 
-  '@typescript-eslint/eslint-plugin@8.41.0(@typescript-eslint/parser@8.41.0(eslint@9.34.0(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.7.3))(eslint@9.34.0(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.7.3)':
+  '@typescript-eslint/eslint-plugin@8.41.0(@typescript-eslint/parser@8.41.0(eslint@9.34.0(jiti@2.6.1))(typescript@5.7.3))(eslint@9.34.0(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.7.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.1
-      '@typescript-eslint/parser': 8.41.0(eslint@9.34.0(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.7.3)
+      '@typescript-eslint/parser': 8.41.0(eslint@9.34.0(jiti@2.6.1))(typescript@5.7.3)
       '@typescript-eslint/scope-manager': 8.41.0
       '@typescript-eslint/type-utils': 8.41.0(eslint@9.34.0(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.7.3)
       '@typescript-eslint/utils': 8.41.0(eslint@9.34.0(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.7.3)
@@ -19325,21 +19328,22 @@ snapshots:
       tinyglobby: 0.2.13
       unrs-resolver: 1.7.9
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.34.0(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.41.0(eslint@9.34.0(jiti@2.6.1))(typescript@5.7.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.34.0(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.34.0(jiti@2.6.1)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.41.0(eslint@9.34.0(jiti@2.6.1))(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.34.0(jiti@2.6.1)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
+      '@typescript-eslint/parser': 8.41.0(eslint@9.34.0(jiti@2.6.1))(typescript@5.7.3)
       eslint: 9.34.0(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.34.0(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.34.0(jiti@2.6.1)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.41.0(eslint@9.34.0(jiti@2.6.1))(typescript@5.7.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.34.0(jiti@2.6.1)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -19350,7 +19354,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.34.0(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.34.0(jiti@2.6.1))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.41.0(eslint@9.34.0(jiti@2.6.1))(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.34.0(jiti@2.6.1))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -19361,6 +19365,8 @@ snapshots:
       semver: 6.3.1
       string.prototype.trimend: 1.0.9
       tsconfig-paths: 3.15.0
+    optionalDependencies:
+      '@typescript-eslint/parser': 8.41.0(eslint@9.34.0(jiti@2.6.1))(typescript@5.7.3)
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
@@ -24357,7 +24363,7 @@ snapshots:
 
   typescript-eslint@8.41.0(eslint@9.34.0(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.7.3):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 8.41.0(@typescript-eslint/parser@8.41.0(eslint@9.34.0(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.7.3))(eslint@9.34.0(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.7.3)
+      '@typescript-eslint/eslint-plugin': 8.41.0(@typescript-eslint/parser@8.41.0(eslint@9.34.0(jiti@2.6.1))(typescript@5.7.3))(eslint@9.34.0(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.7.3)
       '@typescript-eslint/parser': 8.41.0(eslint@9.34.0(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.7.3)
       '@typescript-eslint/typescript-estree': 8.41.0(supports-color@10.2.2)(typescript@5.7.3)
       '@typescript-eslint/utils': 8.41.0(eslint@9.34.0(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.7.3)

--- a/src/graph/src/lockfile/load-nodes.ts
+++ b/src/graph/src/lockfile/load-nodes.ts
@@ -112,7 +112,10 @@ export const loadNodes = (
     node.dev = dev
     node.optional = optional
     node.integrity = integrity ?? referenceNode?.integrity
-    node.resolved = resolved ?? referenceNode?.resolved
+    node.resolved =
+      type === 'remote' ? filepath : (
+        (resolved ?? referenceNode?.resolved)
+      )
     node.projectRoot = graph.projectRoot
     if (!node.resolved) node.setResolved()
     if (location) {

--- a/src/graph/src/lockfile/save.ts
+++ b/src/graph/src/lockfile/save.ts
@@ -85,7 +85,9 @@ const formatNodes = (
       lockfileNode[2] = node.integrity
     }
 
-    if (resolved) {
+    // skip resolved for remote nodes since
+    // these are already part of the dep id
+    if (resolved && !node.id.startsWith('remote')) {
       lockfileNode[3] = resolved
     }
 

--- a/src/graph/src/node.ts
+++ b/src/graph/src/node.ts
@@ -361,6 +361,11 @@ export class Node implements NodeLike {
     const tuple = splitDepID(this.id)
     const [type, resolved] = tuple
     switch (type) {
+      case 'remote': {
+        this.resolved = resolved
+        this.integrity ??= this.manifest?.dist?.integrity
+        break
+      }
       case 'registry':
         this.#registryNodeResolved(tuple)
         break

--- a/src/graph/src/reify/extract-node.ts
+++ b/src/graph/src/reify/extract-node.ts
@@ -88,22 +88,30 @@ export const extractNode = async (
 
     if (removeOptionalFailedNode) {
       try {
-        await packageInfo.extract(spec, target, {
+        const result = await packageInfo.extract(spec, target, {
           from,
           integrity,
           resolved,
         })
+        // Store computed integrity for git/remote deps
+        if (result.integrity && !node.integrity) {
+          node.integrity = result.integrity
+        }
         return { success: true, node }
       } catch (error) {
         removeOptionalFailedNode()
         return { success: false, node, error }
       }
     } else {
-      await packageInfo.extract(spec, target, {
+      const result = await packageInfo.extract(spec, target, {
         from,
         integrity,
         resolved,
       })
+      // Store computed integrity for git/remote deps
+      if (result.integrity && !node.integrity) {
+        node.integrity = result.integrity
+      }
       return { success: true, node }
     }
   } catch (error) {

--- a/src/graph/tap-snapshots/test/ideal/build-ideal-from-starting-graph.ts.test.cjs
+++ b/src/graph/tap-snapshots/test/ideal/build-ideal-from-starting-graph.ts.test.cjs
@@ -150,6 +150,7 @@ exports[`test/ideal/build-ideal-from-starting-graph.ts > TAP > optional subdeps 
         id: '·npm·esbuild@0.25.11',
         location: './node_modules/.vlt/·npm·esbuild@0.25.11/node_modules/esbuild',
         resolved: 'https://registry.npmjs.org/esbuild/-/esbuild-0.25.11.tgz',
+        integrity: 'sha512-00000000000000000000000000000000000000000000000000000000000000000000000000000000000000==',
         edgesOut: [
           Edge spec(@esbuild/darwin-arm64@0.25.11) -optional-> to: Node {
             id: '·npm·@esbuild§darwin-arm64@0.25.11',

--- a/src/graph/tap-snapshots/test/lockfile/load-nodes.ts.test.cjs
+++ b/src/graph/tap-snapshots/test/lockfile/load-nodes.ts.test.cjs
@@ -132,6 +132,23 @@ Array [
     "resolved": "https://registry.npmjs.org/baz/-/baz-1.0.0.tgz",
     "version": "1.0.0",
   },
+  Object {
+    "buildState": "none",
+    "confused": false,
+    "dev": false,
+    "id": "remote·http%3A§§example.com§tarball.tgz",
+    "importer": false,
+    "integrity": "sha512-deadbeefcafebabe==",
+    "location": "./node_modules/.vlt/remote·http%3A§§example.com§tarball.tgz/node_modules/remote-pkg",
+    "manifest": undefined,
+    "modifier": undefined,
+    "name": "remote-pkg",
+    "optional": false,
+    "platform": undefined,
+    "projectRoot": "{ROOT}",
+    "resolved": "http://example.com/tarball.tgz",
+    "version": undefined,
+  },
 ]
 `
 

--- a/src/graph/tap-snapshots/test/node.ts.test.cjs
+++ b/src/graph/tap-snapshots/test/node.ts.test.cjs
@@ -83,6 +83,34 @@ exports[`test/node.ts > TAP > Node > should stringify remote node 1`] = `
 remote(https://x.com/x.tgz):x@1.0.0
 `
 
+exports[`test/node.ts > TAP > Node > should stringify remote node as expected 1`] = `
+remote(https://example.com/x.tgz)
+`
+
+exports[`test/node.ts > TAP > Node > should stringify remote node with integrity 1`] = `
+Object {
+  "buildState": "none",
+  "confused": false,
+  "dev": false,
+  "id": "remote·https%3A§§example.com§x.tgz",
+  "importer": false,
+  "integrity": "sha512-deadbeef",
+  "location": "./node_modules/.vlt/remote·https%3A§§example.com§x.tgz/node_modules/remote·https%3A§§example.com§x.tgz",
+  "manifest": Object {
+    "dist": Object {
+      "integrity": "sha512-deadbeef",
+    },
+  },
+  "modifier": undefined,
+  "name": "remote·https%3A§§example.com§x.tgz",
+  "optional": false,
+  "platform": undefined,
+  "projectRoot": "{ROOT}",
+  "resolved": "https://example.com/x.tgz",
+  "version": undefined,
+}
+`
+
 exports[`test/node.ts > TAP > Node > should stringify remote node with no manifest 1`] = `
 remote(https://x.com/x.tgz)
 `

--- a/src/graph/test/fixtures/reify.ts
+++ b/src/graph/test/fixtures/reify.ts
@@ -107,7 +107,7 @@ export const mockPackageInfo = {
     spec: string | Spec,
     target: string,
     options: PackageInfoClientRequestOptions = {},
-  ) => {
+  ): Promise<Resolution> => {
     spec = Spec.parse(String(spec)).final
     if (spec.type === 'file') {
       return actualPackageInfo.extract(spec, target, options)
@@ -123,6 +123,9 @@ export const mockPackageInfo = {
       mkdirSync(target, { recursive: true })
       extract({ sync: true, file: artifact, strip: 1, cwd: target })
     }
+    // Return Resolution object to match PackageInfoClient.extract signature
+    const res = await mockPackageInfo.resolve(spec, options)
+    return res
   },
 }
 

--- a/src/graph/test/ideal/build-ideal-from-starting-graph.ts
+++ b/src/graph/test/ideal/build-ideal-from-starting-graph.ts
@@ -125,7 +125,13 @@ const packageInfo = {
         return null
     }
   },
-  async extract(): Promise<void> {},
+  async extract(): Promise<{ integrity: string; resolved: string }> {
+    return {
+      integrity:
+        'sha512-00000000000000000000000000000000000000000000000000000000000000000000000000000000000000==',
+      resolved: 'https://example.com/remote-pkg-1.0.0.tgz',
+    }
+  },
 } as unknown as PackageInfoClient
 
 t.test('build from a virtual graph', async t => {

--- a/src/graph/test/ideal/peers.ts
+++ b/src/graph/test/ideal/peers.ts
@@ -1309,7 +1309,16 @@ t.test('integration tests', async t => {
         const key = `${spec.name}@${version}`
         return mockManifests[key] || null
       },
-      async extract() {},
+      async extract(): Promise<{
+        integrity: string
+        resolved: string
+      }> {
+        return {
+          integrity:
+            'sha512-00000000000000000000000000000000000000000000000000000000000000000000000000000000000000==',
+          resolved: 'https://example.com/remote-pkg-1.0.0.tgz',
+        }
+      },
     } as unknown as PackageInfoClient
   }
 

--- a/src/graph/test/lockfile/load-nodes.ts
+++ b/src/graph/test/lockfile/load-nodes.ts
@@ -45,6 +45,11 @@ t.test('load nodes', async t => {
       null,
       './node_modules/.pnpm/baz@1.0.0/node_modules/baz',
     ],
+    [joinDepIDTuple(['remote', 'http://example.com/tarball.tgz'])]: [
+      0,
+      'remote-pkg',
+      'sha512-deadbeefcafebabe==',
+    ],
   } as LockfileData['nodes']
   loadNodes(graph, nodes, {})
   t.matchSnapshot(

--- a/src/graph/test/node.ts
+++ b/src/graph/test/node.ts
@@ -192,6 +192,32 @@ t.test('Node', async t => {
     'should stringify file node with no manifest',
   )
 
+  // test resolved for remote packages
+  const remotePkg = new Node(
+    opts,
+    joinDepIDTuple(['remote', 'https://example.com/x.tgz']),
+  )
+  remotePkg.setResolved()
+  t.strictSame(
+    remotePkg.resolved,
+    'https://example.com/x.tgz',
+    'should set expected resolved value for a remote file type',
+  )
+  t.matchSnapshot(
+    String(remotePkg),
+    'should stringify remote node as expected',
+  )
+
+  // now let's resolve again with an integrity value available
+  remotePkg.manifest = {
+    dist: { integrity: 'sha512-deadbeef' },
+  }
+  remotePkg.setResolved()
+  t.matchSnapshot(
+    remotePkg.toJSON(),
+    'should stringify remote node with integrity',
+  )
+
   const fileMani = new Node(
     opts,
     joinDepIDTuple(['file', 'my-package']),

--- a/src/graph/test/reify/add-nodes.ts
+++ b/src/graph/test/reify/add-nodes.ts
@@ -21,6 +21,11 @@ const mockPackageInfo = {
       throw new Error('failer fails to extract')
     }
     extracted.push([spec, target])
+    return {
+      integrity:
+        'sha512-00000000000000000000000000000000000000000000000000000000000000000000000000000000000000==',
+      resolved: 'https://example.com/remote-pkg-1.0.0.tgz',
+    }
   },
 } as unknown as PackageInfoClient
 

--- a/src/package-info/package.json
+++ b/src/package-info/package.json
@@ -30,6 +30,7 @@
     "@vltpkg/types": "workspace:*",
     "@vltpkg/workspaces": "workspace:*",
     "@vltpkg/xdg": "workspace:*",
+    "ssri": "catalog:",
     "tar": "catalog:"
   },
   "devDependencies": {

--- a/src/package-info/tap-snapshots/test/index.ts.test.cjs
+++ b/src/package-info/tap-snapshots/test/index.ts.test.cjs
@@ -34,6 +34,9 @@ Object {
     "@npmcli/template-oss": "4.8.0",
     "tap": "^16.3.0",
   },
+  "dist": Object {
+    "integrity": "sha512-6/mh1E2u2YgEsCHdY0Yx5oW+61gZU+1vXaoiHHrpKeuRNNgFvS+/jrwHiQhB5apAf5oB7UB7E19ol2R2LKH8hQ==",
+  },
   "engines": Object {
     "node": "^14.17.0 || ^16.13.0 || >=18.0.0",
   },
@@ -154,6 +157,9 @@ Object {
         "@npmcli/eslint-config": "^4.0.0",
         "@npmcli/template-oss": "4.8.0",
         "tap": "^16.3.0",
+      },
+      "dist": Object {
+        "integrity": "sha512-6/mh1E2u2YgEsCHdY0Yx5oW+61gZU+1vXaoiHHrpKeuRNNgFvS+/jrwHiQhB5apAf5oB7UB7E19ol2R2LKH8hQ==",
       },
       "engines": Object {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0",


### PR DESCRIPTION
Add the ability for remote type of dependencies (these are usually random tarball url definitions or git resolutions with known tarball artifacts to download from) to store an integrity value calculated the first time they're download and the ability to check if that integrity value matches anytime you're installing from a lockfile that holds that integrity value.

This adds an extra layer of checks when installing a project from a lockfile with a known remote resolution.