### PR TITLE
fix(satisfies): resolve workspace pkgs from bare semver specs

### DIFF
--- a/src/graph/test/ideal/append-nodes.ts
+++ b/src/graph/test/ideal/append-nodes.ts
@@ -2999,3 +2999,204 @@ t.test(
     )
   },
 )
+
+t.test(
+  'resolves registry specs to workspace packages when name and version match',
+  async t => {
+    // When a workspace package is referenced with a plain semver
+    // spec (e.g. "@scope/lib-a": "^1.0.0"), vlt should resolve it
+    // to the local workspace package if the version satisfies the
+    // range — matching npm/pnpm/yarn behavior.
+    const mainManifest = {
+      name: 'my-monorepo',
+      version: '1.0.0',
+    }
+    const libAManifest = {
+      name: '@scope/lib-a',
+      version: '1.2.3',
+    }
+    const libBManifest = {
+      name: '@scope/lib-b',
+      version: '2.0.0',
+      dependencies: {
+        // plain registry spec that should resolve to workspace
+        '@scope/lib-a': '^1.0.0',
+      },
+    }
+
+    const dir = t.testdir({
+      'package.json': JSON.stringify(mainManifest),
+      packages: {
+        'lib-a': {
+          'package.json': JSON.stringify(libAManifest),
+        },
+        'lib-b': {
+          'package.json': JSON.stringify(libBManifest),
+        },
+      },
+      'vlt.json': JSON.stringify({
+        workspaces: { packages: ['packages/*'] },
+      }),
+    })
+
+    const scurry = new PathScurry(dir)
+    const packageJson = new PackageJson()
+    const monorepo = new Monorepo(dir, {
+      config: { packages: ['packages/*'] },
+      scurry,
+      packageJson,
+      load: { paths: ['packages/lib-a', 'packages/lib-b'] },
+    })
+
+    const graph = new Graph({
+      projectRoot: dir,
+      mainManifest,
+      monorepo,
+      ...configData,
+    })
+
+    // lib-a and lib-b workspace nodes should exist as importers
+    const libANode = [...graph.importers].find(
+      n => n.name === '@scope/lib-a',
+    )
+    const libBNode = [...graph.importers].find(
+      n => n.name === '@scope/lib-b',
+    )
+    t.ok(libANode, 'lib-a should be an importer')
+    t.ok(libBNode, 'lib-b should be an importer')
+
+    // Mock packageInfo that should NOT be called for @scope/lib-a
+    // since it should resolve from the workspace
+    const packageInfo = {
+      async manifest(spec: Spec) {
+        if (spec.name === '@scope/lib-a') {
+          throw new Error(
+            'Should not fetch @scope/lib-a from registry — ' +
+              'it should resolve from workspace',
+          )
+        }
+        return null
+      },
+    } as PackageInfoClient
+
+    // Create a dep that uses a plain registry spec
+    // for a workspace package
+    const dep = asDependency({
+      spec: Spec.parse('@scope/lib-a', '^1.0.0', configData),
+      type: 'prod',
+    })
+
+    // Append nodes from lib-b's perspective
+    await appendNodes(
+      packageInfo,
+      graph,
+      libBNode!,
+      [dep],
+      scurry,
+      configData,
+      new Set<DepID>(),
+      new Map([['@scope/lib-a', dep]]),
+    )
+
+    // Verify lib-b now has an edge to the workspace lib-a node
+    const edge = libBNode!.edgesOut.get('@scope/lib-a')
+    t.ok(edge, 'lib-b should have edge to @scope/lib-a')
+    t.equal(
+      edge?.to?.id,
+      libANode!.id,
+      'edge should point to the workspace lib-a node',
+    )
+    t.equal(
+      edge?.to?.importer,
+      true,
+      'resolved node should be a workspace importer',
+    )
+  },
+)
+
+t.test(
+  'does NOT resolve registry spec to workspace when version is out of range',
+  async t => {
+    const mainManifest = {
+      name: 'my-monorepo',
+      version: '1.0.0',
+    }
+    const libAManifest = {
+      name: '@scope/lib-a',
+      version: '1.2.3',
+    }
+
+    const dir = t.testdir({
+      'package.json': JSON.stringify(mainManifest),
+      packages: {
+        'lib-a': {
+          'package.json': JSON.stringify(libAManifest),
+        },
+      },
+      'vlt.json': JSON.stringify({
+        workspaces: { packages: ['packages/*'] },
+      }),
+    })
+
+    const scurry = new PathScurry(dir)
+    const packageJson = new PackageJson()
+    const monorepo = new Monorepo(dir, {
+      config: { packages: ['packages/*'] },
+      scurry,
+      packageJson,
+      load: { paths: ['packages/lib-a'] },
+    })
+
+    const graph = new Graph({
+      projectRoot: dir,
+      mainManifest,
+      monorepo,
+      ...configData,
+    })
+
+    // Mock packageInfo that should be called because version
+    // doesn't match (workspace is 1.2.3, spec wants ^2.0.0)
+    let fetchCalled = false
+    const packageInfo = {
+      async manifest(spec: Spec) {
+        if (spec.name === '@scope/lib-a') {
+          fetchCalled = true
+          return {
+            name: '@scope/lib-a',
+            version: '2.0.0',
+          }
+        }
+        return null
+      },
+    } as PackageInfoClient
+
+    const dep = asDependency({
+      spec: Spec.parse('@scope/lib-a', '^2.0.0', configData),
+      type: 'prod',
+    })
+
+    await appendNodes(
+      packageInfo,
+      graph,
+      graph.mainImporter,
+      [dep],
+      scurry,
+      configData,
+      new Set<DepID>(),
+      new Map([['@scope/lib-a', dep]]),
+    )
+
+    t.ok(
+      fetchCalled,
+      'should have fetched from registry when version out of range',
+    )
+    // The edge should point to the registry version, not the workspace
+    const edge = graph.mainImporter.edgesOut.get('@scope/lib-a')
+    t.ok(edge, 'should have edge to @scope/lib-a')
+    t.equal(
+      edge?.to?.id,
+      joinDepIDTuple(['registry', '', '@scope/lib-a@2.0.0']),
+      'should resolve to registry version, not workspace',
+    )
+  },
+)

