### PR TITLE
graph: avoid lockfile empty registries key

### DIFF
--- a/src/graph/src/lockfile/save.ts
+++ b/src/graph/src/lockfile/save.ts
@@ -228,7 +228,7 @@ export const lockfileData = ({
       ...(registry !== undefined && registry !== defaultRegistry ?
         { registry }
       : undefined),
-      ...(hasItems(registries) ?
+      ...(hasItems(cleanRegistries) ?
         { registries: cleanRegistries }
       : undefined),
       ...(hasItems(cleanGitHosts) ?

--- a/src/graph/tap-snapshots/test/graph.ts.test.cjs
+++ b/src/graph/tap-snapshots/test/graph.ts.test.cjs
@@ -6,13 +6,13 @@
  */
 'use strict'
 exports[`test/graph.ts > TAP > Graph > should print with special tag name 1`] = `
-@vltpkg/graph.Graph { lockfileVersion: 1, options: [Object], nodes: {}, edges: {} }
+@vltpkg/graph.Graph { lockfileVersion: 1, options: {}, nodes: {}, edges: {} }
 `
 
 exports[`test/graph.ts > TAP > using placePackage > should add a type=git package 1`] = `
 @vltpkg/graph.Graph {
   lockfileVersion: 1,
-  options: { registries: {} },
+  options: {},
   nodes: {
     '~npm~bar@1.0.0': [
       0,
@@ -43,7 +43,7 @@ exports[`test/graph.ts > TAP > using placePackage > should add a type=git packag
 exports[`test/graph.ts > TAP > using placePackage > should find and fix nameless spec packages 1`] = `
 @vltpkg/graph.Graph {
   lockfileVersion: 1,
-  options: { registries: {} },
+  options: {},
   nodes: {
     '~npm~bar@1.0.0': [
       0,
@@ -73,7 +73,7 @@ exports[`test/graph.ts > TAP > using placePackage > should find and fix nameless
 exports[`test/graph.ts > TAP > using placePackage > should have removed baz from the graph 1`] = `
 @vltpkg/graph.Graph {
   lockfileVersion: 1,
-  options: { registries: {} },
+  options: {},
   nodes: {
     '~npm~bar@1.0.0': [
       0,
@@ -101,7 +101,7 @@ exports[`test/graph.ts > TAP > using placePackage > should have removed baz from
 exports[`test/graph.ts > TAP > using placePackage > the graph 1`] = `
 @vltpkg/graph.Graph {
   lockfileVersion: 1,
-  options: { registries: {} },
+  options: {},
   nodes: {
     '~npm~bar@1.0.0': [
       0,

--- a/src/graph/tap-snapshots/test/ideal/append-nodes.ts.test.cjs
+++ b/src/graph/tap-snapshots/test/ideal/append-nodes.ts.test.cjs
@@ -41,7 +41,7 @@ Array [
 exports[`test/ideal/append-nodes.ts > TAP > append different type of dependencies > should install different type of deps on different conditions 1`] = `
 @vltpkg/graph.Graph {
   lockfileVersion: 1,
-  options: { registries: {} },
+  options: {},
   nodes: {
     '~npm~bar@1.0.0': [ 1, 'bar', <3 empty items>, { name: 'bar', version: '1.0.0' } ],
     '~npm~foo@1.0.0': [


### PR DESCRIPTION
Remove the extraneous `options.registries` property and empty object declaration that is appearing on lockfiles after the cli hydration change landed.

Refs: https://github.com/vltpkg/vltpkg/pull/1441