### PR TITLE
docs: add migration guides for npm, yarn, and pnpm to vlt

### DIFF
--- a/www/docs/astro.config.mts
+++ b/www/docs/astro.config.mts
@@ -93,6 +93,11 @@ export default defineConfig({
           autogenerate: { directory: 'cli' },
         },
         {
+          label: 'Migration',
+          collapsed: true,
+          autogenerate: { directory: 'migration' },
+        },
+        {
           label: 'Packages',
           collapsed: true,
           autogenerate: { directory: TypedocPlugin.directory },

--- a/www/docs/src/content/docs/migration/from-npm.mdx
+++ b/www/docs/src/content/docs/migration/from-npm.mdx
@@ -1,0 +1,414 @@
+---
+title: Migrating from npm to vlt
+sidebar:
+  label: From npm
+  order: 1
+---
+
+import { Code } from '@astrojs/starlight/components'
+
+## Quick Start
+
+<Code
+  code={`# Install vlt globally
+$ npm install -g vlt
+
+# In your existing project, run:
+$ vlt install
+$ vlt build`}
+  title="Terminal"
+  lang="bash"
+/>
+
+That's it for basic usage. vlt reads your existing `package.json` and
+resolves dependencies. Below are the details on what's different and
+how to handle specific scenarios.
+
+---
+
+## Command Mapping
+
+| npm                            | vlt                                     | Notes                                        |
+| ------------------------------ | --------------------------------------- | -------------------------------------------- |
+| `npm install`                  | `vlt install`                           | Does **not** run lifecycle scripts           |
+| `npm install <pkg>`            | `vlt install <pkg>`                     | Same behavior                                |
+| `npm install -D <pkg>`         | `vlt install -D <pkg>`                  | Same flags                                   |
+| `npm uninstall <pkg>`          | `vlt uninstall <pkg>`                   | Aliases: `rm`, `u`                           |
+| `npm run <script>`             | `vlt run <script>`                      | Aliases: `r`, `run-script`                   |
+| `npm test`                     | `vlt run test`                          | No `vlt test` shorthand                      |
+| `npm start`                    | `vlt run start`                         | No `vlt start` shorthand                     |
+| `npx <pkg>`                    | `vlx <pkg>`                             | Run remote packages                          |
+| `npm exec <cmd>`               | `vlt exec <cmd>`                        | Local bins on PATH                           |
+| `npm init`                     | `vlt init`                              | Creates `package.json`                       |
+| `npm pack`                     | `vlt pack`                              |                                              |
+| `npm publish`                  | `vlt publish`                           |                                              |
+| `npm login`                    | `vlt login`                             |                                              |
+| `npm whoami`                   | `vlt whoami`                            |                                              |
+| `npm ls`                       | `vlt list`                              | Alias: `ls`                                  |
+| `npm query`                    | `vlt query`                             | Uses DSS, not CSS selectors                  |
+| `npm ci`                       | `vlt install --expect-lockfile`         | Strict lockfile mode                         |
+| `npm install --ignore-scripts` | `vlt install`                           | Default behavior                             |
+| `npm audit`                    | `vlt query ':malware'`                  | More powerful; see [Security](/cli/security) |
+| `npm config set <key>=<val>`   | `vlt config set <key>=<val>`            | Writes to `vlt.json`                         |
+| `npm overrides`                | [Graph Modifiers](/cli/graph-modifiers) | DSS-based, more precise                      |
+
+---
+
+## Configuration
+
+### .npmrc → vlt.json
+
+npm reads configuration from `.npmrc` files (INI format, multiple
+locations). vlt uses a single `vlt.json` file in your project root,
+plus an optional user-level `vlt.json` in the XDG config directory.
+
+<Code
+  code={`# .npmrc (npm)
+registry=https://registry.internal.company.com/
+@mycompany:registry=https://npm.mycompany.com/
+save-exact=true`}
+  title=".npmrc"
+  lang="ini"
+/>
+
+<Code
+  code={JSON.stringify(
+    {
+      registry: 'https://registry.internal.company.com/',
+      'scope-registries': {
+        '@mycompany': 'https://npm.mycompany.com/',
+      },
+    },
+    null,
+    2,
+  )}
+  title="vlt.json"
+  lang="json"
+/>
+
+To create this file interactively:
+
+<Code
+  code={`$ vlt config set registry=https://registry.internal.company.com/
+$ vlt config set scope-registries=@mycompany=https://npm.mycompany.com/`}
+  title="Terminal"
+  lang="bash"
+/>
+
+### User vs Project Config
+
+| npm                          | vlt                           |
+| ---------------------------- | ----------------------------- |
+| `~/.npmrc` (user)            | XDG config dir `vlt/vlt.json` |
+| `.npmrc` (project)           | `vlt.json` (project root)     |
+| `$PREFIX/etc/npmrc` (global) | No global config file         |
+
+View config locations:
+
+<Code
+  code={`$ vlt config location --config=user
+$ vlt config location --config=project`}
+  title="Terminal"
+  lang="bash"
+/>
+
+---
+
+## Registry Configuration
+
+vlt handles registries similarly to npm, with some additions.
+
+### Scoped Registries
+
+npm's scoped registries map directly:
+
+<Code
+  code={`# npm (.npmrc)
+@mycompany:registry=https://npm.mycompany.com/`}
+  title=".npmrc"
+  lang="ini"
+/>
+
+<Code
+  code={JSON.stringify(
+    {
+      'scope-registries': {
+        '@mycompany': 'https://npm.mycompany.com/',
+      },
+    },
+    null,
+    2,
+  )}
+  title="vlt.json"
+  lang="json"
+/>
+
+### Named Registry Aliases
+
+vlt also supports [named registry aliases](/cli/registries), which are
+more explicit than scope-based mapping. This is a vlt-specific
+feature:
+
+<Code
+  code={JSON.stringify(
+    {
+      registries: {
+        internal: 'https://npm.mycompany.com/',
+      },
+    },
+    null,
+    2,
+  )}
+  title="vlt.json"
+  lang="json"
+/>
+
+Then reference packages explicitly:
+
+<Code
+  code="$ vlt install internal:@mycompany/utils@^2.0"
+  title="Terminal"
+  lang="bash"
+/>
+
+---
+
+## Authentication
+
+### Tokens
+
+npm stores auth tokens in `.npmrc`. vlt stores them in an
+XDG-compliant keychain file, which is less likely to be accidentally
+committed to source control.
+
+<Code
+  code={`# npm: tokens live in .npmrc (risky if committed)
+//registry.npmjs.org/:_authToken=npm_abc123
+
+# vlt: log in interactively
+
+$ vlt login
+
+# vlt: or for custom registries
+
+$ vlt login --registry=https://npm.mycompany.com/`} title="Terminal"
+lang="bash" />
+
+### CI Environments
+
+<Code
+  code={`# npm
+NPM_TOKEN=abc123 npm install
+
+# vlt
+
+VLT_TOKEN=abc123 vlt install`} title="Terminal" lang="bash" />
+
+For non-default registries, replace non-alphanumeric characters in the
+URL with `_`:
+
+<Code
+  code="VLT_TOKEN_https_npm_mycompany_com=abc123 vlt install"
+  title="Terminal"
+  lang="bash"
+/>
+
+See [Authentication](/cli/auth) for full details.
+
+---
+
+## Lockfile
+
+npm uses `package-lock.json`. vlt uses `vlt-lock.json`.
+
+When you first run `vlt install`, vlt resolves from your
+`package.json` and creates `vlt-lock.json`. Your existing
+`package-lock.json` is not read or migrated — vlt performs a fresh
+resolution.
+
+**What to do:**
+
+1. Run `vlt install` to generate `vlt-lock.json`
+2. Commit `vlt-lock.json` to source control
+3. Optionally remove `package-lock.json` (or keep it if you're running
+   both tools during a transition period)
+
+### CI / Frozen Lockfile
+
+<Code
+  code={`# npm
+$ npm ci
+
+# vlt
+
+$ vlt install --expect-lockfile`} title="Terminal" lang="bash" />
+
+---
+
+## Install Script Protection
+
+This is the biggest behavioral difference from npm.
+
+**npm** runs all lifecycle scripts (`preinstall`, `install`,
+`postinstall`) automatically during `npm install`. This is a known
+supply chain attack vector.
+
+**vlt** separates installation into two phases:
+
+1. **`vlt install`** — Downloads and extracts packages. No scripts
+   run.
+2. **`vlt build`** — Runs lifecycle scripts selectively.
+
+<Code
+  code={`# Install packages (safe — no code executes)
+$ vlt install
+
+# Run build scripts, automatically excluding packages flagged as malware
+
+$ vlt build`} title="Terminal" lang="bash" />
+
+By default, `vlt build` uses the target
+`:scripts:not(:built):not(:malware)`, which skips packages with known
+malware alerts.
+
+You can be more selective:
+
+<Code
+  code={`# Only allow specific packages to run scripts
+$ vlt build --target="#esbuild, #node-gyp"
+
+# Or allow scripts for direct dependencies only
+
+$ vlt build --target=":root > :scripts"`} title="Terminal" lang="bash"
+/>
+
+If you need legacy npm behavior (not recommended):
+
+<Code
+  code="$ vlt install --allow-scripts='*'"
+  title="Terminal"
+  lang="bash"
+/>
+
+See [`vlt build`](/cli/commands/build) for full details.
+
+---
+
+## Workspaces
+
+npm workspaces are defined in the root `package.json`:
+
+<Code
+  code={JSON.stringify(
+    {
+      workspaces: ['packages/*'],
+    },
+    null,
+    2,
+  )}
+  title="package.json (npm)"
+  lang="json"
+/>
+
+vlt workspaces are defined in `vlt.json`:
+
+<Code
+  code={JSON.stringify(
+    {
+      workspaces: ['packages/*'],
+    },
+    null,
+    2,
+  )}
+  title="vlt.json"
+  lang="json"
+/>
+
+### Key Differences
+
+- **Definition location** — `vlt.json` instead of `package.json`
+- **Named groups** — vlt supports grouping workspaces for targeted
+  operations:
+
+<Code
+  code={JSON.stringify(
+    {
+      workspaces: {
+        apps: 'apps/*',
+        libs: 'packages/*',
+      },
+    },
+    null,
+    2,
+  )}
+  title="vlt.json"
+  lang="json"
+/>
+
+### Workspace Commands
+
+| npm                               | vlt                               |
+| --------------------------------- | --------------------------------- |
+| `npm run test -w packages/a`      | `vlt run test -w packages/a`      |
+| `npm run test --workspaces`       | `vlt run test --recursive`        |
+| `npm install <pkg> -w packages/a` | `vlt install <pkg> -w packages/a` |
+
+See [Workspaces](/cli/workspaces) for full details.
+
+---
+
+## Overrides → Graph Modifiers
+
+npm uses `overrides` in `package.json` to force dependency versions.
+vlt uses [Graph Modifiers](/cli/graph-modifiers) in `vlt.json`, which
+are powered by DSS selectors and offer more precise targeting.
+
+<Code
+  code={JSON.stringify(
+    {
+      overrides: {
+        lodash: '^4.17.21',
+        'express>qs': '6.10.0',
+      },
+    },
+    null,
+    2,
+  )}
+  title="package.json (npm)"
+  lang="json"
+/>
+
+<Code
+  code={JSON.stringify(
+    {
+      modifiers: {
+        '#lodash': '^4.17.21',
+        ':root > #express > #qs': '=6.10.0',
+      },
+    },
+    null,
+    2,
+  )}
+  title="vlt.json"
+  lang="json"
+/>
+
+Graph Modifiers use CSS-like specificity rules when multiple selectors
+match the same dependency.
+
+---
+
+## Migration Checklist
+
+1. Install vlt: `npm install -g vlt`
+2. In your project root, create `vlt.json` with your registry and
+   workspace config (or use `vlt config set`)
+3. Move any scoped registry config from `.npmrc` to `vlt.json`
+4. Move workspace definitions from `package.json` to `vlt.json`
+5. Move `overrides` from `package.json` to `modifiers` in `vlt.json`
+6. Run `vlt install` then `vlt build`
+7. Commit `vlt-lock.json`
+8. Update CI scripts: replace `npm ci` with
+   `vlt install --expect-lockfile && vlt build`
+9. Update CI auth: replace `NPM_TOKEN` with `VLT_TOKEN`
+10. Update any `npx` usage to `vlx`

--- a/www/docs/src/content/docs/migration/from-pnpm.mdx
+++ b/www/docs/src/content/docs/migration/from-pnpm.mdx
@@ -1,0 +1,491 @@
+---
+title: Migrating from pnpm to vlt
+sidebar:
+  label: From pnpm
+  order: 3
+---
+
+import { Code } from '@astrojs/starlight/components'
+
+## Quick Start
+
+<Code
+  code={`# Install vlt globally
+$ npm install -g vlt
+
+# In your existing project, run:
+$ vlt install
+$ vlt build`}
+  title="Terminal"
+  lang="bash"
+/>
+
+vlt reads your existing `package.json` files and resolves
+dependencies. The `pnpm-lock.yaml` file is not migrated — vlt performs
+a fresh resolution and creates `vlt-lock.json`.
+
+---
+
+## Command Mapping
+
+| pnpm                             | vlt                             | Notes                                                              |
+| -------------------------------- | ------------------------------- | ------------------------------------------------------------------ |
+| `pnpm install`                   | `vlt install`                   | Does **not** run lifecycle scripts                                 |
+| `pnpm add <pkg>`                 | `vlt install <pkg>`             |                                                                    |
+| `pnpm add -D <pkg>`              | `vlt install -D <pkg>`          |                                                                    |
+| `pnpm remove <pkg>`              | `vlt uninstall <pkg>`           |                                                                    |
+| `pnpm run <script>`              | `vlt run <script>`              |                                                                    |
+| `pnpm <script>`                  | `vlt run <script>`              | See [fallback-command](/cli/configuring#--fallback-commandcommand) |
+| `pnpm dlx <pkg>`                 | `vlx <pkg>`                     | Run remote packages                                                |
+| `pnpm exec <cmd>`                | `vlt exec <cmd>`                |                                                                    |
+| `pnpm init`                      | `vlt init`                      |                                                                    |
+| `pnpm pack`                      | `vlt pack`                      |                                                                    |
+| `pnpm publish`                   | `vlt publish`                   |                                                                    |
+| `pnpm login`                     | `vlt login`                     |                                                                    |
+| `pnpm whoami`                    | `vlt whoami`                    |                                                                    |
+| `pnpm list`                      | `vlt list`                      |                                                                    |
+| `pnpm why <pkg>`                 | `vlt query '#<pkg>'`            | DSS query; see [Selectors](/cli/selectors)                         |
+| `pnpm install --frozen-lockfile` | `vlt install --frozen-lockfile` |                                                                    |
+| `pnpm audit`                     | `vlt query ':malware'`          | More powerful; see [Security](/cli/security)                       |
+| `pnpm config set <key> <val>`    | `vlt config set <key>=<val>`    |                                                                    |
+
+### Shorthand Script Execution
+
+pnpm lets you run scripts without `run` (e.g., `pnpm build`). vlt
+supports this via the `fallback-command` config:
+
+<Code
+  code="$ vlt config set fallback-command=run-exec"
+  title="Terminal"
+  lang="bash"
+/>
+
+After setting this, `vlt build` will first check for a vlt command
+named `build`, and if none matches, look for a `package.json` script.
+
+---
+
+## Configuration
+
+### .npmrc + pnpm-workspace.yaml → vlt.json
+
+pnpm reads registry config from `.npmrc` and workspace config from
+`pnpm-workspace.yaml`. vlt consolidates everything into `vlt.json`.
+
+**pnpm configuration:**
+
+<Code
+  code={`# .npmrc (pnpm)
+registry=https://registry.internal.company.com/
+@mycompany:registry=https://npm.mycompany.com/
+auto-install-peers=true`}
+  title=".npmrc"
+  lang="ini"
+/>
+
+<Code
+  code={`# pnpm-workspace.yaml
+packages:
+  - "packages/*"
+  - "apps/*"`}
+  title="pnpm-workspace.yaml"
+  lang="yaml"
+/>
+
+**vlt equivalent (single file):**
+
+<Code
+  code={JSON.stringify(
+    {
+      registry: 'https://registry.internal.company.com/',
+      'scope-registries': {
+        '@mycompany': 'https://npm.mycompany.com/',
+      },
+      workspaces: ['packages/*', 'apps/*'],
+    },
+    null,
+    2,
+  )}
+  title="vlt.json"
+  lang="json"
+/>
+
+---
+
+## Registry Configuration
+
+### Scoped Registries
+
+pnpm's scoped registries (from `.npmrc`) map directly to vlt's
+`scope-registries`:
+
+<Code
+  code={JSON.stringify(
+    {
+      'scope-registries': {
+        '@mycompany': 'https://npm.mycompany.com/',
+      },
+    },
+    null,
+    2,
+  )}
+  title="vlt.json"
+  lang="json"
+/>
+
+### Named Registry Aliases
+
+vlt also supports [named registry aliases](/cli/registries) which
+remove the ambiguity of scope-based mapping:
+
+<Code
+  code={JSON.stringify(
+    {
+      registries: {
+        internal: 'https://npm.mycompany.com/',
+      },
+    },
+    null,
+    2,
+  )}
+  title="vlt.json"
+  lang="json"
+/>
+
+Then reference packages explicitly in `package.json`:
+
+<Code
+  code={JSON.stringify(
+    {
+      dependencies: {
+        '@mycompany/utils': 'internal:@mycompany/utils@^2.0',
+      },
+    },
+    null,
+    2,
+  )}
+  title="package.json"
+  lang="json"
+/>
+
+---
+
+## Authentication
+
+pnpm stores auth tokens in `.npmrc`, same as npm. vlt stores them in
+an XDG-compliant keychain file, keeping secrets out of project config
+files.
+
+<Code
+  code={`# Log in to default registry
+$ vlt login
+
+# Log in to custom registry
+
+$ vlt login --registry=https://npm.mycompany.com/`} title="Terminal"
+lang="bash" />
+
+### CI Environments
+
+<Code
+  code={`# pnpm
+NPM_TOKEN=abc123 pnpm install
+
+# vlt
+
+VLT_TOKEN=abc123 vlt install`} title="Terminal" lang="bash" />
+
+See [Authentication](/cli/auth) for full details.
+
+---
+
+## Lockfile
+
+pnpm uses `pnpm-lock.yaml`. vlt uses `vlt-lock.json`.
+
+When you first run `vlt install`, vlt creates `vlt-lock.json` from a
+fresh resolution of your `package.json` files. The `pnpm-lock.yaml` is
+not read.
+
+**What to do:**
+
+1. Run `vlt install` to generate `vlt-lock.json`
+2. Commit `vlt-lock.json`
+3. Optionally remove `pnpm-lock.yaml` once you've fully switched
+
+---
+
+## Install Script Protection
+
+pnpm runs lifecycle scripts by default during install (same as npm).
+pnpm v9+ added `onlyBuiltDependencies` in `package.json` as an
+allowlist, but scripts still run by default for listed packages.
+
+**vlt** takes a different approach: `vlt install` runs **no scripts at
+all** by default. Building is a separate, explicit step:
+
+<Code
+  code={`# Phase 1: Install (no code executes)
+$ vlt install
+
+# Phase 2: Build (runs scripts, skipping known malware)
+
+$ vlt build`} title="Terminal" lang="bash" />
+
+By default, `vlt build` uses the target
+`:scripts:not(:built):not(:malware)` — it automatically skips packages
+flagged as malware by [Socket](https://socket.dev/).
+
+### pnpm onlyBuiltDependencies vs vlt build --target
+
+<Code
+  code={JSON.stringify(
+    {
+      pnpm: {
+        onlyBuiltDependencies: ['esbuild', 'node-gyp'],
+      },
+    },
+    null,
+    2,
+  )}
+  title="package.json (pnpm)"
+  lang="json"
+/>
+
+<Code
+  code="$ vlt build --target='#esbuild, #node-gyp'"
+  title="Terminal (vlt)"
+  lang="bash"
+/>
+
+You can persist the target:
+
+<Code
+  code='$ vlt config set "command.build.target=#esbuild, #node-gyp"'
+  title="Terminal"
+  lang="bash"
+/>
+
+See [`vlt build`](/cli/commands/build) for full details.
+
+---
+
+## Workspaces
+
+### pnpm
+
+pnpm defines workspaces in `pnpm-workspace.yaml`:
+
+<Code
+  code={`packages:
+  - "packages/*"
+  - "apps/*"`}
+  title="pnpm-workspace.yaml"
+  lang="yaml"
+/>
+
+### vlt
+
+vlt defines workspaces in `vlt.json`:
+
+<Code
+  code={JSON.stringify(
+    {
+      workspaces: ['packages/*', 'apps/*'],
+    },
+    null,
+    2,
+  )}
+  title="vlt.json"
+  lang="json"
+/>
+
+vlt also supports **named workspace groups**:
+
+<Code
+  code={JSON.stringify(
+    {
+      workspaces: {
+        apps: 'apps/*',
+        libs: ['packages/*', 'shared/*'],
+      },
+    },
+    null,
+    2,
+  )}
+  title="vlt.json"
+  lang="json"
+/>
+
+### Workspace Commands
+
+| pnpm                               | vlt                                               |
+| ---------------------------------- | ------------------------------------------------- |
+| `pnpm --filter <name> <cmd>`       | `vlt <cmd> -w <path>` or `cd <path> && vlt <cmd>` |
+| `pnpm --filter ./packages/* <cmd>` | `vlt <cmd> -w packages/*`                         |
+| `pnpm -r <cmd>`                    | `vlt <cmd> --recursive`                           |
+| `pnpm -r run test`                 | `vlt run test --recursive`                        |
+
+**Note:** vlt's `--workspace` (`-w`) flag takes paths or glob
+patterns, not package names.
+
+<Code
+  code={`# Run tests in a specific workspace
+$ vlt run test -w packages/core
+
+# Run build across a workspace group
+
+$ vlt run build -g libs`} title="Terminal" lang="bash" />
+
+See [Workspaces](/cli/workspaces) for full details.
+
+---
+
+## Catalogs
+
+If you use pnpm's catalog feature (`pnpm-workspace.yaml`), vlt has
+direct support for [catalogs](/cli/catalogs) with compatible syntax.
+
+**pnpm:**
+
+<Code
+  code={`# pnpm-workspace.yaml
+packages:
+  - "packages/*"
+
+catalog: typescript: "^5.0.0" eslint: "^8.0.0"
+
+catalogs: testing: vitest: "^1.0.0"`} title="pnpm-workspace.yaml"
+lang="yaml" />
+
+**vlt:**
+
+<Code
+  code={JSON.stringify(
+    {
+      workspaces: ['packages/*'],
+      catalog: {
+        typescript: '^5.0.0',
+        eslint: '^8.0.0',
+      },
+      catalogs: {
+        testing: {
+          vitest: '^1.0.0',
+        },
+      },
+    },
+    null,
+    2,
+  )}
+  title="vlt.json"
+  lang="json"
+/>
+
+The `catalog:` protocol in `package.json` works the same way:
+
+<Code
+  code={JSON.stringify(
+    {
+      devDependencies: {
+        typescript: 'catalog:',
+        vitest: 'catalog:testing',
+      },
+    },
+    null,
+    2,
+  )}
+  title="package.json"
+  lang="json"
+/>
+
+See [Catalogs](/cli/catalogs) for full details.
+
+---
+
+## Overrides → Graph Modifiers
+
+pnpm uses `pnpm.overrides` in `package.json`. vlt uses
+[Graph Modifiers](/cli/graph-modifiers) in `vlt.json`.
+
+<Code
+  code={JSON.stringify(
+    {
+      pnpm: {
+        overrides: {
+          lodash: '^4.17.21',
+          'express>qs': '6.10.0',
+        },
+      },
+    },
+    null,
+    2,
+  )}
+  title="package.json (pnpm)"
+  lang="json"
+/>
+
+<Code
+  code={JSON.stringify(
+    {
+      modifiers: {
+        '#lodash': '^4.17.21',
+        ':root > #express > #qs': '=6.10.0',
+      },
+    },
+    null,
+    2,
+  )}
+  title="vlt.json"
+  lang="json"
+/>
+
+Graph Modifiers use DSS selectors, giving you more precise control
+(e.g., target by path, workspace, or semver range).
+
+---
+
+## node_modules Layout
+
+pnpm uses a content-addressable store with symlinks to create a strict
+`node_modules` layout where packages can only access their declared
+dependencies.
+
+vlt also creates a `node_modules` directory but uses a different
+internal layout (under `node_modules/.vlt/`). The result is similar in
+that packages resolve correctly at runtime — your application code
+doesn't need to change.
+
+---
+
+## Features Not in vlt
+
+Some pnpm-specific features don't have direct equivalents:
+
+- **Content-addressable store** — vlt uses its own on-disk
+  [cache](/cli/configuring#--cachepath) but doesn't hard-link from a
+  global store
+- **Side-effects cache** — Not available in vlt
+- **`pnpm patch`** — Not yet available in vlt
+- **`pnpm deploy`** — Not available; use standard deployment tooling
+- **`pnpm.peerDependencyRules`** — vlt handles peer dependencies
+  automatically with [context isolation](/cli/peer-dependencies)
+
+---
+
+## Migration Checklist
+
+1. Install vlt: `npm install -g vlt`
+2. Create `vlt.json` combining your `.npmrc` registry config and
+   `pnpm-workspace.yaml` workspace definitions
+3. Move scoped registry config from `.npmrc` to `vlt.json`
+4. Move catalogs from `pnpm-workspace.yaml` to `vlt.json` (`catalog`
+   and `catalogs` fields)
+5. Move `pnpm.overrides` from `package.json` to `modifiers` in
+   `vlt.json`
+6. Run `vlt install` then `vlt build`
+7. Commit `vlt-lock.json`
+8. Update CI scripts: replace `pnpm install --frozen-lockfile` with
+   `vlt install --frozen-lockfile && vlt build`
+9. Update CI auth: replace `NPM_TOKEN` with `VLT_TOKEN`
+10. Update any `pnpm dlx` usage to `vlx`
+11. Remove `pnpm-workspace.yaml` and pnpm-specific `.npmrc` settings

--- a/www/docs/src/content/docs/migration/from-yarn.mdx
+++ b/www/docs/src/content/docs/migration/from-yarn.mdx
@@ -1,0 +1,426 @@
+---
+title: Migrating from yarn to vlt
+sidebar:
+  label: From yarn
+  order: 2
+---
+
+import { Code } from '@astrojs/starlight/components'
+
+This guide covers migration from both **yarn v1 (classic)** and **yarn
+v2+ (berry)**. Key differences are called out where they apply.
+
+## Quick Start
+
+<Code
+  code={`# Install vlt globally
+$ npm install -g vlt
+
+# In your existing project, run:
+$ vlt install
+$ vlt build`}
+  title="Terminal"
+  lang="bash"
+/>
+
+vlt reads your existing `package.json` files and resolves
+dependencies. The `yarn.lock` file is not migrated — vlt performs a
+fresh resolution and creates `vlt-lock.json`.
+
+---
+
+## Command Mapping
+
+| yarn                             | vlt                             | Notes                                                              |
+| -------------------------------- | ------------------------------- | ------------------------------------------------------------------ |
+| `yarn` / `yarn install`          | `vlt install`                   | Does **not** run lifecycle scripts                                 |
+| `yarn add <pkg>`                 | `vlt install <pkg>`             |                                                                    |
+| `yarn add -D <pkg>`              | `vlt install -D <pkg>`          |                                                                    |
+| `yarn remove <pkg>`              | `vlt uninstall <pkg>`           |                                                                    |
+| `yarn run <script>`              | `vlt run <script>`              |                                                                    |
+| `yarn <script>`                  | `vlt run <script>`              | See [fallback-command](/cli/configuring#--fallback-commandcommand) |
+| `yarn dlx <pkg>` / `npx <pkg>`   | `vlx <pkg>`                     | Run remote packages                                                |
+| `yarn exec <cmd>`                | `vlt exec <cmd>`                |                                                                    |
+| `yarn init`                      | `vlt init`                      |                                                                    |
+| `yarn pack`                      | `vlt pack`                      |                                                                    |
+| `yarn npm publish`               | `vlt publish`                   |                                                                    |
+| `yarn npm login`                 | `vlt login`                     |                                                                    |
+| `yarn npm whoami`                | `vlt whoami`                    |                                                                    |
+| `yarn workspaces list`           | `vlt list`                      |                                                                    |
+| `yarn why <pkg>`                 | `vlt query '#<pkg>'`            | DSS query; see [Selectors](/cli/selectors)                         |
+| `yarn install --frozen-lockfile` | `vlt install --frozen-lockfile` |                                                                    |
+| `yarn install --immutable`       | `vlt install --expect-lockfile` |                                                                    |
+| `yarn config set <key> <val>`    | `vlt config set <key>=<val>`    |                                                                    |
+| `yarn up <pkg>`                  | `vlt install <pkg>`             | Re-resolves to latest matching                                     |
+
+### Shorthand Script Execution
+
+Yarn lets you run scripts without `run` (e.g., `yarn build`). vlt
+supports this via the `fallback-command` config:
+
+<Code
+  code="$ vlt config set fallback-command=run-exec"
+  title="Terminal"
+  lang="bash"
+/>
+
+After setting this, `vlt build` will first check for a vlt command
+named `build`, and if none matches, look for a `package.json` script.
+
+---
+
+## Configuration
+
+### .yarnrc.yml / .yarnrc → vlt.json
+
+yarn v1 uses `.yarnrc` and `.npmrc`. yarn v2+ uses `.yarnrc.yml`. vlt
+uses `vlt.json`.
+
+**yarn v2+ example:**
+
+<Code
+  code={`# .yarnrc.yml (yarn berry)
+npmRegistryServer: "https://registry.internal.company.com/"
+npmScopes:
+  mycompany:
+    npmRegistryServer: "https://npm.mycompany.com/"
+    npmAuthToken: "abc123"`}
+  title=".yarnrc.yml"
+  lang="yaml"
+/>
+
+**vlt equivalent:**
+
+<Code
+  code={JSON.stringify(
+    {
+      registry: 'https://registry.internal.company.com/',
+      'scope-registries': {
+        '@mycompany': 'https://npm.mycompany.com/',
+      },
+    },
+    null,
+    2,
+  )}
+  title="vlt.json"
+  lang="json"
+/>
+
+Auth tokens are stored separately in vlt's keychain, not in config
+files. See [Authentication](#authentication) below.
+
+**yarn v1 example:**
+
+<Code
+  code={`# .npmrc (yarn classic)
+registry=https://registry.internal.company.com/
+@mycompany:registry=https://npm.mycompany.com/`}
+  title=".npmrc"
+  lang="ini"
+/>
+
+Same `vlt.json` as above.
+
+---
+
+## Registry Configuration
+
+### Scoped Registries
+
+Both yarn and vlt support scope-to-registry mapping:
+
+<Code
+  code={JSON.stringify(
+    {
+      'scope-registries': {
+        '@mycompany': 'https://npm.mycompany.com/',
+      },
+    },
+    null,
+    2,
+  )}
+  title="vlt.json"
+  lang="json"
+/>
+
+### Named Registry Aliases
+
+vlt also supports [named registry aliases](/cli/registries), which are
+more explicit than scoped registries. Dependencies reference a named
+registry directly, removing ambiguity:
+
+<Code
+  code={JSON.stringify(
+    {
+      registries: {
+        internal: 'https://npm.mycompany.com/',
+      },
+    },
+    null,
+    2,
+  )}
+  title="vlt.json"
+  lang="json"
+/>
+
+<Code
+  code={JSON.stringify(
+    {
+      dependencies: {
+        '@mycompany/utils': 'internal:@mycompany/utils@^2.0',
+      },
+    },
+    null,
+    2,
+  )}
+  title="package.json"
+  lang="json"
+/>
+
+---
+
+## Authentication
+
+yarn v1 stores tokens in `.npmrc`. yarn v2+ stores them in
+`.yarnrc.yml`. Both approaches risk accidental commits of secrets.
+
+vlt stores auth tokens in an XDG-compliant keychain file, separate
+from project configuration.
+
+<Code
+  code={`# Log in to default registry
+$ vlt login
+
+# Log in to a custom registry
+
+$ vlt login --registry=https://npm.mycompany.com/`} title="Terminal"
+lang="bash" />
+
+### CI Environments
+
+<Code
+  code={`# yarn v2+
+YARN_NPM_AUTH_TOKEN=abc123 yarn install
+
+# vlt
+
+VLT_TOKEN=abc123 vlt install`} title="Terminal" lang="bash" />
+
+See [Authentication](/cli/auth) for full details.
+
+---
+
+## Lockfile
+
+yarn v1 uses `yarn.lock` (custom format). yarn v2+ also uses
+`yarn.lock` (YAML-based). vlt uses `vlt-lock.json`.
+
+When you first run `vlt install`, vlt creates `vlt-lock.json` from a
+fresh resolution. Your `yarn.lock` is not read.
+
+**What to do:**
+
+1. Run `vlt install` to generate `vlt-lock.json`
+2. Commit `vlt-lock.json`
+3. Optionally remove `yarn.lock` once you've fully switched
+
+---
+
+## Install Script Protection
+
+This is a major difference from yarn.
+
+**yarn v1** runs all lifecycle scripts automatically. **yarn v2+**
+runs scripts for direct dependencies but blocks transitive dependency
+scripts by default (you can allowlist via `.yarnrc.yml`).
+
+**vlt** goes further: `vlt install` runs **no scripts at all** by
+default. The build step is completely separate:
+
+<Code
+  code={`# Phase 1: Install (no code executes)
+$ vlt install
+
+# Phase 2: Build (runs scripts, skipping known malware)
+
+$ vlt build`} title="Terminal" lang="bash" />
+
+By default, `vlt build` uses the target
+`:scripts:not(:built):not(:malware)` — it only runs scripts for
+packages that need building and aren't flagged as malware by
+[Socket](https://socket.dev/).
+
+You can target scripts precisely:
+
+<Code
+  code={`# Only allow specific trusted packages
+$ vlt build --target="#esbuild, #node-gyp"
+
+# Persist your choice
+
+$ vlt config set "command.build.target=#esbuild, #node-gyp"`}
+title="Terminal" lang="bash" />
+
+See [`vlt build`](/cli/commands/build) for full details.
+
+---
+
+## Workspaces
+
+### yarn v1
+
+yarn v1 defines workspaces in the root `package.json`:
+
+<Code
+  code={JSON.stringify(
+    {
+      private: true,
+      workspaces: ['packages/*'],
+    },
+    null,
+    2,
+  )}
+  title="package.json (yarn v1)"
+  lang="json"
+/>
+
+### yarn v2+
+
+yarn v2+ is similar but also supports the `workspaces` field in
+`.yarnrc.yml` for additional filtering.
+
+### vlt
+
+vlt defines workspaces in `vlt.json`:
+
+<Code
+  code={JSON.stringify(
+    {
+      workspaces: ['packages/*'],
+    },
+    null,
+    2,
+  )}
+  title="vlt.json"
+  lang="json"
+/>
+
+vlt also supports **named workspace groups** for targeted operations:
+
+<Code
+  code={JSON.stringify(
+    {
+      workspaces: {
+        apps: 'apps/*',
+        libs: ['packages/*', 'shared/*'],
+      },
+    },
+    null,
+    2,
+  )}
+  title="vlt.json"
+  lang="json"
+/>
+
+<Code
+  code={`# Run tests only in the libs group
+$ vlt run test -g libs
+
+# Run build across all workspaces
+
+$ vlt run build --recursive`} title="Terminal" lang="bash" />
+
+### Workspace Commands
+
+| yarn                            | vlt                                               |
+| ------------------------------- | ------------------------------------------------- |
+| `yarn workspace <name> <cmd>`   | `cd <path> && vlt <cmd>` or `vlt <cmd> -w <path>` |
+| `yarn workspaces foreach <cmd>` | `vlt <cmd> --recursive`                           |
+
+See [Workspaces](/cli/workspaces) for full details.
+
+---
+
+## Resolutions → Graph Modifiers
+
+yarn uses `resolutions` in `package.json` to force dependency
+versions. vlt uses [Graph Modifiers](/cli/graph-modifiers) in
+`vlt.json`.
+
+<Code
+  code={JSON.stringify(
+    {
+      resolutions: {
+        lodash: '^4.17.21',
+        'express/qs': '6.10.0',
+      },
+    },
+    null,
+    2,
+  )}
+  title="package.json (yarn)"
+  lang="json"
+/>
+
+<Code
+  code={JSON.stringify(
+    {
+      modifiers: {
+        '#lodash': '^4.17.21',
+        ':root > #express > #qs': '=6.10.0',
+      },
+    },
+    null,
+    2,
+  )}
+  title="vlt.json"
+  lang="json"
+/>
+
+Graph Modifiers use DSS selectors, which give you more precise control
+over which instances of a dependency are affected.
+
+---
+
+## Plug'n'Play (PnP)
+
+If you're using yarn v2+ with Plug'n'Play (no `node_modules`), the
+switch to vlt means going back to a `node_modules`-based layout. This
+is generally straightforward — vlt creates a standard `node_modules`
+directory.
+
+If your project relies on PnP-specific features (like `.pnp.cjs`
+loaders), you'll need to remove those references from your build
+tooling and runtime configuration.
+
+---
+
+## Features Not in vlt
+
+Some yarn-specific features don't have direct equivalents:
+
+- **Plug'n'Play / Zero-Installs** — vlt uses `node_modules`
+- **Constraints** — Use vlt's [DSS query system](/cli/selectors) for
+  dependency policy enforcement
+- **Patches** (`yarn patch`) — Not yet available in vlt
+- **Protocols** (`portal:`, `patch:`) — vlt supports `file:`,
+  `workspace:`, `git:`, and `registry:` specifiers
+
+---
+
+## Migration Checklist
+
+1. Install vlt: `npm install -g vlt`
+2. Create `vlt.json` with registry and workspace configuration
+3. Move scoped registry config from `.yarnrc.yml` / `.npmrc` to
+   `vlt.json`
+4. Move workspace definitions from `package.json` to `vlt.json`
+5. Move `resolutions` from `package.json` to `modifiers` in `vlt.json`
+6. If using PnP, remove `.pnp.cjs`, `.pnp.loader.mjs`, and related
+   `.yarnrc.yml` settings
+7. Run `vlt install` then `vlt build`
+8. Commit `vlt-lock.json`
+9. Update CI scripts: replace `yarn install --immutable` with
+   `vlt install --expect-lockfile && vlt build`
+10. Update CI auth: replace `YARN_NPM_AUTH_TOKEN` with `VLT_TOKEN`
+11. Update any `yarn dlx` usage to `vlx`

--- a/www/docs/src/content/docs/migration/index.mdx
+++ b/www/docs/src/content/docs/migration/index.mdx
@@ -1,0 +1,45 @@
+---
+title: Migrating to vlt
+sidebar:
+  label: Overview
+  order: 0
+---
+
+import { Code } from '@astrojs/starlight/components'
+
+## Migrating to vlt from Other Package Managers
+
+This section covers how to switch from npm, yarn, or pnpm to vlt. Each
+guide walks through the concrete steps: configuration, commands,
+lockfiles, workspaces, and the key differences to be aware of.
+
+### Choose Your Migration Path
+
+- [**From npm**](/migration/from-npm) — Migrate from npm to vlt
+- [**From yarn**](/migration/from-yarn) — Migrate from yarn (v1
+  classic or v2+ berry) to vlt
+- [**From pnpm**](/migration/from-pnpm) — Migrate from pnpm to vlt
+
+### What Changes
+
+Regardless of which package manager you're coming from, the core
+changes are:
+
+1. **Configuration moves to `vlt.json`** — A single JSON file replaces
+   `.npmrc`, `.yarnrc.yml`, or `.npmrc` + `pnpm-workspace.yaml`
+2. **Lockfile format changes** — vlt uses `vlt-lock.json` instead of
+   `package-lock.json`, `yarn.lock`, or `pnpm-lock.yaml`
+3. **Install scripts don't run by default** — vlt separates
+   installation from build. `vlt install` downloads packages without
+   executing any lifecycle scripts. Use `vlt build` to selectively run
+   scripts afterward
+4. **Security is built in** — vlt integrates with
+   [Socket](https://socket.dev/) for malware detection, and the query
+   system lets you audit your dependency graph before any code runs
+
+### What Stays the Same
+
+- Your `package.json` files don't change (dependencies, scripts, etc.)
+- `node_modules` structure is compatible — your code runs the same way
+- Registry authentication uses tokens, just stored differently
+- Workspace packages still use `workspace:` protocol references


### PR DESCRIPTION
## Summary

Add comprehensive migration documentation for switching from npm, yarn, and pnpm to vlt.

### New files

- `www/docs/src/content/docs/migration/index.mdx` — Overview page with common changes across all package managers
- `www/docs/src/content/docs/migration/from-npm.mdx` — Step-by-step migration from npm
- `www/docs/src/content/docs/migration/from-yarn.mdx` — Step-by-step migration from yarn (covers both v1 classic and v2+ berry)
- `www/docs/src/content/docs/migration/from-pnpm.mdx` — Step-by-step migration from pnpm
- `www/docs/astro.config.mts` — Added "Migration" sidebar section

### Topics covered in each guide

- **Command mapping** — Comprehensive table mapping old commands to vlt equivalents
- **Configuration** — How to move from `.npmrc` / `.yarnrc.yml` / `pnpm-workspace.yaml` to `vlt.json`
- **Registry setup** — Scoped registries and named registry aliases
- **Authentication** — Token storage differences (XDG keychain vs config files), CI environment variables
- **Lockfile** — What happens to existing lockfiles, how to generate `vlt-lock.json`
- **Install script protection** — The two-phase install/build model, `vlt build --target` for selective script execution
- **Workspaces** — Workspace definition differences and named workspace groups
- **Overrides/Resolutions → Graph Modifiers** — DSS-based dependency overrides
- **Catalogs** (pnpm guide) — Direct migration path for pnpm catalog feature
- **Migration checklist** — Numbered step-by-step list for each migration path

### Notes

- Follows existing docs conventions (Starlight frontmatter, `<Code>` components, sidebar ordering)
- Practical and concise — real migration steps with before/after examples
- Highlights genuine differentiators (install script protection, security scanning) without marketing tone
- Cross-links to existing docs (Security, Authentication, Workspaces, Registries, etc.)

Closes #97