### PR TITLE
[bugfix] gui: `dependencyClick` bad lookup

### DIFF
--- a/src/gui/src/components/explorer-grid/dependency-sidebar/context.tsx
+++ b/src/gui/src/components/explorer-grid/dependency-sidebar/context.tsx
@@ -7,6 +7,7 @@ import { addRemoveDependency } from '@/lib/add-remove-dependency.ts'
 
 import type { StoreApi } from 'zustand'
 import type { PropsWithChildren } from 'react'
+import type { State, Action } from '@/state/types.ts'
 import type { GridItemData } from '@/components/explorer-grid/types.ts'
 import type { Operation } from '@/lib/add-remove-dependency.ts'
 import type { Filter } from './filter-config.ts'
@@ -37,7 +38,15 @@ type DependencySidebarAction = {
     search: DependencySidebarState['searchTerm'],
   ) => void
   setInProgress: (bool: DependencySidebarState['inProgress']) => void
-  onDependencyClick: (item: GridItemData) => () => undefined
+  onDependencyClick: ({
+    item,
+    query,
+    updateQuery,
+  }: {
+    item: GridItemData
+    query: State['query']
+    updateQuery: Action['updateQuery']
+  }) => () => undefined
   setError: (str: DependencySidebarState['error']) => void
   setDependencyPopoverOpen: (
     o: DependencySidebarState['dependencyPopoverOpen'],

--- a/src/gui/src/components/explorer-grid/dependency-sidebar/index.tsx
+++ b/src/gui/src/components/explorer-grid/dependency-sidebar/index.tsx
@@ -1,3 +1,4 @@
+import { useGraphStore } from '@/state/index.ts'
 import {
   useDependencySidebarStore,
   useOperation,
@@ -21,6 +22,9 @@ export const DependencySideBar = () => {
   const onDependencyClick = useDependencySidebarStore(
     state => state.onDependencyClick,
   )
+  const query = useGraphStore(state => state.query)
+  const updateQuery = useGraphStore(state => state.updateQuery)
+
   const { operation } = useOperation()
 
   // Memoize sorted dependencies to prevent unnecessary re-sorting
@@ -58,7 +62,11 @@ export const DependencySideBar = () => {
                 item={item}
                 key={item.id}
                 dependencies={true}
-                onSelect={onDependencyClick(item)}
+                onSelect={onDependencyClick({
+                  item,
+                  query,
+                  updateQuery,
+                })}
                 onUninstall={() =>
                   operation({
                     item: {

--- a/src/gui/src/components/explorer-grid/selected-item/focused-view/index.tsx
+++ b/src/gui/src/components/explorer-grid/selected-item/focused-view/index.tsx
@@ -35,13 +35,20 @@ import { PartialErrorsIndicator } from '@/components/explorer-grid/selected-item
 import { cn } from '@/lib/utils.ts'
 
 import type { DepID } from '@vltpkg/dep-id'
+import type { State, Action } from '@/state/types.ts'
 import type { Tab } from '@/components/explorer-grid/selected-item/context.tsx'
 import type { GridItemData } from '@/components/explorer-grid/types.ts'
 
 interface FocusedViewProps {
   item: GridItemData
   dependencies: GridItemData[]
-  onDependencyClick: (dependency: GridItemData) => () => undefined
+  onDependencyClick: ({
+    item,
+  }: {
+    item: GridItemData
+    query: State['query']
+    updateQuery: Action['updateQuery']
+  }) => () => undefined
   uninstalledDependencies: GridItemData[]
   importerId?: DepID
 }


### PR DESCRIPTION
## Overview

The existing `dependencyClick` logic used `includes()` to decide whether a query segment was already present. This was too loose since it matched any substring.

For example, if the current `query` is `:root > #socks-proxy-agent` and we navigate to `#socks` (a dependency of `socks-proxy-agent`), the logic sees `"#socks"` as a substring of `"#socks-proxy-agent"` and incorrectly rewrites the query to:

`:root > #socks`

instead of:

`:root > #socks-proxy-agent > #socks`

This PR updates `dependencyClick` to operate on query **segments** (split on `" > "`) and compare full tokens instead of substrings, so navigation behaves correctly for cases like `#socks` / `#socks-proxy-agent`.

It also extracts out the `dependencyClick` function outside of `SelectedItem` and writes some tests to expect correct behaviour.
