### PR TITLE
fix(run): respect TTY status when setting FORCE_COLOR in background mode

### DIFF
--- a/src/run/src/index.ts
+++ b/src/run/src/index.ts
@@ -424,7 +424,7 @@ export const exec = async (
       {
         ...process.env,
         ...env,
-        FORCE_COLOR: color ? '1' : '0',
+        FORCE_COLOR: color && process.stdout.isTTY ? '1' : '0',
       },
       arg0,
     ),

--- a/src/run/test/index.ts
+++ b/src/run/test/index.ts
@@ -1302,3 +1302,78 @@ t.test('node-gyp shim injection into PATH', async t => {
     },
   )
 })
+
+t.test('exec bg FORCE_COLOR respects isTTY', async t => {
+  const cwd = t.testdir({
+    node_modules: { '.bin': {} },
+  })
+
+  const printForceColor = `${node} -p "process.env.FORCE_COLOR"`
+
+  t.test('color=true with isTTY=true sets FORCE_COLOR=1', async t => {
+    const originalIsTTY = process.stdout.isTTY
+    t.teardown(() => {
+      Object.defineProperty(process.stdout, 'isTTY', {
+        value: originalIsTTY,
+        writable: true,
+        configurable: true,
+      })
+    })
+    Object.defineProperty(process.stdout, 'isTTY', {
+      value: true,
+      writable: true,
+      configurable: true,
+    })
+
+    const result = await exec({
+      arg0: printForceColor,
+      cwd,
+      projectRoot: cwd,
+      color: true,
+      'script-shell': true,
+    })
+    t.equal(result.status, 0)
+    t.equal(result.stdout.trim(), '1')
+  })
+
+  t.test(
+    'color=true with isTTY=undefined sets FORCE_COLOR=0',
+    async t => {
+      const originalIsTTY = process.stdout.isTTY
+      t.teardown(() => {
+        Object.defineProperty(process.stdout, 'isTTY', {
+          value: originalIsTTY,
+          writable: true,
+          configurable: true,
+        })
+      })
+      Object.defineProperty(process.stdout, 'isTTY', {
+        value: undefined,
+        writable: true,
+        configurable: true,
+      })
+
+      const result = await exec({
+        arg0: printForceColor,
+        cwd,
+        projectRoot: cwd,
+        color: true,
+        'script-shell': true,
+      })
+      t.equal(result.status, 0)
+      t.equal(result.stdout.trim(), '0')
+    },
+  )
+
+  t.test('color=false always sets FORCE_COLOR=0', async t => {
+    const result = await exec({
+      arg0: printForceColor,
+      cwd,
+      projectRoot: cwd,
+      color: false,
+      'script-shell': true,
+    })
+    t.equal(result.status, 0)
+    t.equal(result.stdout.trim(), '0')
+  })
+})


### PR DESCRIPTION
Fixes vlr FORCE_COLOR handling when stdout is piped.

**Problem**: When running a script via `vlr` and piping output (`vlr script | other`), `vlr` sets `FORCE_COLOR=1` on child processes even though the final output is piped. This causes ANSI color codes to leak into piped output, breaking downstream consumers.

**Solution**: Updated the background exec path so that `FORCE_COLOR` respects the actual TTY status. Specifically:
- If `process.stdout.isTTY` is falsy (vlr's output is piped), `FORCE_COLOR` is `'0'`
- Only set `FORCE_COLOR=1` when stdout IS a TTY
- The foreground path (`execFG`) remains unchanged as it was already working correctly

**Testing**: The change preserves existing behavior for TTY scenarios while fixing the piped output case.