### PR TITLE
fix: flush pending cache writes in integrity tests [ci full-matrix]

### DIFF
--- a/src/package-info/test/index.ts
+++ b/src/package-info/test/index.ts
@@ -881,6 +881,9 @@ t.test('registry tarball integrity verification', async t => {
         { cause: { code: 'EINTEGRITY' } },
         'should throw EINTEGRITY for corrupted tarball',
       )
+      // flush pending cache writes so file handles are released
+      // before t.testdir() cleanup (avoids ENOTEMPTY on macOS)
+      await pi.registryClient.cache.promise()
     },
   )
 
@@ -896,6 +899,9 @@ t.test('registry tarball integrity verification', async t => {
         message: 'Tarball integrity check failed',
         cause: { code: 'EINTEGRITY' },
       })
+      // flush pending cache writes so file handles are released
+      // before t.testdir() cleanup (avoids ENOTEMPTY on macOS)
+      await tb.registryClient.cache.promise()
     },
   )
 


### PR DESCRIPTION
## Summary

On macOS, the `registry tarball integrity verification` tests fail during teardown with:
```
ENOTEMPTY: directory not empty, rmdir .../cache/registry-client
```

The issue: `PackageInfoClient` creates a `RegistryClient` whose `Cache` has background disk writes (`#pending` promises). When `t.rejects()` catches the expected EINTEGRITY error, those background writes may still hold open file descriptors. On macOS (which is stricter about file handle timing than Linux), tap's `t.testdir()` cleanup tries to `rmdir` the cache directory before the writes finish, causing ENOTEMPTY.

## Fix

Added `await pi.registryClient.cache.promise()` after each corruption test's `t.rejects()` call. This flushes all pending cache disk writes, ensuring file handles are fully released before tap cleans up the fixture directory.

The fix is in two subtests:
- `extract throws EINTEGRITY when tarball is corrupted`
- `tarball() throws EINTEGRITY when tarball is corrupted`

No test logic changes — only resource cleanup.

## CI Note

PR title includes `[ci full-matrix]` to run macOS CI and verify the fix.

Co-authored-by: Luke Karrys <luke@lukekarrys.com>