### PR TITLE
Break out query selectors into nested docs pages

### DIFF
--- a/www/docs/src/content/docs/cli/selectors.mdx
+++ b/www/docs/src/content/docs/cli/selectors.mdx
@@ -5,7 +5,11 @@ sidebar:
   order: 3
 ---
 
-import { Code, LinkCard, CardGrid } from '@astrojs/starlight/components'
+import {
+  Code,
+  LinkCard,
+  CardGrid,
+} from '@astrojs/starlight/components'
 
 The vlt query syntax enables usage of CSS-selector-like strings to
 filter and select packages in your dependency graph.
@@ -89,11 +93,7 @@ Find all packages that depend on a vulnerable package:
 
 Find all dev-only dependencies that use eval:
 
-<Code
-  code="$ vlt query ':dev:eval'"
-  title="Terminal"
-  lang="bash"
-/>
+<Code code="$ vlt query ':dev:eval'" title="Terminal" lang="bash" />
 
 Combine multiple selectors:
 

--- a/www/docs/src/content/docs/cli/selectors.mdx
+++ b/www/docs/src/content/docs/cli/selectors.mdx
@@ -25,14 +25,14 @@ notably:
 
 ## Quick Reference
 
-| Category | Examples | Description |
-|---|---|---|
-| [Attribute Selectors](/cli/selectors/attribute-selectors) | `[name=foo]`, `[version^=2]` | Match by `package.json` metadata |
-| [Combinators](/cli/selectors/combinators) | `>`, ` `, `~` | Traverse the dependency graph |
-| [ID Selectors](/cli/selectors/id-selectors) | `#foo` | Shortcut for `[name=foo]` |
-| [Pseudo-class Selectors](/cli/selectors/pseudo-classes) | `:has()`, `:outdated()`, `:semver()` | Functional selectors with arguments |
-| [Pseudo-state Selectors](/cli/selectors/pseudo-states) | `:root`, `:workspace`, `:dev` | State-based selectors |
-| [Security Insights](/cli/selectors/security-insights) | `:malware`, `:cve()`, `:license()` | Security data from [Socket](https://socket.dev/) |
+| Category                                                  | Examples                             | Description                                      |
+| --------------------------------------------------------- | ------------------------------------ | ------------------------------------------------ |
+| [Attribute Selectors](/cli/selectors/attribute-selectors) | `[name=foo]`, `[version^=2]`         | Match by `package.json` metadata                 |
+| [Combinators](/cli/selectors/combinators)                 | `>`, ` `, `~`                        | Traverse the dependency graph                    |
+| [ID Selectors](/cli/selectors/id-selectors)               | `#foo`                               | Shortcut for `[name=foo]`                        |
+| [Pseudo-class Selectors](/cli/selectors/pseudo-classes)   | `:has()`, `:outdated()`, `:semver()` | Functional selectors with arguments              |
+| [Pseudo-state Selectors](/cli/selectors/pseudo-states)    | `:root`, `:workspace`, `:dev`        | State-based selectors                            |
+| [Security Insights](/cli/selectors/security-insights)     | `:malware`, `:cve()`, `:license()`   | Security data from [Socket](https://socket.dev/) |
 
 ## Selector Categories
 

--- a/www/docs/src/content/docs/cli/selectors.mdx
+++ b/www/docs/src/content/docs/cli/selectors.mdx
@@ -5,320 +5,100 @@ sidebar:
   order: 3
 ---
 
-## Supported Dependency Selector Syntax Reference
+import { Code, LinkCard, CardGrid } from '@astrojs/starlight/components'
 
-The vlt query syntax enable usage of css-selector-like strings to
-filter packages.
+The vlt query syntax enables usage of CSS-selector-like strings to
+filter and select packages in your dependency graph.
+
+<Code
+  code="$ vlt query ':root > [name^=@vltpkg]'"
+  title="Terminal"
+  lang="bash"
+/>
 
 Many of the common elements of the CSS language are available,
 notably:
 
-- `*` Universal selector, matches all selected items.
-- `&` Nesting selector, allows for nesting selectors.
-- `{}` Curly braces, when querying can be used to nest selectors.
+- `*` Universal selector — matches all selected items.
+- `&` Nesting selector — allows for nesting selectors.
+- `{}` Curly braces — when querying, can be used to nest selectors.
 
-Split by group of selectors below is the complete reference to
-supported elements.
+## Quick Reference
 
-### Attribute Selectors
+| Category | Examples | Description |
+|---|---|---|
+| [Attribute Selectors](/cli/selectors/attribute-selectors) | `[name=foo]`, `[version^=2]` | Match by `package.json` metadata |
+| [Combinators](/cli/selectors/combinators) | `>`, ` `, `~` | Traverse the dependency graph |
+| [ID Selectors](/cli/selectors/id-selectors) | `#foo` | Shortcut for `[name=foo]` |
+| [Pseudo-class Selectors](/cli/selectors/pseudo-classes) | `:has()`, `:outdated()`, `:semver()` | Functional selectors with arguments |
+| [Pseudo-state Selectors](/cli/selectors/pseudo-states) | `:root`, `:workspace`, `:dev` | State-based selectors |
+| [Security Insights](/cli/selectors/security-insights) | `:malware`, `:cve()`, `:license()` | Security data from [Socket](https://socket.dev/) |
 
-Attribute selectors are used to match a value found in the
-`package.json` metadata for each of the nodes being queried to a
-arbitrary value you choose.
+## Selector Categories
 
-- `[attr]` Matches elements with an `attr` property in its
-  `package.json`.
-- `[attr=value]` Matches elements with a property `attr` whose value
-  is exactly `value`.
-- `[attr^=value]` Matches elements with a property `attr` whose value
-  starts with `value`.
-- `[attr$=value]` Matches elements with a property `attr` whose value
-  ends with `value`.
-- `[attr~=value]` Matches elements with a property `attr` whose value
-  is a whitespace-separated list of words, one of which is exactly
-  `value`.
-- `[attr|=value]` Matches elements with a property `attr` whose value
-  is either `value` or starts with `value-`.
-- `[attr*=value]` Matches elements with a property `attr`.
-- `[attr=value i]` Case-insensitive flag, setting it will cause any
-  comparison to be case-insensitive.
-- `[attr=value s]` Case-sensitive flag, setting it will cause
-  comparisons to be case-sensitive, this is the default behavior.
+<CardGrid>
+  <LinkCard
+    title="Attribute Selectors"
+    description="Match packages by package.json fields like name, version, or any custom property."
+    href="/cli/selectors/attribute-selectors"
+  />
+  <LinkCard
+    title="Combinators"
+    description="Traverse the dependency graph with child, descendant, and sibling combinators."
+    href="/cli/selectors/combinators"
+  />
+  <LinkCard
+    title="ID Selectors"
+    description="Quick shorthand to select packages by name."
+    href="/cli/selectors/id-selectors"
+  />
+  <LinkCard
+    title="Pseudo-class Selectors"
+    description="Functional selectors like :has(), :outdated(), :semver(), :type(), and more."
+    href="/cli/selectors/pseudo-classes"
+  />
+  <LinkCard
+    title="Pseudo-state Selectors"
+    description="State-based selectors like :root, :workspace, :dev, :prod, :private."
+    href="/cli/selectors/pseudo-states"
+  />
+  <LinkCard
+    title="Security Insights"
+    description="Socket-powered security selectors for malware, CVEs, obfuscation, and more."
+    href="/cli/selectors/security-insights"
+  />
+</CardGrid>
 
-### Combinators
+## Examples
 
-- `>` Child combinator, matches packages that are direct dependencies
-  of the previously selected nodes.
-- ` ` Descendant combinator, matches all packages that are direct &
-  transitive dependencies of the previously selected nodes.
-- `~` Sibling combinator, matches packages that are direct
-  dependencies of all dependents of the previously selected nodes.
+Find all outdated direct dependencies:
 
-### ID Selectors
+<Code
+  code="$ vlt query ':root > :outdated'"
+  title="Terminal"
+  lang="bash"
+/>
 
-Identifiers are a shortcut to retrieving packages by name,
-unfortunately this shortcut only works for unscoped packages, with
-that in mind it's advised to rely on using **Attribute selectors**
-(showed above) instead.
+Find all packages that depend on a vulnerable package:
 
-e.g: `#foo` is the same as `[name=foo]`
+<Code
+  code="$ vlt query ':has(> :cve(*))'"
+  title="Terminal"
+  lang="bash"
+/>
 
-### Pseudo Class Selectors
+Find all dev-only dependencies that use eval:
 
-- `:attr(key, [attr=value])` The attribute pseudo-class allows for
-  selecting packages based on nested properties of its `package.json`
-  metadata. As an example, here is a query that filters only packages
-  that declares an optional peer dependency named `foo`:
-  `:attr(peerDependenciesMeta, foo, [optional=true])`
-- `:has(<selector-list>)` Matches only packages that have valid
-  results for the selector expression used. As an example, here is a
-  query that matches all packages that have a peer dependency on
-  `react`: `:has(.peer[name=react])`
-- `:host(<context>)` Switches the current graph context to a new set
-  of graphs loaded from a specific host context. This selector allows
-  querying across multiple projects or switching to different project
-  scopes. The context parameter can be:
-  - A specific project folder path (e.g., `"file:~/my-project"`)
-  - The special `local` context which loads all configured projects
-    from your vlt dashboard Examples with CLI commands:
-  - `vlt query ':host(local) :malware'` - Find malware across all
-    configured projects
-  - `vlt version patch --scope=':host("file:~/tmp/test-vite")'`
-    - Bump version for a specific project
-  - `vlt pkg pick name version --scope=':host(local) > :root > *'`
-    - Get name and version of all direct dependencies across all
-      configured projects
-  - `vlt query ':host("file:~/my-app") :outdated'` - Find outdated
-    packages in a specific project
-- `:is(<forgiving-selector-list>)` Useful for writing large selectors
-  in a more compact form, the `:is()` pseudo-class takes a selector
-  list as its arguments and selects any element that can be selected
-  by one of the selectors in that list. As an example, let's say I
-  want to select packages named `a` & `b` that are direct dependencies
-  of my project root: `:root > [name=a], :root > [name=b]` using the
-  `:is()` pseudo-class, that same expression can be shortened to:
-  `:root > :is([name=a], [name=b])`. Similar to the css pseudo-class
-  of the same name, this selector has a forgiving behavior regarding
-  its nested selector list ignoring any usage of non-existing ids,
-  classes, combinators, operators and pseudo-selectors.
-- `:not(<selector-list>)` Negation pseudo-class, select packages that
-  do not match a list of selectors.
-- `:outdated(<type>)` Matches packages that are outdated, the type
-  parameter is optional and can be one of the following:
-  - `any` (default) a version exists that is greater than the current
-    one
-  - `in-range` a version exists that is greater than the current one,
-    and satisfies at least one if its parent's dependencies
-  - `out-of-range` a version exists that is greater than the current
-    one, does not satisfy at least one of its parent's dependencies
-  - `major` a version exists that is a semver major greater than the
-    current one
-  - `minor` a version exists that is a semver minor greater than the
-    current one
-  - `patch` a version exists that is a semver patch greater than the
-    current one
-- `:published(<date>)` Matches packages based on their publication
-  date. The date parameter can be prefixed with a comparator (`>`,
-  `<`, `>=`, `<=`). If no comparator is provided, it will match exact
-  dates. Please note that the value parameter needs to be quoted if
-  using a comparator. Examples:
-  - `:published(2024-01-01)` - Matches packages published exactly on
-    January 1st, 2024
-  - `:published(">2024")` - Matches packages published after the year
-    2024
-  - `:published("<=2023-12-31")` - Matches packages published on or
-    before December 31st, 2023
-- `:semver(<value>, <function>, <custom-attribute-selector>)` Matches
-  packages based on a semver value, e.g, to retrieve all packages that
-  have a `version` satisfied by the semver value `^1.0.0`:
-  `:semver(^1.0.0)`. It's also possible to define the type of semver
-  comparison function to use by defining a second parameter, e.g:
-  `:semver(^1.0.0, eq)` for an exact match, valid comparison types
-  are: `eq`, `neq`, `gt`, `gte`, `lt`, `lte`, `satisfies` (default). A
-  third parameter allows for specifying a different `package.json`
-  property to use for the comparison, e.g:
-  `:semver(^22, satisfies, :attr(engines, [node]))` for comparing the
-  value of `engines.node`.
-- `:spec(<specifier>)` Matches edges where the package specifier
-  (bareSpec) equals the provided value. This selector allows filtering
-  dependencies by their exact specification string. Examples:
-  - `:spec(^1.0.0)` - Matches edges with semver range `^1.0.0`
-  - `:spec("*")` - Matches edges with wildcard specifier `*`
-  - `:spec("catalog:")` - Matches catalog protocol dependencies
-- `:path("<glob>")` Matches workspace & file packages based on their
-  file path relative to the project root using glob patterns. Path
-  patterns must be quoted strings. Examples:
-  - `:path("*")` - Matches all workspace and file packages found
-  - `:path("./packages/foo")` - Matches a specific dependency path
-  - `:path("packages/**")` - Matches all packages in the packages
-    directory
-- `:type(registry|file|git|remote|workspace)` Matches packages based
-  on their type, e.g, to retrieve all git dependencies: `:type(git)`.
-- `:diff(<commitish>)` Matches packages whose files have changed
-  between the current working tree and the specified git commitish
-  reference. Uses `git diff --name-only` to determine changed files,
-  then maps them to packages by their file path location. When called
-  with no argument, defaults to `HEAD` (uncommitted changes).
-  Examples:
-  - `:diff()` - Packages with uncommitted changes (defaults to HEAD)
-  - `:diff(main)` - Packages changed since the main branch
-  - `:diff(HEAD~1)` - Packages changed since the last commit
-  - `:diff("v1.0.0")` - Packages changed since the v1.0.0 tag
-  - `:workspace:diff(main)` - Only workspaces that have changed
-  - `:has(> :diff(main))` - Packages that depend on changed packages
+<Code
+  code="$ vlt query ':dev:eval'"
+  title="Terminal"
+  lang="bash"
+/>
 
-### Pseudo States
+Combine multiple selectors:
 
-- `:private` Matches packages that have the property `private` set on
-  their `package.json` file.
-- `:empty` Matches packages that have no dependencies installed.
-- `:root` Returns the root node, that represents the package defined
-  at the top-level `package.json` of your project folder.
-- `:scope` Returns the current scope of a given selector
-- `:project` Returns both the root node (as defined below) along with
-  any workspace declared in your project.
-- `:workspace` Matches the current project workspaces (listed in your
-  `vlt.json` file).
-- `:prod` Matches prod dependencies to your current project.
-- `:dev` Matches packages that are only used as dev dependencies in
-  your current project.
-- `:optional` Matches packages that are optional to your current
-  project.
-- `:peer` Matches peer dependencies to your current project.
-- `:link` Matches linked packages only.
-- `:outdated` Matches packages that have any newer version available
-  (equivalent to `:outdated(any)`).
-- `:scanned` Matches packages that have insight security metadata.
-
-### Security Insights Pseudo Classes & States
-
-The following pseudo-selectors rely on security data provided by
-[Socket](https://socket.dev/), the usage of any of these selectors is
-going to require a network call to hydrate package report data. Keep
-in mind that this is going to slow down end-user query usage since the
-security data needs to be fetched prior to a `Query` instantiation.
-
-- `:abandoned` Matches packages that were published by an npm account
-  that no longer exists.
-- `:confused` Matches packages affected by manifest confusion. This
-  could be malicious or caused by an error when publishing the
-  package.
-- `:cve(<id>)` Matches packages that have a CVE alert with the
-  specified CVE ID. The ID parameter is required and should be a valid
-  CVE identifier (e.g., `CVE-2023-1234`). This selector can be used to
-  find packages affected by specific known vulnerabilities.
-- `:cwe(<id>)` Matches packages that have a CWE alert with the
-  specified CWE ID. The ID parameter is required and should be a valid
-  CWE identifier (e.g., `CWE-79`).
-- `:debug` Matches packages that use debug, reflection and dynamic
-  code execution features.
-- `:deprecated` Matches packages marked as deprecated. This could
-  indicate that a single version should not be used, or that the
-  package is no longer maintained and any new vulnerabilities will not
-  be fixed.
-- `:dynamic` Matches packages that uses dynamic imports.
-- `:entropic` Matches packages that contains high entropic strings.
-  This could be a sign of encrypted data, leaked secrets or obfuscated
-  code.
-- `:env` Matches packages that accesses environment variables, which
-  may be a sign of credential stuffing or data theft.
-- `:eval` Matches packages that use dynamic code execution (e.g.,
-  eval()), which is a dangerous practice. This can prevent the code
-  from running in certain environments and increases the risk that the
-  code may contain exploits or malicious behavior.
-- `:fs` Matches packages that accesses the file system, and could
-  potentially read sensitive data.
-- `:license(<type>)` Matches packages based on different potential
-  license issues:
-  - `:license(unlicensed)` Matches packages with no license.
-  - `:license(misc)` Matches packages with fine-grained problems.
-  - `:license(restricted)` Matches packages with a license that is not
-    permissive.
-  - `:license(ambiguous)` Matches packages with ambiguous licensing.
-  - `:license(copyleft)` Matches packages with a copyleft license.
-  - `:license(unknown)` Matches packages that have potential license
-    data but its type could not be determined.
-  - `:license(none)` Matches packages that have no license data.
-  - `:license(exception)` Matches packages that have SPDX license
-    exception.
-- `:malware` Matches packages that may contain malware with severity
-  > = medium (critical, high, medium but excludes low severity
-  > alerts).
-- `:malware(<type>)` Matches packages that may contain malware of a
-  specific severity level. The type parameter can be one of the
-  following:
-  - `critical` or `0`
-  - `high` or `1`
-  - `medium` or `2`
-  - `low` or `3`
-  - Supports comparators: `:malware(">1")`, `:malware(">=medium")`
-- `:minified` Matches packages that contain minified code. This may be
-  harmless in some cases where minified code is included in packaged
-  libraries.
-- `:native` Matches packages that contain native code (e.g., compiled
-  binaries or shared libraries). Including native code can obscure
-  malicious behavior.
-- `:network` Matches packages that access the network.
-- `:obfuscated` Matches packages that use obfuscated files,
-  intentionally packed to hide their behavior. This could be a sign of
-  malware.
-- `:scanned` Matches packages that have insight security metadata.
-- `:squat` Matches packages with names similar to other popular
-  packages at any severity level (equivalent to `:not(:squat(none))`).
-- `:score` Matches packages that have any security score data
-  available (equivalent to `:scanned`).
-- `:license` Matches packages that have any license defined
-  (equivalent to `:not(:license(none))`).
-- `:published` Matches packages that have published metadata available
-  (useful for filtering registry packages).
-- `:score(<rate>, <kind>)` Matches packages based on their security
-  score. The rate parameter is required and should be a value between
-  0 and 100 (or 0 and 1). The rate parameter can be prefixed with a
-  comparator (`>`, `<`, `>=`, `<=`). If no comparator is provided, it
-  will match exact scores. The kind parameter is optional and defaults
-  to 'overall'. Valid kinds are: 'overall', 'license', 'maintenance',
-  'quality', 'supplyChain', and 'vulnerability'. Examples:
-  - `:score(80)` - Matches packages with exactly 0.8 overall score
-  - `:score(">0.8")` - Matches packages with overall score greater
-    than 0.8
-  - `:score("<=0.5", "maintenance")` - Matches packages with
-    maintenance score less than or equal to 0.5
-- `:scripts` Matches packages that have scripts that are run when the
-  package is installed. The majority of malware in npm is hidden in
-  install scripts.
-- `:severity(<level>)` Matches packages based on the severity level of
-  any attached CVE. The level parameter is required and can be one of
-  the following:
-  - `critical` or `0`
-  - `high` or `1`
-  - `medium` or `2`
-  - `low` or `3`
-  - Supports comparators: `:severity(">1")`, `:severity(">=medium")`
-- `:shell` Matches packages that accesses the system shell. Accessing
-  the system shell increases the risk of executing arbitrary code.
-- `:shrinkwrap` Matches packages that contains a shrinkwrap file. This
-  may allow the package to bypass normal install procedures.
-- `:squat(<type>)` Matches packages with names similar to other
-  popular packages and may not be the package you want. The type
-  parameter is required and can be one of the following:
-  - `critical` or `0`
-  - `medium` or `2`
-- `:suspicious` Matches packages that may have its GitHub repository
-  artificially inflated with stars (from bots, crowdsourcing, etc.).
-- `:tracker` Matches packages that contains telemetry which tracks how
-  it is used.
-- `:trivial` Matches packages that have less than 10 lines of code.
-  These packages are easily copied into your own project and may not
-  warrant the additional supply chain risk of an external dependency.
-- `:undesirable` Matches packages that are a joke, parody, or includes
-  undocumented or hidden behavior unrelated to its primary function.
-- `:unknown` Matches packages that have a new npm collaborator
-  publishing a version of the package for the first time. New
-  collaborators are usually benign additions to a project, but do
-  indicate a change to the security surface area of a package.
-- `:unmaintained` Matches packages that have not been updated in more
-  than 5 years and may be unmaintained.
-- `:unpopular` Matches packages that are not very popular.
-- `:unstable` Matches packages with unstable ownership. This indicates
-  a new collaborator has begun publishing package versions. Package
-  stability and security risk may be elevated.
+<Code
+  code="$ vlt query ':workspace > :type(git), :root > :outdated(major)'"
+  title="Terminal"
+  lang="bash"
+/>

--- a/www/docs/src/content/docs/cli/selectors/attribute-selectors.mdx
+++ b/www/docs/src/content/docs/cli/selectors/attribute-selectors.mdx
@@ -14,17 +14,17 @@ but operate on package metadata fields instead of HTML attributes.
 
 ## Syntax
 
-| Selector | Description |
-|---|---|
-| `[attr]` | Has the property `attr` |
-| `[attr=value]` | Property `attr` exactly equals `value` |
-| `[attr^=value]` | Property `attr` starts with `value` |
-| `[attr$=value]` | Property `attr` ends with `value` |
-| `[attr~=value]` | Property `attr` is a whitespace-separated list containing `value` |
-| `[attr\|=value]` | Property `attr` equals `value` or starts with `value-` |
-| `[attr*=value]` | Property `attr` contains `value` |
-| `[attr=value i]` | Case-insensitive comparison |
-| `[attr=value s]` | Case-sensitive comparison (default) |
+| Selector         | Description                                                       |
+| ---------------- | ----------------------------------------------------------------- |
+| `[attr]`         | Has the property `attr`                                           |
+| `[attr=value]`   | Property `attr` exactly equals `value`                            |
+| `[attr^=value]`  | Property `attr` starts with `value`                               |
+| `[attr$=value]`  | Property `attr` ends with `value`                                 |
+| `[attr~=value]`  | Property `attr` is a whitespace-separated list containing `value` |
+| `[attr\|=value]` | Property `attr` equals `value` or starts with `value-`            |
+| `[attr*=value]`  | Property `attr` contains `value`                                  |
+| `[attr=value i]` | Case-insensitive comparison                                       |
+| `[attr=value s]` | Case-sensitive comparison (default)                               |
 
 ## Examples
 
@@ -158,7 +158,7 @@ For nested `package.json` properties (like `engines.node` or
 
 ## See also
 
-- [`:attr()` pseudo-class](/cli/selectors/pseudo-classes/attr) —
-  match nested `package.json` properties
+- [`:attr()` pseudo-class](/cli/selectors/pseudo-classes/attr) — match
+  nested `package.json` properties
 - [ID Selectors](/cli/selectors/id-selectors) — shorthand for
   `[name=value]`

--- a/www/docs/src/content/docs/cli/selectors/attribute-selectors.mdx
+++ b/www/docs/src/content/docs/cli/selectors/attribute-selectors.mdx
@@ -1,0 +1,164 @@
+---
+title: Attribute Selectors
+sidebar:
+  label: Attribute Selectors
+  order: 1
+---
+
+import { Code } from '@astrojs/starlight/components'
+
+Attribute selectors match packages based on values found in their
+`package.json` metadata. They work similarly to
+[CSS attribute selectors](https://developer.mozilla.org/en-US/docs/Web/CSS/Attribute_selectors)
+but operate on package metadata fields instead of HTML attributes.
+
+## Syntax
+
+| Selector | Description |
+|---|---|
+| `[attr]` | Has the property `attr` |
+| `[attr=value]` | Property `attr` exactly equals `value` |
+| `[attr^=value]` | Property `attr` starts with `value` |
+| `[attr$=value]` | Property `attr` ends with `value` |
+| `[attr~=value]` | Property `attr` is a whitespace-separated list containing `value` |
+| `[attr\|=value]` | Property `attr` equals `value` or starts with `value-` |
+| `[attr*=value]` | Property `attr` contains `value` |
+| `[attr=value i]` | Case-insensitive comparison |
+| `[attr=value s]` | Case-sensitive comparison (default) |
+
+## Examples
+
+### Match by name
+
+Select a package with an exact name:
+
+<Code
+  code="$ vlt query '[name=react]'"
+  title="Terminal"
+  lang="bash"
+/>
+
+Select all scoped packages:
+
+<Code
+  code={`$ vlt query '[name^="@"]'`}
+  title="Terminal"
+  lang="bash"
+/>
+
+Select packages in the `@vltpkg` scope:
+
+<Code
+  code={`$ vlt query '[name^="@vltpkg"]'`}
+  title="Terminal"
+  lang="bash"
+/>
+
+### Match by version
+
+Select packages on a specific version:
+
+<Code
+  code="$ vlt query '[version=1.0.0]'"
+  title="Terminal"
+  lang="bash"
+/>
+
+Select packages with major version 2:
+
+<Code
+  code="$ vlt query '[version^=2]'"
+  title="Terminal"
+  lang="bash"
+/>
+
+### Match by any property
+
+Select packages that have a `repository` field:
+
+<Code
+  code="$ vlt query '[repository]'"
+  title="Terminal"
+  lang="bash"
+/>
+
+Select packages with a specific license:
+
+<Code
+  code="$ vlt query '[license=MIT]'"
+  title="Terminal"
+  lang="bash"
+/>
+
+Select packages whose description mentions "parser":
+
+<Code
+  code="$ vlt query '[description*=parser]'"
+  title="Terminal"
+  lang="bash"
+/>
+
+### Case-insensitive matching
+
+Find packages with "React" in the description regardless of case:
+
+<Code
+  code="$ vlt query '[description*=react i]'"
+  title="Terminal"
+  lang="bash"
+/>
+
+### What gets selected
+
+Given a project with these dependencies:
+
+```
+my-app
+├── @vltpkg/cli@1.0.0
+├── react@18.2.0
+├── react-dom@18.2.0
+└── typescript@5.3.0
+```
+
+The query `[name^=react]` selects:
+
+```
+my-app
+├── @vltpkg/cli@1.0.0
+├── react@18.2.0          ✅ name starts with "react"
+├── react-dom@18.2.0      ✅ name starts with "react"
+└── typescript@5.3.0
+```
+
+## Combining with other selectors
+
+Attribute selectors can be combined with
+[combinators](/cli/selectors/combinators) and
+[pseudo-classes](/cli/selectors/pseudo-classes):
+
+<Code
+  code="$ vlt query ':root > [license=MIT]'"
+  title="Terminal"
+  lang="bash"
+/>
+
+This selects only direct dependencies with an MIT license.
+
+## Nested properties
+
+For nested `package.json` properties (like `engines.node` or
+`peerDependenciesMeta`), use the
+[`:attr()` pseudo-class](/cli/selectors/pseudo-classes/attr):
+
+<Code
+  code="$ vlt query ':attr(peerDependenciesMeta, foo, [optional=true])'"
+  title="Terminal"
+  lang="bash"
+/>
+
+## See also
+
+- [`:attr()` pseudo-class](/cli/selectors/pseudo-classes/attr) —
+  match nested `package.json` properties
+- [ID Selectors](/cli/selectors/id-selectors) — shorthand for
+  `[name=value]`

--- a/www/docs/src/content/docs/cli/selectors/combinators.mdx
+++ b/www/docs/src/content/docs/cli/selectors/combinators.mdx
@@ -25,11 +25,7 @@ but describe dependency relationships instead of DOM hierarchy.
 Matches packages that are **direct dependencies** of the previously
 selected nodes. Only one level deep.
 
-<Code
-  code="$ vlt query ':root > *'"
-  title="Terminal"
-  lang="bash"
-/>
+<Code code="$ vlt query ':root > *'" title="Terminal" lang="bash" />
 
 Given this dependency graph:
 

--- a/www/docs/src/content/docs/cli/selectors/combinators.mdx
+++ b/www/docs/src/content/docs/cli/selectors/combinators.mdx
@@ -1,0 +1,171 @@
+---
+title: Combinators
+sidebar:
+  label: Combinators
+  order: 2
+---
+
+import { Code } from '@astrojs/starlight/components'
+
+Combinators define relationships between packages in the dependency
+graph. They work similarly to
+[CSS combinators](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_selectors/Selectors_and_combinators#combinators)
+but describe dependency relationships instead of DOM hierarchy.
+
+## Syntax
+
+| Combinator | Name | Description |
+|---|---|---|
+| `>` | Child | Direct dependencies of the previously selected nodes |
+| ` ` (space) | Descendant | All direct & transitive dependencies |
+| `~` | Sibling | Direct dependencies of all dependents of the previously selected nodes |
+
+## Child combinator `>`
+
+Matches packages that are **direct dependencies** of the previously
+selected nodes. Only one level deep.
+
+<Code
+  code="$ vlt query ':root > *'"
+  title="Terminal"
+  lang="bash"
+/>
+
+Given this dependency graph:
+
+```
+my-app
+├── react@18.2.0
+│   └── loose-envify@1.4.0
+│       └── js-tokens@4.0.0
+└── typescript@5.3.0
+```
+
+`:root > *` selects only direct dependencies:
+
+```
+my-app
+├── react@18.2.0          ✅ direct dependency of root
+│   └── loose-envify@1.4.0
+│       └── js-tokens@4.0.0
+└── typescript@5.3.0      ✅ direct dependency of root
+```
+
+### Chaining child combinators
+
+You can chain `>` to select at specific depths:
+
+<Code
+  code="$ vlt query ':root > * > *'"
+  title="Terminal"
+  lang="bash"
+/>
+
+```
+my-app
+├── react@18.2.0
+│   └── loose-envify@1.4.0    ✅ grandchild of root
+│       └── js-tokens@4.0.0
+└── typescript@5.3.0
+```
+
+## Descendant combinator (space)
+
+Matches **all** packages that are direct or transitive dependencies
+of the previously selected nodes. Any depth.
+
+<Code
+  code="$ vlt query ':root [name=js-tokens]'"
+  title="Terminal"
+  lang="bash"
+/>
+
+```
+my-app
+├── react@18.2.0
+│   └── loose-envify@1.4.0
+│       └── js-tokens@4.0.0   ✅ transitive dependency of root
+└── typescript@5.3.0
+```
+
+### Descendant vs. child
+
+<Code
+  code={`# Direct deps only
+$ vlt query ':root > [name=js-tokens]'
+# → no results (js-tokens is not a direct dependency)
+
+# All transitive deps
+$ vlt query ':root [name=js-tokens]'
+# → js-tokens@4.0.0 (found transitively)`}
+  title="Terminal"
+  lang="bash"
+/>
+
+## Sibling combinator `~`
+
+Matches packages that are **direct dependencies of all dependents**
+of the previously selected nodes. In other words: "other packages
+that share the same parent."
+
+<Code
+  code="$ vlt query '[name=react] ~ *'"
+  title="Terminal"
+  lang="bash"
+/>
+
+Given:
+
+```
+my-app
+├── react@18.2.0
+├── react-dom@18.2.0
+└── typescript@5.3.0
+```
+
+`[name=react] ~ *` selects siblings of react (other direct deps of
+the same parent):
+
+```
+my-app
+├── react@18.2.0
+├── react-dom@18.2.0       ✅ sibling of react
+└── typescript@5.3.0       ✅ sibling of react
+```
+
+## Combining with selectors
+
+Combinators are most powerful when combined with
+[attribute selectors](/cli/selectors/attribute-selectors) and
+[pseudo-classes](/cli/selectors/pseudo-classes):
+
+Find all direct dependencies that are outdated:
+
+<Code
+  code="$ vlt query ':root > :outdated'"
+  title="Terminal"
+  lang="bash"
+/>
+
+Find workspaces that depend on packages with CVEs:
+
+<Code
+  code="$ vlt query ':workspace > :cve(*)'"
+  title="Terminal"
+  lang="bash"
+/>
+
+Find all transitive dependencies of a specific package:
+
+<Code
+  code="$ vlt query '[name=react] *'"
+  title="Terminal"
+  lang="bash"
+/>
+
+## See also
+
+- [Pseudo-state Selectors](/cli/selectors/pseudo-states) — `:root`,
+  `:project`, `:workspace`
+- [`:has()` pseudo-class](/cli/selectors/pseudo-classes/has) — filter
+  by descendant relationships

--- a/www/docs/src/content/docs/cli/selectors/combinators.mdx
+++ b/www/docs/src/content/docs/cli/selectors/combinators.mdx
@@ -14,11 +14,11 @@ but describe dependency relationships instead of DOM hierarchy.
 
 ## Syntax
 
-| Combinator | Name | Description |
-|---|---|---|
-| `>` | Child | Direct dependencies of the previously selected nodes |
-| ` ` (space) | Descendant | All direct & transitive dependencies |
-| `~` | Sibling | Direct dependencies of all dependents of the previously selected nodes |
+| Combinator  | Name       | Description                                                            |
+| ----------- | ---------- | ---------------------------------------------------------------------- |
+| `>`         | Child      | Direct dependencies of the previously selected nodes                   |
+| ` ` (space) | Descendant | All direct & transitive dependencies                                   |
+| `~`         | Sibling    | Direct dependencies of all dependents of the previously selected nodes |
 
 ## Child combinator `>`
 
@@ -71,8 +71,8 @@ my-app
 
 ## Descendant combinator (space)
 
-Matches **all** packages that are direct or transitive dependencies
-of the previously selected nodes. Any depth.
+Matches **all** packages that are direct or transitive dependencies of
+the previously selected nodes. Any depth.
 
 <Code
   code="$ vlt query ':root [name=js-tokens]'"
@@ -96,17 +96,18 @@ $ vlt query ':root > [name=js-tokens]'
 # → no results (js-tokens is not a direct dependency)
 
 # All transitive deps
+
 $ vlt query ':root [name=js-tokens]'
+
 # → js-tokens@4.0.0 (found transitively)`}
-  title="Terminal"
-  lang="bash"
-/>
+
+title="Terminal" lang="bash" />
 
 ## Sibling combinator `~`
 
-Matches packages that are **direct dependencies of all dependents**
-of the previously selected nodes. In other words: "other packages
-that share the same parent."
+Matches packages that are **direct dependencies of all dependents** of
+the previously selected nodes. In other words: "other packages that
+share the same parent."
 
 <Code
   code="$ vlt query '[name=react] ~ *'"
@@ -123,8 +124,8 @@ my-app
 └── typescript@5.3.0
 ```
 
-`[name=react] ~ *` selects siblings of react (other direct deps of
-the same parent):
+`[name=react] ~ *` selects siblings of react (other direct deps of the
+same parent):
 
 ```
 my-app

--- a/www/docs/src/content/docs/cli/selectors/id-selectors.mdx
+++ b/www/docs/src/content/docs/cli/selectors/id-selectors.mdx
@@ -7,8 +7,8 @@ sidebar:
 
 import { Code } from '@astrojs/starlight/components'
 
-ID selectors are a shorthand for selecting packages by name. They
-work like
+ID selectors are a shorthand for selecting packages by name. They work
+like
 [CSS ID selectors](https://developer.mozilla.org/en-US/docs/Web/CSS/ID_selectors)
 but match the `name` field in `package.json`.
 
@@ -20,12 +20,10 @@ but match the `name` field in `package.json`.
 
 This is equivalent to `[name=package-name]`.
 
-:::caution
-ID selectors only work for **unscoped** packages. For scoped
-packages (e.g. `@vltpkg/cli`), use
+:::caution ID selectors only work for **unscoped** packages. For
+scoped packages (e.g. `@vltpkg/cli`), use
 [attribute selectors](/cli/selectors/attribute-selectors) instead:
-`[name=@vltpkg/cli]`.
-:::
+`[name=@vltpkg/cli]`. :::
 
 ## Examples
 

--- a/www/docs/src/content/docs/cli/selectors/id-selectors.mdx
+++ b/www/docs/src/content/docs/cli/selectors/id-selectors.mdx
@@ -29,11 +29,7 @@ scoped packages (e.g. `@vltpkg/cli`), use
 
 Select a package by name:
 
-<Code
-  code="$ vlt query '#react'"
-  title="Terminal"
-  lang="bash"
-/>
+<Code code="$ vlt query '#react'" title="Terminal" lang="bash" />
 
 This is the same as:
 
@@ -47,19 +43,11 @@ This is the same as:
 
 Find all dependencies of `react`:
 
-<Code
-  code="$ vlt query '#react > *'"
-  title="Terminal"
-  lang="bash"
-/>
+<Code code="$ vlt query '#react > *'" title="Terminal" lang="bash" />
 
 Find direct deps that have `react` as a sibling:
 
-<Code
-  code="$ vlt query '#react ~ *'"
-  title="Terminal"
-  lang="bash"
-/>
+<Code code="$ vlt query '#react ~ *'" title="Terminal" lang="bash" />
 
 ### Combining with pseudo-classes
 

--- a/www/docs/src/content/docs/cli/selectors/id-selectors.mdx
+++ b/www/docs/src/content/docs/cli/selectors/id-selectors.mdx
@@ -1,0 +1,87 @@
+---
+title: ID Selectors
+sidebar:
+  label: ID Selectors
+  order: 3
+---
+
+import { Code } from '@astrojs/starlight/components'
+
+ID selectors are a shorthand for selecting packages by name. They
+work like
+[CSS ID selectors](https://developer.mozilla.org/en-US/docs/Web/CSS/ID_selectors)
+but match the `name` field in `package.json`.
+
+## Syntax
+
+```
+#package-name
+```
+
+This is equivalent to `[name=package-name]`.
+
+:::caution
+ID selectors only work for **unscoped** packages. For scoped
+packages (e.g. `@vltpkg/cli`), use
+[attribute selectors](/cli/selectors/attribute-selectors) instead:
+`[name=@vltpkg/cli]`.
+:::
+
+## Examples
+
+Select a package by name:
+
+<Code
+  code="$ vlt query '#react'"
+  title="Terminal"
+  lang="bash"
+/>
+
+This is the same as:
+
+<Code
+  code="$ vlt query '[name=react]'"
+  title="Terminal"
+  lang="bash"
+/>
+
+### Combining with combinators
+
+Find all dependencies of `react`:
+
+<Code
+  code="$ vlt query '#react > *'"
+  title="Terminal"
+  lang="bash"
+/>
+
+Find direct deps that have `react` as a sibling:
+
+<Code
+  code="$ vlt query '#react ~ *'"
+  title="Terminal"
+  lang="bash"
+/>
+
+### Combining with pseudo-classes
+
+Check if a specific package is outdated:
+
+<Code
+  code="$ vlt query '#typescript:outdated'"
+  title="Terminal"
+  lang="bash"
+/>
+
+## When to use attribute selectors instead
+
+Use `[name=value]` instead of `#value` when:
+
+- The package is scoped: `[name=@vltpkg/cli]`
+- You need partial matching: `[name^=react]` (starts with "react")
+- You need case-insensitive matching: `[name=React i]`
+
+## See also
+
+- [Attribute Selectors](/cli/selectors/attribute-selectors) — full
+  attribute matching syntax

--- a/www/docs/src/content/docs/cli/selectors/pseudo-classes/attr.mdx
+++ b/www/docs/src/content/docs/cli/selectors/pseudo-classes/attr.mdx
@@ -1,7 +1,7 @@
 ---
-title: ":attr()"
+title: ':attr()'
 sidebar:
-  label: ":attr()"
+  label: ':attr()'
   order: 1
 ---
 
@@ -110,5 +110,5 @@ Find direct dependencies that have a `build` script:
 
 - [Attribute Selectors](/cli/selectors/attribute-selectors) —
   top-level property matching
-- [`:semver()`](/cli/selectors/pseudo-classes/semver) — compare
-  semver values in nested properties
+- [`:semver()`](/cli/selectors/pseudo-classes/semver) — compare semver
+  values in nested properties

--- a/www/docs/src/content/docs/cli/selectors/pseudo-classes/attr.mdx
+++ b/www/docs/src/content/docs/cli/selectors/pseudo-classes/attr.mdx
@@ -1,0 +1,114 @@
+---
+title: ":attr()"
+sidebar:
+  label: ":attr()"
+  order: 1
+---
+
+import { Code } from '@astrojs/starlight/components'
+
+The `:attr()` pseudo-class selects packages based on **nested
+properties** of their `package.json` metadata. While
+[attribute selectors](/cli/selectors/attribute-selectors) match
+top-level fields, `:attr()` lets you drill into nested objects.
+
+## Syntax
+
+```
+:attr(key, [attr=value])
+:attr(key, nestedKey, [attr=value])
+```
+
+Arguments are a path of property keys, ending with a standard
+attribute selector.
+
+## Examples
+
+### Optional peer dependencies
+
+Select packages that declare `foo` as an optional peer dependency:
+
+<Code
+  code="$ vlt query ':attr(peerDependenciesMeta, foo, [optional=true])'"
+  title="Terminal"
+  lang="bash"
+/>
+
+This is equivalent to checking:
+
+```json
+{
+  "peerDependenciesMeta": {
+    "foo": {
+      "optional": true
+    }
+  }
+}
+```
+
+### Engine requirements
+
+Select packages that have a `node` engine requirement:
+
+<Code
+  code="$ vlt query ':attr(engines, [node])'"
+  title="Terminal"
+  lang="bash"
+/>
+
+### Scripts
+
+Select packages that have a `build` script:
+
+<Code
+  code="$ vlt query ':attr(scripts, [build])'"
+  title="Terminal"
+  lang="bash"
+/>
+
+Select packages that have a `test` script using `vitest`:
+
+<Code
+  code="$ vlt query ':attr(scripts, [test*=vitest])'"
+  title="Terminal"
+  lang="bash"
+/>
+
+### What gets selected
+
+Given this dependency graph:
+
+```
+my-app
+├── react@18.2.0
+│   └── loose-envify@1.4.0  ← has scripts.postinstall
+├── typescript@5.3.0         ← has engines.node
+└── vite@5.0.0               ← has engines.node
+```
+
+The query `:attr(engines, [node])` selects:
+
+```
+my-app
+├── react@18.2.0
+│   └── loose-envify@1.4.0
+├── typescript@5.3.0          ✅ has engines.node
+└── vite@5.0.0                ✅ has engines.node
+```
+
+### Combining with combinators
+
+Find direct dependencies that have a `build` script:
+
+<Code
+  code="$ vlt query ':project > :attr(scripts, [build])'"
+  title="Terminal"
+  lang="bash"
+/>
+
+## See also
+
+- [Attribute Selectors](/cli/selectors/attribute-selectors) —
+  top-level property matching
+- [`:semver()`](/cli/selectors/pseudo-classes/semver) — compare
+  semver values in nested properties

--- a/www/docs/src/content/docs/cli/selectors/pseudo-classes/diff.mdx
+++ b/www/docs/src/content/docs/cli/selectors/pseudo-classes/diff.mdx
@@ -28,21 +28,13 @@ changes).
 
 Find packages with uncommitted changes:
 
-<Code
-  code="$ vlt query ':diff()'"
-  title="Terminal"
-  lang="bash"
-/>
+<Code code="$ vlt query ':diff()'" title="Terminal" lang="bash" />
 
 ### Changes since a branch
 
 Find packages changed since the `main` branch:
 
-<Code
-  code="$ vlt query ':diff(main)'"
-  title="Terminal"
-  lang="bash"
-/>
+<Code code="$ vlt query ':diff(main)'" title="Terminal" lang="bash" />
 
 ### Changes since last commit
 

--- a/www/docs/src/content/docs/cli/selectors/pseudo-classes/diff.mdx
+++ b/www/docs/src/content/docs/cli/selectors/pseudo-classes/diff.mdx
@@ -1,17 +1,16 @@
 ---
-title: ":diff()"
+title: ':diff()'
 sidebar:
-  label: ":diff()"
+  label: ':diff()'
   order: 12
 ---
 
 import { Code } from '@astrojs/starlight/components'
 
-The `:diff()` pseudo-class matches packages whose files have
-changed between the current working tree and a specified git
-commitish reference. It uses `git diff --name-only` to determine
-changed files, then maps them to packages by their file path
-location.
+The `:diff()` pseudo-class matches packages whose files have changed
+between the current working tree and a specified git commitish
+reference. It uses `git diff --name-only` to determine changed files,
+then maps them to packages by their file path location.
 
 ## Syntax
 
@@ -71,8 +70,8 @@ Find packages changed since the `main` branch:
 
 ### What gets selected
 
-Given a monorepo where you changed files in `packages/core/`
-and `packages/utils/` since `main`:
+Given a monorepo where you changed files in `packages/core/` and
+`packages/utils/` since `main`:
 
 ```
 my-monorepo
@@ -112,7 +111,6 @@ Find packages that depend on changed packages:
 
 ## See also
 
-- [`:path()`](/cli/selectors/pseudo-classes/path) — match by file
-  path
+- [`:path()`](/cli/selectors/pseudo-classes/path) — match by file path
 - [`:has()`](/cli/selectors/pseudo-classes/has) — find packages that
   depend on changed packages

--- a/www/docs/src/content/docs/cli/selectors/pseudo-classes/diff.mdx
+++ b/www/docs/src/content/docs/cli/selectors/pseudo-classes/diff.mdx
@@ -1,0 +1,118 @@
+---
+title: ":diff()"
+sidebar:
+  label: ":diff()"
+  order: 12
+---
+
+import { Code } from '@astrojs/starlight/components'
+
+The `:diff()` pseudo-class matches packages whose files have
+changed between the current working tree and a specified git
+commitish reference. It uses `git diff --name-only` to determine
+changed files, then maps them to packages by their file path
+location.
+
+## Syntax
+
+```
+:diff()
+:diff(<commitish>)
+```
+
+When called with no argument, defaults to `HEAD` (uncommitted
+changes).
+
+## Examples
+
+### Uncommitted changes
+
+Find packages with uncommitted changes:
+
+<Code
+  code="$ vlt query ':diff()'"
+  title="Terminal"
+  lang="bash"
+/>
+
+### Changes since a branch
+
+Find packages changed since the `main` branch:
+
+<Code
+  code="$ vlt query ':diff(main)'"
+  title="Terminal"
+  lang="bash"
+/>
+
+### Changes since last commit
+
+<Code
+  code="$ vlt query ':diff(HEAD~1)'"
+  title="Terminal"
+  lang="bash"
+/>
+
+### Changes since a tag
+
+<Code
+  code={`$ vlt query ':diff("v1.0.0")'`}
+  title="Terminal"
+  lang="bash"
+/>
+
+### Only workspaces that changed
+
+<Code
+  code="$ vlt query ':workspace:diff(main)'"
+  title="Terminal"
+  lang="bash"
+/>
+
+### What gets selected
+
+Given a monorepo where you changed files in `packages/core/`
+and `packages/utils/` since `main`:
+
+```
+my-monorepo
+├── packages/core/        ← files changed
+├── packages/utils/       ← files changed
+├── packages/cli/
+└── apps/web/
+```
+
+`:diff(main)` selects:
+
+```
+my-monorepo
+├── packages/core/        ✅ has changed files
+├── packages/utils/       ✅ has changed files
+├── packages/cli/
+└── apps/web/
+```
+
+### CI use cases
+
+Run tests only for changed workspaces:
+
+<Code
+  code="$ vlt query ':workspace:diff(main)' --view=json | xargs -I {} vlr test -w {}"
+  title="Terminal"
+  lang="bash"
+/>
+
+Find packages that depend on changed packages:
+
+<Code
+  code="$ vlt query ':has(> :diff(main))'"
+  title="Terminal"
+  lang="bash"
+/>
+
+## See also
+
+- [`:path()`](/cli/selectors/pseudo-classes/path) — match by file
+  path
+- [`:has()`](/cli/selectors/pseudo-classes/has) — find packages that
+  depend on changed packages

--- a/www/docs/src/content/docs/cli/selectors/pseudo-classes/has.mdx
+++ b/www/docs/src/content/docs/cli/selectors/pseudo-classes/has.mdx
@@ -1,0 +1,105 @@
+---
+title: ":has()"
+sidebar:
+  label: ":has()"
+  order: 2
+---
+
+import { Code } from '@astrojs/starlight/components'
+
+The `:has()` pseudo-class matches packages that **have descendants
+matching** a given selector expression. It's the dependency graph
+equivalent of the
+[CSS `:has()` selector](https://developer.mozilla.org/en-US/docs/Web/CSS/:has).
+
+## Syntax
+
+```
+:has(<selector-list>)
+```
+
+The selector list is evaluated against the descendants of each
+candidate node.
+
+## Examples
+
+### Packages with a peer dependency on react
+
+<Code
+  code="$ vlt query ':has(.peer[name=react])'"
+  title="Terminal"
+  lang="bash"
+/>
+
+Given this dependency graph:
+
+```
+my-app
+├── react@18.2.0
+├── react-dom@18.2.0
+│   └── react@18.2.0 (peer)
+└── @testing-library/react@14.0.0
+    └── react@18.2.0 (peer)
+```
+
+`:has(.peer[name=react])` selects packages that have a peer
+dependency on react:
+
+```
+my-app
+├── react@18.2.0
+├── react-dom@18.2.0                 ✅ has peer dep on react
+│   └── react@18.2.0 (peer)
+└── @testing-library/react@14.0.0   ✅ has peer dep on react
+    └── react@18.2.0 (peer)
+```
+
+### Packages that depend on vulnerable packages
+
+<Code
+  code="$ vlt query ':has(> :cve(*))'"
+  title="Terminal"
+  lang="bash"
+/>
+
+This finds packages whose **direct dependencies** have known CVEs.
+
+### Packages that depend on outdated packages
+
+<Code
+  code="$ vlt query ':has(> :outdated(major))'"
+  title="Terminal"
+  lang="bash"
+/>
+
+### Packages that depend on changed packages
+
+Find packages that have a dependency that was modified:
+
+<Code
+  code="$ vlt query ':has(> :diff(main))'"
+  title="Terminal"
+  lang="bash"
+/>
+
+### Using child combinator inside :has()
+
+The `>` inside `:has()` means **direct dependency**:
+
+<Code
+  code={`# Packages with a direct dep named "lodash"
+$ vlt query ':has(> [name=lodash])'
+
+# Packages with any transitive dep named "lodash"
+$ vlt query ':has([name=lodash])'`}
+  title="Terminal"
+  lang="bash"
+/>
+
+## See also
+
+- [`:not()`](/cli/selectors/pseudo-classes/not) — negation
+  pseudo-class
+- [`:is()`](/cli/selectors/pseudo-classes/is) — forgiving selector
+  list matching
+- [Combinators](/cli/selectors/combinators) — `>`, ` `, `~`

--- a/www/docs/src/content/docs/cli/selectors/pseudo-classes/has.mdx
+++ b/www/docs/src/content/docs/cli/selectors/pseudo-classes/has.mdx
@@ -1,7 +1,7 @@
 ---
-title: ":has()"
+title: ':has()'
 sidebar:
-  label: ":has()"
+  label: ':has()'
   order: 2
 ---
 
@@ -42,8 +42,8 @@ my-app
     └── react@18.2.0 (peer)
 ```
 
-`:has(.peer[name=react])` selects packages that have a peer
-dependency on react:
+`:has(.peer[name=react])` selects packages that have a peer dependency
+on react:
 
 ```
 my-app
@@ -91,10 +91,8 @@ The `>` inside `:has()` means **direct dependency**:
 $ vlt query ':has(> [name=lodash])'
 
 # Packages with any transitive dep named "lodash"
-$ vlt query ':has([name=lodash])'`}
-  title="Terminal"
-  lang="bash"
-/>
+
+$ vlt query ':has([name=lodash])'`} title="Terminal" lang="bash" />
 
 ## See also
 

--- a/www/docs/src/content/docs/cli/selectors/pseudo-classes/host.mdx
+++ b/www/docs/src/content/docs/cli/selectors/pseudo-classes/host.mdx
@@ -1,0 +1,76 @@
+---
+title: ":host()"
+sidebar:
+  label: ":host()"
+  order: 3
+---
+
+import { Code } from '@astrojs/starlight/components'
+
+The `:host()` pseudo-class switches the current graph context to a
+new set of graphs loaded from a specific host context. This allows
+querying across multiple projects or switching to different project
+scopes.
+
+## Syntax
+
+```
+:host(<context>)
+```
+
+The context parameter can be:
+- A specific project folder path (e.g., `"file:~/my-project"`)
+- The special `local` context — loads all configured projects from
+  your vlt dashboard
+
+## Examples
+
+### Find malware across all projects
+
+<Code
+  code="$ vlt query ':host(local) :malware'"
+  title="Terminal"
+  lang="bash"
+/>
+
+### Query a specific project
+
+<Code
+  code="$ vlt query ':host(\"file:~/my-app\") :outdated'"
+  title="Terminal"
+  lang="bash"
+/>
+
+### Bump version for a remote project
+
+<Code
+  code="$ vlt version patch --scope=':host(\"file:~/tmp/test-vite\")'"
+  title="Terminal"
+  lang="bash"
+/>
+
+### Get all direct deps across local projects
+
+<Code
+  code="$ vlt pkg pick name version --scope=':host(local) > :root > *'"
+  title="Terminal"
+  lang="bash"
+/>
+
+## How it works
+
+When you use `:host()`, vlt:
+
+1. Resolves the context to one or more project directories
+2. Loads the dependency graph for each project
+3. Runs the rest of the selector against all loaded graphs
+
+This is particularly useful for organization-wide audits and
+cross-project dependency analysis.
+
+## See also
+
+- [`:diff()`](/cli/selectors/pseudo-classes/diff) — find changed
+  packages
+- [`:outdated()`](/cli/selectors/pseudo-classes/outdated) — find
+  packages with newer versions

--- a/www/docs/src/content/docs/cli/selectors/pseudo-classes/host.mdx
+++ b/www/docs/src/content/docs/cli/selectors/pseudo-classes/host.mdx
@@ -1,14 +1,14 @@
 ---
-title: ":host()"
+title: ':host()'
 sidebar:
-  label: ":host()"
+  label: ':host()'
   order: 3
 ---
 
 import { Code } from '@astrojs/starlight/components'
 
-The `:host()` pseudo-class switches the current graph context to a
-new set of graphs loaded from a specific host context. This allows
+The `:host()` pseudo-class switches the current graph context to a new
+set of graphs loaded from a specific host context. This allows
 querying across multiple projects or switching to different project
 scopes.
 
@@ -19,6 +19,7 @@ scopes.
 ```
 
 The context parameter can be:
+
 - A specific project folder path (e.g., `"file:~/my-project"`)
 - The special `local` context — loads all configured projects from
   your vlt dashboard

--- a/www/docs/src/content/docs/cli/selectors/pseudo-classes/index.mdx
+++ b/www/docs/src/content/docs/cli/selectors/pseudo-classes/index.mdx
@@ -1,0 +1,102 @@
+---
+title: Pseudo-class Selectors
+sidebar:
+  label: Pseudo-classes
+  order: 4
+---
+
+import { LinkCard, CardGrid } from '@astrojs/starlight/components'
+
+Pseudo-class selectors are functional selectors that accept
+arguments to filter packages. They work similarly to
+[CSS pseudo-classes](https://developer.mozilla.org/en-US/docs/Web/CSS/Pseudo-classes)
+but operate on dependency graph nodes.
+
+## Available pseudo-class selectors
+
+<CardGrid>
+  <LinkCard
+    title=":attr()"
+    description="Match packages by nested package.json properties"
+    href="/cli/selectors/pseudo-classes/attr"
+  />
+  <LinkCard
+    title=":has()"
+    description="Match packages that have descendants matching a selector"
+    href="/cli/selectors/pseudo-classes/has"
+  />
+  <LinkCard
+    title=":host()"
+    description="Switch graph context to another project or scope"
+    href="/cli/selectors/pseudo-classes/host"
+  />
+  <LinkCard
+    title=":is()"
+    description="Match any element in a forgiving selector list"
+    href="/cli/selectors/pseudo-classes/is"
+  />
+  <LinkCard
+    title=":not()"
+    description="Negation — exclude packages matching a selector"
+    href="/cli/selectors/pseudo-classes/not"
+  />
+  <LinkCard
+    title=":outdated()"
+    description="Match packages with newer versions available"
+    href="/cli/selectors/pseudo-classes/outdated"
+  />
+  <LinkCard
+    title=":published()"
+    description="Match packages by publication date"
+    href="/cli/selectors/pseudo-classes/published"
+  />
+  <LinkCard
+    title=":semver()"
+    description="Match packages by semver comparisons"
+    href="/cli/selectors/pseudo-classes/semver"
+  />
+  <LinkCard
+    title=":spec()"
+    description="Match edges by their package specifier"
+    href="/cli/selectors/pseudo-classes/spec"
+  />
+  <LinkCard
+    title=":path()"
+    description="Match workspace and file packages by file path"
+    href="/cli/selectors/pseudo-classes/path"
+  />
+  <LinkCard
+    title=":type()"
+    description="Match packages by type (registry, file, git, etc.)"
+    href="/cli/selectors/pseudo-classes/type"
+  />
+  <LinkCard
+    title=":diff()"
+    description="Match packages whose files have changed"
+    href="/cli/selectors/pseudo-classes/diff"
+  />
+</CardGrid>
+
+## Quick reference
+
+| Selector | Description | Example |
+|---|---|---|
+| [`:attr()`](/cli/selectors/pseudo-classes/attr) | Nested property match | `:attr(engines, [node])` |
+| [`:has()`](/cli/selectors/pseudo-classes/has) | Has matching descendants | `:has(.peer[name=react])` |
+| [`:host()`](/cli/selectors/pseudo-classes/host) | Switch graph context | `:host(local) :malware` |
+| [`:is()`](/cli/selectors/pseudo-classes/is) | Match any in list | `:is([name=a], [name=b])` |
+| [`:not()`](/cli/selectors/pseudo-classes/not) | Negation | `:not([license=MIT])` |
+| [`:outdated()`](/cli/selectors/pseudo-classes/outdated) | Newer version exists | `:outdated(major)` |
+| [`:published()`](/cli/selectors/pseudo-classes/published) | By publish date | `:published(">2024")` |
+| [`:semver()`](/cli/selectors/pseudo-classes/semver) | Semver comparison | `:semver(^1.0.0)` |
+| [`:spec()`](/cli/selectors/pseudo-classes/spec) | By specifier string | `:spec(^1.0.0)` |
+| [`:path()`](/cli/selectors/pseudo-classes/path) | By file path | `:path("packages/**")` |
+| [`:type()`](/cli/selectors/pseudo-classes/type) | By package type | `:type(git)` |
+| [`:diff()`](/cli/selectors/pseudo-classes/diff) | Changed files | `:diff(main)` |
+
+## See also
+
+- [Pseudo-state Selectors](/cli/selectors/pseudo-states) — simple
+  state-based selectors (`:root`, `:dev`, etc.)
+- [Security Insights](/cli/selectors/security-insights) —
+  Socket-powered security pseudo-selectors

--- a/www/docs/src/content/docs/cli/selectors/pseudo-classes/index.mdx
+++ b/www/docs/src/content/docs/cli/selectors/pseudo-classes/index.mdx
@@ -7,8 +7,8 @@ sidebar:
 
 import { LinkCard, CardGrid } from '@astrojs/starlight/components'
 
-Pseudo-class selectors are functional selectors that accept
-arguments to filter packages. They work similarly to
+Pseudo-class selectors are functional selectors that accept arguments
+to filter packages. They work similarly to
 [CSS pseudo-classes](https://developer.mozilla.org/en-US/docs/Web/CSS/Pseudo-classes)
 but operate on dependency graph nodes.
 
@@ -79,20 +79,20 @@ but operate on dependency graph nodes.
 
 ## Quick reference
 
-| Selector | Description | Example |
-|---|---|---|
-| [`:attr()`](/cli/selectors/pseudo-classes/attr) | Nested property match | `:attr(engines, [node])` |
-| [`:has()`](/cli/selectors/pseudo-classes/has) | Has matching descendants | `:has(.peer[name=react])` |
-| [`:host()`](/cli/selectors/pseudo-classes/host) | Switch graph context | `:host(local) :malware` |
-| [`:is()`](/cli/selectors/pseudo-classes/is) | Match any in list | `:is([name=a], [name=b])` |
-| [`:not()`](/cli/selectors/pseudo-classes/not) | Negation | `:not([license=MIT])` |
-| [`:outdated()`](/cli/selectors/pseudo-classes/outdated) | Newer version exists | `:outdated(major)` |
-| [`:published()`](/cli/selectors/pseudo-classes/published) | By publish date | `:published(">2024")` |
-| [`:semver()`](/cli/selectors/pseudo-classes/semver) | Semver comparison | `:semver(^1.0.0)` |
-| [`:spec()`](/cli/selectors/pseudo-classes/spec) | By specifier string | `:spec(^1.0.0)` |
-| [`:path()`](/cli/selectors/pseudo-classes/path) | By file path | `:path("packages/**")` |
-| [`:type()`](/cli/selectors/pseudo-classes/type) | By package type | `:type(git)` |
-| [`:diff()`](/cli/selectors/pseudo-classes/diff) | Changed files | `:diff(main)` |
+| Selector                                                  | Description              | Example                   |
+| --------------------------------------------------------- | ------------------------ | ------------------------- |
+| [`:attr()`](/cli/selectors/pseudo-classes/attr)           | Nested property match    | `:attr(engines, [node])`  |
+| [`:has()`](/cli/selectors/pseudo-classes/has)             | Has matching descendants | `:has(.peer[name=react])` |
+| [`:host()`](/cli/selectors/pseudo-classes/host)           | Switch graph context     | `:host(local) :malware`   |
+| [`:is()`](/cli/selectors/pseudo-classes/is)               | Match any in list        | `:is([name=a], [name=b])` |
+| [`:not()`](/cli/selectors/pseudo-classes/not)             | Negation                 | `:not([license=MIT])`     |
+| [`:outdated()`](/cli/selectors/pseudo-classes/outdated)   | Newer version exists     | `:outdated(major)`        |
+| [`:published()`](/cli/selectors/pseudo-classes/published) | By publish date          | `:published(">2024")`     |
+| [`:semver()`](/cli/selectors/pseudo-classes/semver)       | Semver comparison        | `:semver(^1.0.0)`         |
+| [`:spec()`](/cli/selectors/pseudo-classes/spec)           | By specifier string      | `:spec(^1.0.0)`           |
+| [`:path()`](/cli/selectors/pseudo-classes/path)           | By file path             | `:path("packages/**")`    |
+| [`:type()`](/cli/selectors/pseudo-classes/type)           | By package type          | `:type(git)`              |
+| [`:diff()`](/cli/selectors/pseudo-classes/diff)           | Changed files            | `:diff(main)`             |
 
 ## See also
 

--- a/www/docs/src/content/docs/cli/selectors/pseudo-classes/is.mdx
+++ b/www/docs/src/content/docs/cli/selectors/pseudo-classes/is.mdx
@@ -1,0 +1,66 @@
+---
+title: ":is()"
+sidebar:
+  label: ":is()"
+  order: 4
+---
+
+import { Code } from '@astrojs/starlight/components'
+
+The `:is()` pseudo-class takes a forgiving selector list and
+matches any element that can be selected by one of the selectors in
+that list. It works like the
+[CSS `:is()` selector](https://developer.mozilla.org/en-US/docs/Web/CSS/:is)
+and is useful for writing compact selectors.
+
+## Syntax
+
+```
+:is(<forgiving-selector-list>)
+```
+
+The selector list is **forgiving** — any invalid selectors in the
+list are silently ignored rather than causing the entire selector to
+fail.
+
+## Examples
+
+### Compact selector lists
+
+Without `:is()`:
+
+<Code
+  code="$ vlt query ':root > [name=react], :root > [name=vue], :root > [name=svelte]'"
+  title="Terminal"
+  lang="bash"
+/>
+
+With `:is()`:
+
+<Code
+  code="$ vlt query ':root > :is([name=react], [name=vue], [name=svelte])'"
+  title="Terminal"
+  lang="bash"
+/>
+
+Both queries produce the same result — direct dependencies named
+`react`, `vue`, or `svelte`.
+
+### Forgiving behavior
+
+Invalid selectors in the list are ignored:
+
+<Code
+  code="$ vlt query ':is([name=react], :nonexistent, [name=vue])'"
+  title="Terminal"
+  lang="bash"
+/>
+
+This still matches `react` and `vue` — the `:nonexistent`
+pseudo-class is silently skipped.
+
+## See also
+
+- [`:not()`](/cli/selectors/pseudo-classes/not) — negation
+  pseudo-class
+- [`:has()`](/cli/selectors/pseudo-classes/has) — descendant matching

--- a/www/docs/src/content/docs/cli/selectors/pseudo-classes/is.mdx
+++ b/www/docs/src/content/docs/cli/selectors/pseudo-classes/is.mdx
@@ -1,15 +1,15 @@
 ---
-title: ":is()"
+title: ':is()'
 sidebar:
-  label: ":is()"
+  label: ':is()'
   order: 4
 ---
 
 import { Code } from '@astrojs/starlight/components'
 
-The `:is()` pseudo-class takes a forgiving selector list and
-matches any element that can be selected by one of the selectors in
-that list. It works like the
+The `:is()` pseudo-class takes a forgiving selector list and matches
+any element that can be selected by one of the selectors in that list.
+It works like the
 [CSS `:is()` selector](https://developer.mozilla.org/en-US/docs/Web/CSS/:is)
 and is useful for writing compact selectors.
 
@@ -19,9 +19,8 @@ and is useful for writing compact selectors.
 :is(<forgiving-selector-list>)
 ```
 
-The selector list is **forgiving** — any invalid selectors in the
-list are silently ignored rather than causing the entire selector to
-fail.
+The selector list is **forgiving** — any invalid selectors in the list
+are silently ignored rather than causing the entire selector to fail.
 
 ## Examples
 
@@ -56,8 +55,8 @@ Invalid selectors in the list are ignored:
   lang="bash"
 />
 
-This still matches `react` and `vue` — the `:nonexistent`
-pseudo-class is silently skipped.
+This still matches `react` and `vue` — the `:nonexistent` pseudo-class
+is silently skipped.
 
 ## See also
 

--- a/www/docs/src/content/docs/cli/selectors/pseudo-classes/not.mdx
+++ b/www/docs/src/content/docs/cli/selectors/pseudo-classes/not.mdx
@@ -1,0 +1,95 @@
+---
+title: ":not()"
+sidebar:
+  label: ":not()"
+  order: 5
+---
+
+import { Code } from '@astrojs/starlight/components'
+
+The `:not()` pseudo-class is a negation selector — it matches
+packages that **do not match** the given selector list. It works
+like the
+[CSS `:not()` selector](https://developer.mozilla.org/en-US/docs/Web/CSS/:not).
+
+## Syntax
+
+```
+:not(<selector-list>)
+```
+
+## Examples
+
+### Exclude by name
+
+Find all packages except react:
+
+<Code
+  code="$ vlt query ':root > :not([name=react])'"
+  title="Terminal"
+  lang="bash"
+/>
+
+### Exclude by license
+
+Find packages without an MIT license:
+
+<Code
+  code="$ vlt query ':not([license=MIT])'"
+  title="Terminal"
+  lang="bash"
+/>
+
+### Exclude by type
+
+Find all non-registry dependencies:
+
+<Code
+  code="$ vlt query ':not(:type(registry))'"
+  title="Terminal"
+  lang="bash"
+/>
+
+### What gets selected
+
+Given this dependency graph:
+
+```
+my-app
+├── react@18.2.0         ← license: MIT
+├── typescript@5.3.0     ← license: Apache-2.0
+└── vite@5.0.0           ← license: MIT
+```
+
+`:root > :not([license=MIT])` selects:
+
+```
+my-app
+├── react@18.2.0
+├── typescript@5.3.0      ✅ license is NOT MIT
+└── vite@5.0.0
+```
+
+### Combining with other pseudo-classes
+
+Find non-dev dependencies that are outdated:
+
+<Code
+  code="$ vlt query ':not(:dev):outdated'"
+  title="Terminal"
+  lang="bash"
+/>
+
+Find packages that are not private and not workspaces:
+
+<Code
+  code="$ vlt query ':not(:private):not(:workspace)'"
+  title="Terminal"
+  lang="bash"
+/>
+
+## See also
+
+- [`:is()`](/cli/selectors/pseudo-classes/is) — forgiving selector
+  list matching
+- [`:has()`](/cli/selectors/pseudo-classes/has) — descendant matching

--- a/www/docs/src/content/docs/cli/selectors/pseudo-classes/not.mdx
+++ b/www/docs/src/content/docs/cli/selectors/pseudo-classes/not.mdx
@@ -1,15 +1,14 @@
 ---
-title: ":not()"
+title: ':not()'
 sidebar:
-  label: ":not()"
+  label: ':not()'
   order: 5
 ---
 
 import { Code } from '@astrojs/starlight/components'
 
-The `:not()` pseudo-class is a negation selector — it matches
-packages that **do not match** the given selector list. It works
-like the
+The `:not()` pseudo-class is a negation selector — it matches packages
+that **do not match** the given selector list. It works like the
 [CSS `:not()` selector](https://developer.mozilla.org/en-US/docs/Web/CSS/:not).
 
 ## Syntax

--- a/www/docs/src/content/docs/cli/selectors/pseudo-classes/outdated.mdx
+++ b/www/docs/src/content/docs/cli/selectors/pseudo-classes/outdated.mdx
@@ -33,11 +33,7 @@ controls how "outdated" is defined.
 
 ### Find all outdated packages
 
-<Code
-  code="$ vlt query ':outdated'"
-  title="Terminal"
-  lang="bash"
-/>
+<Code code="$ vlt query ':outdated'" title="Terminal" lang="bash" />
 
 ### Find major version bumps
 

--- a/www/docs/src/content/docs/cli/selectors/pseudo-classes/outdated.mdx
+++ b/www/docs/src/content/docs/cli/selectors/pseudo-classes/outdated.mdx
@@ -1,0 +1,112 @@
+---
+title: ":outdated()"
+sidebar:
+  label: ":outdated()"
+  order: 6
+---
+
+import { Code } from '@astrojs/starlight/components'
+
+The `:outdated()` pseudo-class matches packages that have newer
+versions available on the registry. An optional type parameter
+controls how "outdated" is defined.
+
+## Syntax
+
+```
+:outdated
+:outdated(<type>)
+```
+
+### Type parameter
+
+| Type | Description |
+|---|---|
+| `any` (default) | A version exists greater than the current one |
+| `in-range` | A greater version exists that satisfies the parent's dependency range |
+| `out-of-range` | A greater version exists that does NOT satisfy the parent's range |
+| `major` | A semver major version bump is available |
+| `minor` | A semver minor version bump is available |
+| `patch` | A semver patch version bump is available |
+
+## Examples
+
+### Find all outdated packages
+
+<Code
+  code="$ vlt query ':outdated'"
+  title="Terminal"
+  lang="bash"
+/>
+
+### Find major version bumps
+
+<Code
+  code="$ vlt query ':outdated(major)'"
+  title="Terminal"
+  lang="bash"
+/>
+
+### Find safe updates (in-range)
+
+Updates that satisfy the existing dependency range:
+
+<Code
+  code="$ vlt query ':outdated(in-range)'"
+  title="Terminal"
+  lang="bash"
+/>
+
+### Find breaking updates (out-of-range)
+
+Updates that would require changing the dependency range:
+
+<Code
+  code="$ vlt query ':outdated(out-of-range)'"
+  title="Terminal"
+  lang="bash"
+/>
+
+### What gets selected
+
+Given:
+
+```
+my-app
+├── react@17.0.2          ← latest: 18.2.0 (major)
+├── typescript@5.2.0      ← latest: 5.3.0 (minor)
+├── vite@5.0.0            ← latest: 5.0.12 (patch)
+└── lodash@4.17.21        ← latest: 4.17.21 (up to date)
+```
+
+| Query | Selected |
+|---|---|
+| `:outdated` | react, typescript, vite |
+| `:outdated(major)` | react |
+| `:outdated(minor)` | typescript |
+| `:outdated(patch)` | vite |
+
+### Combining with combinators
+
+Find outdated direct dependencies only:
+
+<Code
+  code="$ vlt query ':root > :outdated'"
+  title="Terminal"
+  lang="bash"
+/>
+
+Find outdated direct dependencies with major bumps:
+
+<Code
+  code="$ vlt query ':root > :outdated(major)'"
+  title="Terminal"
+  lang="bash"
+/>
+
+## See also
+
+- [`:semver()`](/cli/selectors/pseudo-classes/semver) — custom semver
+  comparisons
+- [`:published()`](/cli/selectors/pseudo-classes/published) — filter
+  by publication date

--- a/www/docs/src/content/docs/cli/selectors/pseudo-classes/outdated.mdx
+++ b/www/docs/src/content/docs/cli/selectors/pseudo-classes/outdated.mdx
@@ -1,7 +1,7 @@
 ---
-title: ":outdated()"
+title: ':outdated()'
 sidebar:
-  label: ":outdated()"
+  label: ':outdated()'
   order: 6
 ---
 
@@ -20,14 +20,14 @@ controls how "outdated" is defined.
 
 ### Type parameter
 
-| Type | Description |
-|---|---|
-| `any` (default) | A version exists greater than the current one |
-| `in-range` | A greater version exists that satisfies the parent's dependency range |
-| `out-of-range` | A greater version exists that does NOT satisfy the parent's range |
-| `major` | A semver major version bump is available |
-| `minor` | A semver minor version bump is available |
-| `patch` | A semver patch version bump is available |
+| Type            | Description                                                           |
+| --------------- | --------------------------------------------------------------------- |
+| `any` (default) | A version exists greater than the current one                         |
+| `in-range`      | A greater version exists that satisfies the parent's dependency range |
+| `out-of-range`  | A greater version exists that does NOT satisfy the parent's range     |
+| `major`         | A semver major version bump is available                              |
+| `minor`         | A semver minor version bump is available                              |
+| `patch`         | A semver patch version bump is available                              |
 
 ## Examples
 
@@ -79,12 +79,12 @@ my-app
 └── lodash@4.17.21        ← latest: 4.17.21 (up to date)
 ```
 
-| Query | Selected |
-|---|---|
-| `:outdated` | react, typescript, vite |
-| `:outdated(major)` | react |
-| `:outdated(minor)` | typescript |
-| `:outdated(patch)` | vite |
+| Query              | Selected                |
+| ------------------ | ----------------------- |
+| `:outdated`        | react, typescript, vite |
+| `:outdated(major)` | react                   |
+| `:outdated(minor)` | typescript              |
+| `:outdated(patch)` | vite                    |
 
 ### Combining with combinators
 

--- a/www/docs/src/content/docs/cli/selectors/pseudo-classes/path.mdx
+++ b/www/docs/src/content/docs/cli/selectors/pseudo-classes/path.mdx
@@ -1,0 +1,84 @@
+---
+title: ":path()"
+sidebar:
+  label: ":path()"
+  order: 10
+---
+
+import { Code } from '@astrojs/starlight/components'
+
+The `:path()` pseudo-class matches workspace and file packages
+based on their file path relative to the project root. Patterns use
+glob syntax and must be quoted strings.
+
+## Syntax
+
+```
+:path("<glob>")
+```
+
+## Examples
+
+### Match all workspace packages
+
+<Code
+  code={`$ vlt query ':path("*")'`}
+  title="Terminal"
+  lang="bash"
+/>
+
+### Match a specific path
+
+<Code
+  code={`$ vlt query ':path("./packages/foo")'`}
+  title="Terminal"
+  lang="bash"
+/>
+
+### Match with glob patterns
+
+<Code
+  code={`$ vlt query ':path("packages/**")'`}
+  title="Terminal"
+  lang="bash"
+/>
+
+### What gets selected
+
+Given a monorepo:
+
+```
+my-monorepo/
+├── packages/
+│   ├── core/           ← workspace
+│   ├── utils/          ← workspace
+│   └── cli/            ← workspace
+└── apps/
+    └── web/            ← workspace
+```
+
+| Query | Selected |
+|---|---|
+| `:path("*")` | core, utils, cli, web |
+| `:path("packages/**")` | core, utils, cli |
+| `:path("apps/**")` | web |
+| `:path("./packages/core")` | core |
+
+### Combining with other selectors
+
+Find workspaces in `packages/` that have changed since main:
+
+<Code
+  code={`$ vlt query ':path("packages/**"):diff(main)'`}
+  title="Terminal"
+  lang="bash"
+/>
+
+## See also
+
+- [`:workspace`](/cli/selectors/pseudo-states) — match all workspace
+  packages
+- [`:type()`](/cli/selectors/pseudo-classes/type) — match by package
+  type
+- [`:diff()`](/cli/selectors/pseudo-classes/diff) — match by changed
+  files

--- a/www/docs/src/content/docs/cli/selectors/pseudo-classes/path.mdx
+++ b/www/docs/src/content/docs/cli/selectors/pseudo-classes/path.mdx
@@ -1,15 +1,15 @@
 ---
-title: ":path()"
+title: ':path()'
 sidebar:
-  label: ":path()"
+  label: ':path()'
   order: 10
 ---
 
 import { Code } from '@astrojs/starlight/components'
 
-The `:path()` pseudo-class matches workspace and file packages
-based on their file path relative to the project root. Patterns use
-glob syntax and must be quoted strings.
+The `:path()` pseudo-class matches workspace and file packages based
+on their file path relative to the project root. Patterns use glob
+syntax and must be quoted strings.
 
 ## Syntax
 
@@ -57,12 +57,12 @@ my-monorepo/
     └── web/            ← workspace
 ```
 
-| Query | Selected |
-|---|---|
-| `:path("*")` | core, utils, cli, web |
-| `:path("packages/**")` | core, utils, cli |
-| `:path("apps/**")` | web |
-| `:path("./packages/core")` | core |
+| Query                      | Selected              |
+| -------------------------- | --------------------- |
+| `:path("*")`               | core, utils, cli, web |
+| `:path("packages/**")`     | core, utils, cli      |
+| `:path("apps/**")`         | web                   |
+| `:path("./packages/core")` | core                  |
 
 ### Combining with other selectors
 

--- a/www/docs/src/content/docs/cli/selectors/pseudo-classes/published.mdx
+++ b/www/docs/src/content/docs/cli/selectors/pseudo-classes/published.mdx
@@ -1,7 +1,7 @@
 ---
-title: ":published()"
+title: ':published()'
 sidebar:
-  label: ":published()"
+  label: ':published()'
   order: 7
 ---
 
@@ -19,6 +19,7 @@ released.
 ```
 
 The date parameter supports:
+
 - Full dates: `2024-01-01`
 - Year only: `2024`
 - Year-month: `2024-06`

--- a/www/docs/src/content/docs/cli/selectors/pseudo-classes/published.mdx
+++ b/www/docs/src/content/docs/cli/selectors/pseudo-classes/published.mdx
@@ -1,0 +1,100 @@
+---
+title: ":published()"
+sidebar:
+  label: ":published()"
+  order: 7
+---
+
+import { Code } from '@astrojs/starlight/components'
+
+The `:published()` pseudo-class matches packages based on their
+publication date. Useful for auditing when dependencies were last
+released.
+
+## Syntax
+
+```
+:published(<date>)
+:published("<comparator><date>")
+```
+
+The date parameter supports:
+- Full dates: `2024-01-01`
+- Year only: `2024`
+- Year-month: `2024-06`
+
+When using a comparator (`>`, `<`, `>=`, `<=`), the value must be
+quoted.
+
+## Examples
+
+### Exact date match
+
+<Code
+  code="$ vlt query ':published(2024-01-01)'"
+  title="Terminal"
+  lang="bash"
+/>
+
+### After a date
+
+<Code
+  code={`$ vlt query ':published(">2024")'`}
+  title="Terminal"
+  lang="bash"
+/>
+
+### Before a date
+
+<Code
+  code={`$ vlt query ':published("<=2023-12-31")'`}
+  title="Terminal"
+  lang="bash"
+/>
+
+### What gets selected
+
+Given:
+
+```
+my-app
+├── react@18.2.0         ← published: 2022-06-14
+├── typescript@5.3.0     ← published: 2023-11-20
+└── vite@5.0.0           ← published: 2023-11-16
+```
+
+The query `:published(">2023")` selects:
+
+```
+my-app
+├── react@18.2.0
+├── typescript@5.3.0      ✅ published after 2023
+└── vite@5.0.0            ✅ published after 2023
+```
+
+### Finding old packages
+
+Find packages published more than 2 years ago:
+
+<Code
+  code={`$ vlt query ':published("<2024")'`}
+  title="Terminal"
+  lang="bash"
+/>
+
+### Combining with other selectors
+
+Find outdated packages that were published before 2023:
+
+<Code
+  code={`$ vlt query ':outdated:published("<2023")'`}
+  title="Terminal"
+  lang="bash"
+/>
+
+## See also
+
+- [`:outdated()`](/cli/selectors/pseudo-classes/outdated) — find
+  packages with newer versions
+- [`:unmaintained`](/cli/selectors/security-insights) — packages not
+  updated in 5+ years

--- a/www/docs/src/content/docs/cli/selectors/pseudo-classes/semver.mdx
+++ b/www/docs/src/content/docs/cli/selectors/pseudo-classes/semver.mdx
@@ -1,7 +1,7 @@
 ---
-title: ":semver()"
+title: ':semver()'
 sidebar:
-  label: ":semver()"
+  label: ':semver()'
   order: 8
 ---
 
@@ -21,23 +21,23 @@ field, but it can be configured to compare any semver-like value.
 
 ### Parameters
 
-| Parameter | Description | Default |
-|---|---|---|
-| `range` | The semver range to compare against | (required) |
-| `function` | Comparison function | `satisfies` |
-| `custom-attribute-selector` | A different property to compare | `version` |
+| Parameter                   | Description                         | Default     |
+| --------------------------- | ----------------------------------- | ----------- |
+| `range`                     | The semver range to compare against | (required)  |
+| `function`                  | Comparison function                 | `satisfies` |
+| `custom-attribute-selector` | A different property to compare     | `version`   |
 
 ### Comparison functions
 
-| Function | Description |
-|---|---|
-| `satisfies` | Version satisfies the range (default) |
-| `eq` | Version exactly equals the range |
-| `neq` | Version does not equal the range |
-| `gt` | Version is greater than the range |
-| `gte` | Version is greater than or equal to the range |
-| `lt` | Version is less than the range |
-| `lte` | Version is less than or equal to the range |
+| Function    | Description                                   |
+| ----------- | --------------------------------------------- |
+| `satisfies` | Version satisfies the range (default)         |
+| `eq`        | Version exactly equals the range              |
+| `neq`       | Version does not equal the range              |
+| `gt`        | Version is greater than the range             |
+| `gte`       | Version is greater than or equal to the range |
+| `lt`        | Version is less than the range                |
+| `lte`       | Version is less than or equal to the range    |
 
 ## Examples
 
@@ -93,11 +93,11 @@ my-app
 └── lodash@4.17.21
 ```
 
-| Query | Selected |
-|---|---|
-| `:semver(^18.0.0)` | react, react-dom |
-| `:semver(5.0.0, gte)` | typescript |
-| `:semver(^4.0.0)` | lodash |
+| Query                 | Selected         |
+| --------------------- | ---------------- |
+| `:semver(^18.0.0)`    | react, react-dom |
+| `:semver(5.0.0, gte)` | typescript       |
+| `:semver(^4.0.0)`     | lodash           |
 
 ### Combining with other selectors
 

--- a/www/docs/src/content/docs/cli/selectors/pseudo-classes/semver.mdx
+++ b/www/docs/src/content/docs/cli/selectors/pseudo-classes/semver.mdx
@@ -1,0 +1,117 @@
+---
+title: ":semver()"
+sidebar:
+  label: ":semver()"
+  order: 8
+---
+
+import { Code } from '@astrojs/starlight/components'
+
+The `:semver()` pseudo-class matches packages based on semver
+comparisons. By default it compares against the package `version`
+field, but it can be configured to compare any semver-like value.
+
+## Syntax
+
+```
+:semver(<range>)
+:semver(<range>, <function>)
+:semver(<range>, <function>, <custom-attribute-selector>)
+```
+
+### Parameters
+
+| Parameter | Description | Default |
+|---|---|---|
+| `range` | The semver range to compare against | (required) |
+| `function` | Comparison function | `satisfies` |
+| `custom-attribute-selector` | A different property to compare | `version` |
+
+### Comparison functions
+
+| Function | Description |
+|---|---|
+| `satisfies` | Version satisfies the range (default) |
+| `eq` | Version exactly equals the range |
+| `neq` | Version does not equal the range |
+| `gt` | Version is greater than the range |
+| `gte` | Version is greater than or equal to the range |
+| `lt` | Version is less than the range |
+| `lte` | Version is less than or equal to the range |
+
+## Examples
+
+### Basic range matching
+
+Find packages satisfying `^1.0.0`:
+
+<Code
+  code="$ vlt query ':semver(^1.0.0)'"
+  title="Terminal"
+  lang="bash"
+/>
+
+### Exact version matching
+
+Find packages at exactly version `2.0.0`:
+
+<Code
+  code="$ vlt query ':semver(2.0.0, eq)'"
+  title="Terminal"
+  lang="bash"
+/>
+
+### Version comparison
+
+Find packages greater than version 5:
+
+<Code
+  code="$ vlt query ':semver(5.0.0, gt)'"
+  title="Terminal"
+  lang="bash"
+/>
+
+### Custom property comparison
+
+Match packages whose `engines.node` field satisfies `^22`:
+
+<Code
+  code="$ vlt query ':semver(^22, satisfies, :attr(engines, [node]))'"
+  title="Terminal"
+  lang="bash"
+/>
+
+### What gets selected
+
+Given:
+
+```
+my-app
+├── react@18.2.0
+├── react-dom@18.2.0
+├── typescript@5.3.0
+└── lodash@4.17.21
+```
+
+| Query | Selected |
+|---|---|
+| `:semver(^18.0.0)` | react, react-dom |
+| `:semver(5.0.0, gte)` | typescript |
+| `:semver(^4.0.0)` | lodash |
+
+### Combining with other selectors
+
+Find direct dependencies with version >= 18:
+
+<Code
+  code="$ vlt query ':root > :semver(18.0.0, gte)'"
+  title="Terminal"
+  lang="bash"
+/>
+
+## See also
+
+- [`:outdated()`](/cli/selectors/pseudo-classes/outdated) — find
+  packages with newer versions available
+- [Attribute Selectors](/cli/selectors/attribute-selectors) — match
+  the `version` field directly

--- a/www/docs/src/content/docs/cli/selectors/pseudo-classes/spec.mdx
+++ b/www/docs/src/content/docs/cli/selectors/pseudo-classes/spec.mdx
@@ -1,0 +1,74 @@
+---
+title: ":spec()"
+sidebar:
+  label: ":spec()"
+  order: 9
+---
+
+import { Code } from '@astrojs/starlight/components'
+
+The `:spec()` pseudo-class matches edges where the package
+specifier (bareSpec) equals the provided value. This filters
+dependencies by their exact specification string — i.e., what's
+written in `package.json`.
+
+## Syntax
+
+```
+:spec(<specifier>)
+```
+
+## Examples
+
+### Match by semver range
+
+<Code
+  code="$ vlt query ':spec(^1.0.0)'"
+  title="Terminal"
+  lang="bash"
+/>
+
+### Match wildcard dependencies
+
+<Code
+  code={`$ vlt query ':spec("*")'`}
+  title="Terminal"
+  lang="bash"
+/>
+
+### Match catalog dependencies
+
+Find dependencies using the catalog protocol:
+
+<Code
+  code={`$ vlt query ':spec("catalog:")'`}
+  title="Terminal"
+  lang="bash"
+/>
+
+### What gets selected
+
+Given `package.json`:
+
+```json
+{
+  "dependencies": {
+    "react": "^18.2.0",
+    "lodash": "*",
+    "my-lib": "catalog:"
+  }
+}
+```
+
+| Query | Selected |
+|---|---|
+| `:spec(^18.2.0)` | react |
+| `:spec("*")` | lodash |
+| `:spec("catalog:")` | my-lib |
+
+## See also
+
+- [Attribute Selectors](/cli/selectors/attribute-selectors) — match
+  resolved version values
+- [`:type()`](/cli/selectors/pseudo-classes/type) — match by
+  dependency type

--- a/www/docs/src/content/docs/cli/selectors/pseudo-classes/spec.mdx
+++ b/www/docs/src/content/docs/cli/selectors/pseudo-classes/spec.mdx
@@ -1,16 +1,16 @@
 ---
-title: ":spec()"
+title: ':spec()'
 sidebar:
-  label: ":spec()"
+  label: ':spec()'
   order: 9
 ---
 
 import { Code } from '@astrojs/starlight/components'
 
-The `:spec()` pseudo-class matches edges where the package
-specifier (bareSpec) equals the provided value. This filters
-dependencies by their exact specification string — i.e., what's
-written in `package.json`.
+The `:spec()` pseudo-class matches edges where the package specifier
+(bareSpec) equals the provided value. This filters dependencies by
+their exact specification string — i.e., what's written in
+`package.json`.
 
 ## Syntax
 
@@ -60,11 +60,11 @@ Given `package.json`:
 }
 ```
 
-| Query | Selected |
-|---|---|
-| `:spec(^18.2.0)` | react |
-| `:spec("*")` | lodash |
-| `:spec("catalog:")` | my-lib |
+| Query               | Selected |
+| ------------------- | -------- |
+| `:spec(^18.2.0)`    | react    |
+| `:spec("*")`        | lodash   |
+| `:spec("catalog:")` | my-lib   |
 
 ## See also
 

--- a/www/docs/src/content/docs/cli/selectors/pseudo-classes/type.mdx
+++ b/www/docs/src/content/docs/cli/selectors/pseudo-classes/type.mdx
@@ -1,0 +1,97 @@
+---
+title: ":type()"
+sidebar:
+  label: ":type()"
+  order: 11
+---
+
+import { Code } from '@astrojs/starlight/components'
+
+The `:type()` pseudo-class matches packages based on their resolved
+type — how the package is sourced.
+
+## Syntax
+
+```
+:type(<type>)
+```
+
+### Available types
+
+| Type | Description |
+|---|---|
+| `registry` | Packages from npm or another registry |
+| `file` | Local file dependencies (`file:../path`) |
+| `git` | Git repository dependencies |
+| `remote` | Remote URL dependencies |
+| `workspace` | Workspace packages in your monorepo |
+
+## Examples
+
+### Find all git dependencies
+
+<Code
+  code="$ vlt query ':type(git)'"
+  title="Terminal"
+  lang="bash"
+/>
+
+### Find all workspace dependencies
+
+<Code
+  code="$ vlt query ':type(workspace)'"
+  title="Terminal"
+  lang="bash"
+/>
+
+### Find all file dependencies
+
+<Code
+  code="$ vlt query ':type(file)'"
+  title="Terminal"
+  lang="bash"
+/>
+
+### What gets selected
+
+Given:
+
+```
+my-app
+├── react@18.2.0             ← type: registry
+├── my-utils (workspace)     ← type: workspace
+├── my-fork (git)            ← type: git
+└── ../shared-lib (file)     ← type: file
+```
+
+| Query | Selected |
+|---|---|
+| `:type(registry)` | react |
+| `:type(workspace)` | my-utils |
+| `:type(git)` | my-fork |
+| `:type(file)` | ../shared-lib |
+
+### Combining with other selectors
+
+Find all non-registry dependencies:
+
+<Code
+  code="$ vlt query ':not(:type(registry))'"
+  title="Terminal"
+  lang="bash"
+/>
+
+Find outdated git dependencies:
+
+<Code
+  code="$ vlt query ':type(git):outdated'"
+  title="Terminal"
+  lang="bash"
+/>
+
+## See also
+
+- [`:workspace`](/cli/selectors/pseudo-states) — shorthand for
+  matching workspaces
+- [`:spec()`](/cli/selectors/pseudo-classes/spec) — match by
+  specifier string

--- a/www/docs/src/content/docs/cli/selectors/pseudo-classes/type.mdx
+++ b/www/docs/src/content/docs/cli/selectors/pseudo-classes/type.mdx
@@ -1,7 +1,7 @@
 ---
-title: ":type()"
+title: ':type()'
 sidebar:
-  label: ":type()"
+  label: ':type()'
   order: 11
 ---
 
@@ -18,13 +18,13 @@ type — how the package is sourced.
 
 ### Available types
 
-| Type | Description |
-|---|---|
-| `registry` | Packages from npm or another registry |
-| `file` | Local file dependencies (`file:../path`) |
-| `git` | Git repository dependencies |
-| `remote` | Remote URL dependencies |
-| `workspace` | Workspace packages in your monorepo |
+| Type        | Description                              |
+| ----------- | ---------------------------------------- |
+| `registry`  | Packages from npm or another registry    |
+| `file`      | Local file dependencies (`file:../path`) |
+| `git`       | Git repository dependencies              |
+| `remote`    | Remote URL dependencies                  |
+| `workspace` | Workspace packages in your monorepo      |
 
 ## Examples
 
@@ -64,12 +64,12 @@ my-app
 └── ../shared-lib (file)     ← type: file
 ```
 
-| Query | Selected |
-|---|---|
-| `:type(registry)` | react |
-| `:type(workspace)` | my-utils |
-| `:type(git)` | my-fork |
-| `:type(file)` | ../shared-lib |
+| Query              | Selected      |
+| ------------------ | ------------- |
+| `:type(registry)`  | react         |
+| `:type(workspace)` | my-utils      |
+| `:type(git)`       | my-fork       |
+| `:type(file)`      | ../shared-lib |
 
 ### Combining with other selectors
 
@@ -93,5 +93,5 @@ Find outdated git dependencies:
 
 - [`:workspace`](/cli/selectors/pseudo-states) — shorthand for
   matching workspaces
-- [`:spec()`](/cli/selectors/pseudo-classes/spec) — match by
-  specifier string
+- [`:spec()`](/cli/selectors/pseudo-classes/spec) — match by specifier
+  string

--- a/www/docs/src/content/docs/cli/selectors/pseudo-classes/type.mdx
+++ b/www/docs/src/content/docs/cli/selectors/pseudo-classes/type.mdx
@@ -30,11 +30,7 @@ type — how the package is sourced.
 
 ### Find all git dependencies
 
-<Code
-  code="$ vlt query ':type(git)'"
-  title="Terminal"
-  lang="bash"
-/>
+<Code code="$ vlt query ':type(git)'" title="Terminal" lang="bash" />
 
 ### Find all workspace dependencies
 
@@ -46,11 +42,7 @@ type — how the package is sourced.
 
 ### Find all file dependencies
 
-<Code
-  code="$ vlt query ':type(file)'"
-  title="Terminal"
-  lang="bash"
-/>
+<Code code="$ vlt query ':type(file)'" title="Terminal" lang="bash" />
 
 ### What gets selected
 

--- a/www/docs/src/content/docs/cli/selectors/pseudo-states/index.mdx
+++ b/www/docs/src/content/docs/cli/selectors/pseudo-states/index.mdx
@@ -1,0 +1,219 @@
+---
+title: Pseudo-state Selectors
+sidebar:
+  label: Pseudo-states
+  order: 5
+---
+
+import { Code } from '@astrojs/starlight/components'
+
+Pseudo-state selectors match packages based on their relationship
+to the project or their dependency type. Unlike
+[pseudo-classes](/cli/selectors/pseudo-classes), they don't take
+arguments.
+
+## Graph structure states
+
+| Selector | Description |
+|---|---|
+| `:root` | The root package (top-level `package.json`) |
+| `:scope` | The current scope of the selector |
+| `:project` | Root node plus all workspaces |
+| `:workspace` | Workspace packages (listed in `vlt.json`) |
+
+### `:root`
+
+Returns the root node — the package defined at the top-level
+`package.json` of your project.
+
+<Code
+  code="$ vlt query ':root'"
+  title="Terminal"
+  lang="bash"
+/>
+
+Commonly used with [combinators](/cli/selectors/combinators) to
+select direct dependencies:
+
+<Code
+  code="$ vlt query ':root > *'"
+  title="Terminal"
+  lang="bash"
+/>
+
+### `:scope`
+
+Returns the current scope of the selector. Useful when using the
+`--scope` CLI flag to limit the query context.
+
+### `:project`
+
+Returns the root node along with any workspaces declared in your
+project. Useful for selecting "your code" vs. third-party
+dependencies.
+
+<Code
+  code="$ vlt query ':project > *'"
+  title="Terminal"
+  lang="bash"
+/>
+
+### `:workspace`
+
+Matches workspace packages defined in your `vlt.json`.
+
+<Code
+  code="$ vlt query ':workspace'"
+  title="Terminal"
+  lang="bash"
+/>
+
+Find workspaces that have changed since main:
+
+<Code
+  code="$ vlt query ':workspace:diff(main)'"
+  title="Terminal"
+  lang="bash"
+/>
+
+## Dependency type states
+
+| Selector | Description |
+|---|---|
+| `:prod` | Production dependencies |
+| `:dev` | Development-only dependencies |
+| `:optional` | Optional dependencies |
+| `:peer` | Peer dependencies |
+
+### `:prod`
+
+Matches production dependencies:
+
+<Code
+  code="$ vlt query ':prod'"
+  title="Terminal"
+  lang="bash"
+/>
+
+### `:dev`
+
+Matches packages that are only used as dev dependencies:
+
+<Code
+  code="$ vlt query ':dev'"
+  title="Terminal"
+  lang="bash"
+/>
+
+Find all dev dependencies that are outdated:
+
+<Code
+  code="$ vlt query ':dev:outdated'"
+  title="Terminal"
+  lang="bash"
+/>
+
+### `:optional`
+
+Matches optional dependencies:
+
+<Code
+  code="$ vlt query ':optional'"
+  title="Terminal"
+  lang="bash"
+/>
+
+### `:peer`
+
+Matches peer dependencies:
+
+<Code
+  code="$ vlt query ':peer'"
+  title="Terminal"
+  lang="bash"
+/>
+
+## Package property states
+
+| Selector | Description |
+|---|---|
+| `:private` | Packages with `"private": true` |
+| `:empty` | Packages with no dependencies |
+| `:link` | Linked packages |
+| `:scanned` | Packages with security metadata |
+
+### `:private`
+
+Matches packages with `"private": true` in their `package.json`:
+
+<Code
+  code="$ vlt query ':private'"
+  title="Terminal"
+  lang="bash"
+/>
+
+### `:empty`
+
+Matches packages that have no dependencies installed:
+
+<Code
+  code="$ vlt query ':empty'"
+  title="Terminal"
+  lang="bash"
+/>
+
+### `:link`
+
+Matches linked packages only:
+
+<Code
+  code="$ vlt query ':link'"
+  title="Terminal"
+  lang="bash"
+/>
+
+### `:scanned`
+
+Matches packages that have [Socket](https://socket.dev/) security
+metadata. See
+[Security Insights](/cli/selectors/security-insights) for
+security-specific selectors.
+
+<Code
+  code="$ vlt query ':scanned'"
+  title="Terminal"
+  lang="bash"
+/>
+
+## What gets selected
+
+Given a monorepo:
+
+```
+my-monorepo (root)
+├── packages/core (workspace, private)
+│   ├── react@18.2.0 (prod)
+│   └── vitest@1.0.0 (dev)
+├── packages/utils (workspace)
+│   └── lodash@4.17.21 (prod)
+└── typescript@5.3.0 (dev)
+```
+
+| Query | Selected |
+|---|---|
+| `:root` | my-monorepo |
+| `:workspace` | core, utils |
+| `:project` | my-monorepo, core, utils |
+| `:private` | core |
+| `:dev` | vitest, typescript |
+| `:prod` | react, lodash |
+| `:root > :dev` | typescript |
+| `:workspace:private` | core |
+
+## See also
+
+- [Pseudo-class Selectors](/cli/selectors/pseudo-classes) —
+  functional selectors with arguments
+- [Combinators](/cli/selectors/combinators) — traverse the graph
+- [Security Insights](/cli/selectors/security-insights) — security
+  pseudo-selectors

--- a/www/docs/src/content/docs/cli/selectors/pseudo-states/index.mdx
+++ b/www/docs/src/content/docs/cli/selectors/pseudo-states/index.mdx
@@ -7,19 +7,19 @@ sidebar:
 
 import { Code } from '@astrojs/starlight/components'
 
-Pseudo-state selectors match packages based on their relationship
-to the project or their dependency type. Unlike
+Pseudo-state selectors match packages based on their relationship to
+the project or their dependency type. Unlike
 [pseudo-classes](/cli/selectors/pseudo-classes), they don't take
 arguments.
 
 ## Graph structure states
 
-| Selector | Description |
-|---|---|
-| `:root` | The root package (top-level `package.json`) |
-| `:scope` | The current scope of the selector |
-| `:project` | Root node plus all workspaces |
-| `:workspace` | Workspace packages (listed in `vlt.json`) |
+| Selector     | Description                                 |
+| ------------ | ------------------------------------------- |
+| `:root`      | The root package (top-level `package.json`) |
+| `:scope`     | The current scope of the selector           |
+| `:project`   | Root node plus all workspaces               |
+| `:workspace` | Workspace packages (listed in `vlt.json`)   |
 
 ### `:root`
 
@@ -32,8 +32,8 @@ Returns the root node — the package defined at the top-level
   lang="bash"
 />
 
-Commonly used with [combinators](/cli/selectors/combinators) to
-select direct dependencies:
+Commonly used with [combinators](/cli/selectors/combinators) to select
+direct dependencies:
 
 <Code
   code="$ vlt query ':root > *'"
@@ -78,12 +78,12 @@ Find workspaces that have changed since main:
 
 ## Dependency type states
 
-| Selector | Description |
-|---|---|
-| `:prod` | Production dependencies |
-| `:dev` | Development-only dependencies |
-| `:optional` | Optional dependencies |
-| `:peer` | Peer dependencies |
+| Selector    | Description                   |
+| ----------- | ----------------------------- |
+| `:prod`     | Production dependencies       |
+| `:dev`      | Development-only dependencies |
+| `:optional` | Optional dependencies         |
+| `:peer`     | Peer dependencies             |
 
 ### `:prod`
 
@@ -135,11 +135,11 @@ Matches peer dependencies:
 
 ## Package property states
 
-| Selector | Description |
-|---|---|
+| Selector   | Description                     |
+| ---------- | ------------------------------- |
 | `:private` | Packages with `"private": true` |
-| `:empty` | Packages with no dependencies |
-| `:link` | Linked packages |
+| `:empty`   | Packages with no dependencies   |
+| `:link`    | Linked packages                 |
 | `:scanned` | Packages with security metadata |
 
 ### `:private`
@@ -175,9 +175,8 @@ Matches linked packages only:
 ### `:scanned`
 
 Matches packages that have [Socket](https://socket.dev/) security
-metadata. See
-[Security Insights](/cli/selectors/security-insights) for
-security-specific selectors.
+metadata. See [Security Insights](/cli/selectors/security-insights)
+for security-specific selectors.
 
 <Code
   code="$ vlt query ':scanned'"
@@ -199,21 +198,21 @@ my-monorepo (root)
 └── typescript@5.3.0 (dev)
 ```
 
-| Query | Selected |
-|---|---|
-| `:root` | my-monorepo |
-| `:workspace` | core, utils |
-| `:project` | my-monorepo, core, utils |
-| `:private` | core |
-| `:dev` | vitest, typescript |
-| `:prod` | react, lodash |
-| `:root > :dev` | typescript |
-| `:workspace:private` | core |
+| Query                | Selected                 |
+| -------------------- | ------------------------ |
+| `:root`              | my-monorepo              |
+| `:workspace`         | core, utils              |
+| `:project`           | my-monorepo, core, utils |
+| `:private`           | core                     |
+| `:dev`               | vitest, typescript       |
+| `:prod`              | react, lodash            |
+| `:root > :dev`       | typescript               |
+| `:workspace:private` | core                     |
 
 ## See also
 
-- [Pseudo-class Selectors](/cli/selectors/pseudo-classes) —
-  functional selectors with arguments
+- [Pseudo-class Selectors](/cli/selectors/pseudo-classes) — functional
+  selectors with arguments
 - [Combinators](/cli/selectors/combinators) — traverse the graph
 - [Security Insights](/cli/selectors/security-insights) — security
   pseudo-selectors

--- a/www/docs/src/content/docs/cli/selectors/pseudo-states/index.mdx
+++ b/www/docs/src/content/docs/cli/selectors/pseudo-states/index.mdx
@@ -26,20 +26,12 @@ arguments.
 Returns the root node — the package defined at the top-level
 `package.json` of your project.
 
-<Code
-  code="$ vlt query ':root'"
-  title="Terminal"
-  lang="bash"
-/>
+<Code code="$ vlt query ':root'" title="Terminal" lang="bash" />
 
 Commonly used with [combinators](/cli/selectors/combinators) to select
 direct dependencies:
 
-<Code
-  code="$ vlt query ':root > *'"
-  title="Terminal"
-  lang="bash"
-/>
+<Code code="$ vlt query ':root > *'" title="Terminal" lang="bash" />
 
 ### `:scope`
 
@@ -62,11 +54,7 @@ dependencies.
 
 Matches workspace packages defined in your `vlt.json`.
 
-<Code
-  code="$ vlt query ':workspace'"
-  title="Terminal"
-  lang="bash"
-/>
+<Code code="$ vlt query ':workspace'" title="Terminal" lang="bash" />
 
 Find workspaces that have changed since main:
 
@@ -89,21 +77,13 @@ Find workspaces that have changed since main:
 
 Matches production dependencies:
 
-<Code
-  code="$ vlt query ':prod'"
-  title="Terminal"
-  lang="bash"
-/>
+<Code code="$ vlt query ':prod'" title="Terminal" lang="bash" />
 
 ### `:dev`
 
 Matches packages that are only used as dev dependencies:
 
-<Code
-  code="$ vlt query ':dev'"
-  title="Terminal"
-  lang="bash"
-/>
+<Code code="$ vlt query ':dev'" title="Terminal" lang="bash" />
 
 Find all dev dependencies that are outdated:
 
@@ -117,21 +97,13 @@ Find all dev dependencies that are outdated:
 
 Matches optional dependencies:
 
-<Code
-  code="$ vlt query ':optional'"
-  title="Terminal"
-  lang="bash"
-/>
+<Code code="$ vlt query ':optional'" title="Terminal" lang="bash" />
 
 ### `:peer`
 
 Matches peer dependencies:
 
-<Code
-  code="$ vlt query ':peer'"
-  title="Terminal"
-  lang="bash"
-/>
+<Code code="$ vlt query ':peer'" title="Terminal" lang="bash" />
 
 ## Package property states
 
@@ -146,31 +118,19 @@ Matches peer dependencies:
 
 Matches packages with `"private": true` in their `package.json`:
 
-<Code
-  code="$ vlt query ':private'"
-  title="Terminal"
-  lang="bash"
-/>
+<Code code="$ vlt query ':private'" title="Terminal" lang="bash" />
 
 ### `:empty`
 
 Matches packages that have no dependencies installed:
 
-<Code
-  code="$ vlt query ':empty'"
-  title="Terminal"
-  lang="bash"
-/>
+<Code code="$ vlt query ':empty'" title="Terminal" lang="bash" />
 
 ### `:link`
 
 Matches linked packages only:
 
-<Code
-  code="$ vlt query ':link'"
-  title="Terminal"
-  lang="bash"
-/>
+<Code code="$ vlt query ':link'" title="Terminal" lang="bash" />
 
 ### `:scanned`
 
@@ -178,11 +138,7 @@ Matches packages that have [Socket](https://socket.dev/) security
 metadata. See [Security Insights](/cli/selectors/security-insights)
 for security-specific selectors.
 
-<Code
-  code="$ vlt query ':scanned'"
-  title="Terminal"
-  lang="bash"
-/>
+<Code code="$ vlt query ':scanned'" title="Terminal" lang="bash" />
 
 ## What gets selected
 

--- a/www/docs/src/content/docs/cli/selectors/security-insights.mdx
+++ b/www/docs/src/content/docs/cli/selectors/security-insights.mdx
@@ -8,14 +8,12 @@ sidebar:
 import { Code } from '@astrojs/starlight/components'
 
 Security insight selectors rely on data provided by
-[Socket](https://socket.dev/). Using any of these selectors
-triggers a network call to fetch package report data.
+[Socket](https://socket.dev/). Using any of these selectors triggers a
+network call to fetch package report data.
 
-:::note
-Security selectors require fetching data from Socket's API. This
-adds latency to queries — the data is fetched before the query
-runs. Keep this in mind for interactive use.
-:::
+:::note Security selectors require fetching data from Socket's API.
+This adds latency to queries — the data is fetched before the query
+runs. Keep this in mind for interactive use. :::
 
 ## Malware & threats
 
@@ -34,12 +32,12 @@ Matches packages that may contain malware with severity >= medium
 
 Filter by severity level:
 
-| Type | Description |
-|---|---|
+| Type              | Description       |
+| ----------------- | ----------------- |
 | `critical` or `0` | Critical severity |
-| `high` or `1` | High severity |
-| `medium` or `2` | Medium severity |
-| `low` or `3` | Low severity |
+| `high` or `1`     | High severity     |
+| `medium` or `2`   | Medium severity   |
+| `low` or `3`      | Low severity      |
 
 Comparators are supported:
 
@@ -64,11 +62,11 @@ Matches packages with names similar to popular packages
 
 `:squat` without arguments matches any severity. Filter with:
 
-| Type | Description |
-|---|---|
+| Type              | Description               |
+| ----------------- | ------------------------- |
 | `critical` or `0` | High-confidence typosquat |
-| `medium` or `2` | Possible typosquat |
-| `none` | Not a typosquat |
+| `medium` or `2`   | Possible typosquat        |
+| `none`            | Not a typosquat           |
 
 ### `:suspicious`
 
@@ -126,12 +124,12 @@ Matches packages with a specific CWE alert:
 
 Matches packages by CVE severity level:
 
-| Level | Description |
-|---|---|
+| Level             | Description            |
+| ----------------- | ---------------------- |
 | `critical` or `0` | Critical severity CVEs |
-| `high` or `1` | High severity CVEs |
-| `medium` or `2` | Medium severity CVEs |
-| `low` or `3` | Low severity CVEs |
+| `high` or `1`     | High severity CVEs     |
+| `medium` or `2`   | Medium severity CVEs   |
+| `low` or `3`      | Low severity CVEs      |
 
 Comparators are supported:
 
@@ -149,29 +147,28 @@ $ vlt query ':severity(">=medium")'`}
 
 Matches packages based on license issues:
 
-| Type | Description |
-|---|---|
-| `unlicensed` | No license |
-| `misc` | Fine-grained license problems |
-| `restricted` | Non-permissive license |
-| `ambiguous` | Ambiguous licensing |
-| `copyleft` | Copyleft license (GPL, etc.) |
-| `unknown` | License data found but type undetermined |
-| `none` | No license data at all |
-| `exception` | SPDX license exception |
+| Type         | Description                              |
+| ------------ | ---------------------------------------- |
+| `unlicensed` | No license                               |
+| `misc`       | Fine-grained license problems            |
+| `restricted` | Non-permissive license                   |
+| `ambiguous`  | Ambiguous licensing                      |
+| `copyleft`   | Copyleft license (GPL, etc.)             |
+| `unknown`    | License data found but type undetermined |
+| `none`       | No license data at all                   |
+| `exception`  | SPDX license exception                   |
 
 <Code
   code={`# Find packages with copyleft licenses
 $ vlt query ':license(copyleft)'
 
 # Find unlicensed packages
+
 $ vlt query ':license(unlicensed)'
 
 # Find packages with any license
-$ vlt query ':license'`}
-  title="Terminal"
-  lang="bash"
-/>
+
+$ vlt query ':license'`} title="Terminal" lang="bash" />
 
 ## Code behavior signals
 
@@ -238,8 +235,7 @@ Packages with install scripts (postinstall, preinstall, etc.):
 
 ### `:debug`
 
-Packages using debug, reflection, or dynamic code execution
-features:
+Packages using debug, reflection, or dynamic code execution features:
 
 <Code
   code="$ vlt query ':debug'"
@@ -292,8 +288,7 @@ secrets, or obfuscated code):
 
 ### `:native`
 
-Packages containing native code (compiled binaries, shared
-libraries):
+Packages containing native code (compiled binaries, shared libraries):
 
 <Code
   code="$ vlt query ':native'"
@@ -303,8 +298,8 @@ libraries):
 
 ### `:shrinkwrap`
 
-Packages containing a shrinkwrap file that may bypass normal
-install procedures:
+Packages containing a shrinkwrap file that may bypass normal install
+procedures:
 
 <Code
   code="$ vlt query ':shrinkwrap'"
@@ -398,8 +393,7 @@ Packages containing telemetry:
 
 ### `:undesirable`
 
-Packages that are jokes, parodies, or include undocumented
-behavior:
+Packages that are jokes, parodies, or include undocumented behavior:
 
 <Code
   code="$ vlt query ':undesirable'"
@@ -411,10 +405,10 @@ behavior:
 
 Match packages by security score:
 
-| Parameter | Description |
-|---|---|
-| `rate` | Score value 0–100 (or 0–1), with optional comparator |
-| `kind` | Score category (optional, default: `overall`) |
+| Parameter | Description                                          |
+| --------- | ---------------------------------------------------- |
+| `rate`    | Score value 0–100 (or 0–1), with optional comparator |
+| `kind`    | Score category (optional, default: `overall`)        |
 
 Available kinds: `overall`, `license`, `maintenance`, `quality`,
 `supplyChain`, `vulnerability`.
@@ -424,13 +418,13 @@ Available kinds: `overall`, `license`, `maintenance`, `quality`,
 $ vlt query ':score(80)'
 
 # Packages with score > 0.8
+
 $ vlt query ':score(">0.8")'
 
 # Low maintenance score
-$ vlt query ':score("<=0.5", "maintenance")'`}
-  title="Terminal"
-  lang="bash"
-/>
+
+$ vlt query ':score("<=0.5", "maintenance")'`} title="Terminal"
+lang="bash" />
 
 ## Common audit queries
 
@@ -441,19 +435,20 @@ Run a comprehensive security audit:
 $ vlt query ':malware(critical), :cve(*), :obfuscated'
 
 # Supply chain risks
+
 $ vlt query ':abandoned, :unmaintained, :unknown'
 
 # License compliance
+
 $ vlt query ':license(copyleft), :license(unlicensed)'
 
 # Code behavior audit
-$ vlt query ':eval, :shell, :network, :fs'`}
-  title="Terminal"
-  lang="bash"
-/>
+
+$ vlt query ':eval, :shell, :network, :fs'`} title="Terminal"
+lang="bash" />
 
 ## See also
 
-- [`:scanned`](/cli/selectors/pseudo-states) — check if packages
-  have security metadata
+- [`:scanned`](/cli/selectors/pseudo-states) — check if packages have
+  security metadata
 - [vlt security overview](/cli/security) — security features in vlt

--- a/www/docs/src/content/docs/cli/selectors/security-insights.mdx
+++ b/www/docs/src/content/docs/cli/selectors/security-insights.mdx
@@ -22,11 +22,7 @@ runs. Keep this in mind for interactive use. :::
 Matches packages that may contain malware with severity >= medium
 (critical, high, medium — excludes low).
 
-<Code
-  code="$ vlt query ':malware'"
-  title="Terminal"
-  lang="bash"
-/>
+<Code code="$ vlt query ':malware'" title="Terminal" lang="bash" />
 
 #### `:malware(<type>)`
 
@@ -54,11 +50,7 @@ $ vlt query ':malware(">=medium")'`}
 Matches packages with names similar to popular packages
 (typosquatting).
 
-<Code
-  code="$ vlt query ':squat'"
-  title="Terminal"
-  lang="bash"
-/>
+<Code code="$ vlt query ':squat'" title="Terminal" lang="bash" />
 
 `:squat` without arguments matches any severity. Filter with:
 
@@ -73,22 +65,14 @@ Matches packages with names similar to popular packages
 Matches packages with artificially inflated GitHub stars (bots,
 crowdsourcing, etc.):
 
-<Code
-  code="$ vlt query ':suspicious'"
-  title="Terminal"
-  lang="bash"
-/>
+<Code code="$ vlt query ':suspicious'" title="Terminal" lang="bash" />
 
 ### `:confused`
 
 Matches packages affected by manifest confusion — the published
 `package.json` differs from what's in the tarball:
 
-<Code
-  code="$ vlt query ':confused'"
-  title="Terminal"
-  lang="bash"
-/>
+<Code code="$ vlt query ':confused'" title="Terminal" lang="bash" />
 
 ## Vulnerabilities
 
@@ -104,11 +88,7 @@ Matches packages with a specific CVE alert:
 
 Match packages with any CVE:
 
-<Code
-  code="$ vlt query ':cve(*)'"
-  title="Terminal"
-  lang="bash"
-/>
+<Code code="$ vlt query ':cve(*)'" title="Terminal" lang="bash" />
 
 ### `:cwe(<id>)`
 
@@ -177,81 +157,49 @@ $ vlt query ':license'`} title="Terminal" lang="bash" />
 Packages using dynamic code execution (`eval()`, `new Function()`,
 etc.):
 
-<Code
-  code="$ vlt query ':eval'"
-  title="Terminal"
-  lang="bash"
-/>
+<Code code="$ vlt query ':eval'" title="Terminal" lang="bash" />
 
 ### `:network`
 
 Packages that access the network:
 
-<Code
-  code="$ vlt query ':network'"
-  title="Terminal"
-  lang="bash"
-/>
+<Code code="$ vlt query ':network'" title="Terminal" lang="bash" />
 
 ### `:fs`
 
 Packages that access the file system:
 
-<Code
-  code="$ vlt query ':fs'"
-  title="Terminal"
-  lang="bash"
-/>
+<Code code="$ vlt query ':fs'" title="Terminal" lang="bash" />
 
 ### `:env`
 
 Packages that access environment variables:
 
-<Code
-  code="$ vlt query ':env'"
-  title="Terminal"
-  lang="bash"
-/>
+<Code code="$ vlt query ':env'" title="Terminal" lang="bash" />
 
 ### `:shell`
 
 Packages that access the system shell:
 
-<Code
-  code="$ vlt query ':shell'"
-  title="Terminal"
-  lang="bash"
-/>
+<Code code="$ vlt query ':shell'" title="Terminal" lang="bash" />
 
 ### `:scripts`
 
 Packages with install scripts (postinstall, preinstall, etc.):
 
-<Code
-  code="$ vlt query ':scripts'"
-  title="Terminal"
-  lang="bash"
-/>
+<Code code="$ vlt query ':scripts'" title="Terminal" lang="bash" />
 
 ### `:debug`
 
 Packages using debug, reflection, or dynamic code execution features:
 
-<Code
-  code="$ vlt query ':debug'"
-  title="Terminal"
-  lang="bash"
-/>
+<Code code="$ vlt query ':debug'" title="Terminal" lang="bash" />
 
 ### `:dynamic`
 
 Packages using dynamic imports:
 
-<Code
-  code="$ vlt query ':dynamic'"
-  title="Terminal"
-  lang="bash"
-/>
+<Code code="$ vlt query ':dynamic'" title="Terminal" lang="bash" />
 
 ## Obfuscation & hiding
 
@@ -259,53 +207,33 @@ Packages using dynamic imports:
 
 Packages with intentionally obfuscated code:
 
-<Code
-  code="$ vlt query ':obfuscated'"
-  title="Terminal"
-  lang="bash"
-/>
+<Code code="$ vlt query ':obfuscated'" title="Terminal" lang="bash" />
 
 ### `:minified`
 
 Packages containing minified code:
 
-<Code
-  code="$ vlt query ':minified'"
-  title="Terminal"
-  lang="bash"
-/>
+<Code code="$ vlt query ':minified'" title="Terminal" lang="bash" />
 
 ### `:entropic`
 
 Packages with high-entropy strings (possibly encrypted data, leaked
 secrets, or obfuscated code):
 
-<Code
-  code="$ vlt query ':entropic'"
-  title="Terminal"
-  lang="bash"
-/>
+<Code code="$ vlt query ':entropic'" title="Terminal" lang="bash" />
 
 ### `:native`
 
 Packages containing native code (compiled binaries, shared libraries):
 
-<Code
-  code="$ vlt query ':native'"
-  title="Terminal"
-  lang="bash"
-/>
+<Code code="$ vlt query ':native'" title="Terminal" lang="bash" />
 
 ### `:shrinkwrap`
 
 Packages containing a shrinkwrap file that may bypass normal install
 procedures:
 
-<Code
-  code="$ vlt query ':shrinkwrap'"
-  title="Terminal"
-  lang="bash"
-/>
+<Code code="$ vlt query ':shrinkwrap'" title="Terminal" lang="bash" />
 
 ## Package health
 
@@ -313,11 +241,7 @@ procedures:
 
 Packages marked as deprecated:
 
-<Code
-  code="$ vlt query ':deprecated'"
-  title="Terminal"
-  lang="bash"
-/>
+<Code code="$ vlt query ':deprecated'" title="Terminal" lang="bash" />
 
 ### `:unmaintained`
 
@@ -333,51 +257,31 @@ Packages not updated in more than 5 years:
 
 Packages that are not widely used:
 
-<Code
-  code="$ vlt query ':unpopular'"
-  title="Terminal"
-  lang="bash"
-/>
+<Code code="$ vlt query ':unpopular'" title="Terminal" lang="bash" />
 
 ### `:trivial`
 
 Packages with less than 10 lines of code:
 
-<Code
-  code="$ vlt query ':trivial'"
-  title="Terminal"
-  lang="bash"
-/>
+<Code code="$ vlt query ':trivial'" title="Terminal" lang="bash" />
 
 ### `:abandoned`
 
 Packages published by an npm account that no longer exists:
 
-<Code
-  code="$ vlt query ':abandoned'"
-  title="Terminal"
-  lang="bash"
-/>
+<Code code="$ vlt query ':abandoned'" title="Terminal" lang="bash" />
 
 ### `:unknown`
 
 Packages with a new npm collaborator publishing for the first time:
 
-<Code
-  code="$ vlt query ':unknown'"
-  title="Terminal"
-  lang="bash"
-/>
+<Code code="$ vlt query ':unknown'" title="Terminal" lang="bash" />
 
 ### `:unstable`
 
 Packages with unstable ownership (new collaborator publishing):
 
-<Code
-  code="$ vlt query ':unstable'"
-  title="Terminal"
-  lang="bash"
-/>
+<Code code="$ vlt query ':unstable'" title="Terminal" lang="bash" />
 
 ## Other
 
@@ -385,11 +289,7 @@ Packages with unstable ownership (new collaborator publishing):
 
 Packages containing telemetry:
 
-<Code
-  code="$ vlt query ':tracker'"
-  title="Terminal"
-  lang="bash"
-/>
+<Code code="$ vlt query ':tracker'" title="Terminal" lang="bash" />
 
 ### `:undesirable`
 

--- a/www/docs/src/content/docs/cli/selectors/security-insights.mdx
+++ b/www/docs/src/content/docs/cli/selectors/security-insights.mdx
@@ -1,0 +1,459 @@
+---
+title: Security Insights
+sidebar:
+  label: Security Insights
+  order: 6
+---
+
+import { Code } from '@astrojs/starlight/components'
+
+Security insight selectors rely on data provided by
+[Socket](https://socket.dev/). Using any of these selectors
+triggers a network call to fetch package report data.
+
+:::note
+Security selectors require fetching data from Socket's API. This
+adds latency to queries — the data is fetched before the query
+runs. Keep this in mind for interactive use.
+:::
+
+## Malware & threats
+
+### `:malware`
+
+Matches packages that may contain malware with severity >= medium
+(critical, high, medium — excludes low).
+
+<Code
+  code="$ vlt query ':malware'"
+  title="Terminal"
+  lang="bash"
+/>
+
+#### `:malware(<type>)`
+
+Filter by severity level:
+
+| Type | Description |
+|---|---|
+| `critical` or `0` | Critical severity |
+| `high` or `1` | High severity |
+| `medium` or `2` | Medium severity |
+| `low` or `3` | Low severity |
+
+Comparators are supported:
+
+<Code
+  code={`$ vlt query ':malware(critical)'
+$ vlt query ':malware(">1")'
+$ vlt query ':malware(">=medium")'`}
+  title="Terminal"
+  lang="bash"
+/>
+
+### `:squat` / `:squat(<type>)`
+
+Matches packages with names similar to popular packages
+(typosquatting).
+
+<Code
+  code="$ vlt query ':squat'"
+  title="Terminal"
+  lang="bash"
+/>
+
+`:squat` without arguments matches any severity. Filter with:
+
+| Type | Description |
+|---|---|
+| `critical` or `0` | High-confidence typosquat |
+| `medium` or `2` | Possible typosquat |
+| `none` | Not a typosquat |
+
+### `:suspicious`
+
+Matches packages with artificially inflated GitHub stars (bots,
+crowdsourcing, etc.):
+
+<Code
+  code="$ vlt query ':suspicious'"
+  title="Terminal"
+  lang="bash"
+/>
+
+### `:confused`
+
+Matches packages affected by manifest confusion — the published
+`package.json` differs from what's in the tarball:
+
+<Code
+  code="$ vlt query ':confused'"
+  title="Terminal"
+  lang="bash"
+/>
+
+## Vulnerabilities
+
+### `:cve(<id>)`
+
+Matches packages with a specific CVE alert:
+
+<Code
+  code="$ vlt query ':cve(CVE-2023-1234)'"
+  title="Terminal"
+  lang="bash"
+/>
+
+Match packages with any CVE:
+
+<Code
+  code="$ vlt query ':cve(*)'"
+  title="Terminal"
+  lang="bash"
+/>
+
+### `:cwe(<id>)`
+
+Matches packages with a specific CWE alert:
+
+<Code
+  code="$ vlt query ':cwe(CWE-79)'"
+  title="Terminal"
+  lang="bash"
+/>
+
+### `:severity(<level>)`
+
+Matches packages by CVE severity level:
+
+| Level | Description |
+|---|---|
+| `critical` or `0` | Critical severity CVEs |
+| `high` or `1` | High severity CVEs |
+| `medium` or `2` | Medium severity CVEs |
+| `low` or `3` | Low severity CVEs |
+
+Comparators are supported:
+
+<Code
+  code={`$ vlt query ':severity(critical)'
+$ vlt query ':severity(">1")'
+$ vlt query ':severity(">=medium")'`}
+  title="Terminal"
+  lang="bash"
+/>
+
+## Licensing
+
+### `:license(<type>)`
+
+Matches packages based on license issues:
+
+| Type | Description |
+|---|---|
+| `unlicensed` | No license |
+| `misc` | Fine-grained license problems |
+| `restricted` | Non-permissive license |
+| `ambiguous` | Ambiguous licensing |
+| `copyleft` | Copyleft license (GPL, etc.) |
+| `unknown` | License data found but type undetermined |
+| `none` | No license data at all |
+| `exception` | SPDX license exception |
+
+<Code
+  code={`# Find packages with copyleft licenses
+$ vlt query ':license(copyleft)'
+
+# Find unlicensed packages
+$ vlt query ':license(unlicensed)'
+
+# Find packages with any license
+$ vlt query ':license'`}
+  title="Terminal"
+  lang="bash"
+/>
+
+## Code behavior signals
+
+### `:eval`
+
+Packages using dynamic code execution (`eval()`, `new Function()`,
+etc.):
+
+<Code
+  code="$ vlt query ':eval'"
+  title="Terminal"
+  lang="bash"
+/>
+
+### `:network`
+
+Packages that access the network:
+
+<Code
+  code="$ vlt query ':network'"
+  title="Terminal"
+  lang="bash"
+/>
+
+### `:fs`
+
+Packages that access the file system:
+
+<Code
+  code="$ vlt query ':fs'"
+  title="Terminal"
+  lang="bash"
+/>
+
+### `:env`
+
+Packages that access environment variables:
+
+<Code
+  code="$ vlt query ':env'"
+  title="Terminal"
+  lang="bash"
+/>
+
+### `:shell`
+
+Packages that access the system shell:
+
+<Code
+  code="$ vlt query ':shell'"
+  title="Terminal"
+  lang="bash"
+/>
+
+### `:scripts`
+
+Packages with install scripts (postinstall, preinstall, etc.):
+
+<Code
+  code="$ vlt query ':scripts'"
+  title="Terminal"
+  lang="bash"
+/>
+
+### `:debug`
+
+Packages using debug, reflection, or dynamic code execution
+features:
+
+<Code
+  code="$ vlt query ':debug'"
+  title="Terminal"
+  lang="bash"
+/>
+
+### `:dynamic`
+
+Packages using dynamic imports:
+
+<Code
+  code="$ vlt query ':dynamic'"
+  title="Terminal"
+  lang="bash"
+/>
+
+## Obfuscation & hiding
+
+### `:obfuscated`
+
+Packages with intentionally obfuscated code:
+
+<Code
+  code="$ vlt query ':obfuscated'"
+  title="Terminal"
+  lang="bash"
+/>
+
+### `:minified`
+
+Packages containing minified code:
+
+<Code
+  code="$ vlt query ':minified'"
+  title="Terminal"
+  lang="bash"
+/>
+
+### `:entropic`
+
+Packages with high-entropy strings (possibly encrypted data, leaked
+secrets, or obfuscated code):
+
+<Code
+  code="$ vlt query ':entropic'"
+  title="Terminal"
+  lang="bash"
+/>
+
+### `:native`
+
+Packages containing native code (compiled binaries, shared
+libraries):
+
+<Code
+  code="$ vlt query ':native'"
+  title="Terminal"
+  lang="bash"
+/>
+
+### `:shrinkwrap`
+
+Packages containing a shrinkwrap file that may bypass normal
+install procedures:
+
+<Code
+  code="$ vlt query ':shrinkwrap'"
+  title="Terminal"
+  lang="bash"
+/>
+
+## Package health
+
+### `:deprecated`
+
+Packages marked as deprecated:
+
+<Code
+  code="$ vlt query ':deprecated'"
+  title="Terminal"
+  lang="bash"
+/>
+
+### `:unmaintained`
+
+Packages not updated in more than 5 years:
+
+<Code
+  code="$ vlt query ':unmaintained'"
+  title="Terminal"
+  lang="bash"
+/>
+
+### `:unpopular`
+
+Packages that are not widely used:
+
+<Code
+  code="$ vlt query ':unpopular'"
+  title="Terminal"
+  lang="bash"
+/>
+
+### `:trivial`
+
+Packages with less than 10 lines of code:
+
+<Code
+  code="$ vlt query ':trivial'"
+  title="Terminal"
+  lang="bash"
+/>
+
+### `:abandoned`
+
+Packages published by an npm account that no longer exists:
+
+<Code
+  code="$ vlt query ':abandoned'"
+  title="Terminal"
+  lang="bash"
+/>
+
+### `:unknown`
+
+Packages with a new npm collaborator publishing for the first time:
+
+<Code
+  code="$ vlt query ':unknown'"
+  title="Terminal"
+  lang="bash"
+/>
+
+### `:unstable`
+
+Packages with unstable ownership (new collaborator publishing):
+
+<Code
+  code="$ vlt query ':unstable'"
+  title="Terminal"
+  lang="bash"
+/>
+
+## Other
+
+### `:tracker`
+
+Packages containing telemetry:
+
+<Code
+  code="$ vlt query ':tracker'"
+  title="Terminal"
+  lang="bash"
+/>
+
+### `:undesirable`
+
+Packages that are jokes, parodies, or include undocumented
+behavior:
+
+<Code
+  code="$ vlt query ':undesirable'"
+  title="Terminal"
+  lang="bash"
+/>
+
+### `:score(<rate>, <kind>)`
+
+Match packages by security score:
+
+| Parameter | Description |
+|---|---|
+| `rate` | Score value 0–100 (or 0–1), with optional comparator |
+| `kind` | Score category (optional, default: `overall`) |
+
+Available kinds: `overall`, `license`, `maintenance`, `quality`,
+`supplyChain`, `vulnerability`.
+
+<Code
+  code={`# Packages with exactly 0.8 overall score
+$ vlt query ':score(80)'
+
+# Packages with score > 0.8
+$ vlt query ':score(">0.8")'
+
+# Low maintenance score
+$ vlt query ':score("<=0.5", "maintenance")'`}
+  title="Terminal"
+  lang="bash"
+/>
+
+## Common audit queries
+
+Run a comprehensive security audit:
+
+<Code
+  code={`# Critical issues
+$ vlt query ':malware(critical), :cve(*), :obfuscated'
+
+# Supply chain risks
+$ vlt query ':abandoned, :unmaintained, :unknown'
+
+# License compliance
+$ vlt query ':license(copyleft), :license(unlicensed)'
+
+# Code behavior audit
+$ vlt query ':eval, :shell, :network, :fs'`}
+  title="Terminal"
+  lang="bash"
+/>
+
+## See also
+
+- [`:scanned`](/cli/selectors/pseudo-states) — check if packages
+  have security metadata
+- [vlt security overview](/cli/security) — security features in vlt


### PR DESCRIPTION
## Summary

Restructures the single monolithic **Query Selectors** page (`/cli/selectors`) into a nested directory of individual pages, following the [MDN CSS selector docs pattern](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Selectors) for better SEO, deep-linking, and discoverability.

Requested by @darcyclarke in Slack.

## Before

All selectors documented on a single long page at `/cli/selectors` — fine for quick reference but poor for SEO, deep-linking, and detailed examples.

## After

**19 files** (1 index + 18 sub-pages) organized as:

```
cli/selectors.mdx                          ← Overview with CardGrid
cli/selectors/
├── attribute-selectors.mdx                ← [attr], [attr=value], etc.
├── combinators.mdx                        ← >, space, ~
├── id-selectors.mdx                       ← #name shorthand
├── pseudo-classes/
│   ├── index.mdx                          ← Overview with LinkCards
│   ├── attr.mdx                           ← :attr()
│   ├── has.mdx                            ← :has()
│   ├── host.mdx                           ← :host()
│   ├── is.mdx                             ← :is()
│   ├── not.mdx                            ← :not()
│   ├── outdated.mdx                       ← :outdated()
│   ├── published.mdx                      ← :published()
│   ├── semver.mdx                         ← :semver()
│   ├── spec.mdx                           ← :spec()
│   ├── path.mdx                           ← :path()
│   ├── type.mdx                           ← :type()
│   └── diff.mdx                           ← :diff()
├── pseudo-states/
│   └── index.mdx                          ← :root, :dev, :prod, etc.
└── security-insights.mdx                  ← Socket-powered selectors
```

## What each page includes

- **Syntax reference table** — at-a-glance parameter docs
- **Multiple practical examples** — real `vlt query` commands
- **"What gets selected" sections** — ASCII dependency trees showing which packages match (✅)
- **Cross-links** — related selectors, combinators, and docs pages
- **Starlight Code components** — consistent syntax highlighting

## URL structure

Every selector now has a dedicated, linkable URL:
- `/cli/selectors/combinators`
- `/cli/selectors/pseudo-classes/outdated`
- `/cli/selectors/pseudo-classes/diff`
- `/cli/selectors/security-insights`
- etc.

## Notes

- The original `selectors.mdx` is preserved as the index/overview page with a quick-reference table and CardGrid linking to all sub-pages
- Uses the same `commands.mdx` + `commands/` pattern already established in the docs
- All internal cross-links verified against existing pages