### PR TITLE
fix(query): move diff-files provider from query to cli-sdk

### DIFF
--- a/src/cli-sdk/src/commands/query.ts
+++ b/src/cli-sdk/src/commands/query.ts
@@ -8,7 +8,7 @@ import {
 } from '@vltpkg/graph'
 import { error } from '@vltpkg/error-cause'
 import { Query } from '@vltpkg/query'
-import { createDiffFilesProvider } from '@vltpkg/query/diff-files'
+import { createDiffFilesProvider } from '../query-diff-files.ts'
 import { SecurityArchive } from '@vltpkg/security-archive'
 import { commandUsage } from '../config/usage.ts'
 import { createHostContextsMap } from '../query-host-contexts.ts'

--- a/src/cli-sdk/src/exec-command.ts
+++ b/src/cli-sdk/src/exec-command.ts
@@ -20,7 +20,7 @@ import type {
   RunResult,
 } from '@vltpkg/run'
 import { Query } from '@vltpkg/query'
-import { createDiffFilesProvider } from '@vltpkg/query/diff-files'
+import { createDiffFilesProvider } from './query-diff-files.ts'
 import { actual } from '@vltpkg/graph'
 import { isRunResult } from '@vltpkg/run'
 import { Monorepo } from '@vltpkg/workspaces'

--- a/src/cli-sdk/src/query-diff-files.ts
+++ b/src/cli-sdk/src/query-diff-files.ts
@@ -1,6 +1,6 @@
 import { execSync } from 'node:child_process'
 import { error } from '@vltpkg/error-cause'
-import type { DiffFilesProvider } from './types.ts'
+import type { DiffFilesProvider } from '@vltpkg/query'
 
 /**
  * Pattern to validate commitish arguments.

--- a/src/cli-sdk/test/query-diff-files.ts
+++ b/src/cli-sdk/test/query-diff-files.ts
@@ -2,7 +2,7 @@ import t from 'tap'
 import {
   createDiffFilesProvider,
   validateCommitish,
-} from '../src/diff-files.ts'
+} from '../src/query-diff-files.ts'
 
 t.test('validateCommitish', async t => {
   t.test('accepts valid commitish values', async t => {
@@ -95,8 +95,8 @@ t.test('createDiffFilesProvider', async t => {
 
   t.test('parses git output with mocked execSync', async t => {
     const { createDiffFilesProvider: mockedCreate } =
-      await t.mockImport<typeof import('../src/diff-files.ts')>(
-        '../src/diff-files.ts',
+      await t.mockImport<typeof import('../src/query-diff-files.ts')>(
+        '../src/query-diff-files.ts',
         {
           'node:child_process': {
             execSync: () =>

--- a/src/query/package.json
+++ b/src/query/package.json
@@ -57,11 +57,6 @@
       "import": {
         "default": "./src/index.ts"
       }
-    },
-    "./diff-files": {
-      "import": {
-        "default": "./src/diff-files.ts"
-      }
     }
   },
   "files": [


### PR DESCRIPTION
## Problem

The `src/query` workspace is an isomorphic JavaScript implementation designed to run in multiple environments (browser, Node.js, etc). The `:diff()` feature added in #1544 introduced `diff-files.ts` with a direct dependency on `node:child_process` (`execSync`), breaking this contract.

## Solution

Move the Node.js-dependent `diff-files.ts` provider to the `src/cli-sdk` workspace, following the same pattern as the `:host()` selector which defines its provider in `query-host-contexts.ts` within `src/cli-sdk`.

This way:
- `src/query` stays isomorphic — it only defines the `DiffFilesProvider` **type** and the `:diff()` pseudo selector logic
- `src/cli-sdk` provides the concrete Node.js implementation (`createDiffFilesProvider`) that uses `execSync`
- Different environments can implement their own adapters

## Changes

| From | To |
|------|-----|
| `src/query/src/diff-files.ts` | `src/cli-sdk/src/query-diff-files.ts` |
| `src/query/test/diff-files.ts` | `src/cli-sdk/test/query-diff-files.ts` |

- Updated imports in `exec-command.ts` and `commands/query.ts` to use local import
- Removed `./diff-files` subpath export from `@vltpkg/query` package.json
- `DiffFilesProvider` type stays in `src/query/src/types.ts` (type-only, no Node deps)
- `:diff()` pseudo selector stays in `src/query/src/pseudo/diff.ts` (uses only the type)
