### PR TITLE
chore: use relative value for parallelism

### DIFF
--- a/.cursor/rules/graph/reify.mdc
+++ b/.cursor/rules/graph/reify.mdc
@@ -45,7 +45,7 @@ actions:
       - Node extraction and edge deletions:
         - `addNodes(diff, scurry, remover, options, packageInfo)` → returns async actions to fetch/extract nodes into the `.vlt` store (registry/git/tarball installs). Optional deps use `optionalFail()` to remove subgraphs instead of failing the whole reify.
         - `deleteEdges(diff, scurry, remover)` → returns async actions removing outdated links and their bins.
-        - Actions run via `callLimit(actions, { limit })` where `limit = (availableParallelism() - 1) * 8`.
+        - Actions run via `callLimit(actions, { limit })` where `limit = (availableParallelism() - 1) ** 2`.
 
       - Link creation:
         - `addEdges(diff, packageJson, scurry, remover)` → creates symlinks in importer `node_modules` and links package bins into `.bin`. On Windows, uses `@vltpkg/cmd-shim` for executables.

--- a/src/graph/src/reify/index.ts
+++ b/src/graph/src/reify/index.ts
@@ -33,7 +33,7 @@ import { SecurityArchive } from '@vltpkg/security-archive'
 import type { NodeLike } from '@vltpkg/types'
 import { binChmodAll } from './bin-chmod.ts'
 
-const limit = Math.max(availableParallelism() - 1, 1) * 8
+const limit = Math.max(availableParallelism() - 1, 1) ** 2
 
 /**
  * Filter nodes using a DSS query string

--- a/src/server/src/read-project-folders.ts
+++ b/src/server/src/read-project-folders.ts
@@ -4,7 +4,7 @@ import type { PathBase, PathScurry } from 'path-scurry'
 import { callLimit } from 'promise-call-limit'
 import { ignoredHomedirFolderNames } from './ignored-homedir-folder-names.ts'
 
-const limit = Math.max(availableParallelism() - 1, 1) * 8
+const limit = Math.max(availableParallelism() - 1, 1) ** 2
 let home: string
 try {
   home = homedir()

--- a/src/tar/src/pool.ts
+++ b/src/tar/src/pool.ts
@@ -21,7 +21,7 @@ export class Pool {
    * CPUs, or 1.
    */
   /* c8 ignore next */
-  jobs: number = 8 * (Math.max(os.availableParallelism(), 2) - 1)
+  jobs: number = (Math.max(os.availableParallelism(), 2) - 1) ** 2
   /**
    * Set of currently active worker threads
    */

--- a/src/tar/test/pool.ts
+++ b/src/tar/test/pool.ts
@@ -8,7 +8,7 @@ import { resolve } from 'node:path'
 import { makeTar } from './fixtures/make-tar.ts'
 
 const p = new Pool()
-t.equal(p.jobs, 8 * (Math.max(availableParallelism(), 2) - 1))
+t.equal(p.jobs, (Math.max(availableParallelism(), 2) - 1) ** 2)
 
 // make it smaller so we can cover the contention cases
 p.jobs = 2


### PR DESCRIPTION
Instead of arbitrarily multiplying the amount of parallel operations by 8 (which is likely the most common number of thread we've been testing against) let's use the os-provided thread number as the multiplying factor.