### PR TITLE
fix(docs): add frontmatter to md files that are linked to

### DIFF
--- a/src/graph/ARCHITECTURE.md
+++ b/src/graph/ARCHITECTURE.md
@@ -1,3 +1,7 @@
+---
+title: '@vltpkg/graph Architecture'
+---
+
 # @vltpkg/graph Architecture
 
 This document provides an architectural overview of the
@@ -526,7 +530,7 @@ results.
 
 ## Further Reading
 
-- [Cursor Rules](.cursor/rules/graph/) - Detailed implementation
-  guides
+- [Cursor Rules](https://github.com/vltpkg/vltpkg/tree/main/.cursor/rules/graph) -
+  Detailed implementation guides
 - [npm package.json docs](https://docs.npmjs.com/cli/configuring-npm/package-json)
 - [Semantic Versioning](https://semver.org)

--- a/src/graph/README.md
+++ b/src/graph/README.md
@@ -1,3 +1,7 @@
+---
+title: '@vltpkg/graph'
+---
+
 ![graph](https://github.com/user-attachments/assets/dfbed9e0-8ef0-4a43-993d-d3e5d1e5ae1d)
 
 # @vltpkg/graph

--- a/src/graph/src/ideal/README.md
+++ b/src/graph/src/ideal/README.md
@@ -1,3 +1,7 @@
+---
+title: '@vltpkg/graph.ideal'
+---
+
 # @vltpkg/graph.ideal
 
 Build the ideal dependency graph representing the desired

--- a/src/graph/src/lockfile/README.md
+++ b/src/graph/src/lockfile/README.md
@@ -1,3 +1,7 @@
+---
+title: '@vltpkg/graph.lockfile'
+---
+
 # @vltpkg/graph.lockfile
 
 Serialize and deserialize `@vltpkg/graph.Graph` to/from lockfiles.

--- a/src/graph/src/reify/README.md
+++ b/src/graph/src/reify/README.md
@@ -1,3 +1,7 @@
+---
+title: '@vltpkg/graph.reify'
+---
+
 # @vltpkg/graph.reify
 
 Apply graph changes to `node_modules`, transforming the actual state

--- a/www/docs/typedoc/markdown-fixes.mjs
+++ b/www/docs/typedoc/markdown-fixes.mjs
@@ -58,6 +58,26 @@ const fixHeadings =
         textNode => void (textNode.value = 'Entry Points'),
       )
     }
+
+    // Strip leading "abstract" from headings so anchor slugs
+    // match the links typedoc emits (which omit "abstract").
+    if (toString(node).startsWith('abstract ')) {
+      const [firstChild, secondChild] = node.children
+      if (
+        firstChild?.type === 'inlineCode' &&
+        firstChild.value === 'abstract'
+      ) {
+        node.children.shift()
+        if (secondChild?.type === 'text') {
+          secondChild.value = secondChild.value.replace(/^\s+/, '')
+        }
+      } else if (firstChild?.type === 'text') {
+        firstChild.value = firstChild.value.replace(
+          /^abstract\s+/,
+          '',
+        )
+      }
+    }
   }
 
 /** @param {string} page */
@@ -78,6 +98,7 @@ const fixLinks =
         .replace(/\/index\.md$/, '')
         .replace(/\.md$/, '')
         .replace(/\/$/, '')
+        .toLowerCase()
 
     const [path, anchor] = node.url.split('#')
     const normalizedPage = normalize(page)


### PR DESCRIPTION
Also fix abstract links in markdown which typedoc was emitting with the wrong text
