### PR TITLE
fix: consolidate release PR to single commit

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -200,6 +200,11 @@ jobs:
           git diff
           git checkout -- 'src/*/package.json'
 
+      - name: Amend Release Commit with Packed Tarballs
+        run: |
+          git add -A
+          git commit --amend --no-edit
+
       - name: Create or Update PR
         id: pr
         if: needs.pre-check.outputs.dry-run != 'true'


### PR DESCRIPTION
## Summary

The release PR workflow previously produced two commits: one for version bumps (from the explicit `git commit` step) and a second auto-commit from `peter-evans/create-pull-request` for the packed tarballs left as uncommitted changes.

## Fix

Add an **Amend Release Commit with Packed Tarballs** step after **Undo Pack Local Changes** that stages the `.tgz` files and amends them into the existing release commit. When `create-pull-request` runs, there are no uncommitted changes left, so it produces a single clean release commit.

### Step order (unchanged except for new step 8):
1. Version CLI Packages
2. Version Workspaces
3. Version Root
4. Commit Version Bumps
5. Pack
6. Full integrity
7. List Packages
8. Undo Pack Local Changes
9. **Amend Release Commit with Packed Tarballs** ← new
10. Create or Update PR (no uncommitted files → single commit)

The `Pack` and `List Packages` steps continue to use `HEAD~1` correctly since the version bump commit is still created first — only the tarballs get amended into it afterward.