### PR TITLE
cli-sdk: add view count option

### DIFF
--- a/src/cli-sdk/src/commands/list.ts
+++ b/src/cli-sdk/src/commands/list.ts
@@ -28,8 +28,8 @@ export const usage: CommandUsage = () =>
     command: 'ls',
     usage: [
       '',
-      '[package-names...] [--view=human | json | mermaid]',
-      '[--scope=<query>] [--target=<query>] [--view=human | json | mermaid]',
+      '[package-names...] [--view=human | json | mermaid | count]',
+      '[--scope=<query>] [--target=<query>] [--view=human | json | mermaid | count]',
     ],
     description: `List installed dependencies matching given package names or query selectors.
 
@@ -75,9 +75,9 @@ export const usage: CommandUsage = () =>
           'Query selector to filter packages using the DSS query language syntax.',
       },
       view: {
-        value: '[human | json | mermaid]',
+        value: '[human | json | mermaid | count]',
         description:
-          'Output format. Defaults to human-readable or json if no tty.',
+          'Output format. Defaults to human-readable or json if no tty. Count outputs the number of dependency relationships in the result.',
       },
     },
   })
@@ -90,6 +90,7 @@ export const views = {
   json: jsonOutput,
   mermaid: mermaidOutput,
   human: humanReadableOutput,
+  count: (result: ListResult) => result.edges.length,
 } as const satisfies Views<ListResult>
 
 export const command: CommandFn<ListResult> = async conf => {

--- a/src/cli-sdk/src/commands/query.ts
+++ b/src/cli-sdk/src/commands/query.ts
@@ -29,9 +29,9 @@ export const usage: CommandUsage = () =>
     command: 'query',
     usage: [
       '',
-      '<query> --view=<human | json | mermaid>',
+      '<query> --view=<human | json | mermaid | count>',
       '<query> --expect-results=<comparison string>',
-      '--target=<query> --view=<human | json | mermaid>',
+      '--target=<query> --view=<human | json | mermaid | count>',
     ],
     description: `List installed dependencies matching the provided query.
 
@@ -95,9 +95,9 @@ export const usage: CommandUsage = () =>
           'Query selector to filter packages using DSS syntax.',
       },
       view: {
-        value: '[human | json | mermaid]',
+        value: '[human | json | mermaid | count]',
         description:
-          'Output format. Defaults to human-readable or json if no tty.',
+          'Output format. Defaults to human-readable or json if no tty. Count outputs the number of dependency relationships in the result.',
       },
     },
   })
