### PR TITLE
fix(graph): hydrate integrity on existing nodes during placePackage

### DIFF
--- a/src/graph/src/graph.ts
+++ b/src/graph/src/graph.ts
@@ -445,6 +445,20 @@ export class Graph implements GraphLike {
       toFoundNode.detached = false
       toFoundNode.dev &&= flags.dev
       toFoundNode.optional &&= flags.optional
+
+      // Hydrate manifest and integrity on existing nodes (e.g. loaded
+      // from a lockfile without manifest data).  Without this, nodes
+      // that already have `resolved` set from the lockfile will never
+      // get their integrity populated because `setResolved()` is
+      // skipped when `resolved` is already present.
+      if (manifest) {
+        if (!toFoundNode.manifest) {
+          toFoundNode.manifest = manifest
+          this.manifests.set(toFoundNode.id, manifest)
+        }
+        toFoundNode.integrity ??= manifest.dist?.integrity
+      }
+
       return toFoundNode
     }
 

--- a/src/graph/test/graph.ts
+++ b/src/graph/test/graph.ts
@@ -2407,3 +2407,140 @@ t.test('removeNode with keepEdges parameter', async t => {
     )
   })
 })
+
+t.test(
+  'placePackage hydrates manifest and integrity on existing nodes',
+  async t => {
+    const mainManifest = {
+      name: 'my-project',
+      version: '1.0.0',
+    }
+    const projectRoot = t.testdir({ 'vlt.json': '{}' })
+    t.chdir(projectRoot)
+    unload('project')
+    const graph = new Graph({
+      ...configData,
+      projectRoot,
+      mainManifest,
+    })
+
+    const depId = joinDepIDTuple(['registry', '', 'foo@1.0.0'])
+
+    // Simulate a node loaded from lockfile without manifest or integrity
+    // (this is what happens when loadNodes processes nodes from the
+    // normal lockfile which doesn't store manifest data)
+    const existingNode = graph.addNode(
+      depId,
+      undefined,
+      undefined,
+      'foo',
+      '1.0.0',
+    )
+    t.equal(
+      existingNode.manifest,
+      undefined,
+      'node starts without manifest',
+    )
+    t.equal(
+      existingNode.integrity,
+      undefined,
+      'node starts without integrity',
+    )
+
+    const integrity =
+      'sha512-6/mh1E2u2YgEsCHdY0Yx5oW+61gZU+1vXaoiHHrpKeuRNNgFvS+/jrwHiQhB5apAf5oB7UB7E19ol2R2LKH8hQ=='
+    const manifest = normalizeManifest({
+      name: 'foo',
+      version: '1.0.0',
+      dist: {
+        integrity,
+        tarball: 'https://registry.npmjs.org/foo/-/foo-1.0.0.tgz',
+      },
+    })
+
+    // Place the same package again with manifest data
+    // (this is what happens during ideal graph building when the
+    // manifest is fetched from the registry)
+    const placed = graph.placePackage(
+      graph.mainImporter,
+      'prod',
+      Spec.parse('foo', '^1.0.0'),
+      manifest,
+    )
+
+    t.equal(placed, existingNode, 'should return the existing node')
+    t.equal(placed?.manifest, manifest, 'manifest should be hydrated')
+    t.equal(
+      placed?.integrity,
+      integrity,
+      'integrity should be hydrated from manifest',
+    )
+    t.ok(
+      graph.manifests.has(depId),
+      'manifest should be stored in graph.manifests',
+    )
+  },
+)
+
+t.test(
+  'placePackage does not clobber existing manifest or integrity',
+  async t => {
+    const mainManifest = {
+      name: 'my-project',
+      version: '1.0.0',
+    }
+    const projectRoot = t.testdir({ 'vlt.json': '{}' })
+    t.chdir(projectRoot)
+    unload('project')
+    const graph = new Graph({
+      ...configData,
+      projectRoot,
+      mainManifest,
+    })
+
+    const existingIntegrity = 'sha512-EXISTING=='
+    const existingManifest = normalizeManifest({
+      name: 'bar',
+      version: '2.0.0',
+      dist: {
+        integrity: existingIntegrity,
+        tarball: 'https://registry.npmjs.org/bar/-/bar-2.0.0.tgz',
+      },
+    })
+
+    // Create a node WITH manifest and integrity already set
+    const depId = joinDepIDTuple(['registry', '', 'bar@2.0.0'])
+    const existingNode = graph.addNode(depId, existingManifest)
+    existingNode.integrity = existingIntegrity
+
+    const newIntegrity = 'sha512-NEW=='
+    const newManifest = normalizeManifest({
+      name: 'bar',
+      version: '2.0.0',
+      dist: {
+        integrity: newIntegrity,
+        tarball: 'https://registry.npmjs.org/bar/-/bar-2.0.0.tgz',
+      },
+    })
+
+    // Place the same package again with different manifest data
+    const placed = graph.placePackage(
+      graph.mainImporter,
+      'prod',
+      Spec.parse('bar', '^2.0.0'),
+      newManifest,
+    )
+
+    t.equal(placed, existingNode, 'should return the existing node')
+    t.equal(
+      placed?.manifest,
+      existingManifest,
+      'should NOT clobber existing manifest',
+    )
+    t.equal(
+      placed?.integrity,
+      existingIntegrity,
+      'should NOT clobber existing integrity',
+    )
+  },
+)


### PR DESCRIPTION
## Summary

Fixes https://github.com/vltpkg/vltpkg/issues/1581

`vlt install` was producing a `vlt-lock.json` with missing integrity (SHA) hash values for some package nodes. This broke `vlt ci` and weakened supply chain verification.

## Root Cause

When `placePackage` reuses an existing node that was loaded from a lockfile (without manifest data), it returned the node without hydrating its `integrity` field.

The sequence:
1. **Lockfile load**: Nodes are created without manifests. `setResolved()` sets `resolved` via `conventionalRegistryTarball` fallback, but can't set `integrity` because there's no manifest.
2. **Ideal graph build**: `fetchManifestsForDeps` fetches the manifest from the registry.
3. **`placePackage`**: Finds the existing node, creates an edge, but returns **without updating the manifest or integrity**.
4. **Post-placement**: `if (!node.resolved) { node.setResolved() }` is **skipped** because `resolved` is already set from step 1.
5. **Lockfile save**: `formatNodes` writes `null` for integrity.

This primarily affected optional platform-specific deps (e.g. `@esbuild/android-arm`) and peer-context nodes that were loaded from the lockfile but resolved to a different platform.

## Fix

In `Graph.placePackage()`, when reusing an existing node, hydrate its manifest and integrity from the provided manifest if they are missing:

```typescript
if (manifest) {
  if (!toFoundNode.manifest) {
    toFoundNode.manifest = manifest
    this.manifests.set(toFoundNode.id, manifest)
  }
  toFoundNode.integrity ??= manifest.dist?.integrity
}
```

Uses `??=` for integrity and checks `!toFoundNode.manifest` to ensure we never clobber existing values.

## Tests Added

- **`placePackage hydrates manifest and integrity on existing nodes`**: Verifies that when an existing node without manifest/integrity is reused, both are populated from the provided manifest.
- **`placePackage does not clobber existing manifest or integrity`**: Verifies that existing values are preserved and not overwritten.

Co-authored-by: Darcy Clarke <darcy@darcyclarke.me>