### PR TITLE
fix(publish): handle oidc exchange properly

### DIFF
--- a/src/registry-client/src/oidc.ts
+++ b/src/registry-client/src/oidc.ts
@@ -149,7 +149,7 @@ const fetchGitHubIdToken = async (
       },
     })
     log(`GitHub ID token response: status=${res.statusCode}`)
-    if (res.statusCode !== 200) {
+    if (res.statusCode < 200 || res.statusCode >= 300) {
       const body = await safeJson(res)
       log(
         `GitHub ID token error body: ${body ? JSON.stringify(redact(body)) : '(non-JSON response)'}`,
@@ -197,7 +197,7 @@ const exchangeToken = async (
       },
     })
     log(`Exchange response: status=${res.statusCode}`)
-    if (res.statusCode !== 200) {
+    if (res.statusCode < 200 || res.statusCode >= 300) {
       const body = await safeJson(res)
       log(
         `Exchange error body: ${body ? JSON.stringify(redact(body)) : '(non-JSON response)'}`,

--- a/src/registry-client/test/oidc.ts
+++ b/src/registry-client/test/oidc.ts
@@ -357,7 +357,36 @@ t.test(
   },
 )
 
-t.test('exchange returns undefined on non-200', async t => {
+t.test('exchange accepts 201 Created from registry', async t => {
+  process.env.GITHUB_ACTIONS = 'true'
+  process.env.NPM_ID_TOKEN = 'some-token'
+
+  const { oidc } = await t.mockImport<
+    typeof import('../src/oidc.ts')
+  >('../src/oidc.ts', {
+    '../src/auth.ts': mockAuth,
+    undici: createMockUndici(async () => ({
+      statusCode: 201,
+      body: {
+        json: async () => ({
+          token: 'created-token',
+          token_type: 'oidc',
+        }),
+      },
+    })),
+  })
+
+  const result = await oidc({
+    packageName: 'pkg',
+    registry: 'https://registry.npmjs.org/',
+  })
+  t.equal(result, 'Bearer created-token')
+  t.strictSame(runtimeTokensSet, [
+    ['https://registry.npmjs.org/', 'Bearer created-token'],
+  ])
+})
+
+t.test('exchange returns undefined on non-2xx', async t => {
   process.env.GITHUB_ACTIONS = 'true'
   process.env.NPM_ID_TOKEN = 'some-token'
 
@@ -383,7 +412,7 @@ t.test('exchange returns undefined on non-200', async t => {
   t.equal(runtimeTokensSet.length, 0)
 })
 
-t.test('exchange logs non-JSON body on non-200 response', async t => {
+t.test('exchange logs non-JSON body on non-2xx response', async t => {
   process.env.GITHUB_ACTIONS = 'true'
   process.env.NPM_ID_TOKEN = 'some-token'
 


### PR DESCRIPTION
Response status code was `201` from the token exchange & was getting dropped by the previous logic which was trying to match explicitly for `200`