### PR TITLE
fix: prevent trustedIntegrities bypass — manifest() pre-trusts tarball integrity

### DIFF
--- a/src/package-info/src/index.ts
+++ b/src/package-info/src/index.ts
@@ -18,7 +18,7 @@ import type {
   Packument,
   ManifestRegistry,
 } from '@vltpkg/types'
-import { asPackument, isIntegrity } from '@vltpkg/types'
+import { asPackument } from '@vltpkg/types'
 import ssri from 'ssri'
 import { Monorepo } from '@vltpkg/workspaces'
 import { XDG } from '@vltpkg/xdg'
@@ -77,6 +77,13 @@ export type PackageInfoClientExtractOptions =
   PackageInfoClientRequestOptions & {
     integrity?: Integrity
     resolved?: string
+    /**
+     * When true, indicates that integrity + resolved came from a
+     * lockfile (i.e. they were already verified on first install).
+     * Skips the client-side tarball integrity check.
+     * Defaults to false — fresh installs always verify integrity.
+     */
+    fromLockfile?: boolean
   }
 
 // the maximum duration of a manifest cache file
@@ -136,14 +143,18 @@ export class PackageInfoClient {
   ): Promise<Resolution> {
     if (typeof spec === 'string')
       spec = Spec.parse(spec, this.options)
-    const { from = this.#projectRoot, integrity, resolved } = options
+    const {
+      from = this.#projectRoot,
+      integrity,
+      resolved,
+      fromLockfile = false,
+    } = options
     const f = spec.final
-    // Track whether integrity/resolved came from the caller (e.g. lockfile)
-    // vs freshly resolved. We only verify tarball integrity on net-new
-    // installs (fresh resolution), not when replaying from lockfile.
-    const fromLockfile = !!(integrity && resolved)
+    // If the caller already provides both integrity and resolved
+    // (from lockfile or prior resolution), skip re-resolving.
+    const alreadyResolved = !!(integrity && resolved)
     const r =
-      fromLockfile ?
+      alreadyResolved ?
         { resolved, integrity, spec }
       : await this.resolve(spec, options)
 
@@ -651,16 +662,6 @@ export class PackageInfoClient {
               options,
             )
         if (!mani) throw this.#resolveError(spec, options)
-        const { integrity, tarball } =
-          mani.dist ?? /* c8 ignore next */ {}
-        if (isIntegrity(integrity) && tarball) {
-          const registryOrigin = new URL(String(f.registry)).origin
-          const tgzOrigin = new URL(tarball).origin
-          // if it comes from the same origin, trust the integrity
-          if (tgzOrigin === registryOrigin) {
-            this.#trustedIntegrities.set(tarball, integrity)
-          }
-        }
 
         // Cache the manifest data
         if (cachePath) {

--- a/src/package-info/src/index.ts
+++ b/src/package-info/src/index.ts
@@ -198,56 +198,89 @@ export class PackageInfoClient {
       }
 
       case 'registry': {
-        const trustIntegrity =
-          this.#trustedIntegrities.get(r.resolved) === r.integrity
+        const fetchTarball = async (useCache?: false) => {
+          const trustIntegrity =
+            this.#trustedIntegrities.get(r.resolved) === r.integrity
 
-        const response = await this.registryClient.request(
-          r.resolved,
-          {
-            integrity: r.integrity,
-            trustIntegrity,
-          },
-        )
-
-        if (response.statusCode !== 200) {
-          throw this.#resolveError(
-            spec,
-            options,
-            'failed to fetch tarball',
+          const response = await this.registryClient.request(
+            r.resolved,
             {
-              url: r.resolved,
-              response,
+              integrity: r.integrity,
+              trustIntegrity,
+              ...(useCache === false ? { useCache } : {}),
             },
           )
-        }
 
-        // if it's not trusted already, but valid, start trusting
-        if (
-          !trustIntegrity &&
-          response.checkIntegrity({ spec, url: resolved })
-        ) {
-          this.#trustedIntegrities.set(r.resolved, response.integrity)
-        }
-
-        const buf = response.buffer()
-
-        // Verify tarball integrity against the manifest's dist.integrity.
-        // This is a supply-chain security measure: the registry may not
-        // validate integrity, so we do it client-side on every fresh
-        // download. Skip when integrity came from lockfile/cache (it was
-        // already verified on first install).
-        if (r.integrity && !fromLockfile) {
-          const hash = createHash('sha512')
-          hash.update(buf)
-          const computed: Integrity = `sha512-${hash.digest('base64')}`
-          if (computed !== r.integrity) {
-            throw error('Tarball integrity check failed', {
-              code: 'EINTEGRITY',
+          if (response.statusCode !== 200) {
+            throw this.#resolveError(
               spec,
-              url: r.resolved,
-              wanted: r.integrity,
-              found: computed,
-            })
+              options,
+              'failed to fetch tarball',
+              {
+                url: r.resolved,
+                response,
+              },
+            )
+          }
+
+          // if it's not trusted already, but valid, start trusting
+          if (
+            !trustIntegrity &&
+            response.checkIntegrity({ spec, url: resolved })
+          ) {
+            this.#trustedIntegrities.set(
+              r.resolved,
+              response.integrity,
+            )
+          }
+
+          const buf = response.buffer()
+
+          // Verify tarball integrity against the manifest's
+          // dist.integrity. This is a supply-chain security measure:
+          // the registry may not validate integrity, so we do it
+          // client-side on every fresh download. Skip when integrity
+          // came from lockfile/cache (it was already verified on
+          // first install).
+          if (r.integrity && !fromLockfile) {
+            const hash = createHash('sha512')
+            hash.update(buf)
+            const computed: Integrity = `sha512-${hash.digest('base64')}`
+            if (computed !== r.integrity) {
+              throw error('Tarball integrity check failed', {
+                code: 'EINTEGRITY',
+                spec,
+                url: r.resolved,
+                wanted: r.integrity,
+                found: computed,
+              })
+            }
+          }
+
+          return buf
+        }
+
+        let buf: Buffer
+        try {
+          buf = await fetchTarball()
+        } catch (er) {
+          // On EINTEGRITY, retry once bypassing cache. This handles
+          // transient issues such as corrupted downloads or CDN
+          // inconsistencies that cause the cached tarball to not
+          // match the expected integrity hash.
+          if (
+            er instanceof Error &&
+            'cause' in er &&
+            (er.cause as Record<string, unknown> | undefined)
+              ?.code === 'EINTEGRITY'
+          ) {
+            // eslint-disable-next-line no-console
+            console.error(
+              `Integrity check failed for ${String(spec)}, retrying with fresh download...`,
+            )
+            buf = await fetchTarball(false)
+          } else {
+            throw er
           }
         }
 
@@ -488,50 +521,76 @@ export class PackageInfoClient {
           )
         }
 
-        const trustIntegrity =
-          this.#trustedIntegrities.get(tarball) === integrity
+        const fetchTarball = async (useCache?: false) => {
+          const trustIntegrity =
+            this.#trustedIntegrities.get(tarball) === integrity
 
-        const response = await this.registryClient.request(tarball, {
-          ...options,
-          integrity,
-          trustIntegrity,
-        })
-        if (response.statusCode !== 200) {
-          throw this.#resolveError(
-            spec,
-            options,
-            'failed to fetch tarball',
-            { response, url: tarball },
+          const response = await this.registryClient.request(
+            tarball,
+            {
+              ...options,
+              integrity,
+              trustIntegrity,
+              ...(useCache === false ? { useCache } : {}),
+            },
           )
-        }
-
-        // if we don't already trust it, but it's valid, start trusting it
-        if (
-          !trustIntegrity &&
-          response.checkIntegrity({ spec, url: tarball })
-        ) {
-          this.#trustedIntegrities.set(tarball, response.integrity)
-        }
-
-        const buf = response.buffer()
-
-        // Verify tarball integrity against the manifest's dist.integrity.
-        if (integrity) {
-          const hash = createHash('sha512')
-          hash.update(buf)
-          const computed: Integrity = `sha512-${hash.digest('base64')}`
-          if (computed !== integrity) {
-            throw error('Tarball integrity check failed', {
-              code: 'EINTEGRITY',
+          if (response.statusCode !== 200) {
+            throw this.#resolveError(
               spec,
-              url: tarball,
-              wanted: integrity,
-              found: computed,
-            })
+              options,
+              'failed to fetch tarball',
+              { response, url: tarball },
+            )
           }
+
+          // if we don't already trust it, but it's valid, start
+          // trusting it
+          if (
+            !trustIntegrity &&
+            response.checkIntegrity({ spec, url: tarball })
+          ) {
+            this.#trustedIntegrities.set(tarball, response.integrity)
+          }
+
+          const buf = response.buffer()
+
+          // Verify tarball integrity against the manifest's
+          // dist.integrity.
+          if (integrity) {
+            const hash = createHash('sha512')
+            hash.update(buf)
+            const computed: Integrity = `sha512-${hash.digest('base64')}`
+            if (computed !== integrity) {
+              throw error('Tarball integrity check failed', {
+                code: 'EINTEGRITY',
+                spec,
+                url: tarball,
+                wanted: integrity,
+                found: computed,
+              })
+            }
+          }
+
+          return buf
         }
 
-        return buf
+        try {
+          return await fetchTarball()
+        } catch (er) {
+          if (
+            er instanceof Error &&
+            'cause' in er &&
+            (er.cause as Record<string, unknown> | undefined)
+              ?.code === 'EINTEGRITY'
+          ) {
+            // eslint-disable-next-line no-console
+            console.error(
+              `Integrity check failed for ${String(spec)}, retrying with fresh download...`,
+            )
+            return await fetchTarball(false)
+          }
+          throw er
+        }
       }
 
       case 'git': {

--- a/src/package-info/src/index.ts
+++ b/src/package-info/src/index.ts
@@ -242,6 +242,10 @@ export class PackageInfoClient {
           // client-side on every fresh download. Skip when integrity
           // came from lockfile/cache (it was already verified on
           // first install).
+          /* c8 ignore start - defense-in-depth: registry client's
+           * checkIntegrity() usually catches mismatches first since
+           * it checks the same gzip bytes. This fires only when the
+           * registry client check is skipped (trustIntegrity=true). */
           if (r.integrity && !fromLockfile) {
             const hash = createHash('sha512')
             hash.update(buf)
@@ -256,6 +260,7 @@ export class PackageInfoClient {
               })
             }
           }
+          /* c8 ignore stop */
 
           return buf
         }
@@ -274,10 +279,6 @@ export class PackageInfoClient {
             (er.cause as Record<string, unknown> | undefined)
               ?.code === 'EINTEGRITY'
           ) {
-            // eslint-disable-next-line no-console
-            console.error(
-              `Integrity check failed for ${String(spec)}, retrying with fresh download...`,
-            )
             buf = await fetchTarball(false)
           } else {
             throw er
@@ -556,6 +557,7 @@ export class PackageInfoClient {
 
           // Verify tarball integrity against the manifest's
           // dist.integrity.
+          /* c8 ignore start - defense-in-depth (see extract) */
           if (integrity) {
             const hash = createHash('sha512')
             hash.update(buf)
@@ -570,6 +572,7 @@ export class PackageInfoClient {
               })
             }
           }
+          /* c8 ignore stop */
 
           return buf
         }
@@ -583,10 +586,6 @@ export class PackageInfoClient {
             (er.cause as Record<string, unknown> | undefined)
               ?.code === 'EINTEGRITY'
           ) {
-            // eslint-disable-next-line no-console
-            console.error(
-              `Integrity check failed for ${String(spec)}, retrying with fresh download...`,
-            )
             return await fetchTarball(false)
           }
           throw er

--- a/src/package-info/test/index.ts
+++ b/src/package-info/test/index.ts
@@ -228,6 +228,50 @@ const server = createServer((req, res) => {
       res.setHeader('content-length', json.length)
       return res.end(json)
     }
+    case '/corrupted-no-header/-/corrupted-no-header-1.0.0.tgz': {
+      // Serve a corrupted tarball WITHOUT an integrity response
+      // header. The registry client won't verify integrity at its
+      // level, but the client-side sha512 check will catch it.
+      const corrupted = Buffer.from(tgzAbbrev)
+      corrupted[100] = (corrupted[100]! ^ 0xff) & 0xff
+      corrupted[101] = (corrupted[101]! ^ 0xff) & 0xff
+      res.setHeader('content-type', 'application/octet-stream')
+      res.setHeader('content-length', corrupted.byteLength)
+      // NOTE: no 'integrity' header set here
+      return res.end(corrupted)
+    }
+    case '/corrupted-no-header/1.0.0': {
+      const json = JSON.stringify({
+        name: 'corrupted-no-header',
+        version: '1.0.0',
+        dist: {
+          tarball: `${defaultRegistry}corrupted-no-header/-/corrupted-no-header-1.0.0.tgz`,
+          integrity: pakuAbbrev.versions['2.0.0'].dist.integrity,
+        },
+      })
+      res.setHeader('content-type', 'application/json')
+      res.setHeader('content-length', json.length)
+      return res.end(json)
+    }
+    case '/corrupted-no-header': {
+      const json = JSON.stringify({
+        name: 'corrupted-no-header',
+        'dist-tags': { latest: '1.0.0' },
+        versions: {
+          '1.0.0': {
+            name: 'corrupted-no-header',
+            version: '1.0.0',
+            dist: {
+              tarball: `${defaultRegistry}corrupted-no-header/-/corrupted-no-header-1.0.0.tgz`,
+              integrity: pakuAbbrev.versions['2.0.0'].dist.integrity,
+            },
+          },
+        },
+      })
+      res.setHeader('content-type', 'application/json')
+      res.setHeader('content-length', json.length)
+      return res.end(json)
+    }
     case '/corrupted-once/-/corrupted-once-1.0.0.tgz': {
       // First request: serve corrupted tarball.
       // Second request: serve correct tarball.
@@ -964,6 +1008,47 @@ t.test('registry tarball integrity verification', async t => {
       })
       // flush pending cache writes so file handles are released
       // before t.testdir() cleanup (avoids ENOTEMPTY on macOS)
+      await tb.registryClient.cache.promise()
+    },
+  )
+
+  await t.test(
+    'extract throws EINTEGRITY via client-side sha512 check',
+    async t => {
+      // The corrupted-no-header endpoint does NOT send an integrity
+      // response header, so the registry client's checkIntegrity()
+      // has nothing to check. The client-side sha512 check in
+      // extract() catches the mismatch instead.
+      const dir = t.testdir({ 'vlt.json': '{}' })
+      t.chdir(dir)
+      unload()
+      const pi = new PackageInfoClient({
+        ...options,
+        cache: dir + '/cache',
+      })
+      await t.rejects(
+        pi.extract(
+          'corrupted-no-header@1.0.0',
+          dir + '/corrupted-no-header',
+        ),
+        { cause: { code: 'EINTEGRITY' } },
+        'should throw EINTEGRITY via sha512 check',
+      )
+      await pi.registryClient.cache.promise()
+    },
+  )
+
+  await t.test(
+    'tarball() throws EINTEGRITY via client-side sha512 check',
+    async t => {
+      const dir = t.testdir()
+      const tb = new PackageInfoClient({
+        ...options,
+        cache: dir + '/cache',
+      })
+      await t.rejects(tb.tarball('corrupted-no-header@1.0.0'), {
+        cause: { code: 'EINTEGRITY' },
+      })
       await tb.registryClient.cache.promise()
     },
   )

--- a/src/package-info/test/index.ts
+++ b/src/package-info/test/index.ts
@@ -949,10 +949,10 @@ t.test('registry tarball integrity verification', async t => {
   )
 
   await t.test(
-    'extract skips integrity check when integrity comes from lockfile',
+    'extract skips integrity check when fromLockfile is true',
     async t => {
-      // When integrity + resolved are provided (e.g. from lockfile),
-      // the check is skipped because the integrity was already verified
+      // When fromLockfile is explicitly set, the client-side sha512
+      // check is skipped because the integrity was already verified
       // on first install.
       const dir = t.testdir({ 'vlt.json': '{}' })
       t.chdir(dir)
@@ -964,6 +964,7 @@ t.test('registry tarball integrity verification', async t => {
           ...options,
           resolved: `${defaultRegistry}abbrev/-/abbrev-2.0.0.tgz`,
           integrity: pakuAbbrev.versions['2.0.0'].dist.integrity,
+          fromLockfile: true,
         },
       )
       t.match(result, {
@@ -975,6 +976,32 @@ t.test('registry tarball integrity verification', async t => {
       )
       const pkg = JSON.parse(json)
       t.match(pkg, { name: 'abbrev', version: '2.0.0' })
+    },
+  )
+
+  await t.test(
+    'extract DOES verify integrity even when integrity+resolved provided without fromLockfile',
+    async t => {
+      // Previously, the heuristic `!!(integrity && resolved)` would
+      // skip the check whenever both were provided. Now, the check
+      // only skips with an explicit `fromLockfile: true`.
+      const dir = t.testdir({ 'vlt.json': '{}' })
+      t.chdir(dir)
+      unload()
+      const pi = new PackageInfoClient({
+        ...options,
+        cache: dir + '/cache',
+      })
+      await t.rejects(
+        pi.extract('corrupted@1.0.0', dir + '/should-fail', {
+          resolved: `${defaultRegistry}corrupted/-/corrupted-1.0.0.tgz`,
+          integrity: pakuAbbrev.versions['2.0.0'].dist.integrity,
+          // fromLockfile NOT set (defaults to false)
+        }),
+        { cause: { code: 'EINTEGRITY' } },
+        'should verify tarball integrity even with integrity+resolved provided',
+      )
+      await pi.registryClient.cache.promise()
     },
   )
 })

--- a/src/package-info/test/index.ts
+++ b/src/package-info/test/index.ts
@@ -228,6 +228,65 @@ const server = createServer((req, res) => {
       res.setHeader('content-length', json.length)
       return res.end(json)
     }
+    case '/corrupted-once/-/corrupted-once-1.0.0.tgz': {
+      // First request: serve corrupted tarball.
+      // Second request: serve correct tarball.
+      // This simulates a CDN serving stale/corrupted data that gets
+      // fixed on retry.
+      corruptedOnceServed++
+      if (corruptedOnceServed <= 1) {
+        const corrupted = Buffer.from(tgzAbbrev)
+        corrupted[100] = (corrupted[100]! ^ 0xff) & 0xff
+        corrupted[101] = (corrupted[101]! ^ 0xff) & 0xff
+        res.setHeader('content-type', 'application/octet-stream')
+        res.setHeader('content-length', corrupted.byteLength)
+        res.setHeader(
+          'integrity',
+          pakuAbbrev.versions['2.0.0'].dist.integrity,
+        )
+        return res.end(corrupted)
+      }
+      // Second request: correct tarball
+      res.setHeader('content-type', 'application/octet-stream')
+      res.setHeader('content-length', tgzAbbrev.byteLength)
+      res.setHeader(
+        'integrity',
+        pakuAbbrev.versions['2.0.0'].dist.integrity,
+      )
+      return res.end(tgzAbbrev)
+    }
+    case '/corrupted-once/1.0.0': {
+      const json = JSON.stringify({
+        name: 'corrupted-once',
+        version: '1.0.0',
+        dist: {
+          tarball: `${defaultRegistry}corrupted-once/-/corrupted-once-1.0.0.tgz`,
+          integrity: pakuAbbrev.versions['2.0.0'].dist.integrity,
+        },
+      })
+      res.setHeader('content-type', 'application/json')
+      res.setHeader('content-length', json.length)
+      return res.end(json)
+    }
+    case '/corrupted-once': {
+      const json = JSON.stringify({
+        name: 'corrupted-once',
+        'dist-tags': { latest: '1.0.0' },
+        versions: {
+          '1.0.0': {
+            name: 'corrupted-once',
+            version: '1.0.0',
+            dist: {
+              tarball: `${defaultRegistry}corrupted-once/-/corrupted-once-1.0.0.tgz`,
+              integrity: pakuAbbrev.versions['2.0.0'].dist.integrity,
+            },
+          },
+        },
+      })
+      res.setHeader('content-type', 'application/json')
+      res.setHeader('content-length', json.length)
+      return res.end(json)
+    }
     case '/no-integrity/-/no-integrity-1.0.0.tgz': {
       // Serve a valid tarball for a package with no dist.integrity
       res.setHeader('content-type', 'application/octet-stream')
@@ -274,6 +333,7 @@ const server = createServer((req, res) => {
 })
 
 const notFoundURLs: string[] = []
+let corruptedOnceServed = 0
 
 const defaultRegistry = `http://localhost:${PORT}/`
 const options = {
@@ -895,8 +955,11 @@ t.test('registry tarball integrity verification', async t => {
         ...options,
         cache: dir + '/cache',
       })
+      // The tarball retry may cause the final error to come from
+      // the registry client's checkIntegrity (which throws
+      // "Integrity check failure") rather than our client-side
+      // sha512 check ("Tarball integrity check failed").
       await t.rejects(tb.tarball('corrupted@1.0.0'), {
-        message: 'Tarball integrity check failed',
         cause: { code: 'EINTEGRITY' },
       })
       // flush pending cache writes so file handles are released
@@ -1000,6 +1063,37 @@ t.test('registry tarball integrity verification', async t => {
         }),
         { cause: { code: 'EINTEGRITY' } },
         'should verify tarball integrity even with integrity+resolved provided',
+      )
+      await pi.registryClient.cache.promise()
+    },
+  )
+
+  await t.test(
+    'extract retries with cache bust on EINTEGRITY then succeeds',
+    async t => {
+      // The corrupted-once endpoint serves corrupted data the first
+      // time, then correct data on the second request. This
+      // simulates a CDN serving a stale/corrupted cached tarball that
+      // resolves after a fresh download.
+      const dir = t.testdir({ 'vlt.json': '{}' })
+      t.chdir(dir)
+      unload()
+      corruptedOnceServed = 0
+      const pi = new PackageInfoClient({
+        ...options,
+        cache: dir + '/cache',
+      })
+      const result = await pi.extract(
+        'corrupted-once@1.0.0',
+        dir + '/retry-ok',
+      )
+      t.match(result, {
+        resolved: `${defaultRegistry}corrupted-once/-/corrupted-once-1.0.0.tgz`,
+      })
+      t.equal(
+        corruptedOnceServed,
+        2,
+        'should have fetched twice (first corrupted, then fresh)',
       )
       await pi.registryClient.cache.promise()
     },


### PR DESCRIPTION
## Problem

The `manifest()` method in `PackageInfoClient` was pre-populating `#trustedIntegrities` with the manifest's `dist.integrity` for tarball URLs from the same registry origin:

```ts
if (tgzOrigin === registryOrigin) {
  this.#trustedIntegrities.set(tarball, integrity)
}
```

This created a **circular trust issue**:
1. `manifest()` says "trust this hash"
2. `extract()` sees the tarball URL is "already trusted"
3. The registry client skips `checkIntegrity()` entirely
4. **Tarball content is never actually verified** against the hash

Additionally, the `fromLockfile` heuristic (`!!(integrity && resolved)`) was always `true` during graph reification because `extractNode()` always passes both `integrity` and `resolved` from the node — even on fresh installs where the values came from manifest resolution rather than a lockfile. This skipped the client-side SHA-512 check too.

## Fix

1. **Remove `#trustedIntegrities` population from `manifest()`** — that map should only be populated AFTER `extract()`/`tarball()` has actually verified the tarball hash via `response.checkIntegrity()`
2. **Add explicit `fromLockfile` option** to `PackageInfoClientExtractOptions` (defaults to `false`) instead of inferring it from the presence of `integrity + resolved`
3. **Tarball integrity is now always verified** on fresh installs; the client-side SHA-512 check only skips when `fromLockfile` is explicitly set to `true`

## Related PRs
- #1590 — original integrity check implementation
- #1594 — EINTEGRITY retry with cache bust

Co-authored-by: Luke Karrys <luke@lukekarrys.com>