### PR TITLE
fix: pass ignoreMissing to foreground runner for --if-present flag

### DIFF
--- a/src/cli-sdk/src/exec-command.ts
+++ b/src/cli-sdk/src/exec-command.ts
@@ -327,6 +327,8 @@ export class ExecCommand<B extends RunnerBG, F extends RunnerFG> {
       arg0,
       args: this.args,
       env: this.env,
+      ignoreMissing:
+        this.conf.get('if-present') ?? this.#defaultIgnoreMissing,
       projectRoot: this.projectRoot,
       packageJson: this.conf.options.packageJson,
       'script-shell':

--- a/src/cli-sdk/test/commands/run.ts
+++ b/src/cli-sdk/test/commands/run.ts
@@ -436,6 +436,107 @@ t.test('one ws fails, without bail', async t => {
   process.exitCode = exitCode
 })
 
+t.test(
+  'if-present with missing script in single project',
+  async t => {
+    const dir = t.testdir({
+      'package.json': JSON.stringify({
+        scripts: {
+          hello: pass,
+        },
+      }),
+      'vlt.json': JSON.stringify({ config: {} }),
+      '.git': {},
+    })
+    t.chdir(dir)
+    const { Config } = await t.mockImport<
+      typeof import('../../src/config/index.ts')
+    >('../../src/config/index.ts')
+    unload()
+    const conf = await Config.load(t.testdirName, [
+      'goodbye',
+      '--if-present',
+    ])
+    conf.projectRoot = dir
+    const logs = t.capture(console, 'log').args
+    const errs = t.capture(console, 'error').args
+    const result = await command(conf)
+    t.strictSame(result, {
+      command: '',
+      args: [],
+      cwd: dir,
+      status: 0,
+      signal: null,
+      stdout: null,
+      stderr: null,
+    })
+    t.strictSame(logs(), [])
+    t.strictSame(errs(), [])
+  },
+)
+
+t.test(
+  'if-present with no matching scripts across workspaces',
+  async t => {
+    const runTest = async (t: Test, { args }: { args: string[] }) => {
+      const dir = t.testdir({
+        'vlt.json': JSON.stringify({ workspaces: 'src/*' }),
+        'package.json': '{}',
+        src: {
+          a: {
+            'package.json': JSON.stringify({
+              name: 'a',
+              scripts: {
+                hello: pass,
+              },
+            }),
+          },
+          b: {
+            'package.json': JSON.stringify({
+              name: 'b',
+              scripts: {
+                hello: pass,
+              },
+            }),
+          },
+        },
+        '.git': {},
+      })
+      t.chdir(dir)
+
+      const { Config } = await t.mockImport<
+        typeof import('../../src/config/index.ts')
+      >('../../src/config/index.ts')
+      unload()
+      const conf = await Config.load(t.testdirName, [
+        'goodbye',
+        ...args,
+        '--view=human',
+      ])
+      t.equal(conf.projectRoot, dir)
+      const logs = t.capture(console, 'log').args
+      const errs = t.capture(console, 'error').args
+
+      const result = await command(conf)
+      t.strictSame(result, {})
+      t.strictSame(logs(), [])
+      t.strictSame(errs(), [])
+    }
+
+    t.test('with workspaces', async t => {
+      await runTest(t, {
+        args: ['-w', 'src/a', '-w', 'src/b'],
+      })
+    })
+
+    t.test('with scope', async t => {
+      await runTest(t, {
+        args: ['--scope', ':workspace#a, :workspace#b'],
+      })
+    })
+  },
+)
+
 t.test('show scripts if no event specified', async t => {
   const dir = t.testdir({
     'package.json': JSON.stringify({


### PR DESCRIPTION
## Summary

Fixes #1577

The `--if-present` flag for `vlt run` was not working correctly when none of the workspace packages (or a single project) had the specified script. Instead of silently succeeding, it would throw an error as if the flag wasn't passed.

## Root Cause

The `fgArg()` method in `ExecCommand` (used for single-target foreground execution) was missing the `ignoreMissing` option. While `bgArg()` (used for multi-workspace background execution) correctly passed `ignoreMissing` derived from `--if-present`, `fgArg()` did not. This meant:

- **Single project**: `vlt run goodbye --if-present` would throw `Script not defined in package.json`
- **Single workspace target**: Same error when targeting a single workspace without the script

## Fix

Added `ignoreMissing` to `fgArg()`, matching the same logic already present in `bgArg()`:

```typescript
ignoreMissing:
  this.conf.get('if-present') ?? this.#defaultIgnoreMissing,
```

## Tests Added

1. **Single project with `--if-present` and missing script** — verifies it returns a success result (`status: 0`) instead of throwing
2. **Multi-workspace with `--if-present` and no matching scripts** — verifies it returns empty results (`{}`) instead of throwing (both with `-w` and `--scope`)

Co-authored-by: Darcy Clarke <darcy@darcyclarke.me>