@@ -129,6 +129,7 @@ export const views = {
   json: jsonOutput,
   mermaid: mermaidOutput,
   human: humanReadableOutput,
+  count: (result: QueryResult) => result.edges.length,
 } as const satisfies Views<QueryResult>
 
 export const command: CommandFn<QueryResult> = async conf => {

--- a/src/cli-sdk/src/config/definition.ts
+++ b/src/cli-sdk/src/config/definition.ts
@@ -567,6 +567,8 @@ export const definition = j
                     - inspect: Output results with \`util.inspect\`.
                     - mermaid: Output mermaid diagramming syntax. (Only
                       relevant for certain commands.)
+                    - count: Output the number of dependency relationships in
+                      the result set.
                     - silent: Suppress all output to stdout.
 
                     If the requested view format is not supported for the
@@ -577,6 +579,7 @@ export const definition = j
         'human',
         'json',
         'mermaid',
+        'count',
         'inspect',
         'silent',
       ] as const,

--- a/src/cli-sdk/tap-snapshots/test/commands/list.ts.test.cjs
+++ b/src/cli-sdk/tap-snapshots/test/commands/list.ts.test.cjs
@@ -143,8 +143,9 @@ workspace-a
 exports[`test/commands/list.ts > TAP > list > should have usage 1`] = `
 Usage:
   vlt ls
-  vlt ls [package-names...] [--view=human | json | mermaid]
-  vlt ls [--scope=<query>] [--target=<query>] [--view=human | json | mermaid]
+  vlt ls [package-names...] [--view=human | json | mermaid | count]
+  vlt ls [--scope=<query>] [--target=<query>] [--view=human | json | mermaid |
+  count]
 
 List installed dependencies matching given package names or query selectors.
 
@@ -196,9 +197,10 @@ workspace.
       ​--target=<query>
 
     view
-      Output format. Defaults to human-readable or json if no tty.
+      Output format. Defaults to human-readable or json if no tty. Count outputs
+      the number of dependency relationships in the result.
 
-      ​--view=[human | json | mermaid]
+      ​--view=[human | json | mermaid | count]
 
 `
 

--- a/src/cli-sdk/tap-snapshots/test/commands/query.ts.test.cjs
+++ b/src/cli-sdk/tap-snapshots/test/commands/query.ts.test.cjs
@@ -147,9 +147,9 @@ workspace-a
 exports[`test/commands/query.ts > TAP > query > should have usage 1`] = `
 Usage:
   vlt query
-  vlt query <query> --view=<human | json | mermaid>
+  vlt query <query> --view=<human | json | mermaid | count>
   vlt query <query> --expect-results=<comparison string>
-  vlt query --target=<query> --view=<human | json | mermaid>
+  vlt query --target=<query> --view=<human | json | mermaid | count>
 
 List installed dependencies matching the provided query.
 
@@ -226,9 +226,10 @@ Defaults to listing all dependencies of the project root and workspaces.
       ​--target=<query>
 
     view
-      Output format. Defaults to human-readable or json if no tty.
+      Output format. Defaults to human-readable or json if no tty. Count outputs
+      the number of dependency relationships in the result.
 
-      ​--view=[human | json | mermaid]
+      ​--view=[human | json | mermaid | count]
 
 `
 

--- a/src/cli-sdk/tap-snapshots/test/config/definition.ts.test.cjs
+++ b/src/cli-sdk/tap-snapshots/test/config/definition.ts.test.cjs
@@ -457,6 +457,7 @@ Object {
       - json: Parseable JSON output for machines.
       - inspect: Output results with \`util.inspect\`.
       - mermaid: Output mermaid diagramming syntax. (Only relevant for certain commands.)
+      - count: Output the number of dependency relationships in the result set.
       - silent: Suppress all output to stdout.
       
       If the requested view format is not supported for the current command, or if no option is provided, then it will fall back to the default.
@@ -467,6 +468,7 @@ Object {
       "human",
       "json",
       "mermaid",
+      "count",
       "inspect",
       "silent",
     ],

--- a/src/cli-sdk/test/commands/list.ts
+++ b/src/cli-sdk/test/commands/list.ts
@@ -151,6 +151,7 @@ const runCommand = async (
     : values.view === 'human' ?
       cmd.views.human(res, { colors: values.color })
     : values.view === 'mermaid' ? cmd.views.mermaid(res)
+    : values.view === 'count' ? cmd.views.count(res)
     : cmd.views.json(res)
   return values.view === 'json' ?
       JSON.stringify(output, null, 2)
@@ -212,6 +213,15 @@ t.test('list', async t => {
       options,
     }),
     'should list pkgs in mermaid format',
+  )
+
+  t.equal(
+    await runCommand({
+      values: { view: 'count' },
+      options,
+    }),
+    2,
+    'should list pkgs count',
   )
 
   await t.rejects(

--- a/src/cli-sdk/test/commands/query.ts
+++ b/src/cli-sdk/test/commands/query.ts
@@ -151,6 +151,7 @@ const runCommand = async (
     : values.view === 'human' ?
       cmd.views.human(res, { colors: values.color })
     : values.view === 'mermaid' ? cmd.views.mermaid(res)
+    : values.view === 'count' ? cmd.views.count(res)
     : cmd.views.json(res)
   return values.view === 'json' ?
       JSON.stringify(output, null, 2)
@@ -197,6 +198,18 @@ t.test('query', async t => {
       options,
     }),
     'should list mermaid in json format',
+  )
+
+  t.equal(
+    await runCommand({
+      positionals: [],
+      values: {
+        view: 'count',
+      },
+      options,
+    }),
+    5,
+    'should list pkgs count',
   )
 
   await t.test('expect-results option', async t => {

--- a/www/docs/src/content/docs/cli/commands/list.mdx
+++ b/www/docs/src/content/docs/cli/commands/list.mdx
@@ -10,7 +10,7 @@ Usage:
 
 <Code
   code="$ vlt ls
-$ vlt ls <query> --view=[human | json | mermaid | gui]"
+$ vlt ls <query> --view=[human | json | mermaid | count]"
   title="Terminal"
   lang="bash"
 />
@@ -55,5 +55,5 @@ List all peer dependencies of all workspaces
 Output format. Defaults to human-readable or json if no tty.
 
 ```
---view=[human | json | mermaid | gui]
+--view=[human | json | mermaid | count]
 ```

--- a/www/docs/src/content/docs/cli/commands/query.mdx
+++ b/www/docs/src/content/docs/cli/commands/query.mdx
@@ -10,7 +10,7 @@ Usage:
 
 <Code
   code="$ vlt query
-$ vlt query <query> --view=[human | json | mermaid | gui]
+$ vlt query <query> --view=[human | json | mermaid | count]
 "
   title="Terminal"
   lang="bash"
@@ -67,7 +67,7 @@ Find packages with critical security issues
 Output format. Defaults to human-readable or json if no tty.
 
 ```
---view=[human | json | mermaid | gui]
+--view=[human | json | mermaid | count]
 ```
 
 ### expect-results

--- a/www/docs/src/content/docs/cli/configuring.mdx
+++ b/www/docs/src/content/docs/cli/configuring.mdx
@@ -301,7 +301,7 @@ argument as the package, and attempt to run the default executable.
 ### `--view=<output>`
 
 Configures the output format for commands. Valid options: "human",
-"json", "mermaid", "gui"
+"json", "mermaid", "count"
 
 ### `--dashboard-root=<path>`
 


### PR DESCRIPTION
Adds a new `count` supported value to the `--view` option. This view option is supported by both the `list` and `query` commands and it prints the number of direct dependencies (edges) a given query or graph is currently returning.

Fixes: https://github.com/vltpkg/vltpkg/issues/1428