### PR TITLE
fix(package-info): retry tarball download on EINTEGRITY before failing

### DIFF
--- a/src/package-info/src/index.ts
+++ b/src/package-info/src/index.ts
@@ -187,56 +187,89 @@ export class PackageInfoClient {
       }
 
       case 'registry': {
-        const trustIntegrity =
-          this.#trustedIntegrities.get(r.resolved) === r.integrity
+        const fetchTarball = async (useCache?: false) => {
+          const trustIntegrity =
+            this.#trustedIntegrities.get(r.resolved) === r.integrity
 
-        const response = await this.registryClient.request(
-          r.resolved,
-          {
-            integrity: r.integrity,
-            trustIntegrity,
-          },
-        )
-
-        if (response.statusCode !== 200) {
-          throw this.#resolveError(
-            spec,
-            options,
-            'failed to fetch tarball',
+          const response = await this.registryClient.request(
+            r.resolved,
             {
-              url: r.resolved,
-              response,
+              integrity: r.integrity,
+              trustIntegrity,
+              ...(useCache === false ? { useCache } : {}),
             },
           )
-        }
 
-        // if it's not trusted already, but valid, start trusting
-        if (
-          !trustIntegrity &&
-          response.checkIntegrity({ spec, url: resolved })
-        ) {
-          this.#trustedIntegrities.set(r.resolved, response.integrity)
-        }
-
-        const buf = response.buffer()
-
-        // Verify tarball integrity against the manifest's dist.integrity.
-        // This is a supply-chain security measure: the registry may not
-        // validate integrity, so we do it client-side on every fresh
-        // download. Skip when integrity came from lockfile/cache (it was
-        // already verified on first install).
-        if (r.integrity && !fromLockfile) {
-          const hash = createHash('sha512')
-          hash.update(buf)
-          const computed: Integrity = `sha512-${hash.digest('base64')}`
-          if (computed !== r.integrity) {
-            throw error('Tarball integrity check failed', {
-              code: 'EINTEGRITY',
+          if (response.statusCode !== 200) {
+            throw this.#resolveError(
               spec,
-              url: r.resolved,
-              wanted: r.integrity,
-              found: computed,
-            })
+              options,
+              'failed to fetch tarball',
+              {
+                url: r.resolved,
+                response,
+              },
+            )
+          }
+
+          // if it's not trusted already, but valid, start trusting
+          if (
+            !trustIntegrity &&
+            response.checkIntegrity({ spec, url: resolved })
+          ) {
+            this.#trustedIntegrities.set(
+              r.resolved,
+              response.integrity,
+            )
+          }
+
+          const buf = response.buffer()
+
+          // Verify tarball integrity against the manifest's
+          // dist.integrity. This is a supply-chain security measure:
+          // the registry may not validate integrity, so we do it
+          // client-side on every fresh download. Skip when integrity
+          // came from lockfile/cache (it was already verified on first
+          // install).
+          if (r.integrity && !fromLockfile) {
+            const hash = createHash('sha512')
+            hash.update(buf)
+            const computed: Integrity = `sha512-${hash.digest('base64')}`
+            if (computed !== r.integrity) {
+              throw error('Tarball integrity check failed', {
+                code: 'EINTEGRITY',
+                spec,
+                url: r.resolved,
+                wanted: r.integrity,
+                found: computed,
+              })
+            }
+          }
+
+          return buf
+        }
+
+        let buf: Buffer
+        try {
+          buf = await fetchTarball()
+        } catch (er) {
+          // On EINTEGRITY, retry once bypassing cache. This handles
+          // transient issues such as corrupted downloads or CDN
+          // inconsistencies that cause the cached tarball to not match
+          // the expected integrity hash.
+          if (
+            er instanceof Error &&
+            'cause' in er &&
+            (er.cause as Record<string, unknown> | undefined)
+              ?.code === 'EINTEGRITY'
+          ) {
+            // eslint-disable-next-line no-console
+            console.error(
+              `Integrity check failed for ${String(spec)}, retrying with fresh download...`,
+            )
+            buf = await fetchTarball(false)
+          } else {
+            throw er
           }
         }
 
@@ -477,50 +510,76 @@ export class PackageInfoClient {
           )
         }
 
