### PR TITLE
docs: add create to help output and expand docs with examples

### DIFF
--- a/src/cli-sdk/src/custom-help.ts
+++ b/src/cli-sdk/src/custom-help.ts
@@ -100,6 +100,13 @@ const allCommands = [
     showByDefault: false,
   },
   {
+    name: 'create',
+    aliases: [],
+    args: '<initializer> [args...]',
+    desc: 'Create a new project from a template',
+    showByDefault: false,
+  },
+  {
     name: 'docs',
     aliases: [],
     args: '',

--- a/src/cli-sdk/tap-snapshots/test/commands/help.ts.test.cjs
+++ b/src/cli-sdk/tap-snapshots/test/commands/help.ts.test.cjs
@@ -20,6 +20,7 @@ b,       build       <selector>      Build packages with lifecycle scripts
          cache       [add|ls|info|...Manage the package cache
          ci                          Clean install (frozen lockfile)
          config      [get|pick|lis...Get or set configuration
+         create      <initializer>...Create a new project from a template
 
          docs                        Open the docs of the current project
 

--- a/www/docs/src/content/docs/cli/commands/create.mdx
+++ b/www/docs/src/content/docs/cli/commands/create.mdx
@@ -40,6 +40,24 @@ local dependencies.
 
 ## Examples
 
+### Start a Next.js Project
+
+<Code
+  code="$ vlt create next-app my-app"
+  title="Terminal"
+  lang="bash"
+/>
+
+This fetches and runs `create-next-app my-app`. You can also pass
+options through:
+
+<Code
+  code={`$ vlt create next-app my-app --typescript --tailwind --eslint
+$ vlt create next-app my-app --use-pnpm  # or any create-next-app flag`}
+  title="Terminal"
+  lang="bash"
+/>
+
 ### Create a React App
 
 <Code
@@ -60,6 +78,16 @@ This executes `create-react-app my-app`
 
 This executes `create-vite my-project`
 
+### Create a SvelteKit Project
+
+<Code
+  code="$ vlt create svelte@latest my-app"
+  title="Terminal"
+  lang="bash"
+/>
+
+This executes `create-svelte@latest my-app`
+
 ### Use a Scoped Template
 
 <Code
@@ -69,6 +97,16 @@ This executes `create-vite my-project`
 />
 
 This executes `@scope/create-template my-app`
+
+### Skip Confirmation Prompts
+
+Use `--yes` to automatically accept the install prompt:
+
+<Code
+  code="$ vlt create next-app my-app --yes"
+  title="Terminal"
+  lang="bash"
+/>
 
 ## Options
 


### PR DESCRIPTION
## Summary

Add the `create` command to the help output (`vlt -a`) and expand the docs with real-world examples.

## Changes

### Help Output (`vlt -a`)
- Added `create` to the `allCommands` array in `custom-help.ts`
- Now appears alphabetically between `config` and `docs` in `vlt -a`

### Documentation (`create.mdx`)
Added new examples:
- **Next.js**: `vlt create next-app my-app --typescript --tailwind --eslint`
- **SvelteKit**: `vlt create svelte@latest my-app`
- **`--yes` flag**: `vlt create next-app my-app --yes` (skip confirmation prompts)

### Test Snapshot
- Updated `help.ts.test.cjs` snapshot to include the new `create` entry

## Testing
- Help test passes with updated snapshot
- No functional code changes — docs and help display only

Co-authored-by: Darcy Clarke <darcy@darcyclarke.me>