### PR TITLE
graph: deterministic peer deps resolution

### DIFF
--- a/src/graph/src/ideal/append-nodes.ts
+++ b/src/graph/src/ideal/append-nodes.ts
@@ -436,7 +436,11 @@ const processPlacementTasks = async (
         manifest[depTypeName]
 
       if (depRecord && shouldInstallDepType(node, depTypeName)) {
-        for (const [name, bareSpec] of Object.entries(depRecord)) {
+        // Sort Object.entries for deterministic iteration
+        const sortedEntries = Object.entries(depRecord).sort(
+          ([a], [b]) => a.localeCompare(b, 'en'),
+        )
+        for (const [name, bareSpec] of sortedEntries) {
           // might need to skip already placed peer deps here
           if (bundled.has(name)) continue
           const dep = {


### PR DESCRIPTION
Add deterministic sorting at three key points in the peer dependency resolution process to prevent non-deterministic graph outputs caused by Promise.all timing variations and unsorted Map/Object iterations.

Changes:
- Add `getOrderedPeerContextEntries()` helper to sort peer context entries (non-peer deps first, then peer deps, alphabetically by name)
- Sort `childDepsToProcess` and `needsForking` entries in `postPlacementPeerCheck()` by `node.id` before processing
- Sort `queuedEntries` in `startPeerPlacement()` before returning
- Sort `Object.entries(depRecord)` in `append-nodes.ts` when iterating manifest dependencies

This fixes issues where different peerSetHash values could be assigned to packages between runs, causing inconsistent installs to the same project.