### PR TITLE
feat(query): add :registry() pseudo selector

### DIFF
--- a/src/query/src/pseudo.ts
+++ b/src/query/src/pseudo.ts
@@ -40,6 +40,7 @@ import { peer } from './pseudo/peer.ts'
 import { prerelease } from './pseudo/prerelease.ts'
 import { published } from './pseudo/published.ts'
 import { privateParser } from './pseudo/private.ts'
+import { registry } from './pseudo/registry.ts'
 import { prod } from './pseudo/prod.ts'
 import { root } from './pseudo/root.ts'
 import { scanned } from './pseudo/scanned.ts'
@@ -332,6 +333,7 @@ const pseudoSelectors = new Map<string, ParserFn>(
     published,
     private: privateParser,
     prod,
+    registry,
     project,
     root,
     scanned,

--- a/src/query/src/pseudo/registry.ts
+++ b/src/query/src/pseudo/registry.ts
@@ -1,0 +1,29 @@
+import { splitDepID } from '@vltpkg/dep-id/browser'
+import {
+  asPostcssNodeWithChildren,
+  asTagNode,
+} from '@vltpkg/dss-parser'
+import { removeDanglingEdges, removeNode } from './helpers.ts'
+import type { ParserState } from '../types.ts'
+
+/**
+ * :registry(name) Pseudo-Selector, matches only nodes that
+ * belong to the specified registry configuration alias.
+ *
+ * For example, `:registry(npm)` matches deps from the default
+ * npm registry, and `:registry(custom)` matches deps from a
+ * custom-named registry.
+ */
+export const registry = async (state: ParserState) => {
+  const top = asPostcssNodeWithChildren(state.current)
+  const selector = asPostcssNodeWithChildren(top.nodes[0])
+  const name = asTagNode(selector.nodes[0]).value
+  for (const node of state.partial.nodes) {
+    const tuple = splitDepID(node.id)
+    if (tuple[0] !== 'registry' || tuple[1] !== name) {
+      removeNode(state, node)
+    }
+  }
+  removeDanglingEdges(state)
+  return state
+}

--- a/src/query/tap-snapshots/test/pseudo/registry.ts.test.cjs
+++ b/src/query/tap-snapshots/test/pseudo/registry.ts.test.cjs
@@ -1,0 +1,68 @@
+/* IMPORTANT
+ * This snapshot file is auto-generated, but designed for humans.
+ * It should be checked into source control and tracked carefully.
+ * Re-generate by setting TAP_SNAPSHOT=1 and running tests.
+ * Make sure to inspect the output below.  Do not ignore changes!
+ */
+'use strict'
+exports[`test/pseudo/registry.ts > TAP > selects nodes by registry > handles an empty partial state > must match snapshot 1`] = `
+Object {
+  "edges": Array [],
+  "nodes": Array [],
+}
+`
+
+exports[`test/pseudo/registry.ts > TAP > selects nodes by registry > returns no nodes for nonexistent registry > must match snapshot 1`] = `
+Object {
+  "edges": Array [],
+  "nodes": Array [],
+}
+`
+
+exports[`test/pseudo/registry.ts > TAP > selects nodes by registry > selects all registry nodes in simple graph as npm > must match snapshot 1`] = `
+Object {
+  "edges": Array [
+    "a",
+    "b",
+    "c",
+    "d",
+    "e",
+    "e",
+    "f",
+  ],
+  "nodes": Array [
+    "a",
+    "b",
+    "c",
+    "d",
+    "e",
+    "f",
+  ],
+}
+`
+
+exports[`test/pseudo/registry.ts > TAP > selects nodes by registry > selects custom registry nodes in aliased graph > must match snapshot 1`] = `
+Object {
+  "edges": Array [
+    "c",
+  ],
+  "nodes": Array [
+    "c",
+  ],
+}
+`
+
+exports[`test/pseudo/registry.ts > TAP > selects nodes by registry > selects default npm registry nodes in aliased graph > must match snapshot 1`] = `
+Object {
+  "edges": Array [
+    "a",
+    "b",
+    "bar",
+  ],
+  "nodes": Array [
+    "a",
+    "d",
+    "foo",
+  ],
+}
+`

--- a/src/query/test/pseudo/registry.ts
+++ b/src/query/test/pseudo/registry.ts
@@ -1,0 +1,122 @@
+import t from 'tap'
+import postcssSelectorParser from 'postcss-selector-parser'
+import type { ParserState } from '../../src/types.ts'
+import { registry } from '../../src/pseudo/registry.ts'
+import { getSimpleGraph, getAliasedGraph } from '../fixtures/graph.ts'
+
+t.test('selects nodes by registry', async t => {
+  const getState = (query: string, graph = getSimpleGraph()) => {
+    const ast = postcssSelectorParser().astSync(query)
+    const current = ast.first.first
+    const state: ParserState = {
+      comment: '',
+      current,
+      initial: {
+        edges: new Set(graph.edges.values()),
+        nodes: new Set(graph.nodes.values()),
+      },
+      partial: {
+        edges: new Set(graph.edges.values()),
+        nodes: new Set(graph.nodes.values()),
+      },
+      collect: {
+        edges: new Set(),
+        nodes: new Set(),
+      },
+      cancellable: async () => {},
+      walk: async i => i,
+      retries: 0,
+      securityArchive: undefined,
+      importers: new Set(graph.importers),
+      signal: new AbortController().signal,
+      specificity: { idCounter: 0, commonCounter: 0 },
+    }
+    return state
+  }
+
+  await t.test(
+    'selects custom registry nodes in aliased graph',
+    async t => {
+      const graph = getAliasedGraph()
+      const res = await registry(getState(':registry(custom)', graph))
+      t.strictSame(
+        [...res.partial.nodes].map(n => n.name).sort(),
+        ['c'],
+        'should select only custom registry packages',
+      )
+      t.matchSnapshot({
+        nodes: [...res.partial.nodes].map(n => n.name).sort(),
+        edges: [...res.partial.edges].map(e => e.name).sort(),
+      })
+    },
+  )
+
+  await t.test(
+    'selects default npm registry nodes in aliased graph',
+    async t => {
+      const graph = getAliasedGraph()
+      const res = await registry(getState(':registry(npm)', graph))
+      t.strictSame(
+        [...res.partial.nodes].map(n => n.name).sort(),
+        ['a', 'd', 'foo'],
+        'should select only default registry packages',
+      )
+      t.matchSnapshot({
+        nodes: [...res.partial.nodes].map(n => n.name).sort(),
+        edges: [...res.partial.edges].map(e => e.name).sort(),
+      })
+    },
+  )
+
+  await t.test(
+    'returns no nodes for nonexistent registry',
+    async t => {
+      const graph = getAliasedGraph()
+      const res = await registry(
+        getState(':registry(nonexistent)', graph),
+      )
+      t.strictSame(
+        [...res.partial.nodes].map(n => n.name),
+        [],
+        'should not select any packages for nonexistent registry',
+      )
+      t.matchSnapshot({
+        nodes: [...res.partial.nodes].map(n => n.name),
+        edges: [...res.partial.edges].map(e => e.name),
+      })
+    },
+  )
+
+  await t.test('handles an empty partial state', async t => {
+    const state = getState(':registry(npm)')
+    state.partial.nodes.clear()
+    state.partial.edges.clear()
+
+    const res = await registry(state)
+    t.strictSame(
+      [...res.partial.nodes].map(n => n.name),
+      [],
+      'should return empty array when starting with empty partial state',
+    )
+    t.matchSnapshot({
+      nodes: [...res.partial.nodes].map(n => n.name),
+      edges: [...res.partial.edges].map(e => e.name),
+    })
+  })
+
+  await t.test(
+    'selects all registry nodes in simple graph as npm',
+    async t => {
+      const res = await registry(getState(':registry(npm)'))
+      t.strictSame(
+        [...res.partial.nodes].map(n => n.name).sort(),
+        ['a', 'b', 'c', 'd', 'e', 'f'],
+        'should select all registry packages as npm in simple graph',
+      )
+      t.matchSnapshot({
+        nodes: [...res.partial.nodes].map(n => n.name).sort(),
+        edges: [...res.partial.edges].map(e => e.name).sort(),
+      })
+    },
+  )
+})


### PR DESCRIPTION
## Summary

Add a new `:registry(<name>)` pseudo selector that matches dependency nodes based on their registry configuration alias.

### Examples
- `:registry(npm)` — matches deps from the default npm registry
- `:registry(custom)` — matches deps from a custom-named registry

### Implementation
- **`src/query/src/pseudo/registry.ts`** — New selector that reads the registry name from the DepID tuple (`splitDepID(node.id)[1]`) and compares it against the provided parameter name. Non-registry dep types (file, git, workspace, remote) are automatically excluded.
- **`src/query/src/pseudo.ts`** — Register the new `registry` selector in the `pseudoSelectors` map.
- **`src/query/test/pseudo/registry.ts`** — Tests covering custom registry matching, default npm registry matching, nonexistent registry (empty result), empty partial state, and simple graph (all default registry).

All 1243 existing query tests continue to pass.

Closes #1273