### PR TITLE
fix: prevent double JSR name conversion during lockfile hydration

### DIFF
--- a/src/spec/src/browser.ts
+++ b/src/spec/src/browser.ts
@@ -739,7 +739,12 @@ export class Spec implements SpecLike<Spec> {
     this.registry = url
     // @luca/cases@jsr:1.x
     if (!s.startsWith('@')) s = `${this.name}@${s}`
-    const name = `@jsr/${s.replace(/^@/, '').replace(/\//, '__')}`
+    // If the name already starts with @jsr/, it's already in JSR npm
+    // format and should be used as-is (e.g. from lockfile hydration)
+    const name =
+      s.startsWith('@jsr/') ? s : (
+        `@jsr/${s.replace(/^@/, '').replace(/\//, '__')}`
+      )
     this.subspec = this.constructor.parse(name, {
       ...this.options,
       'scope-registries': {

--- a/src/spec/tap-snapshots/test/browser.ts.test.cjs
+++ b/src/spec/tap-snapshots/test/browser.ts.test.cjs
@@ -8154,8 +8154,8 @@ exports[`test/browser.ts > TAP > parse args > @luca/cases@jsr:@a/b@jsr:1 > inspe
     registry: 'https://npm.jsr.io/',
     subspec: @vltpkg/spec.Spec {
       type: 'registry',
-      spec: '@jsr/jsr__a__b@1',
-      name: '@jsr/jsr__a__b',
+      spec: '@jsr/a__b@1',
+      name: '@jsr/a__b',
       scope: '@jsr',
       scopeRegistry: 'https://npm.jsr.io/',
       bareSpec: '1',


### PR DESCRIPTION
## Summary

Fixes #1350

When installing a JSR dependency from a lockfile (without `node_modules`), the package name was being incorrectly converted from `@jsr/std__semver` to `@jsr/jsr__std__semver`. This caused a 404 error when fetching from the registry:

```
Resolve Error: failed to fetch packument
  While fetching: https://npm.jsr.io/@jsr/jsr__std__semver
```

## Root Cause

In `#parseJsrRegistrySpec`, the code was unconditionally converting scoped package names to JSR npm format by replacing `@scope/name` with `@jsr/scope__name`. However, when hydrating from a lockfile, the name was already in JSR format (`@jsr/std__semver`), and it got converted again to `@jsr/jsr__std__semver`.

## Fix

Added a check in `#parseJsrRegistrySpec` to skip conversion if the name already starts with `@jsr/`, as it's already in the correct JSR npm format.