### PR TITLE
ci: migrate release.yml from pnpm to vlt

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,14 +80,18 @@ jobs:
             node --eval "
               // Parse semver and compute prerelease bump
               const v = '$current';
-              const pre = v.match(/-pre\.(\d+)$/);
-              if (pre) {
-                // Already a prerelease — increment the prerelease number
-                console.log(v.replace(/-pre\.\d+$/, '-pre.' + (parseInt(pre[1]) + 1)));
+              const m = v.match(/^(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z]+)(?:\.(\d+))?)?$/);
+              if (!m) { console.error('Invalid semver: ' + v); process.exit(1); }
+              const [, major, minor, patch, id, num] = m;
+              if (id && num !== undefined) {
+                // Has identifier with number (e.g. -rc.18) — increment the number
+                console.log(major + '.' + minor + '.' + patch + '-' + id + '.' + (parseInt(num) + 1));
+              } else if (id) {
+                // Has identifier without number (e.g. -pre) — add .0
+                console.log(major + '.' + minor + '.' + patch + '-' + id + '.0');
               } else {
                 // Not a prerelease — bump patch and add -pre.0
-                const [major, minor, patch] = v.split('-')[0].split('.').map(Number);
-                console.log(major + '.' + minor + '.' + (patch + 1) + '-pre.0');
+                console.log(major + '.' + minor + '.' + (parseInt(patch) + 1) + '-pre.0');
               }
             "
           }
@@ -282,9 +286,12 @@ jobs:
           commit="$(git rev-parse HEAD~1)"
           for dir in $(git diff --name-only "$commit" HEAD | grep -oP '^(src|infra)/[^/]+' | sort -u); do
             if [[ -f "$dir/package.json" ]]; then
-              name=$(jq -r '.name' "$dir/package.json")
-              version=$(jq -r '.version' "$dir/package.json")
-              echo "$name@$version"
+              is_private=$(jq -r '.private // false' "$dir/package.json")
+              if [[ "$is_private" != "true" ]]; then
+                name=$(jq -r '.name' "$dir/package.json")
+                version=$(jq -r '.version' "$dir/package.json")
+                echo "$name@$version"
+              fi
             fi
           done | sort
 
@@ -319,7 +326,7 @@ jobs:
                 continue
               fi
               echo "Publishing $dir..."
-              (cd "$dir" && vlt publish --access=public $dry_run_flag) || true
+              (cd "$dir" && vlt publish --access=public $dry_run_flag)
             fi
           done
         env:


### PR DESCRIPTION
## Summary

Migrates the release workflow (`.github/workflows/release.yml`) from pnpm/npm tooling to vlt, as requested in #1467.

### Changes

**Replaced with vlt equivalents:**
- `pnpm/action-setup@v4` → `vltpkg/setup-vlt@v1`
- `pnpm install` → `vlt install`
- `pnpm pack` → `vlt pack` (per-workspace in changed-package loop)
- `pnpm publish --access=public --no-git-checks` → `vlt publish --access=public`
- Removed `setup-node` pnpm cache config (vlt handles its own caching)
- Removed `npm i npm@11 -g` step (no longer needed)

**Bash workarounds for missing vlt features:**
- **Version bumping** (`npm version prerelease --no-git-tag-version`): `vlt version` always creates git commits/tags — replaced with `jq` to directly modify `package.json` files. Tracked in #1514.
- **Git-change-based filtering** (`pnpm --filter="[commit]"`): vlt has no `:changed()` pseudo-selector — replaced with `git diff --name-only` + bash loops. Tracked in #1515.

Each workaround has a `TODO` comment linking to its tracking issue so they can be replaced when the features ship.

### Feature issues created

- #1514 — `vlt version --no-git-tag-version` / `--no-commit`
- #1515 — `:changed()` pseudo-selector for git-based workspace filtering

### What uses vlt vs bash

| Operation | Tool | Notes |
|-----------|------|-------|
| Setup | `vltpkg/setup-vlt@v1` | ✅ Direct replacement |
| Install | `vlt install` | ✅ Direct replacement |
| Version bump | bash + jq | ⏳ Needs #1514 |
| Pack | `vlt pack` | ✅ (loop finds changed pkgs via git) ⏳ Filtering needs #1515 |
| Publish | `vlt publish --access=public` | ✅ (loop finds changed pkgs via git) ⏳ Filtering needs #1515 |
| List changed packages | bash + git diff | ⏳ Needs #1515 |

Closes #1467

Co-authored-by: Darcy Clarke <darcy@darcyclarke.me>