### PR TITLE
docs: add OIDC publishing documentation

### DIFF
--- a/www/docs/src/content/docs/cli/auth.mdx
+++ b/www/docs/src/content/docs/cli/auth.mdx
@@ -60,6 +60,62 @@ characters in the registry URL with `_`, and set the appropriate
 VLT_TOKEN_https_my_custom_registry_mycompany_local="helloworldtokendeadbeef" vlt install
 ```
 
+## OIDC (OpenID Connect)
+
+If your CI provider supports OpenID Connect, vlt can authenticate
+with the registry automatically — no static tokens needed. vlt
+detects the CI environment, requests an OIDC ID token from the
+provider, and exchanges it with the registry for a short-lived
+publish token. Everything happens behind the scenes.
+
+### Supported Providers
+
+- **GitHub Actions** — native support, no extra config
+- **GitLab CI** — via `NPM_ID_TOKEN` environment variable
+- **CircleCI** — via `NPM_ID_TOKEN` environment variable
+
+### GitHub Actions
+
+Add `id-token: write` to the job's permissions and vlt handles
+the rest:
+
+<Code
+  code={`jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: vltpkg/setup-vlt@v1
+      - run: vlt publish`}
+  title="github-actions.yml"
+  lang="yaml"
+/>
+
+### GitLab CI / CircleCI
+
+Set the `NPM_ID_TOKEN` environment variable with the OIDC ID
+token provided by your CI platform. vlt reads it automatically
+and exchanges it for a publish token.
+
+### How It Works
+
+When you run `vlt publish`, vlt checks for an available OIDC ID
+token from the CI environment. It sends that token to the
+registry's token endpoint, which verifies the token and returns a
+short-lived credential. vlt uses that credential for the publish
+request. No tokens are stored, and nothing persists after the job
+finishes.
+
+### Fallback Behavior
+
+If OIDC isn't available — for example, the registry doesn't
+support it, or the required permissions aren't configured — vlt
+silently falls back to `VLT_TOKEN` or keychain-based auth. No
+errors, no interruptions.
+
 ## OTP
 
 One-time password (OTP) and MFA is supported for non-headless

--- a/www/docs/src/content/docs/cli/commands/publish.mdx
+++ b/www/docs/src/content/docs/cli/commands/publish.mdx
@@ -49,3 +49,38 @@ to it.
   title="Terminal"
   lang="bash"
 />
+
+## Publishing in CI
+
+### OIDC (Recommended)
+
+If your CI provider supports OpenID Connect, vlt can publish
+without any stored tokens. On GitHub Actions, add
+`id-token: write` to your job's permissions and vlt handles
+authentication automatically.
+
+See [Authentication — OIDC](/cli/auth/#oidc-openid-connect) for
+full details on supported providers and configuration.
+
+<Code
+  code={`jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: vltpkg/setup-vlt@v1
+      - run: vlt publish`}
+  title="github-actions.yml"
+  lang="yaml"
+/>
+
+### VLT_TOKEN
+
+For registries that don't support OIDC, set the `VLT_TOKEN`
+environment variable with a valid auth token. See
+[Authentication — CI](/cli/auth/#ci-and-other-headless-environments)
+for details on configuring tokens for default and custom
+registries.


### PR DESCRIPTION
Adds documentation for the new OIDC (OpenID Connect) publishing feature.

## Changes

### `www/docs/src/content/docs/cli/auth.mdx`
- New **OIDC (OpenID Connect)** section after the existing CI section
- Covers automatic tokenless CI authentication
- Supported providers: GitHub Actions, GitLab CI, CircleCI
- GitHub Actions setup with minimal workflow example
- GitLab CI / CircleCI setup via `NPM_ID_TOKEN`
- Brief explanation of how the token exchange works
- Fallback behavior (silent fallback to `VLT_TOKEN` / keychain)

### `www/docs/src/content/docs/cli/commands/publish.mdx`
- New **Publishing in CI** section after the options
- OIDC (recommended) with link to auth page and workflow example
- `VLT_TOKEN` alternative for registries without OIDC support

Co-authored-by: Darcy Clarke <darcy@darcyclarke.me>