### PR TITLE
feat(cli-sdk): change install json view to output diff info

### DIFF
--- a/src/cli-sdk/src/commands/install.ts
+++ b/src/cli-sdk/src/commands/install.ts
@@ -81,6 +81,11 @@ export const views = {
   json: i => {
     const added = i.diff?.nodes.add ?? new Set()
     const deleted = i.diff?.nodes.delete ?? new Set()
+    // The actual (from) graph represents what was on disk before the install.
+    // Used to filter out optional deps that were never installed (e.g.
+    // platform-specific binaries). These end up in the delete set via
+    // optionalFail but should not be reported as removals.
+    const actual = i.diff?.from
 
     // Build a map of deleted nodes by name for detecting changes
     const deletedByName = new Map<
@@ -88,12 +93,15 @@ export const views = {
       { name: string; version?: string }
     >()
     for (const node of deleted) {
-      if (!node.importer) {
-        deletedByName.set(node.name, {
-          name: node.name,
-          version: node.version,
-        })
-      }
+      if (node.importer) continue
+      // Skip nodes that were never on disk — these are optional deps
+      // that failed during install (e.g. wrong platform) and were moved
+      // to the delete set by optionalFail.
+      if (actual && !actual.nodes.has(node.id)) continue
+      deletedByName.set(node.name, {
+        name: node.name,
+        version: node.version,
+      })
     }
 
     const add: { name: string; version?: string }[] = []

--- a/src/cli-sdk/src/commands/install.ts
+++ b/src/cli-sdk/src/commands/install.ts
@@ -3,7 +3,7 @@ import { install } from '@vltpkg/graph'
 import { parseAddArgs } from '../parse-add-remove-args.ts'
 import { InstallReporter } from './install/reporter.ts'
 import type { DepID } from '@vltpkg/dep-id'
-import type { Graph } from '@vltpkg/graph'
+import type { Diff, Graph } from '@vltpkg/graph'
 import type { CommandFn, CommandUsage } from '../index.ts'
 import type { Views } from '../view.ts'
 
@@ -19,6 +19,10 @@ export type InstallResult = {
    * The resulting graph structure at the end of an install.
    */
   graph: Graph
+  /**
+   * The diff between the actual and ideal graphs, if available.
+   */
+  diff?: Diff
 }
 
 export const usage: CommandUsage = () =>
@@ -74,15 +78,64 @@ export const usage: CommandUsage = () =>
   })
 
 export const views = {
-  json: i => ({
-    ...(i.buildQueue?.length ?
-      {
-        buildQueue: i.buildQueue,
-        message: `${i.buildQueue.length} packages that will need to be built, run "vlt build" to complete the install.`,
+  json: i => {
+    const added = i.diff?.nodes.add ?? new Set()
+    const deleted = i.diff?.nodes.delete ?? new Set()
+
+    // Build a map of deleted nodes by name for detecting changes
+    const deletedByName = new Map<
+      string,
+      { name: string; version?: string }
+    >()
+    for (const node of deleted) {
+      if (!node.importer) {
+        deletedByName.set(node.name, {
+          name: node.name,
+          version: node.version,
+        })
       }
-    : null),
-    graph: i.graph.toJSON(),
-  }),
+    }
+
+    const add: { name: string; version?: string }[] = []
+    const change: {
+      name: string
+      from?: string
+      to?: string
+    }[] = []
+    for (const node of added) {
+      if (node.importer) continue
+      const prev = deletedByName.get(node.name)
+      if (prev) {
+        // Package exists in both add and delete = changed
+        change.push({
+          name: node.name,
+          from: prev.version,
+          to: node.version,
+        })
+        deletedByName.delete(node.name)
+      } else {
+        add.push({ name: node.name, version: node.version })
+      }
+    }
+
+    // Remaining deleted nodes that weren't matched = pure removals
+    const remove = [...deletedByName.values()]
+
+    return {
+      add,
+      added: add.length,
+      change,
+      changed: change.length,
+      remove,
+      removed: remove.length,
+      ...(i.buildQueue?.length ?
+        {
+          buildQueue: i.buildQueue,
+          message: `${i.buildQueue.length} packages that will need to be built, run "vlt build" to complete the install.`,
+        }
+      : null),
+    }
+  },
   human: InstallReporter,
 } as const satisfies Views<InstallResult>
 
@@ -101,7 +154,7 @@ export const command: CommandFn<InstallResult> = async conf => {
       String(conf.get('allow-scripts'))
     : ':not(*)'
   /* c8 ignore stop */
-  const { buildQueue, graph } = await install(
+  const { buildQueue, graph, diff } = await install(
     {
       ...conf.options,
       frozenLockfile,
@@ -111,5 +164,5 @@ export const command: CommandFn<InstallResult> = async conf => {
     },
     add,
   )
-  return { buildQueue, graph }
+  return { buildQueue, graph, diff }
 }

--- a/src/cli-sdk/test/commands/install.ts
+++ b/src/cli-sdk/test/commands/install.ts
@@ -159,10 +159,7 @@ t.strictSame(
   Command.views.json({
     graph: {} as any,
     diff: {
-      from: mockFrom(
-        '~~removed-dep@1.0.0',
-        '~~updated-dep@2.0.0',
-      ),
+      from: mockFrom('~~removed-dep@1.0.0', '~~updated-dep@2.0.0'),
       nodes: {
         add: new Set([
           mockNode('new-dep', '1.0.0'),

--- a/src/cli-sdk/test/commands/install.ts
+++ b/src/cli-sdk/test/commands/install.ts
@@ -53,62 +53,199 @@ await Command.command({
 } as unknown as LoadedConfig)
 t.matchSnapshot(log, 'should install adding a new dependency')
 
+// Helper to create mock nodes
+const mockNode = (
+  name: string,
+  version: string,
+  importer = false,
+) => ({
+  name,
+  version,
+  importer,
+})
+
+// Test JSON view with no diff (e.g. lockfile-only mode)
 t.strictSame(
   Command.views.json({
-    graph: {
-      toJSON: () => ({
-        lockfileVersion: 1,
-        options: {},
-        nodes: {},
-        edges: {},
-      }),
+    graph: {} as any,
+  }),
+  {
+    add: [],
+    added: 0,
+    change: [],
+    changed: 0,
+    remove: [],
+    removed: 0,
+  },
+  'json view without diff should return empty diff result',
+)
+
+// Test JSON view with added packages
+t.strictSame(
+  Command.views.json({
+    graph: {} as any,
+    diff: {
+      nodes: {
+        add: new Set([mockNode('simple-output', '3.0.0')]),
+        delete: new Set(),
+      },
     } as any,
   }),
   {
-    graph: { lockfileVersion: 1, options: {}, nodes: {}, edges: {} },
+    add: [{ name: 'simple-output', version: '3.0.0' }],
+    added: 1,
+    change: [],
+    changed: 0,
+    remove: [],
+    removed: 0,
   },
-  'json view without buildQueue should only include graph',
+  'json view should show added packages',
+)
+
+// Test JSON view with removed packages
+t.strictSame(
+  Command.views.json({
+    graph: {} as any,
+    diff: {
+      nodes: {
+        add: new Set(),
+        delete: new Set([mockNode('old-dep', '1.0.0')]),
+      },
+    } as any,
+  }),
+  {
+    add: [],
+    added: 0,
+    change: [],
+    changed: 0,
+    remove: [{ name: 'old-dep', version: '1.0.0' }],
+    removed: 1,
+  },
+  'json view should show removed packages',
+)
+
+// Test JSON view with changed packages (same name in both add and delete)
+t.strictSame(
+  Command.views.json({
+    graph: {} as any,
+    diff: {
+      nodes: {
+        add: new Set([mockNode('my-dep', '2.0.0')]),
+        delete: new Set([mockNode('my-dep', '1.0.0')]),
+      },
+    } as any,
+  }),
+  {
+    add: [],
+    added: 0,
+    change: [{ name: 'my-dep', from: '1.0.0', to: '2.0.0' }],
+    changed: 1,
+    remove: [],
+    removed: 0,
+  },
+  'json view should show changed packages',
+)
+
+// Test JSON view with a mix of add, change, and remove
+t.strictSame(
+  Command.views.json({
+    graph: {} as any,
+    diff: {
+      nodes: {
+        add: new Set([
+          mockNode('new-dep', '1.0.0'),
+          mockNode('updated-dep', '3.0.0'),
+        ]),
+        delete: new Set([
+          mockNode('removed-dep', '1.0.0'),
+          mockNode('updated-dep', '2.0.0'),
+        ]),
+      },
+    } as any,
+  }),
+  {
+    add: [{ name: 'new-dep', version: '1.0.0' }],
+    added: 1,
+    change: [{ name: 'updated-dep', from: '2.0.0', to: '3.0.0' }],
+    changed: 1,
+    remove: [{ name: 'removed-dep', version: '1.0.0' }],
+    removed: 1,
+  },
+  'json view should categorize add, change, and remove correctly',
+)
+
+// Test JSON view filters out importers
+t.strictSame(
+  Command.views.json({
+    graph: {} as any,
+    diff: {
+      nodes: {
+        add: new Set([
+          mockNode('my-project', '1.0.0', true),
+          mockNode('real-dep', '2.0.0'),
+        ]),
+        delete: new Set([mockNode('my-project', '0.9.0', true)]),
+      },
+    } as any,
+  }),
+  {
+    add: [{ name: 'real-dep', version: '2.0.0' }],
+    added: 1,
+    change: [],
+    changed: 0,
+    remove: [],
+    removed: 0,
+  },
+  'json view should filter out importer nodes',
 )
 
 // Test JSON view with buildQueue
 t.strictSame(
   Command.views.json({
     buildQueue: ['~~foo@1.0.0' as any, '~~bar@2.0.0' as any],
-    graph: {
-      toJSON: () => ({
-        lockfileVersion: 1,
-        options: {},
-        nodes: {},
-        edges: {},
-      }),
+    graph: {} as any,
+    diff: {
+      nodes: {
+        add: new Set([
+          mockNode('foo', '1.0.0'),
+          mockNode('bar', '2.0.0'),
+        ]),
+        delete: new Set(),
+      },
     } as any,
   }),
   {
+    add: [
+      { name: 'foo', version: '1.0.0' },
+      { name: 'bar', version: '2.0.0' },
+    ],
+    added: 2,
+    change: [],
+    changed: 0,
+    remove: [],
+    removed: 0,
     buildQueue: ['~~foo@1.0.0', '~~bar@2.0.0'],
     message:
       '2 packages that will need to be built, run "vlt build" to complete the install.',
-    graph: { lockfileVersion: 1, options: {}, nodes: {}, edges: {} },
   },
-  'json view with buildQueue should include buildQueue, message, and graph',
+  'json view with buildQueue should include buildQueue and message',
 )
 
 // Test JSON view with empty buildQueue (should not include buildQueue or message)
 t.strictSame(
   Command.views.json({
     buildQueue: [],
-    graph: {
-      toJSON: () => ({
-        lockfileVersion: 1,
-        options: {},
-        nodes: {},
-        edges: {},
-      }),
-    } as any,
+    graph: {} as any,
   }),
   {
-    graph: { lockfileVersion: 1, options: {}, nodes: {}, edges: {} },
+    add: [],
+    added: 0,
+    change: [],
+    changed: 0,
+    remove: [],
+    removed: 0,
   },
-  'json view with empty buildQueue should only include graph',
+  'json view with empty buildQueue should not include buildQueue or message',
 )
 
 t.test('frozen-lockfile flag', async t => {

--- a/src/cli-sdk/test/commands/install.ts
+++ b/src/cli-sdk/test/commands/install.ts
@@ -59,9 +59,15 @@ const mockNode = (
   version: string,
   importer = false,
 ) => ({
+  id: `~~${name}@${version}`,
   name,
   version,
   importer,
+})
+
+// Helper to create a mock "from" (actual) graph with a set of node IDs
+const mockFrom = (...ids: string[]) => ({
+  nodes: new Map(ids.map(id => [id, true])),
 })
 
 // Test JSON view with no diff (e.g. lockfile-only mode)
@@ -102,11 +108,12 @@ t.strictSame(
   'json view should show added packages',
 )
 
-// Test JSON view with removed packages
+// Test JSON view with removed packages (node was on disk = real removal)
 t.strictSame(
   Command.views.json({
     graph: {} as any,
     diff: {
+      from: mockFrom('~~old-dep@1.0.0'),
       nodes: {
         add: new Set(),
         delete: new Set([mockNode('old-dep', '1.0.0')]),
@@ -129,6 +136,7 @@ t.strictSame(
   Command.views.json({
     graph: {} as any,
     diff: {
+      from: mockFrom('~~my-dep@1.0.0'),
       nodes: {
         add: new Set([mockNode('my-dep', '2.0.0')]),
         delete: new Set([mockNode('my-dep', '1.0.0')]),
@@ -151,6 +159,10 @@ t.strictSame(
   Command.views.json({
     graph: {} as any,
     diff: {
+      from: mockFrom(
+        '~~removed-dep@1.0.0',
+        '~~updated-dep@2.0.0',
+      ),
       nodes: {
         add: new Set([
           mockNode('new-dep', '1.0.0'),
@@ -197,6 +209,65 @@ t.strictSame(
     removed: 0,
   },
   'json view should filter out importer nodes',
+)
+
+// Test JSON view: already-missing optional deps should NOT be reported as removed.
+// These are platform-specific binaries (e.g. lightningcss-android-arm64) that
+// were never installed because they don't match the current OS/arch. The diff's
+// optionalFail moves them to the delete set, but they were never on disk (not
+// in the "from" actual graph) so they should be filtered out.
+t.strictSame(
+  Command.views.json({
+    graph: {} as any,
+    diff: {
+      from: mockFrom(), // empty actual graph — nothing was on disk
+      nodes: {
+        add: new Set(),
+        delete: new Set([
+          mockNode('lightningcss-android-arm64', '1.29.3'),
+          mockNode('@rolldown/binding-win32-x64-msvc', '1.0.0'),
+        ]),
+      },
+    } as any,
+  }),
+  {
+    add: [],
+    added: 0,
+    change: [],
+    changed: 0,
+    remove: [],
+    removed: 0,
+  },
+  'json view should NOT report already-missing optional deps as removed',
+)
+
+// Test JSON view: optional dep that WAS installed and is actually being
+// removed should still appear in the remove list.
+t.strictSame(
+  Command.views.json({
+    graph: {} as any,
+    diff: {
+      // The dep existed in the actual graph (was on disk)
+      from: mockFrom('~~lightningcss-linux-x64-gnu@1.29.3'),
+      nodes: {
+        add: new Set(),
+        delete: new Set([
+          mockNode('lightningcss-linux-x64-gnu', '1.29.3'),
+        ]),
+      },
+    } as any,
+  }),
+  {
+    add: [],
+    added: 0,
+    change: [],
+    changed: 0,
+    remove: [
+      { name: 'lightningcss-linux-x64-gnu', version: '1.29.3' },
+    ],
+    removed: 1,
+  },
+  'json view should report actually-installed optional dep as removed when deleted',
 )
 
 // Test JSON view with buildQueue


### PR DESCRIPTION
## Summary

Change the JSON output view for the `vlt install` command to display diff information (added/changed/removed packages) instead of the full dependency graph.

### New JSON output format

When running `vlt install --view=json`, the output now shows:

```json
{
  "add": [
    {
      "name": "simple-output",
      "version": "3.0.0"
    }
  ],
  "added": 1,
  "change": [],
  "changed": 0,
  "remove": [],
  "removed": 0
}
```

### Changes

- **`src/cli-sdk/src/commands/install.ts`**:
  - Added `diff` (type `Diff | undefined`) to the `InstallResult` type
  - Captured `diff` from the `install()` return value (it was already returned but ignored)
  - Replaced the JSON view to output categorized diff info instead of the raw graph
  - Packages appearing in both add and delete sets (same name, different version) are classified as "changed"
  - Importer nodes are filtered out from the output
  - `buildQueue`/`message` fields are preserved when packages need building

- **`src/cli-sdk/test/commands/install.ts`**:
  - Updated all JSON view tests to validate the new diff-based output
  - Added test cases for: no diff, added packages, removed packages, changed packages, mixed operations, importer filtering, buildQueue integration, empty buildQueue

Co-authored-by: Ruy Adorno <ruyadorno@users.noreply.github.com>