### PR TITLE
graph: preserve lockfile custom resolved values

### DIFF
--- a/src/graph/src/ideal/append-nodes.ts
+++ b/src/graph/src/ideal/append-nodes.ts
@@ -545,7 +545,13 @@ const processPlacementTasks = async (
     if (fileTypeInfo?.path && fileTypeInfo.isDirectory) {
       node.location = fileTypeInfo.path
     }
-    node.setResolved()
+    // Do not clobber lockfile-provided resolved values.
+    // `setResolved()` cannot infer a tarball without a manifest,
+    // which can cause `resolved` to become undefined and the
+    // main lockfile to mutate across installs.
+    if (!node.resolved) {
+      node.setResolved()
+    }
 
     // collect child dependencies for processing in the next level
     const nextPeerDeps = new Map<string, Dependency>()


### PR DESCRIPTION
Prevents `setResolved()` from clobbering
lockfile-provided resolved values, which would cause
the resolved field to become undefined and trigger
unwanted lockfile mutations across installs.

Refs: https://github.com/vltpkg/vltpkg/issues/1404