### PR TITLE
graph: lockfile version check

### DIFF
--- a/src/error-cause/src/index.ts
+++ b/src/error-cause/src/index.ts
@@ -207,6 +207,7 @@ export type Codes =
   | 'EUSAGE'
   | 'EREQUEST'
   | 'ECONFIG'
+  | 'ELOCKFILEVERSION'
 
 // `captureStackTrace` is non-standard so explicitly type it as possibly
 // undefined since it might be in browsers.

--- a/src/graph/src/actual/load.ts
+++ b/src/graph/src/actual/load.ts
@@ -477,8 +477,9 @@ export const load = (options: LoadOptions): Graph => {
       done()
       return graph
     } catch {
-      // if validation fails or any other error occurs,
-      // fall back to filesystem traversal
+      // Hidden lockfile is cache-only, safe to regenerate on any error
+      // as it will fall back to filesystem traversal
+      // TODO: Warn version mismatch to @vltpkg/output for debugging
     }
   }
 

--- a/src/graph/src/ideal/build.ts
+++ b/src/graph/src/ideal/build.ts
@@ -87,7 +87,23 @@ export const build = async (
       mainManifest,
       monorepo,
     })
-  } catch {
+  } catch (err) {
+    // Check if this is a lockfile version mismatch
+    const cause = (
+      err as Error & {
+        cause?: { code?: string; found?: number; wanted?: number }
+      }
+    ).cause
+    if (cause?.code === 'ELOCKFILEVERSION') {
+      // If lockfile is from a different vlt version, hard fail
+      if (
+        typeof cause.found === 'number' &&
+        typeof cause.wanted === 'number'
+      ) {
+        throw err
+      }
+      // TODO: add warning to CLI layer via @vltpkg/output when available
+    }
     graph = loadActual({
       ...options,
       mainManifest,

--- a/src/graph/src/lockfile/save.ts
+++ b/src/graph/src/lockfile/save.ts
@@ -12,7 +12,11 @@ import {
 } from '@vltpkg/spec'
 import { mkdirSync, writeFileSync } from 'node:fs'
 import { dirname, resolve } from 'node:path'
-import { getFlagNumFromNode, getBuildStateFromNode } from './types.ts'
+import {
+  getFlagNumFromNode,
+  getBuildStateFromNode,
+  LOCKFILE_VERSION,
+} from './types.ts'
 import type { DepID } from '@vltpkg/dep-id'
 import type { SpecOptions } from '@vltpkg/spec'
 import type { Edge } from '../edge.ts'
@@ -208,7 +212,7 @@ export const lockfileData = ({
   const hasItems = (clean: Record<string, unknown> | undefined) =>
     clean && Object.keys(clean).length
   return {
-    lockfileVersion: 0,
+    lockfileVersion: LOCKFILE_VERSION,
     options: {
       ...(hasItems(cleanModifiers) ?
         { modifiers: cleanModifiers }

--- a/src/graph/src/lockfile/types.ts
+++ b/src/graph/src/lockfile/types.ts
@@ -33,6 +33,13 @@ export type LockfileData = {
   edges: LockfileEdges
 }
 
+/**
+ * Current lockfile format version.
+ * Only lockfiles with matching version are considered valid.
+ * Bump when making breaking format changes.
+ */
+export const LOCKFILE_VERSION = 0
+
 export const getFlagNumFromNode = (node: {
   optional?: boolean
   dev?: boolean

--- a/src/graph/src/reify/index.ts
+++ b/src/graph/src/reify/index.ts
@@ -95,6 +95,7 @@ export type ReifyOptions = LoadOptions & {
   packageInfo: PackageInfoClient
   modifiers?: GraphModifier
   remover: RollbackRemove
+  update?: boolean
 }
 
 export type ReifyResult = {
@@ -131,8 +132,9 @@ export const reify = async (
     !options.add?.modifiedDependencies &&
     !options.remove?.modifiedDependencies
   const skipOptionalOnly = noModifiedDependencies && diff.optionalOnly
+  const skippable = skipOptionalOnly && !options.update
   const res: ReifyResult = { diff }
-  if (!diff.hasChanges() || skipOptionalOnly) {
+  if (!diff.hasChanges() || skippable) {
     // nothing to do, so just return the diff
     done()
     return res

--- a/src/graph/src/update.ts
+++ b/src/graph/src/update.ts
@@ -63,6 +63,7 @@ export const update = async (options: UpdateOptions) => {
       loadManifests: true,
       modifiers,
       remover,
+      update: true,
     })
 
     return { buildQueue, graph, diff }

--- a/src/graph/test/lockfile/types.ts
+++ b/src/graph/test/lockfile/types.ts
@@ -22,6 +22,7 @@ import {
   BuildStateNeeded,
   BuildStateBuilt,
   BuildStateFailed,
+  LOCKFILE_VERSION,
 } from '../../src/lockfile/types.ts'
 
 t.test('lockfile type checks', t => {
@@ -437,4 +438,8 @@ t.test('lockfile type constraints', t => {
   )
 
   t.end()
+})
+
+t.test('LOCKFILE_VERSION constant', async t => {
+  t.equal(typeof LOCKFILE_VERSION, 'number', 'is a number')
 })


### PR DESCRIPTION
Adds validation check of lockfile versions against the current supported lockfile version of the CLI.

Refs: https://github.com/vltpkg/vltpkg/pull/1420