--- a/src/graph/test/ideal/append-nodes.ts
+++ b/src/graph/test/ideal/append-nodes.ts
@@ -3077,7 +3077,7 @@ t.test(
         }
         return null
       },
-    } as PackageInfoClient
+    } as unknown as PackageInfoClient
 
     // Create a dep that uses a plain registry spec
     // for a workspace package

--- a/src/satisfies/src/index.ts
+++ b/src/satisfies/src/index.ts
@@ -37,6 +37,21 @@ export const satisfiesTuple = (
   const { options } = spec
   spec = spec.final
   const [type, first, second] = tuple
+
+  // When a registry spec matches a workspace package by name and
+  // version, treat it as satisfied. This allows monorepo packages
+  // that reference each other with plain semver specs (e.g.
+  // "@dev/build-tools": "^1.0.0") to resolve to local workspace
+  // packages, matching npm/pnpm/yarn behavior.
+  if (spec.type === 'registry' && type === 'workspace') {
+    if (!monorepo) return false
+    const ws = monorepo.get(first)
+    if (!ws || ws.name !== spec.name) return false
+    if (!spec.range) return true
+    const v = parse(ws.manifest.version ?? '')
+    return !!v && spec.range.test(v)
+  }
+
   if (spec.type !== type) return false
 
   switch (spec.type) {

--- a/src/satisfies/src/index.ts
+++ b/src/satisfies/src/index.ts
@@ -46,7 +46,7 @@ export const satisfiesTuple = (
   if (spec.type === 'registry' && type === 'workspace') {
     if (!monorepo) return false
     const ws = monorepo.get(first)
-    if (!ws || ws.name !== spec.name) return false
+    if (ws?.name !== spec.name) return false
     if (!spec.range) return true
     const v = parse(ws.manifest.version ?? '')
     return !!v && spec.range.test(v)

--- a/src/satisfies/test/index.ts
+++ b/src/satisfies/test/index.ts
@@ -128,6 +128,81 @@ t.test('ids that satisfy the spec', t => {
   t.end()
 })
 
+t.test('registry specs satisfied by workspace dep ids', t => {
+  // When a monorepo workspace package is referenced with a plain
+  // semver spec (e.g. "a@1.x"), it should satisfy a workspace
+  // DepID if the workspace version matches. This mirrors
+  // npm/pnpm/yarn behavior of auto-resolving workspace packages.
+  const satisfied: [Spec, DepID][] = [
+    // exact version match
+    [Spec.parse('a@1.2.3'), joinDepIDTuple(['workspace', 'src/a'])],
+    // semver range match
+    [Spec.parse('a@^1.0.0'), joinDepIDTuple(['workspace', 'src/a'])],
+    // x-range match
+    [Spec.parse('a@1.x'), joinDepIDTuple(['workspace', 'src/a'])],
+    // dist-tag (no range) should match any workspace version
+    [Spec.parse('a@latest'), joinDepIDTuple(['workspace', 'src/a'])],
+    // * range matches any version
+    [Spec.parse('a@*'), joinDepIDTuple(['workspace', 'src/a'])],
+  ]
+
+  for (const [spec, depid] of satisfied) {
+    t.equal(
+      satisfies(depid, spec, projectRoot, projectRoot, monorepo),
+      true,
+      {
+        spec: spec,
+        depid,
+      },
+    )
+  }
+
+  t.end()
+})
+
+t.test('registry specs NOT satisfied by workspace dep ids', t => {
+  const unsatisfied: [Spec, DepID][] = [
+    // version out of range (workspace a is 1.2.3, spec wants 2.x)
+    [Spec.parse('a@2.x'), joinDepIDTuple(['workspace', 'src/a'])],
+    // name mismatch (no workspace named 'nonexistent')
+    [
+      Spec.parse('nonexistent@1.x'),
+      joinDepIDTuple(['workspace', 'src/a']),
+    ],
+    // workspace without a version (b has no version)
+    [Spec.parse('b@1.x'), joinDepIDTuple(['workspace', 'src/b'])],
+  ]
+
+  for (const [spec, depid] of unsatisfied) {
+    t.equal(
+      satisfies(depid, spec, projectRoot, projectRoot, monorepo),
+      false,
+      {
+        spec: spec,
+        depid,
+      },
+    )
+  }
+
+  t.end()
+})
+
+t.test('registry spec vs workspace dep id without monorepo', t => {
+  // Without a monorepo, registry specs should never match
+  // workspace dep ids
+  t.equal(
+    satisfies(
+      joinDepIDTuple(['workspace', 'src/a']),
+      Spec.parse('a@1.x'),
+      projectRoot,
+      projectRoot,
+      undefined,
+    ),
+    false,
+  )
+  t.end()
+})
+
 t.test('ids that do not satisfy the spec', t => {
   const unsatisfied: [Spec, DepID][] = [
     [


### PR DESCRIPTION
## Problem

When a monorepo workspace package is referenced with a plain semver spec (e.g. `"@dev/build-tools": "^1.0.0"`), `vlt install` tries to fetch it from the npm registry instead of resolving it as a local workspace package. This fails for private workspace packages that only exist locally.

This is in contrast to npm, pnpm, and yarn which automatically prefer workspace packages when the name and version match.

**Reproduction**: Any monorepo where workspace packages reference each other with plain version specs instead of `workspace:` protocol. The BabylonJS monorepo (used as a benchmark fixture) is one example — it has 86+ workspace packages under scopes like `@dev/`, `@tools/`, and `@lts/` that reference each other with specs like `"@dev/build-tools": "^1.0.0"`.

## Root Cause

In `@vltpkg/satisfies`, the `satisfiesTuple` function has an early return `if (spec.type !== type) return false` that prevents a registry spec (`type: 'registry'`) from ever matching a workspace DepID (`type: 'workspace'`). This means `Graph.findResolution()` never finds workspace nodes when resolving registry specs.

## Fix

Added cross-type matching in `satisfiesTuple`: when comparing a `registry` spec against a `workspace` DepID, check if:
1. A monorepo context exists
2. The workspace package name matches the spec name
3. The workspace version satisfies the spec's semver range

If all conditions are met, the workspace node satisfies the spec. This allows `findResolution` to find workspace nodes, which then follow the existing "reuse importer node" path in `appendNodes`.

### Changes
- **`src/satisfies/src/index.ts`**: Add registry→workspace cross-type matching in `satisfiesTuple`
- **`src/satisfies/test/index.ts`**: Add tests for satisfied, unsatisfied, and no-monorepo cases
- **`src/graph/test/ideal/append-nodes.ts`**: Add integration tests verifying workspace resolution from registry specs and version-out-of-range fallback

### What it does NOT do
- Does not rewrite the spec to `workspace:` — the original registry spec is preserved on the edge
- Does not modify package.json — the user's original spec is kept as-is
- Does not affect resolution when the workspace version doesn't satisfy the range — falls back to normal registry fetch

Fixes #1534