### PR TITLE
fix(package-info): validate dist.integrity against downloaded tarball

### DIFF
--- a/src/package-info/src/index.ts
+++ b/src/package-info/src/index.ts
@@ -22,7 +22,7 @@ import { asPackument, isIntegrity } from '@vltpkg/types'
 import ssri from 'ssri'
 import { Monorepo } from '@vltpkg/workspaces'
 import { XDG } from '@vltpkg/xdg'
-import { randomBytes } from 'node:crypto'
+import { createHash, randomBytes } from 'node:crypto'
 import {
   mkdir,
   readFile,
@@ -214,8 +214,30 @@ export class PackageInfoClient {
           this.#trustedIntegrities.set(r.resolved, response.integrity)
         }
 
+        const buf = response.buffer()
+
+        // Verify tarball integrity against the manifest's dist.integrity.
+        // This is a supply-chain security measure: the registry may not
+        // validate integrity, so we do it client-side on every fresh
+        // download (not from lockfile/cache where it was already verified).
+        if (r.integrity) {
+          const hash = createHash('sha512')
+          hash.update(buf)
+          const computed: Integrity =
+            `sha512-${hash.digest('base64')}`
+          if (computed !== r.integrity) {
+            throw error('Tarball integrity check failed', {
+              code: 'EINTEGRITY',
+              spec,
+              url: r.resolved,
+              wanted: r.integrity,
+              found: computed,
+            })
+          }
+        }
+
         try {
-          await this.tarPool.unpack(response.buffer(), target)
+          await this.tarPool.unpack(buf, target)
         } catch (er) {
           throw this.#resolveError(
             spec,
@@ -476,7 +498,26 @@ export class PackageInfoClient {
           this.#trustedIntegrities.set(tarball, response.integrity)
         }
 
-        return response.buffer()
+        const buf = response.buffer()
+
+        // Verify tarball integrity against the manifest's dist.integrity.
+        if (integrity) {
+          const hash = createHash('sha512')
+          hash.update(buf)
+          const computed: Integrity =
+            `sha512-${hash.digest('base64')}`
+          if (computed !== integrity) {
+            throw error('Tarball integrity check failed', {
+              code: 'EINTEGRITY',
+              spec,
+              url: tarball,
+              wanted: integrity,
+              found: computed,
+            })
+          }
+        }
+
+        return buf
       }
 
       case 'git': {

--- a/src/package-info/src/index.ts
+++ b/src/package-info/src/index.ts
@@ -228,8 +228,7 @@ export class PackageInfoClient {
         if (r.integrity && !fromLockfile) {
           const hash = createHash('sha512')
           hash.update(buf)
-          const computed: Integrity =
-            `sha512-${hash.digest('base64')}`
+          const computed: Integrity = `sha512-${hash.digest('base64')}`
           if (computed !== r.integrity) {
             throw error('Tarball integrity check failed', {
               code: 'EINTEGRITY',
@@ -509,8 +508,7 @@ export class PackageInfoClient {
         if (integrity) {
           const hash = createHash('sha512')
           hash.update(buf)
-          const computed: Integrity =
-            `sha512-${hash.digest('base64')}`
+          const computed: Integrity = `sha512-${hash.digest('base64')}`
           if (computed !== integrity) {
             throw error('Tarball integrity check failed', {
               code: 'EINTEGRITY',

--- a/src/package-info/src/index.ts
+++ b/src/package-info/src/index.ts
@@ -138,8 +138,12 @@ export class PackageInfoClient {
       spec = Spec.parse(spec, this.options)
     const { from = this.#projectRoot, integrity, resolved } = options
     const f = spec.final
+    // Track whether integrity/resolved came from the caller (e.g. lockfile)
+    // vs freshly resolved. We only verify tarball integrity on net-new
+    // installs (fresh resolution), not when replaying from lockfile.
+    const fromLockfile = !!(integrity && resolved)
     const r =
-      integrity && resolved ?
+      fromLockfile ?
         { resolved, integrity, spec }
       : await this.resolve(spec, options)
 
@@ -219,8 +223,9 @@ export class PackageInfoClient {
         // Verify tarball integrity against the manifest's dist.integrity.
         // This is a supply-chain security measure: the registry may not
         // validate integrity, so we do it client-side on every fresh
-        // download (not from lockfile/cache where it was already verified).
-        if (r.integrity) {
+        // download. Skip when integrity came from lockfile/cache (it was
+        // already verified on first install).
+        if (r.integrity && !fromLockfile) {
           const hash = createHash('sha512')
           hash.update(buf)
           const computed: Integrity =

--- a/src/package-info/test/index.ts
+++ b/src/package-info/test/index.ts
@@ -942,6 +942,37 @@ t.test('registry tarball integrity verification', async t => {
       )
     },
   )
+
+  await t.test(
+    'extract skips integrity check when integrity comes from lockfile',
+    async t => {
+      // When integrity + resolved are provided (e.g. from lockfile),
+      // the check is skipped because the integrity was already verified
+      // on first install.
+      const dir = t.testdir({ 'vlt.json': '{}' })
+      t.chdir(dir)
+      unload()
+      const result = await extract(
+        'abbrev@2',
+        dir + '/from-lockfile',
+        {
+          ...options,
+          resolved: `${defaultRegistry}abbrev/-/abbrev-2.0.0.tgz`,
+          integrity:
+            pakuAbbrev.versions['2.0.0'].dist.integrity,
+        },
+      )
+      t.match(result, {
+        resolved: `${defaultRegistry}abbrev/-/abbrev-2.0.0.tgz`,
+      })
+      const json = readFileSync(
+        `${dir}/from-lockfile/package.json`,
+        'utf8',
+      )
+      const pkg = JSON.parse(json)
+      t.match(pkg, { name: 'abbrev', version: '2.0.0' })
+    },
+  )
 })
 
 t.test('extraction failures', async t => {

--- a/src/package-info/test/index.ts
+++ b/src/package-info/test/index.ts
@@ -202,8 +202,7 @@ const server = createServer((req, res) => {
         version: '1.0.0',
         dist: {
           tarball: `${defaultRegistry}corrupted/-/corrupted-1.0.0.tgz`,
-          integrity:
-            pakuAbbrev.versions['2.0.0'].dist.integrity,
+          integrity: pakuAbbrev.versions['2.0.0'].dist.integrity,
         },
       })
       res.setHeader('content-type', 'application/json')
@@ -220,8 +219,7 @@ const server = createServer((req, res) => {
             version: '1.0.0',
             dist: {
               tarball: `${defaultRegistry}corrupted/-/corrupted-1.0.0.tgz`,
-              integrity:
-                pakuAbbrev.versions['2.0.0'].dist.integrity,
+              integrity: pakuAbbrev.versions['2.0.0'].dist.integrity,
             },
           },
         },
@@ -858,11 +856,7 @@ t.test('registry tarball integrity verification', async t => {
       const dir = t.testdir({ 'vlt.json': '{}' })
       t.chdir(dir)
       unload()
-      const result = await extract(
-        'abbrev@2',
-        dir + '/good',
-        options,
-      )
+      const result = await extract('abbrev@2', dir + '/good', options)
       t.match(result, {
         resolved: `${defaultRegistry}abbrev/-/abbrev-2.0.0.tgz`,
       })
@@ -915,10 +909,7 @@ t.test('registry tarball integrity verification', async t => {
       t.match(result, {
         resolved: `${defaultRegistry}no-integrity/-/no-integrity-1.0.0.tgz`,
       })
-      const json = readFileSync(
-        `${dir}/no-int/package.json`,
-        'utf8',
-      )
+      const json = readFileSync(`${dir}/no-int/package.json`, 'utf8')
       const pkg = JSON.parse(json)
       t.match(pkg, { name: 'abbrev', version: '2.0.0' })
     },
@@ -958,8 +949,7 @@ t.test('registry tarball integrity verification', async t => {
         {
           ...options,
           resolved: `${defaultRegistry}abbrev/-/abbrev-2.0.0.tgz`,
-          integrity:
-            pakuAbbrev.versions['2.0.0'].dist.integrity,
+          integrity: pakuAbbrev.versions['2.0.0'].dist.integrity,
         },
       )
       t.match(result, {

--- a/src/package-info/test/index.ts
+++ b/src/package-info/test/index.ts
@@ -887,7 +887,11 @@ t.test('registry tarball integrity verification', async t => {
   await t.test(
     'tarball() throws EINTEGRITY when tarball is corrupted',
     async t => {
-      const tb = new PackageInfoClient(options)
+      const dir = t.testdir()
+      const tb = new PackageInfoClient({
+        ...options,
+        cache: dir + '/cache',
+      })
       await t.rejects(tb.tarball('corrupted@1.0.0'), {
         message: 'Tarball integrity check failed',
         cause: { code: 'EINTEGRITY' },
@@ -918,7 +922,11 @@ t.test('registry tarball integrity verification', async t => {
   await t.test(
     'tarball() succeeds when dist.integrity is missing',
     async t => {
-      const tb = new PackageInfoClient(options)
+      const dir = t.testdir()
+      const tb = new PackageInfoClient({
+        ...options,
+        cache: dir + '/cache',
+      })
       const buf = await tb.tarball('no-integrity@1.0.0')
       t.ok(buf.length > 0, 'should return tarball data')
       t.equal(

--- a/src/package-info/test/index.ts
+++ b/src/package-info/test/index.ts
@@ -181,6 +181,91 @@ const server = createServer((req, res) => {
       res.setHeader('content-length', j.byteLength)
       return res.end(j)
     }
+    case '/corrupted/-/corrupted-1.0.0.tgz': {
+      // Serve a tarball whose content does NOT match the integrity
+      // in the manifest (simulates a supply-chain attack / registry bug)
+      const corrupted = Buffer.from(tgzAbbrev)
+      // Flip some bytes to corrupt it while keeping gzip magic
+      corrupted[100] = (corrupted[100]! ^ 0xff) & 0xff
+      corrupted[101] = (corrupted[101]! ^ 0xff) & 0xff
+      res.setHeader('content-type', 'application/octet-stream')
+      res.setHeader('content-length', corrupted.byteLength)
+      res.setHeader(
+        'integrity',
+        pakuAbbrev.versions['2.0.0'].dist.integrity,
+      )
+      return res.end(corrupted)
+    }
+    case '/corrupted/1.0.0': {
+      const json = JSON.stringify({
+        name: 'corrupted',
+        version: '1.0.0',
+        dist: {
+          tarball: `${defaultRegistry}corrupted/-/corrupted-1.0.0.tgz`,
+          integrity:
+            pakuAbbrev.versions['2.0.0'].dist.integrity,
+        },
+      })
+      res.setHeader('content-type', 'application/json')
+      res.setHeader('content-length', json.length)
+      return res.end(json)
+    }
+    case '/corrupted': {
+      const json = JSON.stringify({
+        name: 'corrupted',
+        'dist-tags': { latest: '1.0.0' },
+        versions: {
+          '1.0.0': {
+            name: 'corrupted',
+            version: '1.0.0',
+            dist: {
+              tarball: `${defaultRegistry}corrupted/-/corrupted-1.0.0.tgz`,
+              integrity:
+                pakuAbbrev.versions['2.0.0'].dist.integrity,
+            },
+          },
+        },
+      })
+      res.setHeader('content-type', 'application/json')
+      res.setHeader('content-length', json.length)
+      return res.end(json)
+    }
+    case '/no-integrity/-/no-integrity-1.0.0.tgz': {
+      // Serve a valid tarball for a package with no dist.integrity
+      res.setHeader('content-type', 'application/octet-stream')
+      res.setHeader('content-length', tgzAbbrev.byteLength)
+      return res.end(tgzAbbrev)
+    }
+    case '/no-integrity/1.0.0': {
+      const json = JSON.stringify({
+        name: 'no-integrity',
+        version: '1.0.0',
+        dist: {
+          tarball: `${defaultRegistry}no-integrity/-/no-integrity-1.0.0.tgz`,
+        },
+      })
+      res.setHeader('content-type', 'application/json')
+      res.setHeader('content-length', json.length)
+      return res.end(json)
+    }
+    case '/no-integrity': {
+      const json = JSON.stringify({
+        name: 'no-integrity',
+        'dist-tags': { latest: '1.0.0' },
+        versions: {
+          '1.0.0': {
+            name: 'no-integrity',
+            version: '1.0.0',
+            dist: {
+              tarball: `${defaultRegistry}no-integrity/-/no-integrity-1.0.0.tgz`,
+            },
+          },
+        },
+      })
+      res.setHeader('content-type', 'application/json')
+      res.setHeader('content-length', json.length)
+      return res.end(json)
+    }
     default: {
       res.statusCode = 404
       t.comment('not found', req.url)
@@ -761,6 +846,99 @@ t.test('remote integrity computation', async t => {
         ),
         { cause: { code: 'EINTEGRITY' } },
         'should throw EINTEGRITY when integrity mismatch',
+      )
+    },
+  )
+})
+
+t.test('registry tarball integrity verification', async t => {
+  await t.test(
+    'extract succeeds when tarball matches dist.integrity',
+    async t => {
+      const dir = t.testdir({ 'vlt.json': '{}' })
+      t.chdir(dir)
+      unload()
+      const result = await extract(
+        'abbrev@2',
+        dir + '/good',
+        options,
+      )
+      t.match(result, {
+        resolved: `${defaultRegistry}abbrev/-/abbrev-2.0.0.tgz`,
+      })
+      const json = readFileSync(`${dir}/good/package.json`, 'utf8')
+      const pkg = JSON.parse(json)
+      t.match(pkg, { name: 'abbrev', version: '2.0.0' })
+    },
+  )
+
+  await t.test(
+    'extract throws EINTEGRITY when tarball is corrupted',
+    async t => {
+      const dir = t.testdir({ 'vlt.json': '{}' })
+      t.chdir(dir)
+      unload()
+      const pi = new PackageInfoClient({
+        ...options,
+        cache: dir + '/cache',
+      })
+      await t.rejects(
+        pi.extract('corrupted@1.0.0', dir + '/corrupted'),
+        { cause: { code: 'EINTEGRITY' } },
+        'should throw EINTEGRITY for corrupted tarball',
+      )
+    },
+  )
+
+  await t.test(
+    'tarball() throws EINTEGRITY when tarball is corrupted',
+    async t => {
+      const tb = new PackageInfoClient(options)
+      await t.rejects(tb.tarball('corrupted@1.0.0'), {
+        message: 'Tarball integrity check failed',
+        cause: { code: 'EINTEGRITY' },
+      })
+    },
+  )
+
+  await t.test(
+    'extract succeeds when dist.integrity is missing',
+    async t => {
+      const dir = t.testdir({ 'vlt.json': '{}' })
+      t.chdir(dir)
+      unload()
+      const result = await extract(
+        'no-integrity@1.0.0',
+        dir + '/no-int',
+        options,
+      )
+      t.match(result, {
+        resolved: `${defaultRegistry}no-integrity/-/no-integrity-1.0.0.tgz`,
+      })
+      const json = readFileSync(
+        `${dir}/no-int/package.json`,
+        'utf8',
+      )
+      const pkg = JSON.parse(json)
+      t.match(pkg, { name: 'abbrev', version: '2.0.0' })
+    },
+  )
+
+  await t.test(
+    'tarball() succeeds when dist.integrity is missing',
+    async t => {
+      const tb = new PackageInfoClient(options)
+      const buf = await tb.tarball('no-integrity@1.0.0')
+      t.ok(buf.length > 0, 'should return tarball data')
+      t.equal(
+        buf[0],
+        0x1f,
+        'should be a gzip file (first magic byte)',
+      )
+      t.equal(
+        buf[1],
+        0x8b,
+        'should be a gzip file (second magic byte)',
       )
     },
   )


### PR DESCRIPTION
## Summary

On net-new installs (when installing a package version for the first time, NOT from an existing lockfile), compute the SHA-512 hash of the downloaded tarball and compare it against the manifest's `dist.integrity` value.

This is a supply-chain security measure: the npm registry does not reliably validate integrity against tarballs. npm, pnpm, and bun all do this client-side validation today — vlt should too.

## What changed

### `src/package-info/src/index.ts`
- Added `createHash` import from `node:crypto`
- **`extract()` registry case**: After downloading the tarball, computes SHA-512 hash and compares against `r.integrity` (from manifest `dist.integrity`). Throws `EINTEGRITY` on mismatch.
- **`tarball()` registry case**: Same integrity verification after downloading the tarball buffer.

### Behavior
- **Mismatch → clear EINTEGRITY error** with `wanted` (expected) and `found` (computed) hashes
- **Missing `dist.integrity`** → skip check (some packages/registries don't provide it)
- **Lockfile/cache loads** → skip check (integrity was already verified on first install; the lockfile stores trusted integrity values)

### Performance
- Adds one SHA-512 hash computation per fresh tarball download (acceptable trade-off per discussion)

## Tests added (`src/package-info/test/index.ts`)

1. **extract succeeds when tarball matches dist.integrity** — normal case
2. **extract throws EINTEGRITY when tarball is corrupted** — simulates supply-chain attack where tarball bytes don't match manifest integrity  
3. **tarball() throws EINTEGRITY when tarball is corrupted** — same check in tarball() path
4. **extract succeeds when dist.integrity is missing** — graceful handling of packages without integrity
5. **tarball() succeeds when dist.integrity is missing** — same for tarball() path

Co-authored-by: Darcy Clarke <darcy@darcyclarke.me>