### PR TITLE
fix(publish): do not default access to public

### DIFF
--- a/src/cli-sdk/src/commands/publish.ts
+++ b/src/cli-sdk/src/commands/publish.ts
@@ -53,7 +53,7 @@ export type CommandResultSingle = {
   shasum?: string
   integrity?: string
   size: number
-  access: string
+  access?: string
   unpackedSize: number
   files: string[]
 }
@@ -246,7 +246,7 @@ const commandSingle = async (
         },
       },
     },
-    access,
+    ...(access ? { access } : {}),
     _attachments: {
       [tarballName]: {
         content_type: 'application/octet-stream',
@@ -306,7 +306,7 @@ const commandSingle = async (
     name,
     version,
     tag,
-    access,
+    ...(access ? { access } : {}),
     registry: registryUrl.origin,
     integrity,
     shasum,

--- a/src/cli-sdk/src/config/definition.ts
+++ b/src/cli-sdk/src/config/definition.ts
@@ -695,7 +695,6 @@ export const definition = j
     access: {
       description: 'Set the access level of the package',
       validOptions: ['public', 'restricted'] as const,
-      default: 'public',
     },
   })
   .opt({


### PR DESCRIPTION
## Summary

When running `vlt publish` without `--access`, the publish metadata always included `access: 'public'`. For existing restricted/private packages, this would override their access level to public — a serious bug.

## Changes

- **`src/cli-sdk/src/config/definition.ts`**: Remove `default: 'public'` from the `access` config option. The field is now `undefined` when not explicitly set.
- **`src/cli-sdk/src/commands/publish.ts`**: Conditionally include `access` in publish metadata and return value only when explicitly provided. Updated `CommandResultSingle` type to make `access` optional.
- **`src/cli-sdk/test/commands/publish.ts`**: Added test case verifying that publish metadata does not include `access` when `--access` is not provided.

## Test Plan

- All existing tests pass (85/85)
- New test: "does not send access when not explicitly set" — verifies the publish request body omits the `access` field and the result has `access: undefined`
- Existing test: "uses custom access level" — still passes, confirming explicit `--access public` still works

Fixes #1018