### PR TITLE
graph: fix peer deps resolution

### DIFF
--- a/src/graph/tap-snapshots/test/ideal/append-nodes.ts.test.cjs
+++ b/src/graph/tap-snapshots/test/ideal/append-nodes.ts.test.cjs
@@ -92,6 +92,19 @@ exports[`test/ideal/append-nodes.ts > TAP > append file type of nodes > should h
 ]
 `
 
+exports[`test/ideal/append-nodes.ts > TAP > fork peer context when existing node has incompatible peer edges > graph with forked peer contexts 1`] = `
+flowchart TD
+a("root:my-project")
+a -->|"parent-a#64;^1.0.0"| b("npm:parent-a#64;1.0.0")
+b -->|"react#64;^18.0.0"| d("npm:react#64;18.3.1")
+b -->|"flexible#64;^1.0.0"| e("npm:flexible#64;1.0.0")
+e -->|"react#64;>=17.0.0 (peer)"| d
+a -->|"parent-b#64;^1.0.0"| c("npm:parent-b#64;1.0.0")
+c -->|"react#64;^19.0.0"| f("npm:react#64;19.2.0")
+c -->|"flexible#64;^1.0.0"| g("npm:flexible#64;1.0.0")
+g -->|"react#64;>=17.0.0 (peer)"| f
+`
+
 exports[`test/ideal/append-nodes.ts > TAP > inject transient dependencies from transientAdd > graph should match snapshot 1`] = `
 flowchart TD
 a("root:my-project")

--- a/src/graph/tap-snapshots/test/ideal/peers.ts.test.cjs
+++ b/src/graph/tap-snapshots/test/ideal/peers.ts.test.cjs
@@ -96,3 +96,24 @@ e -->|"react#64;18 || 19"| f
 e -->|"#64;isaacs/peer-dep-cycle-a#64;1"| g
 e -->|"#64;ruyadorno/package-with-flexible-peer-deps#64;^1.1.0"| h
 `
+
+exports[`test/ideal/peers.ts > TAP > integration tests > outlier peer - workspace sibling with different peer context > should build graph with outlier peer context handling 1`] = `
+flowchart TD
+a("root:outlier-peer")
+a -->|"#64;ruyadorno/package-peer-parent-2#64;^1.0.0"| b("npm:#64;ruyadorno/package-peer-parent-2#64;1.0.0")
+b -->|"react#64;^19.1.0"| f("npm:react#64;19.2.0")
+b -->|"#64;isaacs/peer-dep-cycle-a#64;^2.0.0"| g("npm:#64;isaacs/peer-dep-cycle-a#64;2.0.0")
+g -->|"#64;isaacs/peer-dep-cycle-b#64;^2.0.0 (peer)"| j("npm:#64;isaacs/peer-dep-cycle-b#64;2.0.0")
+j -->|"#64;isaacs/peer-dep-cycle-c#64;^2.0.0 (peer)"| i("npm:#64;isaacs/peer-dep-cycle-c#64;2.0.0")
+i -->|"#64;isaacs/peer-dep-cycle-a#64;^2.0.0 (peer)"| g
+b -->|"#64;ruyadorno/package-with-flexible-peer-deps#64;^1.1.0"| e("npm:#64;ruyadorno/package-with-flexible-peer-deps#64;1.1.0")
+e -->|"react#64;18 || 19 (peer)"| c("npm:react#64;18.3.1")
+c -->|"loose-envify#64;^1.1.0"| h("npm:loose-envify#64;1.4.0")
+h -->|"js-tokens#64;^3.0.0 || ^4.0.0"| k("npm:js-tokens#64;4.0.0")
+e -->|"#64;isaacs/peer-dep-cycle-a#64;1 || 2 (peer)"| g
+e -->|"#64;isaacs/peer-dep-cycle-c#64;1 || 2 (peer)"| i
+a -->|"react#64;18"| c
+a -->|"a#64;workspace:*"| d("workspace:a")
+d -->|"react#64;18"| c
+d -->|"#64;ruyadorno/package-with-flexible-peer-deps#64;^1.0.0"| e
+`


### PR DESCRIPTION
Adds an extra layer of peer dep placement checks during the fetch manifest phase of the `append-nodes.ts` module that allows for an early fork of peer contexts when reusing nodes already available in the graph.

This fixes a problematic behavior when transitive dependencies deep down the graph resolution would leak to other unrelated peer context sets when building an ideal graph.

Fixes: https://github.com/vltpkg/vltpkg/issues/1378