### PR TITLE
add url field to parsePerson and normalizeContributors

### DIFF
--- a/src/types/src/index.ts
+++ b/src/types/src/index.ts
@@ -245,24 +245,30 @@ export const parsePerson = (
       typeof person.email === 'string' ? person.email
       : typeof person.mail === 'string' ? person.mail
       : undefined
+    const url =
+      typeof person.url === 'string' ? person.url : undefined
 
-    if (!name && !email) return undefined
+    if (!name && !email && !url) return undefined
 
     return {
       name,
       email,
+      ...(url ? { url } : {}),
       [kWriteAccess]: writeAccess ?? false,
       [kIsPublisher]: isPublisher ?? false,
     }
   } else if (typeof person === 'string') {
     const NAME_PATTERN = /^([^(<]+)/
     const EMAIL_PATTERN = /<([^<>]+)>/
+    const URL_PATTERN = /\(([^()]+)\)/
     const name = NAME_PATTERN.exec(person)?.[0].trim() || ''
     const email = EMAIL_PATTERN.exec(person)?.[1] || ''
-    if (!name && !email) return undefined
+    const url = URL_PATTERN.exec(person)?.[1] || ''
+    if (!name && !email && !url) return undefined
     return {
       name: name || undefined,
       email: email || undefined,
+      ...(url ? { url } : {}),
       [kWriteAccess]: writeAccess ?? false,
       [kIsPublisher]: isPublisher ?? false,
     }
@@ -283,6 +289,7 @@ export type NormalizedContributors = NormalizedContributorEntry[]
 export type NormalizedContributorEntry = {
   email?: string
   name?: string
+  url?: string
   // in-memory we store those keys as symbols so that they
   // don't get written to user-managed package.json files
   [kWriteAccess]?: boolean
@@ -301,10 +308,15 @@ export const isNormalizedContributorEntry = (
 ): o is NormalizedContributorEntry => {
   return (
     isObject(o) &&
-    typeof o.name === 'string' &&
-    !!o.name &&
-    typeof o.email === 'string' &&
-    !!o.email &&
+    (typeof o.name === 'string' ||
+      typeof o.email === 'string' ||
+      typeof o.url === 'string') &&
+    (typeof o.name === 'undefined' ||
+      (typeof o.name === 'string' && !!o.name)) &&
+    (typeof o.email === 'undefined' ||
+      (typeof o.email === 'string' && !!o.email)) &&
+    (typeof o.url === 'undefined' ||
+      (typeof o.url === 'string' && !!o.url)) &&
     (isBoolean((o as NormalizedContributorEntry)[kWriteAccess]) ||
       isBoolean(o.writeAccess)) &&
     (isBoolean((o as NormalizedContributorEntry)[kIsPublisher]) ||

--- a/src/types/test/index.ts
+++ b/src/types/test/index.ts
@@ -87,14 +87,40 @@ const kIsPublisher = Symbol.for('isPublisher')
 const createExpectedContributor = (
   name?: string,
   email?: string,
-  writeAccess = false,
-  isPublisher = false,
-) => ({
-  name,
-  email,
-  [kWriteAccess]: writeAccess,
-  [kIsPublisher]: isPublisher,
-})
+  urlOrWriteAccess?: string | boolean,
+  writeAccessOrIsPublisher?: boolean,
+  isPublisher?: boolean,
+) => {
+  // Handle the two calling patterns:
+  // 1. New: name, email, url, writeAccess, isPublisher
+  // 2. Old: name, email, writeAccess, isPublisher
+  let url: string | undefined
+  let writeAccess: boolean
+  let isPublisherFlag: boolean
+
+  if (
+    typeof urlOrWriteAccess === 'string' ||
+    urlOrWriteAccess === undefined
+  ) {
+    // New pattern
+    url = urlOrWriteAccess
+    writeAccess = writeAccessOrIsPublisher ?? false
+    isPublisherFlag = isPublisher ?? false
+  } else {
+    // Old pattern
+    url = undefined
+    writeAccess = urlOrWriteAccess
+    isPublisherFlag = writeAccessOrIsPublisher ?? false
+  }
+
+  return {
+    name,
+    email,
+    ...(url ? { url } : {}),
+    [kWriteAccess]: writeAccess,
+    [kIsPublisher]: isPublisherFlag,
+  }
+}
 
 t.test('manifest', t => {
   t.equal(isManifest(true), false)
@@ -1732,6 +1758,109 @@ t.test('parsePerson', t => {
       t.end()
     },
   )
+
+  t.test('parses string with URL only', t => {
+    const result = parsePerson('John Doe (http://johndoe.com)')
+    t.same(
+      result,
+      createExpectedContributor(
+        'John Doe',
+        undefined,
+        'http://johndoe.com',
+        false,
+        false,
+      ),
+    )
+    t.end()
+  })
+
+  t.test('parses string with name, email, and URL', t => {
+    const result = parsePerson(
+      'Barney Rubble <barney@npmjs.com> (http://barnyrubble.npmjs.com/)',
+    )
+    t.same(
+      result,
+      createExpectedContributor(
+        'Barney Rubble',
+        'barney@npmjs.com',
+        'http://barnyrubble.npmjs.com/',
+        false,
+        false,
+      ),
+    )
+    t.end()
+  })
+
+  t.test('parses string with email and URL only', t => {
+    const result = parsePerson(
+      '<barney@npmjs.com> (http://barnyrubble.npmjs.com/)',
+    )
+    t.same(
+      result,
+      createExpectedContributor(
+        undefined,
+        'barney@npmjs.com',
+        'http://barnyrubble.npmjs.com/',
+        false,
+        false,
+      ),
+    )
+    t.end()
+  })
+
+  t.test('parses object format with URL', t => {
+    const result = parsePerson({
+      name: 'John Doe',
+      email: 'john@example.com',
+      url: 'http://johndoe.com',
+    })
+    t.same(
+      result,
+      createExpectedContributor(
+        'John Doe',
+        'john@example.com',
+        'http://johndoe.com',
+        false,
+        false,
+      ),
+    )
+    t.end()
+  })
+
+  t.test('parses object with only URL', t => {
+    const result = parsePerson({
+      url: 'http://johndoe.com',
+    })
+    t.same(
+      result,
+      createExpectedContributor(
+        undefined,
+        undefined,
+        'http://johndoe.com',
+        false,
+        false,
+      ),
+    )
+    t.end()
+  })
+
+  t.test('handles empty URL patterns', t => {
+    const result1 = parsePerson('John Doe ()')
+    t.same(
+      result1,
+      createExpectedContributor(
+        'John Doe',
+        undefined,
+        undefined,
+        false,
+        false,
+      ),
+    )
+
+    const result2 = parsePerson('()')
+    t.equal(result2, undefined)
+    t.end()
+  })
 
   t.end()
 })


### PR DESCRIPTION
The `author` and `contributors` fields can have a `url` property. @vltpkg/types currently discards this. I'd like to get access to the url, so this PR parses this property and returns it.