### PR TITLE
fix(create): fix arg parsing so user args aren't treated as commands

### DIFF
--- a/src/cli-sdk/src/commands/create.ts
+++ b/src/cli-sdk/src/commands/create.ts
@@ -111,24 +111,29 @@ export const command: CommandFn<ExecResult> = async conf => {
     : ':not(*)'
   /* c8 ignore stop */
 
-  // Use vlx to resolve the create-* package, using the same strategy as vlt exec
-  // Pass the package name via options.package, and remaining args as positionals
+  const yesFlag = conf.get('yes')
+
+  // Resolve the create-* package using vlx. We pass the package name as
+  // a synthetic positional so vlx treats it as the command to resolve —
+  // NOT the user's args (like "app"). Without this, vlx would mistake
+  // the first user arg as the executable to spawn.
   const arg0 = await vlx.resolve(
-    args,
+    [packageName],
     {
       ...conf.options,
-      package: packageName,
       query: undefined,
       allowScripts,
     },
-    promptFn,
+    yesFlag ? async () => 'y' : promptFn,
   )
 
-  // Set positionals to the resolved command and its args
+  // Set positionals to the resolved executable and the user's args
   if (arg0) {
     conf.positionals = [arg0, ...args]
   } else {
-    conf.positionals = args
+    throw new Error(
+      `Could not resolve executable for package "${packageName}"`,
+    )
   }
 
   // Execute the create package

--- a/src/cli-sdk/test/commands/create.ts
+++ b/src/cli-sdk/test/commands/create.ts
@@ -87,10 +87,10 @@ t.test('command', async t => {
           _promptFn?: PromptFn,
         ) => {
           calledResolve = true
-          t.strictSame(args, ['my-app'])
+          // vlx receives the package name as a positional (not user args)
+          t.strictSame(args, ['create-react-app'])
           t.strictSame(options, {
             ...mockOptions,
-            package: 'create-react-app',
             query: undefined,
             allowScripts: ':not(*)',
           })
@@ -130,12 +130,11 @@ t.test('command', async t => {
       '@vltpkg/vlx': {
         resolve: async (
           args: string[],
-          options: VlxOptions,
+          _options: VlxOptions,
           _promptFn?: PromptFn,
         ) => {
           calledResolve = true
-          t.strictSame(args, ['my-project'])
-          t.strictSame(options.package, '@scope/create-template')
+          t.strictSame(args, ['@scope/create-template'])
           return 'arg0'
         },
       },
@@ -187,12 +186,11 @@ t.test('command', async t => {
       '@vltpkg/vlx': {
         resolve: async (
           args: string[],
-          options: VlxOptions,
+          _options: VlxOptions,
           _promptFn?: PromptFn,
         ) => {
           calledResolve = true
-          t.strictSame(args, ['my-project'])
-          t.strictSame(options.package, '@scope/create')
+          t.strictSame(args, ['@scope/create'])
           return 'arg0'
         },
       },
@@ -226,10 +224,11 @@ t.test('command', async t => {
       },
       '@vltpkg/vlx': {
         resolve: async (
-          _args: string[],
+          args: string[],
           options: VlxOptions,
           _promptFn?: PromptFn,
         ) => {
+          t.strictSame(args, ['create-vite'])
           t.strictSame(options.allowScripts, 'create-*')
           return 'arg0'
         },
@@ -245,7 +244,8 @@ t.test('command', async t => {
     await command(conf)
   })
 
-  t.test('when vlx.resolve returns undefined', async t => {
+  t.test('--yes flag auto-accepts prompts', async t => {
+    let promptUsed: PromptFn | undefined
     const mockOptions = {}
     const result = {
       status: 0,
@@ -266,6 +266,47 @@ t.test('command', async t => {
         resolve: async (
           _args: string[],
           _options: VlxOptions,
+          prompt?: PromptFn,
+        ) => {
+          promptUsed = prompt
+          return 'arg0'
+        },
+      },
+    })
+    unload()
+    const conf = {
+      positionals: ['next', 'app'],
+      options: mockOptions,
+      get: (key: string) => (key === 'yes' ? true : undefined),
+    } as unknown as LoadedConfig
+    await command(conf)
+    t.ok(promptUsed, 'promptFn was provided')
+    // When --yes is set, promptFn should auto-accept
+    const answer = await promptUsed!(
+      Spec.parse('a@1'),
+      '/some/path',
+      'https://example.com',
+    )
+    t.equal(answer, 'y', '--yes auto-accepts prompts')
+  })
+
+  t.test('when vlx.resolve returns undefined', async t => {
+    const mockOptions = {}
+    const { command } = await t.mockImport<
+      typeof import('../../src/commands/create.ts')
+    >('../../src/commands/create.ts', {
+      '../../src/exec-command.ts': {
+        views: {},
+        ExecCommand: class {
+          async run() {
+            return { status: 0, signal: null }
+          }
+        },
+      },
+      '@vltpkg/vlx': {
+        resolve: async (
+          _args: string[],
+          _options: VlxOptions,
           _promptFn?: PromptFn,
         ) => {
           return undefined
@@ -278,7 +319,9 @@ t.test('command', async t => {
       options: mockOptions,
       get: (_key: string) => undefined,
     } as unknown as LoadedConfig
-    t.strictSame(await command(conf), result)
-    t.strictSame(conf.positionals, ['my-app'])
+    await t.rejects(
+      command(conf),
+      /Could not resolve executable for package/,
+    )
   })
 })


### PR DESCRIPTION
## Summary

`vlt create --yes next@latest app` was failing with `spawn app ENOENT` because `app` (the user's project directory argument) was being passed to `vlx.resolve()` as a positional, causing vlx to treat it as the executable to spawn.

## Root Cause

In `create.ts`, the `args` array (remaining positionals after the initializer) was passed directly to `vlx.resolve()`. Since `options.package` was also set, vlx would:
1. Install the create package ✅
2. Set `arg0 = args[0]` (i.e. `'app'`) ❌
3. Return `'app'` as the executable to spawn → ENOENT

## Fix

Instead of passing user args as vlx positionals, pass the create-\* package name as the sole positional. This lets vlx resolve it normally:
1. Treat the positional as a package specifier
2. Install the package
3. Infer the default executable from the manifest
4. Return the correct binary path

User args (like the project directory name) are then passed to the resolved executable separately via `conf.positionals = [arg0, ...args]`.

Also fixes `--yes` flag to auto-accept vlx install prompts (was not being forwarded).

## Changes

- **`src/cli-sdk/src/commands/create.ts`**: Pass package name as positional to vlx.resolve; remove `--package` option; forward `--yes` flag to prompt
- **`src/cli-sdk/test/commands/create.ts`**: Updated tests to match new behavior; added `--yes` test; `vlx.resolve() → undefined` now throws instead of silently falling back

Co-authored-by: Darcy Clarke <darcy@darcyclarke.me>