### PR TITLE
chore: revert benchmark action runners

### DIFF
--- a/.github/workflows/base_benchmarks.yml
+++ b/.github/workflows/base_benchmarks.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   benchmark_base_branch:
     name: Continuous Benchmarking with Bencher
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         fixture: ['vue']
@@ -66,7 +66,7 @@ jobs:
     needs: [benchmark_base_branch]
     permissions:
       checks: write
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -14,7 +14,7 @@ concurrency:
 jobs:
   lint:
     name: Benchmark
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4

--- a/.github/workflows/fork_pr_benchmarks_closed.yml
+++ b/.github/workflows/fork_pr_benchmarks_closed.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   archive_fork_pr_branch:
     name: Archive closed fork PR branch with Bencher
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: bencherdev/bencher@main

--- a/.github/workflows/fork_pr_benchmarks_run.yml
+++ b/.github/workflows/fork_pr_benchmarks_run.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   benchmark_fork_pr_branch:
     name: Run Fork PR Benchmarks
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     timeout-minutes: 20
     strategy:
       matrix:
@@ -65,7 +65,7 @@ jobs:
   consolidate:
     name: Consolidate Benchmark Results
     needs: [benchmark_fork_pr_branch]
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     steps:
       - name: Download Results
         uses: actions/download-artifact@v4

--- a/.github/workflows/fork_pr_benchmarks_track.yml
+++ b/.github/workflows/fork_pr_benchmarks_track.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   track_fork_pr_branch:
     if: github.event.workflow_run.conclusion == 'success'
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     permissions:
       pull-requests: write
     steps:


### PR DESCRIPTION
Use GitHub standard runners instead of Blacksmith to address the increased time variation observed in the PR benchmark targets after migrating the runners.