### PR TITLE
feat(cli-sdk): improve human output for multi-workspace vlt run

### DIFF
--- a/src/cli-sdk/src/exec-command.ts
+++ b/src/cli-sdk/src/exec-command.ts
@@ -71,6 +71,13 @@ const setExitCode = (result: RunResult) => {
   process.exitCode ||= result.status ?? 1
 }
 
+const formatElapsed = (ms: number): string => {
+  if (ms >= 1000) {
+    return `${(ms / 1000).toFixed(1)}s`
+  }
+  return `${Math.round(ms)}ms`
+}
+
 export const views = {
   // run results for single or multiple will be printed along the way.
   human: result => {
@@ -213,29 +220,47 @@ export class ExecCommand<B extends RunnerBG, F extends RunnerFG> {
       return this.noArgsMulti()
     }
 
+    // Compute max path length for alignment
+    const targets = this.getTargets()
+    this.#maxPathLength = 0
+    for (const { label } of targets) {
+      if (label.length > this.#maxPathLength) {
+        this.#maxPathLength = label.length
+      }
+    }
+
+    const scriptName = this.arg0
+    const totalStart = performance.now()
+
     // run across workspaces
     let failed = false as boolean
+    let taskCount = 0
     const runInDir = async (cwd: string, label: string) => {
+      const start = performance.now()
       const result = await this.bg(this.bgArg(cwd)).catch(
         (er: unknown) => {
+          const elapsed = performance.now() - start
           if (isErrorWithCause(er) && isRunResult(er.cause)) {
-            this.printResult(label, er.cause)
+            this.printResult(label, er.cause, scriptName, elapsed)
           }
           failed = true
           throw er
         },
       )
+      const elapsed = performance.now() - start
       // If we are allowed to ignore missing commands, then command might be
       // an emptry string. If so, we don't print anything and return null to
       // be filtered out later.
       if (!result.command) return null
-      if (!failed) this.printResult(label, result)
+      taskCount++
+      if (!failed)
+        this.printResult(label, result, scriptName, elapsed)
       return result
     }
 
     const resultMap = new Map<string, SpawnResultStdioStrings>()
     if (this.#nodes) {
-      for (const { label, cwd } of this.getTargets()) {
+      for (const { label, cwd } of targets) {
         const result = await runInDir(cwd, label)
         if (result) resultMap.set(label, result)
       }
@@ -248,6 +273,13 @@ export class ExecCommand<B extends RunnerBG, F extends RunnerFG> {
       }
     }
 
+    // Print summary line for multi-workspace runs
+    if (this.view === 'human' && taskCount > 0) {
+      const totalElapsed = performance.now() - totalStart
+      const summary = `\n${taskCount} ${taskCount === 1 ? 'task' : 'tasks'} · ${formatElapsed(totalElapsed)} total`
+      stdout(styleTextStdout('dim', summary))
+    }
+
     const results: Record<string, RunResult> = {}
     for (const [path, result] of resultMap) {
       results[path] = result
@@ -255,27 +287,58 @@ export class ExecCommand<B extends RunnerBG, F extends RunnerFG> {
     return results
   }
 
-  printResult(path: string, result: RunResult) {
+  /** Max path length for alignment in multi-workspace output */
+  #maxPathLength = 0
+
+  printResult(
+    path: string,
+    result: RunResult,
+    scriptName?: string,
+    elapsed = 0,
+  ) {
     // non-human results just get printed at the end
     if (this.view !== 'human') return
 
+    const isMulti = scriptName !== undefined
     if (result.status === 0 && result.signal === null) {
       /* c8 ignore start */
       if (result.stderr) stderr(ansiToAnsi(result.stderr))
       if (result.stdout) stdout(ansiToAnsi(result.stdout))
       /* c8 ignore stop */
-      stdout(path, 'ok')
+      if (isMulti) {
+        const paddedPath = path.padEnd(this.#maxPathLength)
+        const check = styleTextStdout('green', '✓')
+        const time = formatElapsed(elapsed)
+        stdout(
+          `${styleTextStdout('bold', paddedPath)}  ${check} ${scriptName} ${styleTextStdout('dim', `(${time})`)}`,
+        )
+      } /* c8 ignore start */ else {
+        stdout(path, 'ok')
+      } /* c8 ignore stop */
     } else {
-      stdout(
-        styleTextStdout(
-          ['bgWhiteBright', 'black', 'bold'],
-          path + ' failure',
-        ),
-        {
-          status: result.status,
-          signal: result.signal,
-        },
-      )
+      if (isMulti) {
+        const paddedPath = path.padEnd(this.#maxPathLength)
+        const cross = styleTextStdout('red', '✗')
+        const time = formatElapsed(elapsed)
+        const exitInfo =
+          result.signal ?
+            `signal ${result.signal}`
+          : `exit code ${result.status}`
+        stdout(
+          `${styleTextStdout('bold', paddedPath)}  ${cross} ${scriptName} ${styleTextStdout('dim', `(${time})`)}  ${exitInfo}`,
+        )
+      } /* c8 ignore start */ else {
+        stdout(
+          styleTextStdout(
+            ['bgWhiteBright', 'black', 'bold'],
+            path + ' failure',
+          ),
+          {
+            status: result.status,
+            signal: result.signal,
+          },
+        )
+      } /* c8 ignore stop */
       /* c8 ignore start */
       if (result.stderr) stderr(ansiToAnsi(result.stderr))
       if (result.stdout) stdout(ansiToAnsi(result.stdout))

--- a/src/cli-sdk/test/commands/exec-local.ts
+++ b/src/cli-sdk/test/commands/exec-local.ts
@@ -1,5 +1,4 @@
 import { unload } from '@vltpkg/vlt-json'
-import { ansiToAnsi } from 'ansi-to-pre'
 import { resolve } from 'node:path'
 import t from 'tap'
 import {
@@ -158,14 +157,18 @@ t.test('run script across several workspaces', async t => {
       stderr: '',
     },
   })
-  t.strictSame(
-    new Set(logs()),
-    new Set([
-      [ansiToAnsi('ok')],
-      ['src/a', 'ok'],
-      [ansiToAnsi('ok')],
-      ['src/b', 'ok'],
-    ]),
+  const logEntries = logs()
+  // 2 stdout lines + 2 per-workspace lines + 1 summary
+  const wsLines = logEntries.filter(
+    l => typeof l[0] === 'string' && l[0].includes('✓'),
   )
+  t.equal(wsLines.length, 2)
+  t.match(wsLines[0]?.[0], /src\/[ab]\s+✓ echo \(\d+(\.\d+)?m?s\)/)
+  t.match(wsLines[1]?.[0], /src\/[ab]\s+✓ echo \(\d+(\.\d+)?m?s\)/)
+  const summaryLine = logEntries.find(
+    l => typeof l[0] === 'string' && l[0].includes('total'),
+  )
+  t.ok(summaryLine, 'should have a summary line')
+  t.match(summaryLine?.[0], /2 tasks · \d+(\.\d+)?m?s total/)
   t.strictSame(new Set(errs()), new Set())
 })

--- a/src/cli-sdk/test/commands/run-exec.ts
+++ b/src/cli-sdk/test/commands/run-exec.ts
@@ -1,5 +1,4 @@
 import { unload } from '@vltpkg/vlt-json'
-import { ansiToAnsi } from 'ansi-to-pre'
 import { resolve } from 'node:path'
 import t from 'tap'
 import { command, usage } from '../../src/commands/run-exec.ts'
@@ -133,14 +132,18 @@ t.test('run script across several workspaces', async t => {
       stderr: '',
     },
   })
-  t.strictSame(
-    new Set(logs()),
-    new Set([
-      [ansiToAnsi('ok')],
-      ['src/a', 'ok'],
-      [ansiToAnsi('pj script ok')],
-      ['src/b', 'ok'],
-    ]),
+  const logEntries = logs()
+  // stdout lines + per-workspace lines + summary
+  const wsLines = logEntries.filter(
+    l => typeof l[0] === 'string' && l[0].includes('✓'),
   )
+  t.equal(wsLines.length, 2)
+  t.match(wsLines[0]?.[0], /src\/[ab]\s+✓ echo \(\d+(\.\d+)?m?s\)/)
+  t.match(wsLines[1]?.[0], /src\/[ab]\s+✓ echo \(\d+(\.\d+)?m?s\)/)
+  const summaryLine = logEntries.find(
+    l => typeof l[0] === 'string' && l[0].includes('total'),
+  )
+  t.ok(summaryLine, 'should have a summary line')
+  t.match(summaryLine?.[0], /2 tasks · \d+(\.\d+)?m?s total/)
   t.strictSame(new Set(errs()), new Set())
 })

--- a/src/cli-sdk/test/commands/run.ts
+++ b/src/cli-sdk/test/commands/run.ts
@@ -146,13 +146,19 @@ t.test('run script across several workspaces', async t => {
         stderr: '',
       },
     })
-    t.strictSame(
-      new Set(logs()),
+    const logEntries = logs()
+    // 2 per-workspace lines + 1 summary line
+    t.equal(logEntries.length, 3)
+    const perWs = logEntries.slice(0, 2).map(l => l[0] as string)
+    t.match(
+      new Set(perWs),
       new Set([
-        ['src/a', 'ok'],
-        ['src/b', 'ok'],
+        /src\/a\s+✓ hello \(\d+(\.\d+)?m?s\)/,
+        /src\/b\s+✓ hello \(\d+(\.\d+)?m?s\)/,
       ]),
     )
+    // summary line
+    t.match(logEntries[2]?.[0], /2 tasks · \d+(\.\d+)?m?s total/)
     t.strictSame(new Set(errs()), new Set())
   }
 
@@ -219,7 +225,11 @@ t.test('run script across workspaces with some missing', async t => {
         stderr: '',
       },
     })
-    t.strictSame(new Set(logs()), new Set([['src/a', 'ok']]))
+    const logEntries = logs()
+    // 1 per-workspace line + 1 summary line
+    t.equal(logEntries.length, 2)
+    t.match(logEntries[0]?.[0], /src\/a\s+✓ hello \(\d+(\.\d+)?m?s\)/)
+    t.match(logEntries[1]?.[0], /1 task · \d+(\.\d+)?m?s total/)
     t.strictSame(new Set(errs()), new Set())
   }
 
@@ -349,16 +359,16 @@ t.test('one ws fails, with bail', async t => {
     },
   })
 
+  const logEntries = logs()
+  // At least 1 failure line (no summary since bail throws)
+  t.ok(logEntries.length >= 1)
+  const failLine = logEntries.find(
+    l => typeof l[0] === 'string' && l[0].includes('✗'),
+  )
+  t.ok(failLine, 'should have a failure line')
   t.match(
-    new Set(logs()),
-    new Set([
-      [
-        'src/a failure',
-        {
-          status: 1,
-        },
-      ],
-    ]),
+    failLine?.[0],
+    /src\/a\s+✗ hello \(\d+(\.\d+)?m?s\)\s+exit code 1/,
   )
   t.strictSame(new Set(errs()), new Set())
   t.equal(process.exitCode, exitCode || 1)
@@ -420,17 +430,27 @@ t.test('one ws fails, without bail', async t => {
       stderr: '',
     },
   })
-  t.match(
-    new Set(logs()),
-    new Set([
-      [
-        'src/a failure',
-        {
-          status: 1,
-        },
-      ],
-    ]),
+  const logEntries = logs()
+  // Per-workspace lines + summary
+  const failLine = logEntries.find(
+    l => typeof l[0] === 'string' && l[0].includes('✗'),
   )
+  t.ok(failLine, 'should have a failure line')
+  t.match(
+    failLine?.[0],
+    /src\/a\s+✗ hello \(\d+(\.\d+)?m?s\)\s+exit code 1/,
+  )
+  const successLine = logEntries.find(
+    l => typeof l[0] === 'string' && l[0].includes('✓'),
+  )
+  t.ok(successLine, 'should have a success line')
+  t.match(successLine?.[0], /src\/b\s+✓ hello \(\d+(\.\d+)?m?s\)/)
+  // summary line
+  const summaryLine = logEntries.find(
+    l => typeof l[0] === 'string' && l[0].includes('total'),
+  )
+  t.ok(summaryLine, 'should have a summary line')
+  t.match(summaryLine?.[0], /2 tasks · \d+(\.\d+)?m?s total/)
   t.strictSame(new Set(errs()), new Set())
   t.equal(process.exitCode, exitCode || 1)
   process.exitCode = exitCode

--- a/src/cli-sdk/test/exec-command.ts
+++ b/src/cli-sdk/test/exec-command.ts
@@ -63,6 +63,69 @@ t.test('with view', t => {
   t.end()
 })
 
+t.test('printResult multi-workspace formatting', t => {
+  const { exitCode } = process
+  const logs = t.capture(console, 'log').args
+  const e = new ExecCommand(
+    {
+      projectRoot: t.testdirName,
+      positionals: ['build'],
+      get() {},
+      options: {
+        packageJson: {
+          read: () => ({}),
+        },
+      },
+      values: {},
+    } as unknown as LoadedConfig,
+    exec,
+    execFG,
+  )
+
+  // success with timing >= 1s
+  e.printResult(
+    'packages/ui',
+    {
+      command: 'tsc',
+      args: [],
+      cwd: '/tmp',
+      stdout: '',
+      stderr: '',
+      status: 0,
+      signal: null,
+    },
+    'build',
+    3100,
+  )
+  const successLogs = logs()
+  t.equal(successLogs.length, 1)
+  t.match(successLogs[0]?.[0], /packages\/ui.*✓ build \(3\.1s\)/)
+
+  // failure with signal
+  e.printResult(
+    'packages/api',
+    {
+      command: 'tsc',
+      args: [],
+      cwd: '/tmp',
+      stdout: '',
+      stderr: '',
+      status: null,
+      signal: 'SIGTERM',
+    } as unknown as RunResult,
+    'build',
+    500,
+  )
+  const failLogs = logs()
+  t.equal(failLogs.length, 1)
+  t.match(
+    failLogs[0]?.[0],
+    /packages\/api.*✗ build \(500ms\)\s+signal SIGTERM/,
+  )
+  process.exitCode = exitCode
+  t.end()
+})
+
 t.test('getCwd', async t => {
   // fallback to process.cwd() when no nodes/monorepo
   // This matches npx behavior and is required for tools like node-gyp


### PR DESCRIPTION
## Summary

Improves the human-readable output when `vlt run` executes scripts across multiple workspaces.

### Before
```
packages/config ok
packages/ui ok
packages/shared ok
```

### After
```
packages/shared  ✓ build (1.2s)
packages/config  ✓ build (0.8s)
packages/ui      ✓ build (3.1s)

3 tasks · 5.1s total
```

### Failure output
```
packages/shared  ✓ build (1.2s)
packages/config  ✗ build (0.8s)  exit code 1
```

## Changes

- **`printResult()`**: Enhanced to accept script name and elapsed time. Shows green ✓/red ✗ status indicators, aligned workspace paths, timing in parentheses, and exit code/signal on failure.
- **`run()`**: Wraps each `bg()` call with `performance.now()` timing. Computes `maxPathLength` from targets for alignment. Prints summary line after all tasks complete.
- **Color coding**: Green checkmark, red failure indicator, bold workspace path, dim/grey timing and summary (via `styleTextStdout`).
- **Single workspace**: Unchanged — enhanced output only applies to multi-workspace runs.

## Tests

- Updated existing multi-workspace tests in `run.ts`, `exec-local.ts`, `run-exec.ts` to match new output format
- Added new `printResult multi-workspace formatting` test covering seconds formatting and signal-based failures

Closes #1511

Co-authored-by: Ruy Adorno <ruyadorno@users.noreply.github.com>