-        const trustIntegrity =
-          this.#trustedIntegrities.get(tarball) === integrity
+        const fetchTarball = async (useCache?: false) => {
+          const trustIntegrity =
+            this.#trustedIntegrities.get(tarball) === integrity
 
-        const response = await this.registryClient.request(tarball, {
-          ...options,
-          integrity,
-          trustIntegrity,
-        })
-        if (response.statusCode !== 200) {
-          throw this.#resolveError(
-            spec,
-            options,
-            'failed to fetch tarball',
-            { response, url: tarball },
+          const response = await this.registryClient.request(
+            tarball,
+            {
+              ...options,
+              integrity,
+              trustIntegrity,
+              ...(useCache === false ? { useCache } : {}),
+            },
           )
-        }
-
-        // if we don't already trust it, but it's valid, start trusting it
-        if (
-          !trustIntegrity &&
-          response.checkIntegrity({ spec, url: tarball })
-        ) {
-          this.#trustedIntegrities.set(tarball, response.integrity)
-        }
-
-        const buf = response.buffer()
-
-        // Verify tarball integrity against the manifest's dist.integrity.
-        if (integrity) {
-          const hash = createHash('sha512')
-          hash.update(buf)
-          const computed: Integrity = `sha512-${hash.digest('base64')}`
-          if (computed !== integrity) {
-            throw error('Tarball integrity check failed', {
-              code: 'EINTEGRITY',
+          if (response.statusCode !== 200) {
+            throw this.#resolveError(
               spec,
-              url: tarball,
-              wanted: integrity,
-              found: computed,
-            })
+              options,
+              'failed to fetch tarball',
+              { response, url: tarball },
+            )
           }
+
+          // if we don't already trust it, but it's valid, start
+          // trusting it
+          if (
+            !trustIntegrity &&
+            response.checkIntegrity({ spec, url: tarball })
+          ) {
+            this.#trustedIntegrities.set(tarball, response.integrity)
+          }
+
+          const buf = response.buffer()
+
+          // Verify tarball integrity against the manifest's
+          // dist.integrity.
+          if (integrity) {
+            const hash = createHash('sha512')
+            hash.update(buf)
+            const computed: Integrity = `sha512-${hash.digest('base64')}`
+            if (computed !== integrity) {
+              throw error('Tarball integrity check failed', {
+                code: 'EINTEGRITY',
+                spec,
+                url: tarball,
+                wanted: integrity,
+                found: computed,
+              })
+            }
+          }
+
+          return buf
         }
 
-        return buf
+        try {
+          return await fetchTarball()
+        } catch (er) {
+          if (
+            er instanceof Error &&
+            'cause' in er &&
+            (er.cause as Record<string, unknown> | undefined)
+              ?.code === 'EINTEGRITY'
+          ) {
+            // eslint-disable-next-line no-console
+            console.error(
+              `Integrity check failed for ${String(spec)}, retrying with fresh download...`,
+            )
+            return await fetchTarball(false)
+          }
+          throw er
+        }
       }
 
       case 'git': {

--- a/src/package-info/test/index.ts
+++ b/src/package-info/test/index.ts
@@ -228,6 +228,62 @@ const server = createServer((req, res) => {
       res.setHeader('content-length', json.length)
       return res.end(json)
     }
+    case '/transient-corrupt/-/transient-corrupt-1.0.0.tgz': {
+      // First request serves corrupted data, subsequent requests
+      // serve the real tarball (simulates transient CDN corruption)
+      transientCorruptHits++
+      if (transientCorruptHits === 1) {
+        const corrupted = Buffer.from(tgzAbbrev)
+        corrupted[100] = (corrupted[100]! ^ 0xff) & 0xff
+        corrupted[101] = (corrupted[101]! ^ 0xff) & 0xff
+        res.setHeader('content-type', 'application/octet-stream')
+        res.setHeader('content-length', corrupted.byteLength)
+        res.setHeader(
+          'integrity',
+          pakuAbbrev.versions['2.0.0'].dist.integrity,
+        )
+        return res.end(corrupted)
+      }
+      res.setHeader('content-type', 'application/octet-stream')
+      res.setHeader('content-length', tgzAbbrev.byteLength)
+      res.setHeader(
+        'integrity',
+        pakuAbbrev.versions['2.0.0'].dist.integrity,
+      )
+      return res.end(tgzAbbrev)
+    }
+    case '/transient-corrupt/1.0.0': {
+      const json = JSON.stringify({
+        name: 'transient-corrupt',
+        version: '1.0.0',
+        dist: {
+          tarball: `${defaultRegistry}transient-corrupt/-/transient-corrupt-1.0.0.tgz`,
+          integrity: pakuAbbrev.versions['2.0.0'].dist.integrity,
+        },
+      })
+      res.setHeader('content-type', 'application/json')
+      res.setHeader('content-length', json.length)
+      return res.end(json)
+    }
+    case '/transient-corrupt': {
+      const json = JSON.stringify({
+        name: 'transient-corrupt',
+        'dist-tags': { latest: '1.0.0' },
+        versions: {
+          '1.0.0': {
+            name: 'transient-corrupt',
+            version: '1.0.0',
+            dist: {
+              tarball: `${defaultRegistry}transient-corrupt/-/transient-corrupt-1.0.0.tgz`,
+              integrity: pakuAbbrev.versions['2.0.0'].dist.integrity,
+            },
+          },
+        },
+      })
+      res.setHeader('content-type', 'application/json')
+      res.setHeader('content-length', json.length)
+      return res.end(json)
+    }
     case '/no-integrity/-/no-integrity-1.0.0.tgz': {
       // Serve a valid tarball for a package with no dist.integrity
       res.setHeader('content-type', 'application/octet-stream')
@@ -274,6 +330,7 @@ const server = createServer((req, res) => {
 })
 
 const notFoundURLs: string[] = []
+let transientCorruptHits = 0
 
 const defaultRegistry = `http://localhost:${PORT}/`
 const options = {
@@ -975,6 +1032,133 @@ t.test('registry tarball integrity verification', async t => {
       )
       const pkg = JSON.parse(json)
       t.match(pkg, { name: 'abbrev', version: '2.0.0' })
+    },
+  )
+})
+
+t.test('EINTEGRITY retry with cache bust', async t => {
+  await t.test(
+    'extract retries on transient EINTEGRITY and succeeds',
+    async t => {
+      const dir = t.testdir({ 'vlt.json': '{}' })
+      t.chdir(dir)
+      unload()
+      // Reset the counter so the first tarball request is corrupted
+      transientCorruptHits = 0
+      const errs: string[] = []
+      const origError = console.error
+      t.teardown(() => (console.error = origError))
+      console.error = (...args: unknown[]) =>
+        errs.push(args.join(' '))
+      const pi = new PackageInfoClient({
+        ...options,
+        cache: dir + '/cache',
+      })
+      const result = await pi.extract(
+        'transient-corrupt@1.0.0',
+        dir + '/retry-ok',
+      )
+      t.match(result, {
+        resolved: `${defaultRegistry}transient-corrupt/-/transient-corrupt-1.0.0.tgz`,
+      })
+      t.equal(
+        transientCorruptHits,
+        2,
+        'should have hit the server twice (initial + retry)',
+      )
+      t.equal(errs.length, 1, 'should have logged one warning')
+      t.match(
+        errs[0],
+        /Integrity check failed.*retrying with fresh download/,
+        'warning message mentions retry',
+      )
+      const json = readFileSync(
+        `${dir}/retry-ok/package.json`,
+        'utf8',
+      )
+      const pkg = JSON.parse(json)
+      t.match(pkg, { name: 'abbrev', version: '2.0.0' })
+      await pi.registryClient.cache.promise()
+    },
+  )
+
+  await t.test(
+    'extract fails after retry when corruption is persistent',
+    async t => {
+      const dir = t.testdir({ 'vlt.json': '{}' })
+      t.chdir(dir)
+      unload()
+      const errs: string[] = []
+      const origError = console.error
+      t.teardown(() => (console.error = origError))
+      console.error = (...args: unknown[]) =>
+        errs.push(args.join(' '))
+      const pi = new PackageInfoClient({
+        ...options,
+        cache: dir + '/cache',
+      })
+      await t.rejects(
+        pi.extract('corrupted@1.0.0', dir + '/still-bad'),
+        { cause: { code: 'EINTEGRITY' } },
+        'should still throw EINTEGRITY after retry fails',
+      )
+      t.equal(errs.length, 1, 'should have logged one warning')
+      t.match(
+        errs[0],
+        /Integrity check failed.*retrying with fresh download/,
+        'warning message mentions retry',
+      )
+      await pi.registryClient.cache.promise()
+    },
+  )
+
+  await t.test(
+    'tarball() retries on transient EINTEGRITY and succeeds',
+    async t => {
+      const dir = t.testdir()
+      // Reset the counter so the first tarball request is corrupted
+      transientCorruptHits = 0
+      const errs: string[] = []
+      const origError = console.error
+      t.teardown(() => (console.error = origError))
+      console.error = (...args: unknown[]) =>
+        errs.push(args.join(' '))
+      const pi = new PackageInfoClient({
+        ...options,
+        cache: dir + '/cache',
+      })
+      const buf = await pi.tarball('transient-corrupt@1.0.0')
+      t.ok(buf.length > 0, 'should return tarball data')
+      t.equal(buf[0], 0x1f, 'should be a gzip file (first byte)')
+      t.equal(buf[1], 0x8b, 'should be a gzip file (second byte)')
+      t.equal(
+        transientCorruptHits,
+        2,
+        'should have hit the server twice',
+      )
+      t.equal(errs.length, 1, 'should have logged one warning')
+      await pi.registryClient.cache.promise()
+    },
+  )
+
+  await t.test(
+    'tarball() fails after retry when corruption is persistent',
+    async t => {
+      const dir = t.testdir()
+      const errs: string[] = []
+      const origError = console.error
+      t.teardown(() => (console.error = origError))
+      console.error = (...args: unknown[]) =>
+        errs.push(args.join(' '))
+      const pi = new PackageInfoClient({
+        ...options,
+        cache: dir + '/cache',
+      })
+      await t.rejects(pi.tarball('corrupted@1.0.0'), {
+        cause: { code: 'EINTEGRITY' },
+      })
+      t.equal(errs.length, 1, 'should have logged one warning')
+      await pi.registryClient.cache.promise()
     },
   )
 })


### PR DESCRIPTION
## Problem

When vlt encounters an EINTEGRITY error during `vlt install`, it hard-fails immediately with no retry. This caused a DNF in benchmarks when a transient issue (corrupted download or CDN inconsistency) produced a tarball that didn't match the expected integrity hash.

Other package managers (npm, pnpm, yarn) handle this by retrying with a cache bust.

## Fix

In `PackageInfoClient.extract()` and `PackageInfoClient.tarball()`, both in the `case 'registry'` block:

1. **Extract the fetch + integrity check** into a `fetchTarball(useCache?)` helper
2. **Catch EINTEGRITY** from any of the three integrity check points:
   - `registryClient.request()` internal integrity check (gzip-level)
   - `response.checkIntegrity()` explicit call
   - Manual sha512 hash verification against `dist.integrity`
3. **Log a warning** to stderr: `Integrity check failed for <spec>, retrying with fresh download...`
4. **Retry once** with `useCache: false` to bypass the registry client cache and re-download from the origin
5. **If retry also fails → throw** the EINTEGRITY error (bail behavior preserved for real integrity failures)
6. **If retry succeeds → continue** with the fresh tarball

## Tests

Added 4 new test cases covering both `extract()` and `tarball()` methods:
- Transient corruption: first request corrupted, retry succeeds ✅
- Persistent corruption: both requests corrupted, throws EINTEGRITY ✅
- Warning message is logged on retry ✅
- Server hit count confirms exactly 2 requests (initial + retry) ✅

Co-authored-by: Luke Karrys <luke@lukekarrys.com>