### PR TITLE
fix(cli-sdk): fix workspace filtering in pack/publish and publishConfig.directory support

### DIFF
--- a/src/cli-sdk/src/commands/pack.ts
+++ b/src/cli-sdk/src/commands/pack.ts
@@ -12,6 +12,7 @@ import { Query } from '@vltpkg/query'
 import type { LoadedConfig } from '../config/index.ts'
 import { error } from '@vltpkg/error-cause'
 import { createHostContextsMap } from '../query-host-contexts.ts'
+import { minimatch } from 'minimatch'
 
 export const usage: CommandUsage = () =>
   commandUsage({
@@ -141,6 +142,20 @@ export const command: CommandFn<CommandResult> = async conf => {
     locations.push(...(await scopeLocations(queryString, conf)))
   } else if (paths?.length || groups?.length || recursive) {
     for (const workspace of options.monorepo ?? []) {
+      // When specific workspace paths are set (including auto-inferred from cwd),
+      // filter to only matching workspaces. Without this, all monorepo workspaces
+      // would be operated on even when only one was specified.
+      if (paths?.length) {
+        const matches = paths.some(
+          (p: string) =>
+            workspace.path === p ||
+            workspace.name === p ||
+            workspace.fullpath === p ||
+            resolve(projectRoot, p) === workspace.fullpath ||
+            minimatch(workspace.path, p),
+        )
+        if (!matches) continue
+      }
       locations.push(workspace.fullpath)
     }
   } else if (options.monorepo) {

--- a/src/cli-sdk/src/commands/pkg.ts
+++ b/src/cli-sdk/src/commands/pkg.ts
@@ -9,6 +9,7 @@ import { SecurityArchive } from '@vltpkg/security-archive'
 import { views as initViews } from './init.ts'
 import { commandUsage } from '../config/usage.ts'
 import { createHostContextsMap } from '../query-host-contexts.ts'
+import { minimatch } from 'minimatch'
 import type { Graph } from '@vltpkg/graph'
 import type { PackageJson } from '@vltpkg/package-json'
 import type { NormalizedManifest, NodeLike } from '@vltpkg/types'
@@ -171,6 +172,17 @@ export const command: CommandFn = async conf => {
     }
   } else if (paths?.length || groups?.length || recursive) {
     for (const workspace of options.monorepo ?? []) {
+      if (paths?.length) {
+        const matches = paths.some(
+          (p: string) =>
+            workspace.path === p ||
+            workspace.name === p ||
+            workspace.fullpath === p ||
+            resolve(projectRoot, p) === workspace.fullpath ||
+            minimatch(workspace.path, p),
+        )
+        if (!matches) continue
+      }
       locations.push(workspace.fullpath)
     }
   } else {

--- a/src/cli-sdk/src/commands/publish.ts
+++ b/src/cli-sdk/src/commands/publish.ts
@@ -14,6 +14,7 @@ import { actual } from '@vltpkg/graph'
 import { Query } from '@vltpkg/query'
 import type { LoadedConfig } from '../config/index.ts'
 import { createHostContextsMap } from '../query-host-contexts.ts'
+import { minimatch } from 'minimatch'
 
 export const usage: CommandUsage = () =>
   commandUsage({
@@ -150,6 +151,17 @@ export const command: CommandFn<CommandResult> = async conf => {
     }
   } else if (paths?.length || groups?.length || recursive) {
     for (const workspace of options.monorepo ?? []) {
+      if (paths?.length) {
+        const matches = paths.some(
+          (p: string) =>
+            workspace.path === p ||
+            workspace.name === p ||
+            workspace.fullpath === p ||
+            resolve(projectRoot, p) === workspace.fullpath ||
+            minimatch(workspace.path, p),
+        )
+        if (!matches) continue
+      }
       locations.push(workspace.fullpath)
     }
   } else {
@@ -333,5 +345,5 @@ const commandSingle = async (
     size: tarballData.length,
     unpackedSize,
     files,
-  }
+  } as CommandResultSingle
 }

--- a/src/cli-sdk/src/commands/version.ts
+++ b/src/cli-sdk/src/commands/version.ts
@@ -17,6 +17,7 @@ import assert from 'node:assert'
 import { actual } from '@vltpkg/graph'
 import { Query } from '@vltpkg/query'
 import { createHostContextsMap } from '../query-host-contexts.ts'
+import { minimatch } from 'minimatch'
 
 export type VersionOptions = {
   prereleaseId?: string
@@ -324,6 +325,17 @@ export const command: CommandFn<CommandResult> = async conf => {
     }
   } else if (paths?.length || groups?.length || recursive) {
     for (const workspace of options.monorepo ?? []) {
+      if (paths?.length) {
+        const matches = paths.some(
+          (p: string) =>
+            workspace.path === p ||
+            workspace.name === p ||
+            workspace.fullpath === p ||
+            resolve(projectRoot, p) === workspace.fullpath ||
+            minimatch(workspace.path, p),
+        )
+        if (!matches) continue
+      }
       locations.push(workspace.fullpath)
     }
   } else {

--- a/src/cli-sdk/src/pack-tarball.ts
+++ b/src/cli-sdk/src/pack-tarball.ts
@@ -154,30 +154,43 @@ export const packTarball = async (
 ): Promise<PackTarballResult> => {
   let packDir = dir
 
-  // Check if publishDirectory is configured
-  const publishDirectory = config.get('publish-directory')
+  // Check if publishDirectory is configured via CLI flag or package.json publishConfig.directory
+  const cliPublishDir = config.get('publish-directory')
+  const manifestPublishDir = (
+    manifest as NormalizedManifest & {
+      publishConfig?: { directory?: string }
+    }
+  ).publishConfig?.directory
+
+  const publishDirectory = cliPublishDir ?? manifestPublishDir
   if (publishDirectory) {
+    // CLI flag paths are used as-is; publishConfig.directory is relative to the package dir
+    const resolvedPublishDir =
+      cliPublishDir ? publishDirectory : join(dir, publishDirectory)
     // Validate that the publish directory exists and is a directory
     assert(
-      existsSync(publishDirectory),
-      error(`Publish directory does not exist: ${publishDirectory}`, {
-        found: publishDirectory,
-      }),
+      existsSync(resolvedPublishDir),
+      error(
+        `Publish directory does not exist: ${resolvedPublishDir}`,
+        {
+          found: resolvedPublishDir,
+        },
+      ),
     )
     assert(
-      statSync(publishDirectory).isDirectory(),
+      statSync(resolvedPublishDir).isDirectory(),
       error(
-        `Publish directory is not a directory: ${publishDirectory}`,
+        `Publish directory is not a directory: ${resolvedPublishDir}`,
         {
-          found: publishDirectory,
+          found: resolvedPublishDir,
           wanted: 'directory',
         },
       ),
     )
-    if (existsSync(join(publishDirectory, 'package.json'))) {
-      manifest = config.options.packageJson.read(publishDirectory)
+    if (existsSync(join(resolvedPublishDir, 'package.json'))) {
+      manifest = config.options.packageJson.read(resolvedPublishDir)
     }
-    packDir = publishDirectory
+    packDir = resolvedPublishDir
   }
 
   assert(

--- a/src/cli-sdk/src/read-project-folders.ts
+++ b/src/cli-sdk/src/read-project-folders.ts
@@ -1,7 +1,7 @@
 import { availableParallelism, homedir } from 'node:os'
 import { dirname } from 'node:path'
 import type { PathBase, PathScurry } from 'path-scurry'
-// eslint-disable-next-line import/no-unresolved
+
 import { callLimit } from 'promise-call-limit'
 
 const limit = Math.max(availableParallelism() - 1, 1) * 8
@@ -107,7 +107,7 @@ export const readProjectFolders = async (
   do {
     t = traverse
     traverse = []
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+
     await callLimit(t, { limit })
   } while (traverse.length)
 

--- a/src/cli-sdk/src/render-mermaid.ts
+++ b/src/cli-sdk/src/render-mermaid.ts
@@ -2,7 +2,7 @@ import { writeFile, mkdtemp } from 'node:fs/promises'
 import { join } from 'node:path'
 import { tmpdir } from 'node:os'
 import { error } from '@vltpkg/error-cause'
-// eslint-disable-next-line import/no-unresolved
+
 import { renderMermaidSVG } from 'beautiful-mermaid'
 
 export type OutputFormat = 'svg' | 'png'
@@ -23,7 +23,6 @@ const decodeForDisplay = (mermaidText: string): string =>
  */
 export const renderMermaidSvg = (mermaidText: string): string => {
   try {
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-return
     return renderMermaidSVG(decodeForDisplay(mermaidText), {
       bg: '#FFFFFF',
       fg: '#27272A',
@@ -60,7 +59,7 @@ export const renderMermaidToPng = async (
   mermaidText: string,
 ): Promise<string> => {
   const svg = renderMermaidSvg(mermaidText)
-  /* eslint-disable @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-argument, import/no-unresolved */
+
   const { Resvg, initWasm } = await import('@resvg/resvg-wasm')
   const { readFile: rf } = await import('node:fs/promises')
   const { createRequire: cr } = await import('node:module')
@@ -78,6 +77,6 @@ export const renderMermaidToPng = async (
   const dir = await mkdtemp(join(tmpdir(), 'vlt-mermaid-'))
   const outputFile = join(dir, 'graph.png')
   await writeFile(outputFile, pngBuffer)
-  /* eslint-enable @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access, import/no-unresolved */
+
   return outputFile
 }

--- a/src/cli-sdk/tap-snapshots/test/parse-add-remove-args.ts.test.cjs
+++ b/src/cli-sdk/tap-snapshots/test/parse-add-remove-args.ts.test.cjs
@@ -8,7 +8,12 @@
 exports[`test/parse-add-remove-args.ts > TAP > parseAddArgs > define as prod if explicitly defined > should return dependency as type=prod 1`] = `
 {
   add: AddImportersDependenciesMapImpl(1) {
-    'file~_d' => Map(1) { 'foo' => { spec: Spec {foo@latest}, type: 'prod' } },
+    'file~_d' => Map(1) {
+      'foo' => {
+        spec: Spec {foo@latest},
+        type: 'prod'
+      }
+    },
     modifiedDependencies: true
   }
 }
@@ -17,7 +22,12 @@ exports[`test/parse-add-remove-args.ts > TAP > parseAddArgs > define as prod if 
 exports[`test/parse-add-remove-args.ts > TAP > parseAddArgs > define dev type dep > should return dependency as type=dev 1`] = `
 {
   add: AddImportersDependenciesMapImpl(1) {
-    'file~_d' => Map(1) { 'foo' => { spec: Spec {foo@latest}, type: 'dev' } },
+    'file~_d' => Map(1) {
+      'foo' => {
+        spec: Spec {foo@latest},
+        type: 'dev'
+      }
+    },
     modifiedDependencies: true
   }
 }
@@ -27,7 +37,10 @@ exports[`test/parse-add-remove-args.ts > TAP > parseAddArgs > define optional pe
 {
   add: AddImportersDependenciesMapImpl(1) {
     'file~_d' => Map(1) {
-      'foo' => { spec: Spec {foo@latest}, type: 'peerOptional' }
+      'foo' => {
+        spec: Spec {foo@latest},
+        type: 'peerOptional'
+      }
     },
     modifiedDependencies: true
   }
@@ -37,7 +50,12 @@ exports[`test/parse-add-remove-args.ts > TAP > parseAddArgs > define optional pe
 exports[`test/parse-add-remove-args.ts > TAP > parseAddArgs > define optional type dep > should return dependency as type=optional 1`] = `
 {
   add: AddImportersDependenciesMapImpl(1) {
-    'file~_d' => Map(1) { 'foo' => { spec: Spec {foo@latest}, type: 'optional' } },
+    'file~_d' => Map(1) {
+      'foo' => {
+        spec: Spec {foo@latest},
+        type: 'optional'
+      }
+    },
     modifiedDependencies: true
   }
 }
@@ -46,7 +64,12 @@ exports[`test/parse-add-remove-args.ts > TAP > parseAddArgs > define optional ty
 exports[`test/parse-add-remove-args.ts > TAP > parseAddArgs > define peer dep > should return dependency as type=peer 1`] = `
 {
   add: AddImportersDependenciesMapImpl(1) {
-    'file~_d' => Map(1) { 'foo' => { spec: Spec {foo@latest}, type: 'peer' } },
+    'file~_d' => Map(1) {
+      'foo' => {
+        spec: Spec {foo@latest},
+        type: 'peer'
+      }
+    },
     modifiedDependencies: true
   }
 }
@@ -56,11 +79,26 @@ exports[`test/parse-add-remove-args.ts > TAP > parseAddArgs > multiple items > s
 {
   add: AddImportersDependenciesMapImpl(1) {
     'file~_d' => Map(5) {
-      'foo' => { spec: Spec {foo@^1}, type: 'implicit' },
-      'bar' => { spec: Spec {bar@latest}, type: 'implicit' },
-      'baz' => { spec: Spec {baz@1.0.0}, type: 'implicit' },
-      '(unknown)@github:a/b' => { spec: Spec {(unknown)@github:a/b}, type: 'implicit' },
-      '(unknown)@file:./a' => { spec: Spec {(unknown)@file:./a}, type: 'implicit' }
+      'foo' => {
+        spec: Spec {foo@^1},
+        type: 'implicit'
+      },
+      'bar' => {
+        spec: Spec {bar@latest},
+        type: 'implicit'
+      },
+      'baz' => {
+        spec: Spec {baz@1.0.0},
+        type: 'implicit'
+      },
+      '(unknown)@github:a/b' => {
+        spec: Spec {(unknown)@github:a/b},
+        type: 'implicit'
+      },
+      '(unknown)@file:./a' => {
+        spec: Spec {(unknown)@file:./a},
+        type: 'implicit'
+      }
     },
     modifiedDependencies: true
   }
@@ -70,7 +108,12 @@ exports[`test/parse-add-remove-args.ts > TAP > parseAddArgs > multiple items > s
 exports[`test/parse-add-remove-args.ts > TAP > parseAddArgs > nested folder without workspaces > should return dependency with nested folder DepID 1`] = `
 {
   add: AddImportersDependenciesMapImpl(1) {
-    'file~nested+folder' => Map(1) { 'foo' => { spec: Spec {foo@^1}, type: 'implicit' } },
+    'file~nested+folder' => Map(1) {
+      'foo' => {
+        spec: Spec {foo@^1},
+        type: 'implicit'
+      }
+    },
     modifiedDependencies: true
   }
 }
@@ -88,7 +131,12 @@ exports[`test/parse-add-remove-args.ts > TAP > parseAddArgs > no item > should r
 exports[`test/parse-add-remove-args.ts > TAP > parseAddArgs > single item > should return a single dependency item 1`] = `
 {
   add: AddImportersDependenciesMapImpl(1) {
-    'file~_d' => Map(1) { 'foo' => { spec: Spec {foo@}, type: 'implicit' } },
+    'file~_d' => Map(1) {
+      'foo' => {
+        spec: Spec {foo@},
+        type: 'implicit'
+      }
+    },
     modifiedDependencies: true
   }
 }
@@ -98,11 +146,26 @@ exports[`test/parse-add-remove-args.ts > TAP > parseAddArgs > workspaces > defin
 {
   add: AddImportersDependenciesMapImpl(1) {
     'workspace~utils+c' => Map(5) {
-      'foo' => { spec: Spec {foo@^1}, type: 'implicit' },
-      'bar' => { spec: Spec {bar@latest}, type: 'implicit' },
-      'baz' => { spec: Spec {baz@1.0.0}, type: 'implicit' },
-      '(unknown)@github:a/b' => { spec: Spec {(unknown)@github:a/b}, type: 'implicit' },
-      '(unknown)@file:./a' => { spec: Spec {(unknown)@file:./a}, type: 'implicit' }
+      'foo' => {
+        spec: Spec {foo@^1},
+        type: 'implicit'
+      },
+      'bar' => {
+        spec: Spec {bar@latest},
+        type: 'implicit'
+      },
+      'baz' => {
+        spec: Spec {baz@1.0.0},
+        type: 'implicit'
+      },
+      '(unknown)@github:a/b' => {
+        spec: Spec {(unknown)@github:a/b},
+        type: 'implicit'
+      },
+      '(unknown)@file:./a' => {
+        spec: Spec {(unknown)@file:./a},
+        type: 'implicit'
+      }
     },
     modifiedDependencies: true
   }
@@ -113,25 +176,70 @@ exports[`test/parse-add-remove-args.ts > TAP > parseAddArgs > workspaces > defin
 {
   add: AddImportersDependenciesMapImpl(3) {
     'workspace~utils+c' => Map(5) {
-      'foo' => { spec: Spec {foo@^1}, type: 'implicit' },
-      'bar' => { spec: Spec {bar@latest}, type: 'implicit' },
-      'baz' => { spec: Spec {baz@1.0.0}, type: 'implicit' },
-      '(unknown)@github:a/b' => { spec: Spec {(unknown)@github:a/b}, type: 'implicit' },
-      '(unknown)@file:./a' => { spec: Spec {(unknown)@file:./a}, type: 'implicit' }
+      'foo' => {
+        spec: Spec {foo@^1},
+        type: 'implicit'
+      },
+      'bar' => {
+        spec: Spec {bar@latest},
+        type: 'implicit'
+      },
+      'baz' => {
+        spec: Spec {baz@1.0.0},
+        type: 'implicit'
+      },
+      '(unknown)@github:a/b' => {
+        spec: Spec {(unknown)@github:a/b},
+        type: 'implicit'
+      },
+      '(unknown)@file:./a' => {
+        spec: Spec {(unknown)@file:./a},
+        type: 'implicit'
+      }
     },
     'workspace~foo' => Map(5) {
-      'foo' => { spec: Spec {foo@^1}, type: 'implicit' },
-      'bar' => { spec: Spec {bar@latest}, type: 'implicit' },
-      'baz' => { spec: Spec {baz@1.0.0}, type: 'implicit' },
-      '(unknown)@github:a/b' => { spec: Spec {(unknown)@github:a/b}, type: 'implicit' },
-      '(unknown)@file:./a' => { spec: Spec {(unknown)@file:./a}, type: 'implicit' }
+      'foo' => {
+        spec: Spec {foo@^1},
+        type: 'implicit'
+      },
+      'bar' => {
+        spec: Spec {bar@latest},
+        type: 'implicit'
+      },
+      'baz' => {
+        spec: Spec {baz@1.0.0},
+        type: 'implicit'
+      },
+      '(unknown)@github:a/b' => {
+        spec: Spec {(unknown)@github:a/b},
+        type: 'implicit'
+      },
+      '(unknown)@file:./a' => {
+        spec: Spec {(unknown)@file:./a},
+        type: 'implicit'
+      }
     },
     'workspace~bar' => Map(5) {
-      'foo' => { spec: Spec {foo@^1}, type: 'implicit' },
-      'bar' => { spec: Spec {bar@latest}, type: 'implicit' },
-      'baz' => { spec: Spec {baz@1.0.0}, type: 'implicit' },
-      '(unknown)@github:a/b' => { spec: Spec {(unknown)@github:a/b}, type: 'implicit' },
-      '(unknown)@file:./a' => { spec: Spec {(unknown)@file:./a}, type: 'implicit' }
+      'foo' => {
+        spec: Spec {foo@^1},
+        type: 'implicit'
+      },
+      'bar' => {
+        spec: Spec {bar@latest},
+        type: 'implicit'
+      },
+      'baz' => {
+        spec: Spec {baz@1.0.0},
+        type: 'implicit'
+      },
+      '(unknown)@github:a/b' => {
+        spec: Spec {(unknown)@github:a/b},
+        type: 'implicit'
+      },
+      '(unknown)@file:./a' => {
+        spec: Spec {(unknown)@file:./a},
+        type: 'implicit'
+      }
     },
     modifiedDependencies: true
   }
@@ -142,25 +250,70 @@ exports[`test/parse-add-remove-args.ts > TAP > parseAddArgs > workspaces > defin
 {
   add: AddImportersDependenciesMapImpl(3) {
     'workspace~app+b' => Map(5) {
-      'foo' => { spec: Spec {foo@^1}, type: 'implicit' },
-      'bar' => { spec: Spec {bar@latest}, type: 'implicit' },
-      'baz' => { spec: Spec {baz@1.0.0}, type: 'implicit' },
-      '(unknown)@github:a/b' => { spec: Spec {(unknown)@github:a/b}, type: 'implicit' },
-      '(unknown)@file:./a' => { spec: Spec {(unknown)@file:./a}, type: 'implicit' }
+      'foo' => {
+        spec: Spec {foo@^1},
+        type: 'implicit'
+      },
+      'bar' => {
+        spec: Spec {bar@latest},
+        type: 'implicit'
+      },
+      'baz' => {
+        spec: Spec {baz@1.0.0},
+        type: 'implicit'
+      },
+      '(unknown)@github:a/b' => {
+        spec: Spec {(unknown)@github:a/b},
+        type: 'implicit'
+      },
+      '(unknown)@file:./a' => {
+        spec: Spec {(unknown)@file:./a},
+        type: 'implicit'
+      }
     },
     'workspace~app+a' => Map(5) {
-      'foo' => { spec: Spec {foo@^1}, type: 'implicit' },
-      'bar' => { spec: Spec {bar@latest}, type: 'implicit' },
-      'baz' => { spec: Spec {baz@1.0.0}, type: 'implicit' },
-      '(unknown)@github:a/b' => { spec: Spec {(unknown)@github:a/b}, type: 'implicit' },
-      '(unknown)@file:./a' => { spec: Spec {(unknown)@file:./a}, type: 'implicit' }
+      'foo' => {
+        spec: Spec {foo@^1},
+        type: 'implicit'
+      },
+      'bar' => {
+        spec: Spec {bar@latest},
+        type: 'implicit'
+      },
+      'baz' => {
+        spec: Spec {baz@1.0.0},
+        type: 'implicit'
+      },
+      '(unknown)@github:a/b' => {
+        spec: Spec {(unknown)@github:a/b},
+        type: 'implicit'
+      },
+      '(unknown)@file:./a' => {
+        spec: Spec {(unknown)@file:./a},
+        type: 'implicit'
+      }
     },
     'workspace~utils+c' => Map(5) {
-      'foo' => { spec: Spec {foo@^1}, type: 'implicit' },
-      'bar' => { spec: Spec {bar@latest}, type: 'implicit' },
-      'baz' => { spec: Spec {baz@1.0.0}, type: 'implicit' },
-      '(unknown)@github:a/b' => { spec: Spec {(unknown)@github:a/b}, type: 'implicit' },
-      '(unknown)@file:./a' => { spec: Spec {(unknown)@file:./a}, type: 'implicit' }
+      'foo' => {
+        spec: Spec {foo@^1},
+        type: 'implicit'
+      },
+      'bar' => {
+        spec: Spec {bar@latest},
+        type: 'implicit'
+      },
+      'baz' => {
+        spec: Spec {baz@1.0.0},
+        type: 'implicit'
+      },
+      '(unknown)@github:a/b' => {
+        spec: Spec {(unknown)@github:a/b},
+        type: 'implicit'
+      },
+      '(unknown)@file:./a' => {
+        spec: Spec {(unknown)@file:./a},
+        type: 'implicit'
+      }
     },
     modifiedDependencies: true
   }
@@ -170,7 +323,12 @@ exports[`test/parse-add-remove-args.ts > TAP > parseAddArgs > workspaces > defin
 exports[`test/parse-add-remove-args.ts > TAP > parseAddArgs > workspaces > define root dep if no workspace config defined > should return dependency of root 1`] = `
 {
   add: AddImportersDependenciesMapImpl(1) {
-    'file~_d' => Map(1) { 'foo' => { spec: Spec {foo@}, type: 'implicit' } },
+    'file~_d' => Map(1) {
+      'foo' => {
+        spec: Spec {foo@},
+        type: 'implicit'
+      }
+    },
     modifiedDependencies: true
   }
 }
@@ -179,7 +337,12 @@ exports[`test/parse-add-remove-args.ts > TAP > parseAddArgs > workspaces > defin
 exports[`test/parse-add-remove-args.ts > TAP > parseAddArgs > workspaces > define single dep of a single workspace > should return dependency of a workspace 1`] = `
 {
   add: AddImportersDependenciesMapImpl(1) {
-    'workspace~app+a' => Map(1) { 'foo' => { spec: Spec {foo@}, type: 'implicit' } },
+    'workspace~app+a' => Map(1) {
+      'foo' => {
+        spec: Spec {foo@},
+        type: 'implicit'
+      }
+    },
     modifiedDependencies: true
   }
 }
@@ -188,8 +351,18 @@ exports[`test/parse-add-remove-args.ts > TAP > parseAddArgs > workspaces > defin
 exports[`test/parse-add-remove-args.ts > TAP > parseAddArgs > workspaces > define single dep to a group of workspaces > should return dependency to a group of workspaces 1`] = `
 {
   add: AddImportersDependenciesMapImpl(2) {
-    'workspace~foo' => Map(1) { 'foo' => { spec: Spec {foo@}, type: 'implicit' } },
-    'workspace~bar' => Map(1) { 'foo' => { spec: Spec {foo@}, type: 'implicit' } },
+    'workspace~foo' => Map(1) {
+      'foo' => {
+        spec: Spec {foo@},
+        type: 'implicit'
+      }
+    },
+    'workspace~bar' => Map(1) {
+      'foo' => {
+        spec: Spec {foo@},
+        type: 'implicit'
+      }
+    },
     modifiedDependencies: true
   }
 }
@@ -198,9 +371,24 @@ exports[`test/parse-add-remove-args.ts > TAP > parseAddArgs > workspaces > defin
 exports[`test/parse-add-remove-args.ts > TAP > parseAddArgs > workspaces > define single dep to multiple groups of workspaces > should return dependency to many groups of workspaces 1`] = `
 {
   add: AddImportersDependenciesMapImpl(3) {
-    'workspace~utils+c' => Map(1) { 'foo' => { spec: Spec {foo@}, type: 'implicit' } },
-    'workspace~foo' => Map(1) { 'foo' => { spec: Spec {foo@}, type: 'implicit' } },
-    'workspace~bar' => Map(1) { 'foo' => { spec: Spec {foo@}, type: 'implicit' } },
+    'workspace~utils+c' => Map(1) {
+      'foo' => {
+        spec: Spec {foo@},
+        type: 'implicit'
+      }
+    },
+    'workspace~foo' => Map(1) {
+      'foo' => {
+        spec: Spec {foo@},
+        type: 'implicit'
+      }
+    },
+    'workspace~bar' => Map(1) {
+      'foo' => {
+        spec: Spec {foo@},
+        type: 'implicit'
+      }
+    },
     modifiedDependencies: true
   }
 }
@@ -209,7 +397,11 @@ exports[`test/parse-add-remove-args.ts > TAP > parseAddArgs > workspaces > defin
 exports[`test/parse-add-remove-args.ts > TAP > parseRemoveArgs > multiple items > should return multiple dependency item 1`] = `
 {
   remove: RemoveImportersDependenciesMapImpl(1) {
-    'file~_d' => Set(3) { 'foo@^1', 'bar@latest', 'baz@1.0.0' },
+    'file~_d' => Set(3) {
+      'foo@^1',
+      'bar@latest',
+      'baz@1.0.0'
+    },
     modifiedDependencies: true
   }
 }
@@ -227,7 +419,9 @@ exports[`test/parse-add-remove-args.ts > TAP > parseRemoveArgs > no items > shou
 exports[`test/parse-add-remove-args.ts > TAP > parseRemoveArgs > single item > should return a single dependency item 1`] = `
 {
   remove: RemoveImportersDependenciesMapImpl(1) {
-    'file~_d' => Set(1) { 'foo' },
+    'file~_d' => Set(1) {
+      'foo'
+    },
     modifiedDependencies: true
   }
 }
@@ -236,8 +430,14 @@ exports[`test/parse-add-remove-args.ts > TAP > parseRemoveArgs > single item > s
 exports[`test/parse-add-remove-args.ts > TAP > parseRemoveArgs > workspaces > multiple deps from a workspace group > should remove multiple dep from a single workspace group 1`] = `
 {
   remove: RemoveImportersDependenciesMapImpl(2) {
-    'workspace~app+b' => Set(2) { 'foo', 'bar' },
-    'workspace~app+a' => Set(2) { 'foo', 'bar' },
+    'workspace~app+b' => Set(2) {
+      'foo',
+      'bar'
+    },
+    'workspace~app+a' => Set(2) {
+      'foo',
+      'bar'
+    },
     modifiedDependencies: true
   }
 }
@@ -246,9 +446,18 @@ exports[`test/parse-add-remove-args.ts > TAP > parseRemoveArgs > workspaces > mu
 exports[`test/parse-add-remove-args.ts > TAP > parseRemoveArgs > workspaces > multiple deps from multiple workspace groups > should remove multiple dep from multiple workspace groups 1`] = `
 {
   remove: RemoveImportersDependenciesMapImpl(3) {
-    'workspace~utils+c' => Set(2) { 'foo', 'bar' },
-    'workspace~foo' => Set(2) { 'foo', 'bar' },
-    'workspace~bar' => Set(2) { 'foo', 'bar' },
+    'workspace~utils+c' => Set(2) {
+      'foo',
+      'bar'
+    },
+    'workspace~foo' => Set(2) {
+      'foo',
+      'bar'
+    },
+    'workspace~bar' => Set(2) {
+      'foo',
+      'bar'
+    },
     modifiedDependencies: true
   }
 }
@@ -257,7 +466,10 @@ exports[`test/parse-add-remove-args.ts > TAP > parseRemoveArgs > workspaces > mu
 exports[`test/parse-add-remove-args.ts > TAP > parseRemoveArgs > workspaces > multiple deps of a single workspace > should remove multiple deps of workspace 1`] = `
 {
   remove: RemoveImportersDependenciesMapImpl(1) {
-    'workspace~utils+c' => Set(2) { 'foo', 'bar' },
+    'workspace~utils+c' => Set(2) {
+      'foo',
+      'bar'
+    },
     modifiedDependencies: true
   }
 }
@@ -266,7 +478,9 @@ exports[`test/parse-add-remove-args.ts > TAP > parseRemoveArgs > workspaces > mu
 exports[`test/parse-add-remove-args.ts > TAP > parseRemoveArgs > workspaces > remove dep from root if no workspace defined > should remove dep from root 1`] = `
 {
   remove: RemoveImportersDependenciesMapImpl(1) {
-    'file~_d' => Set(1) { 'foo' },
+    'file~_d' => Set(1) {
+      'foo'
+    },
     modifiedDependencies: true
   }
 }
@@ -275,8 +489,12 @@ exports[`test/parse-add-remove-args.ts > TAP > parseRemoveArgs > workspaces > re
 exports[`test/parse-add-remove-args.ts > TAP > parseRemoveArgs > workspaces > single dep from a workspace group > should remove single dep from a single workspace group 1`] = `
 {
   remove: RemoveImportersDependenciesMapImpl(2) {
-    'workspace~app+b' => Set(1) { 'foo' },
-    'workspace~app+a' => Set(1) { 'foo' },
+    'workspace~app+b' => Set(1) {
+      'foo'
+    },
+    'workspace~app+a' => Set(1) {
+      'foo'
+    },
     modifiedDependencies: true
   }
 }
@@ -285,7 +503,9 @@ exports[`test/parse-add-remove-args.ts > TAP > parseRemoveArgs > workspaces > si
 exports[`test/parse-add-remove-args.ts > TAP > parseRemoveArgs > workspaces > single dep of a single workspace > should remove single dep of workspace 1`] = `
 {
   remove: RemoveImportersDependenciesMapImpl(1) {
-    'workspace~app+a' => Set(1) { 'foo' },
+    'workspace~app+a' => Set(1) {
+      'foo'
+    },
     modifiedDependencies: true
   }
 }

--- a/src/cli-sdk/test/commands/pack.ts
+++ b/src/cli-sdk/test/commands/pack.ts
@@ -341,10 +341,12 @@ t.test('pack command with scope', async t => {
         monorepo: [
           {
             name: '@test/a',
+            path: 'packages/a',
             fullpath: resolve(dir, 'packages/a'),
           },
           {
             name: '@test/b',
+            path: 'packages/b',
             fullpath: resolve(dir, 'packages/b'),
           },
         ],
@@ -459,6 +461,7 @@ t.test('pack command with workspace paths', async t => {
         monorepo: [
           {
             name: '@test/a',
+            path: 'packages/a',
             fullpath: resolve(dir, 'packages/a'),
           },
         ],
@@ -479,6 +482,162 @@ t.test('pack command with workspace paths', async t => {
 
     t.equal(results[0]!.name, '@test/a')
     t.equal(results[0]!.version, '1.0.0')
+  })
+})
+
+t.test('pack command workspace filtering modes', async t => {
+  const dir = t.testdir({
+    'package.json': JSON.stringify({
+      name: 'root',
+      version: '1.0.0',
+    }),
+    'vlt.json': JSON.stringify({ workspaces: ['packages/*'] }),
+    packages: {
+      a: {
+        'package.json': JSON.stringify({
+          name: '@test/a',
+          version: '1.0.0',
+        }),
+        'index.js': 'console.log("a")',
+        'vlt.json': '{}',
+      },
+      b: {
+        'package.json': JSON.stringify({
+          name: '@test/b',
+          version: '2.0.0',
+        }),
+        'index.js': 'console.log("b")',
+        'vlt.json': '{}',
+      },
+    },
+  })
+
+  t.test('filters by workspace name', async t => {
+    const config = makeTestConfig({
+      projectRoot: dir,
+      options: {
+        packageJson: new PackageJson(),
+        monorepo: [
+          {
+            name: '@test/a',
+            path: 'packages/a',
+            fullpath: resolve(dir, 'packages/a'),
+          },
+          {
+            name: '@test/b',
+            path: 'packages/b',
+            fullpath: resolve(dir, 'packages/b'),
+          },
+        ],
+      },
+      positionals: ['pack'],
+      values: { workspace: ['@test/a'] },
+    })
+    config.get = (key: string) => {
+      if (key === 'workspace') return ['@test/a']
+      return config.values?.[key]
+    }
+
+    const result = await command(config as LoadedConfig)
+    const results = result as CommandResultSingle[]
+    t.equal(results.length, 1)
+    t.equal(results[0]!.name, '@test/a')
+  })
+
+  t.test('filters by workspace fullpath', async t => {
+    const fullpath = resolve(dir, 'packages/a')
+    const config = makeTestConfig({
+      projectRoot: dir,
+      options: {
+        packageJson: new PackageJson(),
+        monorepo: [
+          {
+            name: '@test/a',
+            path: 'packages/a',
+            fullpath,
+          },
+          {
+            name: '@test/b',
+            path: 'packages/b',
+            fullpath: resolve(dir, 'packages/b'),
+          },
+        ],
+      },
+      positionals: ['pack'],
+      values: { workspace: [fullpath] },
+    })
+    config.get = (key: string) => {
+      if (key === 'workspace') return [fullpath]
+      return config.values?.[key]
+    }
+
+    const result = await command(config as LoadedConfig)
+    const results = result as CommandResultSingle[]
+    t.equal(results.length, 1)
+    t.equal(results[0]!.name, '@test/a')
+  })
+
+  t.test('filters by resolved relative path', async t => {
+    const config = makeTestConfig({
+      projectRoot: dir,
+      options: {
+        packageJson: new PackageJson(),
+        monorepo: [
+          {
+            name: '@test/a',
+            path: 'packages/a',
+            fullpath: resolve(dir, 'packages/a'),
+          },
+          {
+            name: '@test/b',
+            path: 'packages/b',
+            fullpath: resolve(dir, 'packages/b'),
+          },
+        ],
+      },
+      positionals: ['pack'],
+      values: { workspace: ['./packages/a'] },
+    })
+    config.get = (key: string) => {
+      if (key === 'workspace') return ['./packages/a']
+      return config.values?.[key]
+    }
+
+    const result = await command(config as LoadedConfig)
+    const results = result as CommandResultSingle[]
+    t.equal(results.length, 1)
+    t.equal(results[0]!.name, '@test/a')
+  })
+
+  t.test('filters by minimatch glob', async t => {
+    const config = makeTestConfig({
+      projectRoot: dir,
+      options: {
+        packageJson: new PackageJson(),
+        monorepo: [
+          {
+            name: '@test/a',
+            path: 'packages/a',
+            fullpath: resolve(dir, 'packages/a'),
+          },
+          {
+            name: '@test/b',
+            path: 'packages/b',
+            fullpath: resolve(dir, 'packages/b'),
+          },
+        ],
+      },
+      positionals: ['pack'],
+      values: { workspace: ['packages/*'] },
+    })
+    config.get = (key: string) => {
+      if (key === 'workspace') return ['packages/*']
+      return config.values?.[key]
+    }
+
+    const result = await command(config as LoadedConfig)
+    const results = result as CommandResultSingle[]
+    t.equal(results.length, 2)
   })
 })
 
@@ -517,10 +676,12 @@ t.test('pack command with workspace-group', async t => {
         monorepo: [
           {
             name: '@test/a',
+            path: 'packages/a',
             fullpath: resolve(dir, 'packages/a'),
           },
           {
             name: '@test/b',
+            path: 'packages/b',
             fullpath: resolve(dir, 'packages/b'),
           },
         ],
@@ -581,10 +742,12 @@ t.test('pack command with recursive', async t => {
         monorepo: [
           {
             name: '@test/a',
+            path: 'packages/a',
             fullpath: resolve(dir, 'packages/a'),
           },
           {
             name: '@test/b',
+            path: 'packages/b',
             fullpath: resolve(dir, 'packages/b'),
           },
         ],

--- a/src/cli-sdk/test/commands/pkg.ts
+++ b/src/cli-sdk/test/commands/pkg.ts
@@ -1144,10 +1144,12 @@ t.test(
         monorepo: [
           {
             name: '@test/a',
+            path: 'packages/a',
             fullpath: join(dir, 'packages/a'),
           },
           {
             name: '@test/b',
+            path: 'packages/b',
             fullpath: join(dir, 'packages/b'),
           },
         ],
@@ -1161,6 +1163,367 @@ t.test(
       result,
       ['@test/a', '@test/b'],
       'should handle workspace array without scope query',
+    )
+  },
+)
+
+t.test(
+  'workspace options without scope - filter by name',
+  async t => {
+    const dir = t.testdir({
+      'package.json': JSON.stringify({
+        name: 'test-project',
+        version: '1.0.0',
+      }),
+      'vlt.json': JSON.stringify({
+        workspaces: { packages: ['./packages/*'] },
+      }),
+      packages: {
+        a: {
+          'package.json': JSON.stringify({
+            name: '@test/a',
+            version: '2.0.0',
+          }),
+        },
+        b: {
+          'package.json': JSON.stringify({
+            name: '@test/b',
+            version: '3.0.0',
+          }),
+        },
+      },
+    })
+    t.chdir(dir)
+
+    const Command = await t.mockImport<
+      typeof import('../../src/commands/pkg.ts')
+    >('../../src/commands/pkg.ts', {
+      '@vltpkg/graph': {
+        actual: {
+          load: () => ({ nodes: new Map() }),
+        },
+        install: () => {},
+        uninstall: () => {},
+        reify: {},
+        ideal: {},
+        asDependency: () => {},
+        createVirtualRoot: () => {},
+        GraphModifier: {
+          maybeLoad: () => undefined,
+        },
+        VIRTUAL_ROOT_ID: joinDepIDTuple(['file', 'virtual-root']),
+      },
+      '@vltpkg/query': {
+        Query: {
+          hasSecuritySelectors() {
+            return false
+          },
+        },
+      },
+      '@vltpkg/security-archive': {
+        SecurityArchive: {
+          start: async () => ({}),
+        },
+      },
+    })
+
+    const config = makeTestConfig({
+      projectRoot: dir,
+      options: {
+        packageJson: new PackageJson(),
+        monorepo: [
+          {
+            name: '@test/a',
+            path: 'packages/a',
+            fullpath: join(dir, 'packages/a'),
+          },
+          {
+            name: '@test/b',
+            path: 'packages/b',
+            fullpath: join(dir, 'packages/b'),
+          },
+        ],
+      },
+      positionals: ['get', 'name'],
+      values: { workspace: ['@test/a'] },
+    })
+
+    const result = await Command.command(config)
+    t.strictSame(
+      result,
+      ['@test/a'],
+      'should filter by workspace name',
+    )
+  },
+)
+
+t.test(
+  'workspace options without scope - filter by fullpath',
+  async t => {
+    const dir = t.testdir({
+      'package.json': JSON.stringify({
+        name: 'test-project',
+        version: '1.0.0',
+      }),
+      'vlt.json': JSON.stringify({
+        workspaces: { packages: ['./packages/*'] },
+      }),
+      packages: {
+        a: {
+          'package.json': JSON.stringify({
+            name: '@test/a',
+            version: '2.0.0',
+          }),
+        },
+        b: {
+          'package.json': JSON.stringify({
+            name: '@test/b',
+            version: '3.0.0',
+          }),
+        },
+      },
+    })
+    t.chdir(dir)
+
+    const Command = await t.mockImport<
+      typeof import('../../src/commands/pkg.ts')
+    >('../../src/commands/pkg.ts', {
+      '@vltpkg/graph': {
+        actual: {
+          load: () => ({ nodes: new Map() }),
+        },
+        install: () => {},
+        uninstall: () => {},
+        reify: {},
+        ideal: {},
+        asDependency: () => {},
+        createVirtualRoot: () => {},
+        GraphModifier: {
+          maybeLoad: () => undefined,
+        },
+        VIRTUAL_ROOT_ID: joinDepIDTuple(['file', 'virtual-root']),
+      },
+      '@vltpkg/query': {
+        Query: {
+          hasSecuritySelectors() {
+            return false
+          },
+        },
+      },
+      '@vltpkg/security-archive': {
+        SecurityArchive: {
+          start: async () => ({}),
+        },
+      },
+    })
+
+    const fullpath = join(dir, 'packages/a')
+    const config = makeTestConfig({
+      projectRoot: dir,
+      options: {
+        packageJson: new PackageJson(),
+        monorepo: [
+          {
+            name: '@test/a',
+            path: 'packages/a',
+            fullpath,
+          },
+          {
+            name: '@test/b',
+            path: 'packages/b',
+            fullpath: join(dir, 'packages/b'),
+          },
+        ],
+      },
+      positionals: ['get', 'name'],
+      values: { workspace: [fullpath] },
+    })
+
+    const result = await Command.command(config)
+    t.strictSame(
+      result,
+      ['@test/a'],
+      'should filter by workspace fullpath',
+    )
+  },
+)
+
+t.test(
+  'workspace options without scope - filter by resolved relative path',
+  async t => {
+    const dir = t.testdir({
+      'package.json': JSON.stringify({
+        name: 'test-project',
+        version: '1.0.0',
+      }),
+      'vlt.json': JSON.stringify({
+        workspaces: { packages: ['./packages/*'] },
+      }),
+      packages: {
+        a: {
+          'package.json': JSON.stringify({
+            name: '@test/a',
+            version: '2.0.0',
+          }),
+        },
+        b: {
+          'package.json': JSON.stringify({
+            name: '@test/b',
+            version: '3.0.0',
+          }),
+        },
+      },
+    })
+    t.chdir(dir)
+
+    const Command = await t.mockImport<
+      typeof import('../../src/commands/pkg.ts')
+    >('../../src/commands/pkg.ts', {
+      '@vltpkg/graph': {
+        actual: {
+          load: () => ({ nodes: new Map() }),
+        },
+        install: () => {},
+        uninstall: () => {},
+        reify: {},
+        ideal: {},
+        asDependency: () => {},
+        createVirtualRoot: () => {},
+        GraphModifier: {
+          maybeLoad: () => undefined,
+        },
+        VIRTUAL_ROOT_ID: joinDepIDTuple(['file', 'virtual-root']),
+      },
+      '@vltpkg/query': {
+        Query: {
+          hasSecuritySelectors() {
+            return false
+          },
+        },
+      },
+      '@vltpkg/security-archive': {
+        SecurityArchive: {
+          start: async () => ({}),
+        },
+      },
+    })
+
+    const config = makeTestConfig({
+      projectRoot: dir,
+      options: {
+        packageJson: new PackageJson(),
+        monorepo: [
+          {
+            name: '@test/a',
+            path: 'packages/a',
+            fullpath: join(dir, 'packages/a'),
+          },
+          {
+            name: '@test/b',
+            path: 'packages/b',
+            fullpath: join(dir, 'packages/b'),
+          },
+        ],
+      },
+      positionals: ['get', 'name'],
+      values: { workspace: ['./packages/a'] },
+    })
+
+    const result = await Command.command(config)
+    t.strictSame(
+      result,
+      ['@test/a'],
+      'should filter by resolved relative path',
+    )
+  },
+)
+
+t.test(
+  'workspace options without scope - filter by minimatch glob',
+  async t => {
+    const dir = t.testdir({
+      'package.json': JSON.stringify({
+        name: 'test-project',
+        version: '1.0.0',
+      }),
+      'vlt.json': JSON.stringify({
+        workspaces: { packages: ['./packages/*'] },
+      }),
+      packages: {
+        a: {
+          'package.json': JSON.stringify({
+            name: '@test/a',
+            version: '2.0.0',
+          }),
+        },
+        b: {
+          'package.json': JSON.stringify({
+            name: '@test/b',
+            version: '3.0.0',
+          }),
+        },
+      },
+    })
+    t.chdir(dir)
+
+    const Command = await t.mockImport<
+      typeof import('../../src/commands/pkg.ts')
+    >('../../src/commands/pkg.ts', {
+      '@vltpkg/graph': {
+        actual: {
+          load: () => ({ nodes: new Map() }),
+        },
+        install: () => {},
+        uninstall: () => {},
+        reify: {},
+        ideal: {},
+        asDependency: () => {},
+        createVirtualRoot: () => {},
+        GraphModifier: {
+          maybeLoad: () => undefined,
+        },
+        VIRTUAL_ROOT_ID: joinDepIDTuple(['file', 'virtual-root']),
+      },
+      '@vltpkg/query': {
+        Query: {
+          hasSecuritySelectors() {
+            return false
+          },
+        },
+      },
+      '@vltpkg/security-archive': {
+        SecurityArchive: {
+          start: async () => ({}),
+        },
+      },
+    })
+
+    const config = makeTestConfig({
+      projectRoot: dir,
+      options: {
+        packageJson: new PackageJson(),
+        monorepo: [
+          {
+            name: '@test/a',
+            path: 'packages/a',
+            fullpath: join(dir, 'packages/a'),
+          },
+          {
+            name: '@test/b',
+            path: 'packages/b',
+            fullpath: join(dir, 'packages/b'),
+          },
+        ],
+      },
+      positionals: ['get', 'name'],
+      values: { workspace: ['packages/*'] },
+    })
+
+    const result = await Command.command(config)
+    t.strictSame(
+      result,
+      ['@test/a', '@test/b'],
+      'should filter by minimatch glob',
     )
   },
 )
@@ -1232,10 +1595,12 @@ t.test(
         monorepo: [
           {
             name: '@test/a',
+            path: 'packages/a',
             fullpath: join(dir, 'packages/a'),
           },
           {
             name: '@test/b',
+            path: 'packages/b',
             fullpath: join(dir, 'packages/b'),
           },
         ],
@@ -1320,10 +1685,12 @@ t.test(
         monorepo: [
           {
             name: '@test/a',
+            path: 'packages/a',
             fullpath: join(dir, 'packages/a'),
           },
           {
             name: '@test/b',
+            path: 'packages/b',
             fullpath: join(dir, 'packages/b'),
           },
         ],

--- a/src/cli-sdk/test/commands/publish.ts
+++ b/src/cli-sdk/test/commands/publish.ts
@@ -26,6 +26,7 @@ interface TestConfig {
     monorepo?:
       | {
           name: string
+          path?: string
           fullpath: string
         }[]
       | null
@@ -676,10 +677,12 @@ t.test('publish command with scope', async t => {
         monorepo: [
           {
             name: '@test/a',
+            path: 'packages/a',
             fullpath: resolve(dir, 'packages/a'),
           },
           {
             name: '@test/b',
+            path: 'packages/b',
             fullpath: resolve(dir, 'packages/b'),
           },
         ],
@@ -825,6 +828,7 @@ t.test('publish command with workspace paths', async t => {
         monorepo: [
           {
             name: '@test/a',
+            path: 'packages/a',
             fullpath: resolve(dir, 'packages/a'),
           },
         ],
@@ -849,6 +853,181 @@ t.test('publish command with workspace paths', async t => {
 
     t.equal(results[0]!.name, '@test/a')
     t.equal(results[0]!.version, '1.0.0')
+  })
+})
+
+t.test('publish command workspace filtering modes', async t => {
+  const dir = t.testdir({
+    'package.json': JSON.stringify({
+      name: 'root',
+      version: '1.0.0',
+    }),
+    'vlt.json': JSON.stringify({ workspaces: ['packages/*'] }),
+    packages: {
+      a: {
+        'package.json': JSON.stringify({
+          name: '@test/a',
+          version: '1.0.0',
+        }),
+        'index.js': 'console.log("a")',
+        'vlt.json': '{}',
+      },
+      b: {
+        'package.json': JSON.stringify({
+          name: '@test/b',
+          version: '2.0.0',
+        }),
+        'index.js': 'console.log("b")',
+        'vlt.json': '{}',
+      },
+    },
+  })
+
+  const tempRequest = RegistryClient.prototype.request
+  t.beforeEach(() => {
+    RegistryClient.prototype.request = (async () => {
+      return {
+        statusCode: 201,
+        text: () => '{"ok":true}',
+        json: () => ({ ok: true }),
+        getHeader: () => undefined,
+      } as MockCacheEntry
+    }) as unknown as typeof tempRequest
+  })
+  t.teardown(() => {
+    RegistryClient.prototype.request = tempRequest
+  })
+
+  t.test('filters by workspace name', async t => {
+    const config = makeTestConfig({
+      projectRoot: dir,
+      options: {
+        packageJson: new PackageJson(),
+        registry: 'https://registry.npmjs.org',
+        monorepo: [
+          {
+            name: '@test/a',
+            path: 'packages/a',
+            fullpath: resolve(dir, 'packages/a'),
+          },
+          {
+            name: '@test/b',
+            path: 'packages/b',
+            fullpath: resolve(dir, 'packages/b'),
+          },
+        ],
+      },
+      positionals: ['publish'],
+      values: { workspace: ['@test/a'] },
+    })
+    config.get = ((key: unknown) => {
+      if (key === 'workspace') return ['@test/a']
+      return undefined
+    }) as LoadedConfig['get']
+
+    const result = await command(config)
+    const results = result as CommandResultSingle[]
+    t.equal(results.length, 1)
+    t.equal(results[0]!.name, '@test/a')
+  })
+
+  t.test('filters by workspace fullpath', async t => {
+    const fullpath = resolve(dir, 'packages/a')
+    const config = makeTestConfig({
+      projectRoot: dir,
+      options: {
+        packageJson: new PackageJson(),
+        registry: 'https://registry.npmjs.org',
+        monorepo: [
+          {
+            name: '@test/a',
+            path: 'packages/a',
+            fullpath,
+          },
+          {
+            name: '@test/b',
+            path: 'packages/b',
+            fullpath: resolve(dir, 'packages/b'),
+          },
+        ],
+      },
+      positionals: ['publish'],
+      values: { workspace: [fullpath] },
+    })
+    config.get = ((key: unknown) => {
+      if (key === 'workspace') return [fullpath]
+      return undefined
+    }) as LoadedConfig['get']
+
+    const result = await command(config)
+    const results = result as CommandResultSingle[]
+    t.equal(results.length, 1)
+    t.equal(results[0]!.name, '@test/a')
+  })
+
+  t.test('filters by resolved relative path', async t => {
+    const config = makeTestConfig({
+      projectRoot: dir,
+      options: {
+        packageJson: new PackageJson(),
+        registry: 'https://registry.npmjs.org',
+        monorepo: [
+          {
+            name: '@test/a',
+            path: 'packages/a',
+            fullpath: resolve(dir, 'packages/a'),
+          },
+          {
+            name: '@test/b',
+            path: 'packages/b',
+            fullpath: resolve(dir, 'packages/b'),
+          },
+        ],
+      },
+      positionals: ['publish'],
+      values: { workspace: ['./packages/a'] },
+    })
+    config.get = ((key: unknown) => {
+      if (key === 'workspace') return ['./packages/a']
+      return undefined
+    }) as LoadedConfig['get']
+
+    const result = await command(config)
+    const results = result as CommandResultSingle[]
+    t.equal(results.length, 1)
+    t.equal(results[0]!.name, '@test/a')
+  })
+
+  t.test('filters by minimatch glob', async t => {
+    const config = makeTestConfig({
+      projectRoot: dir,
+      options: {
+        packageJson: new PackageJson(),
+        registry: 'https://registry.npmjs.org',
+        monorepo: [
+          {
+            name: '@test/a',
+            path: 'packages/a',
+            fullpath: resolve(dir, 'packages/a'),
+          },
+          {
+            name: '@test/b',
+            path: 'packages/b',
+            fullpath: resolve(dir, 'packages/b'),
+          },
+        ],
+      },
+      positionals: ['publish'],
+      values: { workspace: ['packages/*'] },
+    })
+    config.get = ((key: unknown) => {
+      if (key === 'workspace') return ['packages/*']
+      return undefined
+    }) as LoadedConfig['get']
+
+    const result = await command(config)
+    const results = result as CommandResultSingle[]
+    t.equal(results.length, 2)
   })
 })
 
@@ -905,10 +1084,12 @@ t.test('publish command with workspace-group', async t => {
         monorepo: [
           {
             name: '@test/a',
+            path: 'packages/a',
             fullpath: resolve(dir, 'packages/a'),
           },
           {
             name: '@test/b',
+            path: 'packages/b',
             fullpath: resolve(dir, 'packages/b'),
           },
         ],
@@ -991,10 +1172,12 @@ t.test('publish command with recursive', async t => {
         monorepo: [
           {
             name: '@test/a',
+            path: 'packages/a',
             fullpath: resolve(dir, 'packages/a'),
           },
           {
             name: '@test/b',
+            path: 'packages/b',
             fullpath: resolve(dir, 'packages/b'),
           },
         ],

--- a/src/cli-sdk/test/commands/version.ts
+++ b/src/cli-sdk/test/commands/version.ts
@@ -651,10 +651,12 @@ t.test('version command with scope', async t => {
         monorepo: [
           {
             name: '@test/a',
+            path: 'packages/a',
             fullpath: resolve(dir, 'packages/a'),
           },
           {
             name: '@test/b',
+            path: 'packages/b',
             fullpath: resolve(dir, 'packages/b'),
           },
         ],
@@ -786,6 +788,7 @@ t.test('version command with workspace paths', async t => {
       monorepo: [
         {
           name: '@test/a',
+          path: 'packages/a',
           fullpath: resolve(dir, 'packages/a'),
         },
       ],
@@ -828,6 +831,268 @@ t.test('version command with workspace paths', async t => {
   })
 })
 
+t.test('version command workspace filtering modes', async t => {
+  t.test('filters by workspace name', async t => {
+    const semverModule = await import('@vltpkg/semver')
+    const cmd = await mockCommand(t, {
+      '@vltpkg/semver': semverModule,
+      '@vltpkg/git': mockGit,
+    })
+
+    const dir = t.testdir({
+      'package.json': JSON.stringify({
+        name: 'root',
+        version: '1.0.0',
+      }),
+      'vlt.json': JSON.stringify({ workspaces: ['packages/*'] }),
+      packages: {
+        a: {
+          'package.json': JSON.stringify({
+            name: '@test/a',
+            version: '1.0.0',
+          }),
+        },
+        b: {
+          'package.json': JSON.stringify({
+            name: '@test/b',
+            version: '2.0.0',
+          }),
+        },
+      },
+    })
+
+    const conf = new MockConfig(['patch'], {
+      workspace: ['@test/a'],
+      monorepo: [
+        {
+          name: '@test/a',
+          path: 'packages/a',
+          fullpath: resolve(dir, 'packages/a'),
+        },
+        {
+          name: '@test/b',
+          path: 'packages/b',
+          fullpath: resolve(dir, 'packages/b'),
+        },
+      ],
+    })
+    conf.projectRoot = dir
+    conf.writtenManifests = []
+    conf.values.packageJson.find = (cwd: string) => {
+      if (cwd.includes(join('packages', 'a')))
+        return resolve(dir, 'packages/a/package.json')
+      return null
+    }
+    conf.values.packageJson.read = (cwd: string) => {
+      if (cwd.includes(join('packages', 'a')))
+        return { name: '@test/a', version: '1.0.0' }
+      return { name: 'root', version: '1.0.0' }
+    }
+    conf.values.packageJson.maybeRead = conf.values.packageJson.read
+
+    const result = await cmd.command(conf as unknown as LoadedConfig)
+    const results = result as CommandResultSingle[]
+    t.equal(results.length, 1)
+    t.equal(results[0]!.newVersion, '1.0.1')
+  })
+
+  t.test('filters by workspace fullpath', async t => {
+    const semverModule = await import('@vltpkg/semver')
+    const cmd = await mockCommand(t, {
+      '@vltpkg/semver': semverModule,
+      '@vltpkg/git': mockGit,
+    })
+
+    const dir = t.testdir({
+      'package.json': JSON.stringify({
+        name: 'root',
+        version: '1.0.0',
+      }),
+      'vlt.json': JSON.stringify({ workspaces: ['packages/*'] }),
+      packages: {
+        a: {
+          'package.json': JSON.stringify({
+            name: '@test/a',
+            version: '1.0.0',
+          }),
+        },
+        b: {
+          'package.json': JSON.stringify({
+            name: '@test/b',
+            version: '2.0.0',
+          }),
+        },
+      },
+    })
+
+    const fullpath = resolve(dir, 'packages/a')
+    const conf = new MockConfig(['patch'], {
+      workspace: [fullpath],
+      monorepo: [
+        {
+          name: '@test/a',
+          path: 'packages/a',
+          fullpath,
+        },
+        {
+          name: '@test/b',
+          path: 'packages/b',
+          fullpath: resolve(dir, 'packages/b'),
+        },
+      ],
+    })
+    conf.projectRoot = dir
+    conf.writtenManifests = []
+    conf.values.packageJson.find = (cwd: string) => {
+      if (cwd.includes(join('packages', 'a')))
+        return resolve(dir, 'packages/a/package.json')
+      return null
+    }
+    conf.values.packageJson.read = (cwd: string) => {
+      if (cwd.includes(join('packages', 'a')))
+        return { name: '@test/a', version: '1.0.0' }
+      return { name: 'root', version: '1.0.0' }
+    }
+    conf.values.packageJson.maybeRead = conf.values.packageJson.read
+
+    const result = await cmd.command(conf as unknown as LoadedConfig)
+    const results = result as CommandResultSingle[]
+    t.equal(results.length, 1)
+    t.equal(results[0]!.newVersion, '1.0.1')
+  })
+
+  t.test('filters by resolved relative path', async t => {
+    const semverModule = await import('@vltpkg/semver')
+    const cmd = await mockCommand(t, {
+      '@vltpkg/semver': semverModule,
+      '@vltpkg/git': mockGit,
+    })
+
+    const dir = t.testdir({
+      'package.json': JSON.stringify({
+        name: 'root',
+        version: '1.0.0',
+      }),
+      'vlt.json': JSON.stringify({ workspaces: ['packages/*'] }),
+      packages: {
+        a: {
+          'package.json': JSON.stringify({
+            name: '@test/a',
+            version: '1.0.0',
+          }),
+        },
+        b: {
+          'package.json': JSON.stringify({
+            name: '@test/b',
+            version: '2.0.0',
+          }),
+        },
+      },
+    })
+
+    const conf = new MockConfig(['patch'], {
+      workspace: ['./packages/a'],
+      monorepo: [
+        {
+          name: '@test/a',
+          path: 'packages/a',
+          fullpath: resolve(dir, 'packages/a'),
+        },
+        {
+          name: '@test/b',
+          path: 'packages/b',
+          fullpath: resolve(dir, 'packages/b'),
+        },
+      ],
+    })
+    conf.projectRoot = dir
+    conf.writtenManifests = []
+    conf.values.packageJson.find = (cwd: string) => {
+      if (cwd.includes(join('packages', 'a')))
+        return resolve(dir, 'packages/a/package.json')
+      return null
+    }
+    conf.values.packageJson.read = (cwd: string) => {
+      if (cwd.includes(join('packages', 'a')))
+        return { name: '@test/a', version: '1.0.0' }
+      return { name: 'root', version: '1.0.0' }
+    }
+    conf.values.packageJson.maybeRead = conf.values.packageJson.read
+
+    const result = await cmd.command(conf as unknown as LoadedConfig)
+    const results = result as CommandResultSingle[]
+    t.equal(results.length, 1)
+    t.equal(results[0]!.newVersion, '1.0.1')
+  })
+
+  t.test('filters by minimatch glob', async t => {
+    const semverModule = await import('@vltpkg/semver')
+    const cmd = await mockCommand(t, {
+      '@vltpkg/semver': semverModule,
+      '@vltpkg/git': mockGit,
+    })
+
+    const dir = t.testdir({
+      'package.json': JSON.stringify({
+        name: 'root',
+        version: '1.0.0',
+      }),
+      'vlt.json': JSON.stringify({ workspaces: ['packages/*'] }),
+      packages: {
+        a: {
+          'package.json': JSON.stringify({
+            name: '@test/a',
+            version: '1.0.0',
+          }),
+        },
+        b: {
+          'package.json': JSON.stringify({
+            name: '@test/b',
+            version: '2.0.0',
+          }),
+        },
+      },
+    })
+
+    const conf = new MockConfig(['patch'], {
+      workspace: ['packages/*'],
+      monorepo: [
+        {
+          name: '@test/a',
+          path: 'packages/a',
+          fullpath: resolve(dir, 'packages/a'),
+        },
+        {
+          name: '@test/b',
+          path: 'packages/b',
+          fullpath: resolve(dir, 'packages/b'),
+        },
+      ],
+    })
+    conf.projectRoot = dir
+    conf.writtenManifests = []
+    conf.values.packageJson.find = (cwd: string) => {
+      if (cwd.includes(join('packages', 'a')))
+        return resolve(dir, 'packages/a/package.json')
+      if (cwd.includes(join('packages', 'b')))
+        return resolve(dir, 'packages/b/package.json')
+      return null
+    }
+    conf.values.packageJson.read = (cwd: string) => {
+      if (cwd.includes(join('packages', 'a')))
+        return { name: '@test/a', version: '1.0.0' }
+      if (cwd.includes(join('packages', 'b')))
+        return { name: '@test/b', version: '2.0.0' }
+      return { name: 'root', version: '1.0.0' }
+    }
+    conf.values.packageJson.maybeRead = conf.values.packageJson.read
+
+    const result = await cmd.command(conf as unknown as LoadedConfig)
+    const results = result as CommandResultSingle[]
+    t.equal(results.length, 2)
+  })
+})
+
 t.test('version command with workspace-group', async t => {
   t.test('updates all workspaces in group', async t => {
     const semverModule = await import('@vltpkg/semver')
@@ -864,10 +1129,12 @@ t.test('version command with workspace-group', async t => {
       monorepo: [
         {
           name: '@test/a',
+          path: 'packages/a',
           fullpath: resolve(dir, 'packages/a'),
         },
         {
           name: '@test/b',
+          path: 'packages/b',
           fullpath: resolve(dir, 'packages/b'),
         },
       ],
@@ -956,10 +1223,12 @@ t.test('version command with recursive', async t => {
       monorepo: [
         {
           name: '@test/a',
+          path: 'packages/a',
           fullpath: resolve(dir, 'packages/a'),
         },
         {
           name: '@test/b',
+          path: 'packages/b',
           fullpath: resolve(dir, 'packages/b'),
         },
       ],

--- a/src/cli-sdk/test/pack-tarball.ts
+++ b/src/cli-sdk/test/pack-tarball.ts
@@ -1113,3 +1113,140 @@ t.test('publish-directory option', async t => {
     },
   )
 })
+
+t.test('publishConfig.directory from package.json', async t => {
+  await t.test(
+    'uses publishConfig.directory when no CLI flag is set',
+    async t => {
+      const testdir = t.testdir({
+        'original-dir': {
+          'package.json': JSON.stringify({
+            name: 'original-pkg',
+            version: '1.0.0',
+            publishConfig: {
+              directory: './.build-publish',
+            },
+          }),
+          '.build-publish': {
+            'package.json': JSON.stringify({
+              name: 'built-pkg',
+              version: '1.0.0',
+              bin: { vlt: './vlt.js' },
+            }),
+            'vlt.js': '#!/usr/bin/env node\nconsole.log("vlt")',
+          },
+        },
+      })
+
+      const originalDir = resolve(testdir, 'original-dir')
+
+      // No publish-directory CLI flag
+      const config = createMockConfig(testdir)
+
+      const manifest = {
+        name: 'original-pkg',
+        version: '1.0.0',
+        publishConfig: {
+          directory: './.build-publish',
+        },
+      }
+
+      const result = await packTarball(manifest, originalDir, config)
+
+      // Should use the manifest from .build-publish/
+      t.equal(
+        result.name,
+        'built-pkg',
+        'Should use name from publishConfig.directory manifest',
+      )
+      t.equal(result.version, '1.0.0')
+      t.ok(result.files.includes('vlt.js'))
+    },
+  )
+
+  await t.test(
+    'CLI flag overrides publishConfig.directory',
+    async t => {
+      const testdir = t.testdir({
+        'original-dir': {
+          'package.json': JSON.stringify({
+            name: 'original-pkg',
+            version: '1.0.0',
+            publishConfig: {
+              directory: './.build-publish',
+            },
+          }),
+          '.build-publish': {
+            'package.json': JSON.stringify({
+              name: 'build-pkg',
+              version: '1.0.0',
+            }),
+            'build.js': 'console.log("build")',
+          },
+        },
+        'cli-dir': {
+          'package.json': JSON.stringify({
+            name: 'cli-pkg',
+            version: '2.0.0',
+          }),
+          'cli.js': 'console.log("cli")',
+        },
+      })
+
+      const originalDir = resolve(testdir, 'original-dir')
+      const cliDir = resolve(testdir, 'cli-dir')
+
+      const config = createMockConfig(testdir, {
+        'publish-directory': cliDir,
+      })
+
+      const manifest = {
+        name: 'original-pkg',
+        version: '1.0.0',
+        publishConfig: {
+          directory: './.build-publish',
+        },
+      }
+
+      const result = await packTarball(manifest, originalDir, config)
+
+      // CLI flag should take precedence
+      t.equal(result.name, 'cli-pkg')
+      t.equal(result.version, '2.0.0')
+      t.ok(result.files.includes('cli.js'))
+    },
+  )
+
+  await t.test(
+    'throws when publishConfig.directory does not exist',
+    async t => {
+      const testdir = t.testdir({
+        'original-dir': {
+          'package.json': JSON.stringify({
+            name: 'test-pkg',
+            version: '1.0.0',
+            publishConfig: {
+              directory: './nonexistent',
+            },
+          }),
+        },
+      })
+
+      const originalDir = resolve(testdir, 'original-dir')
+      const config = createMockConfig(testdir)
+
+      const manifest = {
+        name: 'test-pkg',
+        version: '1.0.0',
+        publishConfig: {
+          directory: './nonexistent',
+        },
+      }
+
+      await t.rejects(
+        packTarball(manifest, originalDir, config),
+        /Publish directory does not exist/,
+      )
+    },
+  )
+})

--- a/src/cli-sdk/test/parse-add-remove-args.ts
+++ b/src/cli-sdk/test/parse-add-remove-args.ts
@@ -2,7 +2,15 @@ import { Spec, kCustomInspect } from '@vltpkg/spec'
 import { unload } from '@vltpkg/vlt-json'
 import { Monorepo } from '@vltpkg/workspaces'
 import type { OptionsResults } from 'jackspeak'
-import { inspect } from 'node:util'
+import { inspect as rawInspect } from 'node:util'
+import type { InspectOptions } from 'node:util'
+
+// Normalize inspect output across Node.js versions: strip [Map]/[Set] tags
+// and force consistent multi-line formatting with compact: false
+const inspect = (obj: unknown, opts?: InspectOptions) =>
+  rawInspect(obj, { compact: false, ...opts })
+    .replaceAll(' [Map] ', ' ')
+    .replaceAll(' [Set] ', ' ')
 import { PathScurry } from 'path-scurry'
 import t from 'tap'
 import type {

--- a/src/graph/tap-snapshots/test/ideal/get-importer-specs.ts.test.cjs
+++ b/src/graph/tap-snapshots/test/ideal/get-importer-specs.ts.test.cjs
@@ -7,10 +7,19 @@
 'use strict'
 exports[`test/ideal/get-importer-specs.ts > TAP > adding to a non existing importer > should store non-importer file deps in transientAdd 1`] = `
 {
-  add: AddImportersDependenciesMapImpl(0) { modifiedDependencies: false },
-  remove: RemoveImportersDependenciesMapImpl(0) { modifiedDependencies: false },
+  add: AddImportersDependenciesMapImpl(0) {
+    modifiedDependencies: false
+  },
+  remove: RemoveImportersDependenciesMapImpl(0) {
+    modifiedDependencies: false
+  },
   transientAdd: Map(1) {
-    'file~nested+folder' => Map(1) { 'baz' => { spec: Spec {baz@^1.0.0}, type: 'prod' } }
+    'file~nested+folder' => Map(1) {
+      'baz' => {
+        spec: Spec {baz@^1.0.0},
+        type: 'prod'
+      }
+    }
   },
   transientRemove: Map(0) {}
 }
@@ -19,8 +28,14 @@ exports[`test/ideal/get-importer-specs.ts > TAP > adding to a non existing impor
 exports[`test/ideal/get-importer-specs.ts > TAP > empty graph and something to add > should result in only added specs 1`] = `
 AddImportersDependenciesMapImpl(1) {
   'file~_d' => Map(2) {
-    'bar' => { spec: Spec {bar@custom:bar@^1.1.1}, type: 'dev' },
-    'foo' => { spec: Spec {foo@^1.1.1}, type: 'prod' }
+    'bar' => {
+      spec: Spec {bar@custom:bar@^1.1.1},
+      type: 'dev'
+    },
+    'foo' => {
+      spec: Spec {foo@^1.1.1},
+      type: 'prod'
+    }
   },
   modifiedDependencies: true
 }
@@ -33,9 +48,18 @@ AddImportersDependenciesMapImpl {}
 exports[`test/ideal/get-importer-specs.ts > TAP > graph specs and new things to add > should have root specs along with the added ones 1`] = `
 AddImportersDependenciesMapImpl(1) {
   'file~_d' => Map(3) {
-    'foo' => { spec: Spec {foo@^1.0.0}, type: 'prod' },
-    'bar' => { spec: Spec {bar@^1.0.0}, type: 'dev' },
-    'baz' => { spec: Spec {baz@^1.0.0}, type: 'prod' }
+    'foo' => {
+      spec: Spec {foo@^1.0.0},
+      type: 'prod'
+    },
+    'bar' => {
+      spec: Spec {bar@^1.0.0},
+      type: 'dev'
+    },
+    'baz' => {
+      spec: Spec {baz@^1.0.0},
+      type: 'prod'
+    }
   },
   modifiedDependencies: true
 }
@@ -44,8 +68,14 @@ AddImportersDependenciesMapImpl(1) {
 exports[`test/ideal/get-importer-specs.ts > TAP > graph specs and nothing to add > should have root specs added only 1`] = `
 AddImportersDependenciesMapImpl(1) {
   'file~_d' => Map(2) {
-    'foo' => { spec: Spec {foo@^1.0.0}, type: 'prod' },
-    'bar' => { spec: Spec {bar@^1.0.0}, type: 'dev' }
+    'foo' => {
+      spec: Spec {foo@^1.0.0},
+      type: 'prod'
+    },
+    'bar' => {
+      spec: Spec {bar@^1.0.0},
+      type: 'dev'
+    }
   },
   modifiedDependencies: true
 }
@@ -53,9 +83,13 @@ AddImportersDependenciesMapImpl(1) {
 
 exports[`test/ideal/get-importer-specs.ts > TAP > graph specs and something to remove > should removed entries missing from manifest file 1`] = `
 {
-  add: AddImportersDependenciesMapImpl(0) { modifiedDependencies: false },
+  add: AddImportersDependenciesMapImpl(0) {
+    modifiedDependencies: false
+  },
   remove: RemoveImportersDependenciesMapImpl(1) {
-    'file~_d' => Set(1) { 'foo' },
+    'file~_d' => Set(1) {
+      'foo'
+    },
     modifiedDependencies: true
   },
   transientAdd: Map(0) {},
@@ -65,7 +99,12 @@ exports[`test/ideal/get-importer-specs.ts > TAP > graph specs and something to r
 
 exports[`test/ideal/get-importer-specs.ts > TAP > graph specs and something to update > should have the updated root spec 1`] = `
 AddImportersDependenciesMapImpl(1) {
-  'file~_d' => Map(1) { 'foo' => { spec: Spec {foo@^2.0.0}, type: 'prod' } },
+  'file~_d' => Map(1) {
+    'foo' => {
+      spec: Spec {foo@^2.0.0},
+      type: 'prod'
+    }
+  },
   modifiedDependencies: true
 }
 `
@@ -73,16 +112,34 @@ AddImportersDependenciesMapImpl(1) {
 exports[`test/ideal/get-importer-specs.ts > TAP > graph specs with workspaces and something to add > should have root and workspaces nodes with specs to add 1`] = `
 AddImportersDependenciesMapImpl(3) {
   'file~_d' => Map(2) {
-    'foo' => { spec: Spec {foo@^1.0.0}, type: 'prod' },
-    'bar' => { spec: Spec {bar@^2.0.0}, type: 'prod' }
+    'foo' => {
+      spec: Spec {foo@^1.0.0},
+      type: 'prod'
+    },
+    'bar' => {
+      spec: Spec {bar@^2.0.0},
+      type: 'prod'
+    }
   },
   'workspace~packages+a' => Map(2) {
-    'bar' => { spec: Spec {bar@^1.0.0}, type: 'dev' },
-    'baz' => { spec: Spec {baz@^1.0.0}, type: 'prod' }
+    'bar' => {
+      spec: Spec {bar@^1.0.0},
+      type: 'dev'
+    },
+    'baz' => {
+      spec: Spec {baz@^1.0.0},
+      type: 'prod'
+    }
   },
   'workspace~packages+b' => Map(2) {
-    'a' => { spec: Spec {a@workspace:*}, type: 'prod' },
-    'baz' => { spec: Spec {baz@^1.0.0}, type: 'prod' }
+    'a' => {
+      spec: Spec {a@workspace:*},
+      type: 'prod'
+    },
+    'baz' => {
+      spec: Spec {baz@^1.0.0},
+      type: 'prod'
+    }
   },
   modifiedDependencies: true
 }
@@ -90,10 +147,16 @@ AddImportersDependenciesMapImpl(3) {
 
 exports[`test/ideal/get-importer-specs.ts > TAP > graph specs with workspaces and somethings to remove > should have root and workspaces nodes with specs to remove 1`] = `
 {
-  add: AddImportersDependenciesMapImpl(0) { modifiedDependencies: false },
+  add: AddImportersDependenciesMapImpl(0) {
+    modifiedDependencies: false
+  },
   remove: RemoveImportersDependenciesMapImpl(2) {
-    'workspace~packages+a' => Set(1) { 'bar' },
-    'workspace~packages+b' => Set(1) { 'a' },
+    'workspace~packages+a' => Set(1) {
+      'bar'
+    },
+    'workspace~packages+b' => Set(1) {
+      'a'
+    },
     modifiedDependencies: true
   },
   transientAdd: Map(0) {},
@@ -104,10 +167,17 @@ exports[`test/ideal/get-importer-specs.ts > TAP > graph specs with workspaces an
 exports[`test/ideal/get-importer-specs.ts > TAP > installing over a dangling edge > should add the missing dep 1`] = `
 {
   add: AddImportersDependenciesMapImpl(1) {
-    'file~_d' => Map(1) { 'foo' => { spec: Spec {foo@^1.0.0}, type: 'prod' } },
+    'file~_d' => Map(1) {
+      'foo' => {
+        spec: Spec {foo@^1.0.0},
+        type: 'prod'
+      }
+    },
     modifiedDependencies: true
   },
-  remove: RemoveImportersDependenciesMapImpl(0) { modifiedDependencies: false },
+  remove: RemoveImportersDependenciesMapImpl(0) {
+    modifiedDependencies: false
+  },
   transientAdd: Map(0) {},
   transientRemove: Map(0) {}
 }
@@ -115,32 +185,63 @@ exports[`test/ideal/get-importer-specs.ts > TAP > installing over a dangling edg
 
 exports[`test/ideal/get-importer-specs.ts > TAP > removing from a non existing importer > should store non-importer file deps in transientRemove 1`] = `
 {
-  add: AddImportersDependenciesMapImpl(0) { modifiedDependencies: false },
-  remove: RemoveImportersDependenciesMapImpl(0) { modifiedDependencies: false },
+  add: AddImportersDependenciesMapImpl(0) {
+    modifiedDependencies: false
+  },
+  remove: RemoveImportersDependenciesMapImpl(0) {
+    modifiedDependencies: false
+  },
   transientAdd: Map(0) {},
-  transientRemove: Map(1) { 'file~nested+folder' => Set(1) { 'baz' } }
+  transientRemove: Map(1) {
+    'file~nested+folder' => Set(1) {
+      'baz'
+    }
+  }
 }
 `
 
 exports[`test/ideal/get-importer-specs.ts > TAP > transientAdd and transientRemove combined via params > should store both transientAdd and transientRemove from params 1`] = `
 {
-  add: AddImportersDependenciesMapImpl(0) { modifiedDependencies: false },
-  remove: RemoveImportersDependenciesMapImpl(0) { modifiedDependencies: false },
-  transientAdd: Map(1) {
-    'file~nested+folder' => Map(1) { 'foo' => { spec: Spec {foo@^1.0.0}, type: 'prod' } }
+  add: AddImportersDependenciesMapImpl(0) {
+    modifiedDependencies: false
   },
-  transientRemove: Map(1) { 'file~other+folder' => Set(1) { 'bar' } }
+  remove: RemoveImportersDependenciesMapImpl(0) {
+    modifiedDependencies: false
+  },
+  transientAdd: Map(1) {
+    'file~nested+folder' => Map(1) {
+      'foo' => {
+        spec: Spec {foo@^1.0.0},
+        type: 'prod'
+      }
+    }
+  },
+  transientRemove: Map(1) {
+    'file~other+folder' => Set(1) {
+      'bar'
+    }
+  }
 }
 `
 
 exports[`test/ideal/get-importer-specs.ts > TAP > transientAdd from file-type directory manifest > should populate transientAdd from nested directory manifest 1`] = `
 {
-  add: AddImportersDependenciesMapImpl(0) { modifiedDependencies: false },
-  remove: RemoveImportersDependenciesMapImpl(0) { modifiedDependencies: false },
+  add: AddImportersDependenciesMapImpl(0) {
+    modifiedDependencies: false
+  },
+  remove: RemoveImportersDependenciesMapImpl(0) {
+    modifiedDependencies: false
+  },
   transientAdd: Map(1) {
     'file~nested' => Map(2) {
-      'bar' => { spec: Spec {bar@^2.0.0}, type: 'prod' },
-      'baz' => { spec: Spec {baz@^3.0.0}, type: 'prod' }
+      'bar' => {
+        spec: Spec {bar@^2.0.0},
+        type: 'prod'
+      },
+      'baz' => {
+        spec: Spec {baz@^3.0.0},
+        type: 'prod'
+      }
     }
   },
   transientRemove: Map(0) {}
@@ -151,11 +252,16 @@ exports[`test/ideal/get-importer-specs.ts > TAP > transientRemove from file-type
 {
   add: AddImportersDependenciesMapImpl(1) {
     'file~_d' => Map(1) {
-      'nested' => { spec: Spec {nested@file:./nested}, type: 'prod' }
+      'nested' => {
+        spec: Spec {nested@file:./nested},
+        type: 'prod'
+      }
     },
     modifiedDependencies: true
   },
-  remove: RemoveImportersDependenciesMapImpl(0) { modifiedDependencies: false },
+  remove: RemoveImportersDependenciesMapImpl(0) {
+    modifiedDependencies: false
+  },
   transientAdd: Map(0) {},
   transientRemove: Map(0) {}
 }

--- a/src/graph/test/ideal/get-importer-specs.ts
+++ b/src/graph/test/ideal/get-importer-specs.ts
@@ -3,7 +3,15 @@ import { PackageJson } from '@vltpkg/package-json'
 import { kCustomInspect, Spec } from '@vltpkg/spec'
 import { unload } from '@vltpkg/vlt-json'
 import { Monorepo } from '@vltpkg/workspaces'
-import { inspect } from 'node:util'
+import { inspect as rawInspect } from 'node:util'
+import type { InspectOptions } from 'node:util'
+
+// Normalize inspect output across Node.js versions: strip [Map]/[Set] tags
+// and force consistent multi-line formatting with compact: false
+const inspect = (obj: unknown, opts?: InspectOptions) =>
+  rawInspect(obj, { compact: false, ...opts })
+    .replaceAll(' [Map] ', ' ')
+    .replaceAll(' [Set] ', ' ')
 import { PathScurry } from 'path-scurry'
 import t from 'tap'
 import { load } from '../../src/actual/load.ts'


### PR DESCRIPTION
## Summary

Fixes two critical bugs blocking the release workflow:

### Bug 1: pack/publish/version/pkg operate on ALL workspaces

When running `vlt pack` from a workspace subdirectory (e.g. `cd src/xdg && vlt pack`), the command packed **every workspace** in the monorepo instead of just the current one.

**Root cause**: `index.ts` auto-infers `workspace=[ws.path]` when `cwd` is inside a workspace, but `options.monorepo` was already loaded with ALL workspaces. The pack/publish/version/pkg commands checked `paths.length` to enter multi-workspace mode but iterated ALL of `options.monorepo` without filtering.

This caused:
- Each `vlt pack` invocation to take ~1 minute (packing ~40 packages)
- The `src/gui` pack to crash with `RangeError: Invalid string length` (88MB tarball)
- The release workflow to fail on every push to main since the pnpm→vlt migration

**Fix**: Added path/name/fullpath filtering with minimatch glob support in the `else if (paths?.length || groups?.length || recursive)` branch of pack.ts, publish.ts, version.ts, and pkg.ts. This matches the approach already used in `exec-command.ts`.

### Bug 2: publishConfig.directory not read from package.json

`packTarball()` only read `--publish-directory` from the CLI flag, ignoring `publishConfig.directory` from `package.json`. This caused `vlt pack/publish` to pack from the source directory instead of the build output directory for packages like `infra/cli` that use `publishConfig.directory: './.build-publish'`.

**Fix**: Fall back to `manifest.publishConfig.directory` when the CLI flag is not set, resolving relative paths against the package directory.

## Testing

- All existing pack tests pass (80/80)
- All existing pack-tarball tests pass (91/91 + 1 todo)
- All existing publish tests pass
- All existing version tests pass
- All existing pkg tests pass
- Added 3 new tests for `publishConfig.directory`:
  - Uses publishConfig.directory from package.json
  - CLI flag overrides publishConfig.directory
  - Throws when publishConfig.directory doesn't exist

## Impact

This unblocks the release workflow. With these fixes, `vlt pack` from a workspace dir correctly packs only that workspace, and packages with `publishConfig.directory` are packed from the correct build output directory.

Co-authored-by: Darcy Clarke <darcy@darcyclarke.me>