### PR TITLE
fix(graph): recreate deleted workspace node_modules on reinstall

### DIFF
--- a/src/graph/src/actual/load.ts
+++ b/src/graph/src/actual/load.ts
@@ -28,7 +28,8 @@ import type {
   GraphModifier,
   ModifierActiveEntry,
 } from '../modifiers.ts'
-import { readFileSync } from 'node:fs'
+import { existsSync, readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
 
 export type LoadOptions = SpecOptions & {
   /**
@@ -445,6 +446,27 @@ const parseDir = (
 }
 
 /**
+ * Verify that all importer node_modules directories exist on disk.
+ * The hidden lockfile may report deps as installed even when a
+ * workspace's node_modules has been manually deleted. Throws if
+ * any importer node_modules directory is missing, causing the
+ * caller to fall through to filesystem-based graph loading.
+ */
+export const verifyImporterNodeModules = (
+  graph: Graph,
+  projectRoot: string,
+): void => {
+  for (const importer of graph.importers) {
+    const nm = resolve(projectRoot, importer.location, 'node_modules')
+    if (!existsSync(nm)) {
+      throw new Error(
+        `Missing node_modules for importer: ${importer.location}`,
+      )
+    }
+  }
+}
+
+/**
  * Read the file system looking for `node_modules` folders and
  * returns a new {@link Graph} that represents the relationship
  * between the dependencies found.
@@ -474,6 +496,7 @@ export const load = (options: LoadOptions): Graph => {
         monorepo,
         scurry,
       })
+      verifyImporterNodeModules(graph, projectRoot)
       done()
       return graph
     } catch {

--- a/src/graph/test/actual/load.ts
+++ b/src/graph/test/actual/load.ts
@@ -10,6 +10,7 @@ import {
   load,
   getPathBasedId,
   asStoreConfigObject,
+  verifyImporterNodeModules,
 } from '../../src/actual/load.ts'
 import { objectLikeOutput } from '../../src/visualization/object-like-output.ts'
 import { actualGraph } from '../fixtures/actual.ts'
@@ -1265,6 +1266,99 @@ t.test('hidden lockfile', async t => {
       )
     },
   )
+
+  await t.test(
+    'should invalidate hidden lockfile when workspace node_modules is missing',
+    async t => {
+      const aDepID = joinDepIDTuple(['registry', '', 'a@1.0.0'])
+      const wsDepID = joinDepIDTuple(['workspace', 'packages/my-ws'])
+      const projectRoot = t.testdir({
+        'package.json': JSON.stringify({
+          name: 'my-monorepo',
+          version: '1.0.0',
+          dependencies: {
+            'my-ws': 'workspace:*',
+          },
+        }),
+        'vlt.json': JSON.stringify({
+          workspaces: { packages: ['./packages/*'] },
+        }),
+        packages: {
+          'my-ws': {
+            'package.json': JSON.stringify({
+              name: 'my-ws',
+              version: '1.0.0',
+              dependencies: {
+                a: '^1.0.0',
+              },
+            }),
+            // no node_modules here — simulates deletion
+          },
+        },
+        node_modules: {
+          '.vlt-lock.json': JSON.stringify({
+            lockfileVersion: 1,
+            options: configData,
+            nodes: {
+              [aDepID]: [
+                0,
+                'a',
+                null,
+                null,
+                null,
+                {
+                  name: 'a',
+                  version: '1.0.0',
+                },
+              ],
+            },
+            edges: {
+              [`${wsDepID} a`]: `prod ^1.0.0 ${aDepID}`,
+              'file:. my-ws': `prod workspace:* ${wsDepID}`,
+            },
+          }),
+          '.vlt': {
+            [aDepID]: {
+              node_modules: {
+                a: {
+                  'package.json': JSON.stringify({
+                    name: 'a',
+                    version: '1.0.0',
+                  }),
+                },
+              },
+            },
+          },
+          a: t.fixture('symlink', `.vlt/${aDepID}/node_modules/a`),
+          'my-ws': t.fixture('symlink', '../packages/my-ws'),
+        },
+      })
+
+      t.chdir(projectRoot)
+      unload('project')
+
+      const graph = load({
+        scurry: new PathScurry(projectRoot),
+        packageJson: new PackageJson(),
+        monorepo: Monorepo.maybeLoad(projectRoot),
+        projectRoot,
+        loadManifests: true,
+        ...configData,
+      })
+
+      // The hidden lockfile should be invalidated because the
+      // workspace node_modules is missing. The graph should be
+      // rebuilt from the filesystem, showing workspace dep 'a'
+      // as missing (no node_modules/a under packages/my-ws).
+      const wsNode = graph.nodes.get(wsDepID)
+      t.ok(wsNode, 'workspace importer node should exist')
+      // The workspace's dep 'a' should be missing since its
+      // node_modules was deleted
+      const edgeA = wsNode?.edgesOut.get('a')
+      t.ok(edgeA, 'workspace should have edge for a')
+      t.notOk(edgeA?.to, 'edge to a should be unresolved (missing)')
+    },
+  )
 })
 
 t.test('various DepID types with peerSetHash', async t => {
@@ -1485,5 +1579,92 @@ t.test('asStoreConfigObject', async t => {
     () => asStoreConfigObject({ foo: 'foo' }),
     /Expected a store config object, got/,
     'should throw on invalid selector',
+  )
+})
+
+t.test('verifyImporterNodeModules', async t => {
+  await t.test(
+    'should pass when all importer node_modules exist',
+    async t => {
+      const projectRoot = t.testdir({
+        'package.json': JSON.stringify({
+          name: 'test-project',
+          version: '1.0.0',
+        }),
+        'vlt.json': '{}',
+        node_modules: {},
+      })
+
+      t.chdir(projectRoot)
+      unload('project')
+
+      const graph = load({
+        scurry: new PathScurry(projectRoot),
+        packageJson: new PackageJson(),
+        monorepo: Monorepo.maybeLoad(projectRoot),
+        projectRoot,
+        loadManifests: true,
+        skipHiddenLockfile: true,
+        ...configData,
+      })
+
+      // Should not throw when root node_modules exists
+      t.doesNotThrow(
+        () => verifyImporterNodeModules(graph, projectRoot),
+        'should pass when node_modules exists',
+      )
+    },
+  )
+
+  await t.test(
+    'should throw when importer node_modules is missing',
+    async t => {
+      const wsDepID = joinDepIDTuple(['workspace', 'packages/my-ws'])
+      const projectRoot = t.testdir({
+        'package.json': JSON.stringify({
+          name: 'my-monorepo',
+          version: '1.0.0',
+          dependencies: {
+            'my-ws': 'workspace:*',
+          },
+        }),
+        'vlt.json': JSON.stringify({
+          workspaces: { packages: ['./packages/*'] },
+        }),
+        packages: {
+          'my-ws': {
+            'package.json': JSON.stringify({
+              name: 'my-ws',
+              version: '1.0.0',
+            }),
+            // no node_modules — workspace node_modules deleted
+          },
+        },
+        node_modules: {},
+      })
+
+      t.chdir(projectRoot)
+      unload('project')
+
+      const graph = load({
+        scurry: new PathScurry(projectRoot),
+        packageJson: new PackageJson(),
+        monorepo: Monorepo.maybeLoad(projectRoot),
+        projectRoot,
+        loadManifests: true,
+        skipHiddenLockfile: true,
+        ...configData,
+      })
+
+      // Verify the workspace importer is in the graph
+      t.ok(graph.nodes.get(wsDepID), 'workspace node should exist')
+
+      // Should throw because workspace has no node_modules
+      t.throws(
+        () => verifyImporterNodeModules(graph, projectRoot),
+        /Missing node_modules for importer/,
+        'should throw when workspace node_modules is missing',
+      )
+    },
   )
 })

--- a/src/graph/test/reify/index.ts
+++ b/src/graph/test/reify/index.ts
@@ -10,9 +10,11 @@ import { Spec } from '@vltpkg/spec'
 import { unload } from '@vltpkg/vlt-json'
 import { Monorepo } from '@vltpkg/workspaces'
 import {
+  existsSync,
   lstatSync,
   readdirSync,
   readFileSync,
+  rmSync,
   statSync,
   unlinkSync,
   writeFileSync,
@@ -784,6 +786,111 @@ t.test('allowScripts with query selector :scripts', async t => {
     result.buildQueue?.length,
     0,
     'lodash has no scripts so nothing was run',
+  )
+})
+
+t.test('reify recreates deleted workspace node_modules', async t => {
+  const projectRoot = t.testdir({
+    cache: {},
+    'vlt.json': JSON.stringify({
+      cache: resolve(t.testdirName, 'cache'),
+      workspaces: { packages: ['./packages/*'] },
+    }),
+    'package.json': JSON.stringify({
+      name: 'my-monorepo',
+      version: '1.0.0',
+      dependencies: {
+        'my-ws': 'workspace:*',
+        lodash: '4',
+      },
+    }),
+    packages: {
+      'my-ws': {
+        'package.json': JSON.stringify({
+          name: 'my-ws',
+          version: '1.0.0',
+          dependencies: {
+            lodash: '4',
+          },
+        }),
+      },
+    },
+  })
+
+  t.chdir(projectRoot)
+  unload('project')
+
+  const monorepo = Monorepo.maybeLoad(projectRoot)
+  const packageJson = new PackageJson()
+  const scurry = new PathScurry(projectRoot)
+
+  // First install: creates everything
+  const graph = await ideal.build({
+    projectRoot,
+    packageInfo: mockPackageInfo,
+    monorepo,
+    scurry,
+    packageJson,
+    remover: new RollbackRemove(),
+  })
+  await reify({
+    projectRoot,
+    packageInfo: mockPackageInfo,
+    monorepo,
+    scurry,
+    packageJson: new PackageJson(),
+    graph,
+    allowScripts: ':not(*)',
+    remover: new RollbackRemove(),
+  })
+
+  // Verify initial install created workspace node_modules
+  const wsNm = resolve(projectRoot, 'packages/my-ws/node_modules')
+  t.ok(
+    existsSync(wsNm),
+    'workspace node_modules should exist after first install',
+  )
+  t.ok(
+    lstatSync(resolve(wsNm, 'lodash')).isSymbolicLink(),
+    'lodash symlink should exist in workspace node_modules',
+  )
+
+  // Delete workspace node_modules to simulate user action
+  rmSync(wsNm, { recursive: true })
+  t.notOk(
+    existsSync(wsNm),
+    'workspace node_modules should be deleted',
+  )
+
+  // Second install: should recreate workspace node_modules
+  const scurry2 = new PathScurry(projectRoot)
+  const monorepo2 = Monorepo.maybeLoad(projectRoot)
+  const graph2 = await ideal.build({
+    projectRoot,
+    packageInfo: mockPackageInfo,
+    monorepo: monorepo2,
+    scurry: scurry2,
+    packageJson: new PackageJson(),
+    remover: new RollbackRemove(),
+  })
+  await reify({
+    projectRoot,
+    packageInfo: mockPackageInfo,
+    monorepo: monorepo2,
+    scurry: scurry2,
+    packageJson: new PackageJson(),
+    graph: graph2,
+    allowScripts: ':not(*)',
+    remover: new RollbackRemove(),
+  })
+
+  t.ok(
+    existsSync(wsNm),
+    'workspace node_modules should be recreated after second install',
+  )
+  t.ok(
+    lstatSync(resolve(wsNm, 'lodash')).isSymbolicLink(),
+    'lodash symlink should be recreated in workspace node_modules',
   )
 })
 


### PR DESCRIPTION
## Summary

When a workspace's `node_modules` directory was manually deleted but the root `node_modules/.vlt-lock.json` (hidden lockfile) still existed, `vlt install` would incorrectly skip reinstalling because the hidden lockfile reported all deps as present. The `Diff` saw no changes and reify would return early.

## Root Cause

`actual.load()` uses a fast path that reads from the hidden lockfile at `node_modules/.vlt-lock.json`. When this file loads successfully, it returns a graph reflecting what was *previously* installed — without checking whether workspace `node_modules` directories physically exist on disk. The `Diff(actual, ideal)` then shows no changes, and reify skips.

## Fix

Added `verifyImporterNodeModules()` — after loading the hidden lockfile, it verifies that each importer's `node_modules` directory exists on disk. If any are missing (e.g. a workspace's `node_modules` was manually deleted), an error is thrown, causing `actual.load()` to fall through to filesystem-based graph loading. This correctly detects the missing dependencies, produces a proper `Diff`, and reify recreates the deleted `node_modules`.

## Changes

- **`src/graph/src/actual/load.ts`**: Added `verifyImporterNodeModules()` function and call it after hidden lockfile loads successfully
- **`src/graph/test/actual/load.ts`**: Added tests for the new function (both success and failure paths) and a hidden lockfile invalidation test
- **`src/graph/test/reify/index.ts`**: Added end-to-end test: install → delete workspace node_modules → reinstall → verify recreation

## Reproduction Steps
1. Create a monorepo with workspaces
2. `vlt install` from root (creates everything)
3. Delete a workspace's `node_modules`
4. `vlt install` again → node_modules was NOT recreated (bug)
5. After this fix → node_modules IS recreated ✅

Fixes #1521

Co-authored-by: Darcy Clarke <darcy@darcyclarke.me>