### PR TITLE
docs: dont add workspaces with no exports

### DIFF
--- a/www/docs/src/plugins/typedoc.ts
+++ b/www/docs/src/plugins/typedoc.ts
@@ -1,9 +1,9 @@
 import { rm, stat } from 'node:fs/promises'
 import { spawn } from 'node:child_process'
 import type { AstroIntegrationLogger } from 'astro'
-import { typedocBasePath } from '../../typedoc/constants.mts'
+import { typedocContentPath } from '../../typedoc/constants.mts'
 
-export const directory = typedocBasePath
+export const directory = typedocContentPath
 
 export const plugin = {
   name: directory,
@@ -54,17 +54,6 @@ export const plugin = {
           )
           .on('error', rej)
       })
-
-      // Remove _media directory if it exists (contains files like LICENSE.md, CONTRIBUTING.md
-      // that are copied from source packages but shouldn't be included in the docs site)
-      const mediaDir = `${directory}/_media`
-      const mediaExists = await stat(mediaDir)
-        .then(f => f.isDirectory())
-        .catch(() => false)
-      if (mediaExists) {
-        o.logger.info(`removing ${mediaDir}`)
-        await rm(mediaDir, { recursive: true, force: true })
-      }
     },
   },
 }

--- a/www/docs/typedoc.workspace.mjs
+++ b/www/docs/typedoc.workspace.mjs
@@ -20,24 +20,31 @@ const readPkg = cwd => {
  */
 export default cwd => {
   const pkg = readPkg(cwd)
+  // Private workspaces are not included in the docs site.
+
   if (pkg.private) {
     return
   }
+
   const exports =
     'exports' in pkg && typeof pkg.exports === 'object' ?
       pkg.exports
     : null
-  if (!exports) {
+
+  // get actual code entry points from package.json exports
+  const entryPoints = Object.values(exports ?? {})
+    .map(p => (typeof p === 'string' ? p : p.import.default))
+    .filter(p => !p.endsWith('package.json'))
+    .map(p => join(cwd, p))
+
+  // If there are no entry points (like the gui) then it means to skip this workspace.
+  if (entryPoints.length === 0) {
     return
   }
+
   return {
     // get readme local to workspace
     readme: join(cwd, './README.md'),
-    // get entry points from package.json exports
-    entryPoints: Object.values(exports)
-      .map(p => (typeof p === 'string' ? p : p.import.default))
-      .filter(p => !p.endsWith('package.json'))
-      .map(p => (console.log(p), p))
-      .map(p => join(cwd, p)),
+    entryPoints,
   }
 }


### PR DESCRIPTION
This was previously handled by checking if a workspace used thsy but when that was removed in #1344, the `gui` workspace was trying to be added to the docs site even though it had no exports. The gui was never meant to be in the docs site so it's usage of markdown was breaking the build in a few ways.