### PR TITLE
fix: manifest drift post pack/publish lifecycle scripts

### DIFF
--- a/src/cli-sdk/src/commands/publish.ts
+++ b/src/cli-sdk/src/commands/publish.ts
@@ -236,6 +236,11 @@ const commandSingle = async (
     arg0: 'prepare',
   })
 
+  // Re-read the manifest after lifecycle scripts, which may have modified package.json.
+  const updatedManifest = conf.options.packageJson.read(manifestDir, {
+    reload: true,
+  })
+
   const {
     name,
     version,
@@ -246,7 +251,7 @@ const commandSingle = async (
     integrity,
     shasum,
     resolvedManifest,
-  } = await packTarball(manifest, manifestDir, conf)
+  } = await packTarball(updatedManifest, manifestDir, conf)
 
   await run({
     ...runOptions,


### PR DESCRIPTION
The [original fix](https://github.com/vltpkg/vltpkg/pull/1559) for this issue only addressed when `publishConfig.directory` was being used & not the base-case