### PR TITLE
Allow publishing of unscoped packages in vsr

### DIFF
--- a/src/vsr/src/utils/packages.ts
+++ b/src/vsr/src/utils/packages.ts
@@ -40,6 +40,9 @@ export function packageSpec(c: HonoContext): PackageSpec {
   } else if (scope) {
     // Unscoped package (scope is actually the package name)
     return { name: scope, pkg: scope }
+  } else if (pkg) {
+    // Also unscoped packages. Some routes set 'pkg', not 'scope'
+    return { name: pkg, pkg: pkg }
   }
 
   return {}


### PR DESCRIPTION
This PR allows unscoped packages to be published in vsr.

The route for unscoped packages sets a 'pkg' parameter, but not a 'scope'. The `packageSpec` utility doesn't handle this case and would consistently emit a `403`.

