### PR TITLE
fix(package-info): make notFoundURLs snapshot deterministic

### DIFF
--- a/src/package-info/tap-snapshots/test/index.ts.test.cjs
+++ b/src/package-info/tap-snapshots/test/index.ts.test.cjs
@@ -5,6 +5,14 @@
  * Make sure to inspect the output below.  Do not ignore changes!
  */
 'use strict'
+exports[`test/index.ts > TAP > fails on non-200 response > expected not-found URLs 1`] = `
+Set {
+  "/lodash",
+  "/lodash.tgz",
+  "/missing.tgz",
+}
+`
+
 exports[`test/index.ts > TAP > fake packument with manifest lacking name/version > must match snapshot 1`] = `
 Object {
   "dist-tags": Object {
@@ -260,13 +268,5 @@ Object {
       "version": "2.0.0",
     },
   },
-}
-`
-
-exports[`test/index.ts > TAP > verify we got the expected missing urls > must match snapshot 1`] = `
-Set {
-  "/lodash",
-  "/lodash.tgz",
-  "/missing.tgz",
 }
 `

--- a/src/package-info/test/index.ts
+++ b/src/package-info/test/index.ts
@@ -1158,6 +1158,10 @@ t.test('file spec must have file', async t => {
 })
 
 t.test('fails on non-200 response', async t => {
+  // Reset the global 404 tracker so we only capture URLs from this test,
+  // making the snapshot deterministic regardless of test execution order.
+  notFoundURLs.length = 0
+
   const d = t.testdir()
   await t.rejects(packument('lodash', options))
   await t.rejects(manifest('lodash', options))
@@ -1177,6 +1181,12 @@ t.test('fails on non-200 response', async t => {
   )
   await t.rejects(
     extract(`lodash@${defaultRegistry}lodash.tgz`, d, options),
+  )
+
+  // Verify the expected 404 URLs were hit during this test
+  t.matchSnapshot(
+    new Set(notFoundURLs.sort((a, b) => a.localeCompare(b))),
+    'expected not-found URLs',
   )
 })
 
@@ -1259,13 +1269,6 @@ t.test('workspace group option', async t => {
   t.equal(pi.monorepo?.get('bb'), undefined)
   t.equal(pi.monorepo?.get('aa'), undefined)
   await t.rejects(pi.resolve('aa@workspace:*'))
-  t.end()
-})
-
-t.test('verify we got the expected missing urls', t => {
-  t.matchSnapshot(
-    new Set(notFoundURLs.sort((a, b) => a.localeCompare(b))),
-  )
   t.end()
 })
 


### PR DESCRIPTION
## Problem

The test `verify we got the expected missing urls` in `src/package-info/test/index.ts` snapshots a global `notFoundURLs` array that accumulates 404 URLs from ALL tests. This is non-deterministic across platforms — it passes on Ubuntu/Windows but fails on macOS because test execution order/timing differs, causing the accumulated set of 404 URLs to vary.

## Solution

- **Moved** the 404 URL tracking assertion from a standalone global test into the `'fails on non-200 response'` test that actually generates the 404s
- **Reset** the global `notFoundURLs` array at the start of that test (`notFoundURLs.length = 0`) so only URLs from that specific test are captured
- **Removed** the standalone `'verify we got the expected missing urls'` test that depended on global mutable state
- **Regenerated** snapshots to reflect the new test structure

This eliminates dependence on test execution order/timing, making the snapshot deterministic regardless of platform.

## Changes

- `src/package-info/test/index.ts` — isolated 404 URL tracking to the relevant test
- `src/package-info/tap-snapshots/test/index.ts.test.cjs` — updated snapshot key

Co-authored-by: Luke Karrys <luke@lukekarrys.com>