### PR TITLE
[bugfix] gui: double rerender on `explore` route

### DIFF
--- a/src/gui/src/components/explorer-grid/index.tsx
+++ b/src/gui/src/components/explorer-grid/index.tsx
@@ -157,8 +157,6 @@ export const ExplorerGrid = ({
   const edges = useGraphStore(state => state.edges)
   const nodes = useGraphStore(state => state.nodes)
   const query = useGraphStore(state => state.query)
-  const stamp = useGraphStore(state => state.stamp)
-  const graphStamp = useGraphStore(state => state.graphStamp)
   const isExternalPackage = useGraphStore(
     state => state.isExternalPackage,
   )
@@ -195,15 +193,14 @@ export const ExplorerGrid = ({
   const items = getItemsData(edges, nodes, query)
 
   // Show loading when:
-  // 1. Graph is reloading (project switch)
-  // 2. Query is explicitly loading
-  // 3. The loaded query doesn't match the current query (prevents FOUC)
+  // 1. Query is explicitly loading
+  // 2. The loaded query doesn't match the current query (prevents FOUC)
   const hasQuery = query.trim().length > 0
   // If we have a query, but it doesn't match what we've loaded, show loading.
   // This handles initial load (loadedQuery is undefined) and transitions.
   const queryMismatch = hasQuery && query !== loadedQuery
 
-  if (stamp !== graphStamp || isLoading || queryMismatch) {
+  if (isLoading || queryMismatch) {
     return null
   }
 

--- a/src/gui/src/state/index.ts
+++ b/src/gui/src/state/index.ts
@@ -77,7 +77,6 @@ const initialState: State = {
   q: undefined,
   specOptions: undefined,
   stamp: newStamp(),
-  graphStamp: '', // Empty until first graph data loads
   theme: localStorage.getItem('vite-ui-theme') as State['theme'],
   focused: JSON.parse(
     localStorage.getItem('focused') ?? 'false',
@@ -130,8 +129,6 @@ export const useGraphStore = create<Action & State>((set, get) => {
     updateSpecOptions: (specOptions: State['specOptions']) =>
       set(() => ({ specOptions })),
     updateStamp: () => set(() => ({ stamp: newStamp() })),
-    updateGraphStamp: (graphStamp: State['graphStamp']) =>
-      set(() => ({ graphStamp })),
     updateTheme: (theme: State['theme']) => set(() => ({ theme })),
     updateFocused: (focused: State['focused']) => {
       set(() => ({ focused }))

--- a/src/gui/src/state/types.ts
+++ b/src/gui/src/state/types.ts
@@ -24,7 +24,6 @@ export type Action = {
   updateProjectInfo: (projectInfo: State['projectInfo']) => void
   updateSpecOptions: (specOptions: State['specOptions']) => void
   updateStamp: () => void
-  updateGraphStamp: (graphStamp: State['graphStamp']) => void
   updateTheme: (theme: State['theme']) => void
   updateQueryBuilderDisplay: (
     queryBuilderDisplay: State['queryBuilderDisplay'],
@@ -156,11 +155,6 @@ export type State = {
    * A random string to control when graph data should be reloaded.
    */
   stamp: string
-  /**
-   * The stamp value when the current graph data was loaded.
-   * Used to prevent rendering with stale edges/nodes.
-   */
-  graphStamp: string
   /**
    * Store the current theme value.
    */

--- a/src/gui/test/app/__snapshots__/explorer.tsx.snap
+++ b/src/gui/test/app/__snapshots__/explorer.tsx.snap
@@ -7,8 +7,17 @@ exports[`explorer has project root info 1`] = `
     class="h-full"
     style="opacity: 0; filter: blur(4px);"
   >
-    <gui-explorer-grid isloading="true">
+    <gui-explorer-grid isloading="false">
     </gui-explorer-grid>
+  </div>
+  <div
+    class="absolute inset-0 z-100 flex h-full w-full justify-center"
+    style="opacity: 0; filter: blur(4px);"
+  >
+    <div class="relative flex h-full w-full items-center justify-center">
+      <gui-jelly-triangle-spinner classname="text-primary">
+      </gui-jelly-triangle-spinner>
+    </div>
   </div>
 </div>
 
@@ -30,8 +39,17 @@ exports[`render default 1`] = `
     class="h-full"
     style="opacity: 0; filter: blur(4px);"
   >
-    <gui-explorer-grid isloading="true">
+    <gui-explorer-grid isloading="false">
     </gui-explorer-grid>
+  </div>
+  <div
+    class="absolute inset-0 z-100 flex h-full w-full justify-center"
+    style="opacity: 0; filter: blur(4px);"
+  >
+    <div class="relative flex h-full w-full items-center justify-center">
+      <gui-jelly-triangle-spinner classname="text-primary">
+      </gui-jelly-triangle-spinner>
+    </div>
   </div>
 </div>
 
@@ -44,8 +62,17 @@ exports[`render no results if search throws 1`] = `
     class="h-full"
     style="opacity: 0; filter: blur(4px);"
   >
-    <gui-explorer-grid isloading="true">
+    <gui-explorer-grid isloading="false">
     </gui-explorer-grid>
+  </div>
+  <div
+    class="absolute inset-0 z-100 flex h-full w-full justify-center"
+    style="opacity: 0; filter: blur(4px);"
+  >
+    <div class="relative flex h-full w-full items-center justify-center">
+      <gui-jelly-triangle-spinner classname="text-primary">
+      </gui-jelly-triangle-spinner>
+    </div>
   </div>
 </div>
 

--- a/src/gui/test/app/explorer.tsx
+++ b/src/gui/test/app/explorer.tsx
@@ -109,8 +109,6 @@ test('render default', async () => {
       state => state.updateProjectInfo,
     )
     const updateGraph = useStore(state => state.updateGraph)
-    const updateGraphStamp = useStore(state => state.updateGraphStamp)
-    const stamp = useStore(state => state.stamp)
     const updateQ = useStore(state => state.updateQ)
     updateProjectInfo({
       homedirRelativeRoot: '.',
@@ -119,7 +117,6 @@ test('render default', async () => {
       vltInstalled: true,
     })
     updateGraph({ projectRoot: '/path/to/project' } as GraphLike)
-    updateGraphStamp(stamp)
     // Provide a minimal Query object to avoid async loading
     const q = {
       search() {
@@ -139,8 +136,6 @@ test('explorer has project root info', async () => {
       state => state.updateProjectInfo,
     )
     const updateGraph = useStore(state => state.updateGraph)
-    const updateGraphStamp = useStore(state => state.updateGraphStamp)
-    const stamp = useStore(state => state.stamp)
     const updateQ = useStore(state => state.updateQ)
     updateProjectInfo({
       homedirRelativeRoot: '.',
@@ -149,7 +144,6 @@ test('explorer has project root info', async () => {
       vltInstalled: true,
     })
     updateGraph({ projectRoot: '/path/to/project' } as GraphLike)
-    updateGraphStamp(stamp)
     // Provide a minimal Query object to avoid async loading
     const q = {
       search() {
@@ -173,22 +167,19 @@ test('update nodes and edges info on query change', async () => {
   }
 
   const Container = () => {
-    const updateGraph = useStore(state => state.updateGraph)
     const updateProjectInfo = useStore(
       state => state.updateProjectInfo,
     )
-    const updateQ = useStore(state => state.updateQ)
+    const updateGraph = useStore(state => state.updateGraph)
     const updateQuery = useStore(state => state.updateQuery)
-    const updateGraphStamp = useStore(state => state.updateGraphStamp)
-    const stamp = useStore(state => state.stamp)
-    updateGraph({ projectRoot: '/path/to/project' } as GraphLike)
+    const updateQ = useStore(state => state.updateQ)
     updateProjectInfo({
       homedirRelativeRoot: '.',
       root: '.',
       tools: ['vlt'],
-      vltInstalled: true,
+      vltInstalled: false,
     })
-    updateGraphStamp(stamp)
+    updateGraph({ projectRoot: '/path/to/project' } as GraphLike)
     updateQ(q as unknown as Query)
     updateQuery('#foo')
     return <Explorer />
@@ -232,8 +223,6 @@ test('render no results if search throws', async () => {
     )
     const updateQ = useStore(state => state.updateQ)
     const updateQuery = useStore(state => state.updateQuery)
-    const updateGraphStamp = useStore(state => state.updateGraphStamp)
-    const stamp = useStore(state => state.stamp)
 
     // sets a node and edge just to test it got reset later on
     const node = {
@@ -255,7 +244,6 @@ test('render no results if search throws', async () => {
       tools: ['vlt'],
       vltInstalled: true,
     })
-    updateGraphStamp(stamp)
     updateQ(q as unknown as Query)
     updateQuery('#bar')
     return <Explorer />
@@ -293,8 +281,6 @@ test('explorer not vlt installed', async () => {
     const updateProjectInfo = useStore(
       state => state.updateProjectInfo,
     )
-    const updateGraphStamp = useStore(state => state.updateGraphStamp)
-    const stamp = useStore(state => state.stamp)
     updateGraph({ projectRoot: '/path/to/project' } as GraphLike)
     updateProjectInfo({
       homedirRelativeRoot: '.',
@@ -302,7 +288,6 @@ test('explorer not vlt installed', async () => {
       tools: [],
       vltInstalled: false,
     })
-    updateGraphStamp(stamp)
     return <Explorer />
   }
   render(<Container />)


### PR DESCRIPTION
## Overview

This PR eliminates the double render on the explore load and project switching.

The explorer had double rerenders in the following scenarios:
- **initial mount**: rendered twice when first loading the `/explore` route
- **project switching**: when navigating from `project-a` -> `project-b` from the dashboard

The root causes were:
1. redundant `graphStamp` sync, this was a manual state sync thats no longer needed since the Effect refactor of `external-info` handled the race conditions.
2. Stale data on project switch: when `stamp` was changed (indicating a project switch or graph update) the old graph/edges/nodes remained in the graph store while new data loaded
3. unbatched state updates: multiple zustand updates triggered seperate renders

The solution:
1. Remove the `graphStamp` manual state sync
2. Clear stale data asap when project switching 
    - when `stamp` changes clear the old data **before** fetching new data, preventing FOUC
3. Batch state updates with `startTransition`
    - we can leverage this to batch multiple state updates into single renders

other changes:
- added `keys` to the `AnimatePresence` to help React differentiate the two content states 
