### PR TITLE
graph: exclude workspaces from mermaid output

### DIFF
--- a/src/graph/src/visualization/mermaid-output.ts
+++ b/src/graph/src/visualization/mermaid-output.ts
@@ -107,7 +107,7 @@ const nodeRef = (
       options.highlightSelection &&
       isSelected(options, undefined, node)
     ) ?
-      ':::selected'
+      ':::a'
     : ''
   if (labeledNodes.has(node.id)) {
     return shortId + selectedClass
@@ -214,12 +214,7 @@ export function mermaidOutput(options: MermaidOutputGraph) {
     seen.add(item.self)
 
     if (item.self instanceof Edge) {
-      // Workspace edges are stored in mainImporter.workspaces and not in graph.edges,
-      // so we need to check for workspace spec type to always include them
-      if (
-        edges.includes(item.self) ||
-        item.self.spec.type === 'workspace'
-      ) {
+      if (edges.includes(item.self)) {
         includedItems.set(item.self, true)
       }
       if (item.self.to) {
@@ -274,9 +269,7 @@ export function mermaidOutput(options: MermaidOutputGraph) {
     .join('\n')
 
   const styleDefinition =
-    highlightSelection ?
-      '\nclassDef selected fill:gold,color:#242424'
-    : ''
+    highlightSelection ? '\nclassDef a fill:gold,color:#242424' : ''
 
   return 'flowchart TD\n' + graphOutput + styleDefinition
 }

--- a/src/graph/tap-snapshots/test/visualization/mermaid-output.ts.test.cjs
+++ b/src/graph/tap-snapshots/test/visualization/mermaid-output.ts.test.cjs
@@ -9,11 +9,8 @@ exports[`test/visualization/mermaid-output.ts > TAP > actual graph > highlight s
 flowchart TD
 a("root:my-project")
 a -->|"bar#64;^1.0.0 (optional)"| g("npm:bar#64;1.0.0")
-g -->|"baz#64;custom:baz#64;^1.0.0"| m("custom:baz#64;1.0.0"):::selected
-a -->|"workspace-b#64;workspace:*"| b("workspace:workspace-b")
-a -->|"workspace-a#64;workspace:*"| c("workspace:workspace-a")
-c -->|"workspace-b#64;workspace:* (dev)"| b
-classDef selected fill:gold,color:#242424
+g -->|"baz#64;custom:baz#64;^1.0.0"| m("custom:baz#64;1.0.0"):::a
+classDef a fill:gold,color:#242424
 `
 
 exports[`test/visualization/mermaid-output.ts > TAP > actual graph > selected packages > should print selected packages 1`] = `
@@ -21,9 +18,6 @@ flowchart TD
 a("root:my-project")
 a -->|"bar#64;^1.0.0 (optional)"| g("npm:bar#64;1.0.0")
 g -->|"baz#64;custom:baz#64;^1.0.0"| m("custom:baz#64;1.0.0")
-a -->|"workspace-b#64;workspace:*"| b("workspace:workspace-b")
-a -->|"workspace-a#64;workspace:*"| c("workspace:workspace-a")
-c -->|"workspace-b#64;workspace:* (dev)"| b
 `
 
 exports[`test/visualization/mermaid-output.ts > TAP > actual graph > should print from an actual loaded graph 1`] = `
@@ -70,6 +64,12 @@ flowchart TD
 a("root:my-project")
 a -->|"b#64;workspace:*"| b("workspace:b")
 a -->|"a#64;workspace:*"| c("workspace:a")
+`
+
+exports[`test/visualization/mermaid-output.ts > TAP > workspaces with dependencies > select only which package > should exclude workspace b when only which is selected 1`] = `
+flowchart TD
+c("workspace:a")
+c -->|"which#64;^6.0.0"| d("npm:which#64;6.0.0")
 `
 
 exports[`test/visualization/mermaid-output.ts > TAP > workspaces with dependencies > should print workspaces with dependencies 1`] = `

--- a/src/graph/test/visualization/mermaid-output.ts
+++ b/src/graph/test/visualization/mermaid-output.ts
@@ -244,6 +244,23 @@ t.test('workspaces with dependencies', async t => {
     }),
     'should print workspaces with dependencies',
   )
+
+  await t.test('select only which package', async t => {
+    const edges = [...graph.edges].filter(e => e.name === 'which')
+    const nodes = [
+      graph.nodes.get(
+        joinDepIDTuple(['registry', '', 'which@6.0.0']),
+      )!,
+    ]
+    t.matchSnapshot(
+      mermaidOutput({
+        edges,
+        importers: graph.importers,
+        nodes,
+      }),
+      'should exclude workspace b when only which is selected',
+    )
+  })
 })
 
 t.test('cycle', async t => {


### PR DESCRIPTION
Remove auto-inclusion of all workspace edges in mermaid visualization. The reverse pass already handles workspace edges correctly when their descendants are selected.

Also shorten CSS class name from `selected` to `a`.