### PR TITLE
fix(cli-sdk): use process.cwd() for exec command working directory

### DIFF
--- a/src/cli-sdk/src/exec-command.ts
+++ b/src/cli-sdk/src/exec-command.ts
@@ -305,9 +305,11 @@ export class ExecCommand<B extends RunnerBG, F extends RunnerFG> {
       assert(first, error('no nodes found'))
       return resolve(this.projectRoot, first)
     }
+    // When no workspace/monorepo targeting is specified, use the current
+    // working directory. This matches npx behavior and is required for
+    // tools like node-gyp that must run in the correct directory.
     return (
-      this.#monorepo?.values().next().value?.fullpath ??
-      this.projectRoot
+      this.#monorepo?.values().next().value?.fullpath ?? process.cwd()
     )
   }
 

--- a/src/cli-sdk/test/exec-command.ts
+++ b/src/cli-sdk/test/exec-command.ts
@@ -64,7 +64,9 @@ t.test('with view', t => {
 })
 
 t.test('getCwd', async t => {
-  // fallback to projectRoot when no nodes/monorepo
+  // fallback to process.cwd() when no nodes/monorepo
+  // This matches npx behavior and is required for tools like node-gyp
+  // that must run in the directory where they were invoked
   {
     const e = new ExecCommand(
       {
@@ -81,7 +83,7 @@ t.test('getCwd', async t => {
       (async () => ({})) as any,
       (async () => ({})) as any,
     )
-    t.equal(e.getCwd(), t.testdirName)
+    t.equal(e.getCwd(), process.cwd())
   }
 
   // when nodes are selected via --scope, cwd is the first node absolute path


### PR DESCRIPTION
When vlt exec/vlx runs a command without workspace targeting, it should
use the current working directory rather than the discovered project root.
This is required for tools like node-gyp that must run in the exact
directory they were invoked from.

Previously, vlt exec would walk up to find vlt.json and use that as the
working directory, causing node-gyp to fail when run via the implicit
node-gyp shim during `vlt build`.

Closes #1368
