### PR TITLE
fix(graph): preserve catalog: specs when saving to package.json

### DIFF
--- a/src/graph/src/reify/calculate-save-value.ts
+++ b/src/graph/src/reify/calculate-save-value.ts
@@ -7,6 +7,13 @@ export const calculateSaveValue = (
   existing: string | undefined,
   nodeVersion: string | undefined,
 ): string => {
+  // Catalog specs should always be preserved as-is in package.json.
+  // The catalog reference (e.g. "catalog:dev") is the user's intent;
+  // the resolved version is tracked in the lockfile.
+  if (spec.type === 'catalog') {
+    return spec.bareSpec
+  }
+
   if (
     // if not from the registry, save whatever we requested
     nodeType === 'registry' &&

--- a/src/graph/test/reify/calculate-save-value.ts
+++ b/src/graph/test/reify/calculate-save-value.ts
@@ -67,6 +67,26 @@ const cases: [
   ['1.2 || 2.5', '1.2', '1.2 || 2.5', 'saved what was requested'],
 ]
 
+t.test('catalog spec preserved as-is', t => {
+  const s = Spec.parse('typescript', 'catalog:dev', {
+    catalog: {},
+    catalogs: { dev: { typescript: 'npm:typescript@^5.0.0' } },
+    registry: 'https://registry.npmjs.org/',
+    registries: {},
+  })
+  t.equal(
+    calculateSaveValue('registry', s, undefined, '5.9.3'),
+    'catalog:dev',
+    'catalog spec saved as catalog:dev, not resolved value',
+  )
+  t.equal(
+    calculateSaveValue('registry', s, '^4.0.0', '5.9.3'),
+    'catalog:dev',
+    'catalog spec replaces existing non-catalog dep',
+  )
+  t.end()
+})
+
 t.test('registry cases', t => {
   t.plan(cases.length)
   for (const [bareSpec, existing, expect, comment] of cases) {


### PR DESCRIPTION
## Summary

When installing a catalog dependency (e.g. `vlt install -w ./packages/workspace -D typescript@catalog:dev`), the `package.json` was incorrectly saving the resolved spec (e.g. `npm:typescript@^5.0.0`) instead of the catalog reference (`catalog:dev`).

## Root Cause

In `calculateSaveValue()`, catalog specs resolved through `spec.final` to their underlying registry spec. The save logic then treated them as regular npm aliases and wrote the resolved value.

## Fix

Added an early return for `spec.type === 'catalog'` in `calculateSaveValue()`, preserving the original `catalog:*` reference in `package.json`. The resolved version is correctly tracked in the lockfile.

## Changes

- **`src/graph/src/reify/calculate-save-value.ts`**: Early return for catalog specs
- **`src/graph/test/reify/calculate-save-value.ts`**: Added tests for catalog spec preservation

## Before

```json
// package.json after: vlt install -D typescript@catalog:dev
{ "devDependencies": { "typescript": "npm:typescript@^5.0.0" } }
```

## After

```json
// package.json after: vlt install -D typescript@catalog:dev
{ "devDependencies": { "typescript": "catalog:dev" } }
```

Fixes #1179

Co-authored-by: Darcy Clarke <darcy@darcyclarke.me>