### PR TITLE
fix: preserve path in auth keys for path-scoped registries

### DIFF
--- a/src/cli-sdk/src/commands/token.ts
+++ b/src/cli-sdk/src/commands/token.ts
@@ -1,5 +1,9 @@
 import { error } from '@vltpkg/error-cause'
-import { deleteToken, setToken } from '@vltpkg/registry-client'
+import {
+  deleteToken,
+  normalizeRegistryKey,
+  setToken,
+} from '@vltpkg/registry-client'
 import { commandUsage } from '../config/usage.ts'
 import { readPassword } from '../read-password.ts'
 import type { CommandFn, CommandUsage } from '../index.ts'
@@ -22,7 +26,7 @@ export const usage: CommandUsage = () =>
   })
 
 export const command: CommandFn<void> = async conf => {
-  const reg = new URL(conf.options.registry).origin
+  const reg = normalizeRegistryKey(conf.options.registry)
   switch (conf.positionals[0]) {
     case 'add': {
       await setToken(

--- a/src/cli-sdk/test/commands/token.ts
+++ b/src/cli-sdk/test/commands/token.ts
@@ -7,6 +7,10 @@ const { usage, command } = await t.mockImport<
   typeof import('../../src/commands/token.ts')
 >('../../src/commands/token.ts', {
   '@vltpkg/registry-client': {
+    normalizeRegistryKey(url: string) {
+      const u = new URL(url)
+      return (u.origin + u.pathname).replace(/\/+$/, '')
+    },
     async setToken(reg: string, tok: Token) {
       log.push(['add', reg, tok])
     },
@@ -39,6 +43,43 @@ t.strictSame(log, [
   ['add', 'https://registry.vlt.javascript', 'Bearer result'],
   ['delete', 'https://registry.vlt.javascript'],
 ])
+
+t.test('preserves path for path-scoped registry', async t => {
+  const pathLog: string[][] = []
+  const { command: cmd } = await t.mockImport<
+    typeof import('../../src/commands/token.ts')
+  >('../../src/commands/token.ts', {
+    '@vltpkg/registry-client': {
+      normalizeRegistryKey(url: string) {
+        const u = new URL(url)
+        return (u.origin + u.pathname).replace(/\/+$/, '')
+      },
+      async setToken(reg: string, tok: Token) {
+        pathLog.push(['add', reg, tok])
+      },
+      async deleteToken(reg: string) {
+        pathLog.push(['delete', reg])
+      },
+    },
+    '../../src/read-password.ts': {
+      async readPassword(_prompt: string) {
+        return 'tok123'
+      },
+    },
+  })
+  await cmd({
+    options: { registry: 'https://registry.vlt.io/luke/' },
+    positionals: ['add'],
+  } as LoadedConfig)
+  await cmd({
+    options: { registry: 'https://registry.vlt.io/luke/' },
+    positionals: ['rm'],
+  } as LoadedConfig)
+  t.strictSame(pathLog, [
+    ['add', 'https://registry.vlt.io/luke', 'Bearer tok123'],
+    ['delete', 'https://registry.vlt.io/luke'],
+  ])
+})
 
 t.test('invalid token sub command', async t => {
   await t.rejects(

--- a/src/keychain/src/index.ts
+++ b/src/keychain/src/index.ts
@@ -59,6 +59,14 @@ export class Keychain<V extends string = string> {
     return !!this.#data && Object.hasOwn(this.#data, key)
   }
 
+  async keys(): Promise<string[]> {
+    return (await this.#load()).keysSync()
+  }
+
+  keysSync(): string[] {
+    return this.#data ? Object.keys(this.#data) : []
+  }
+
   async #mkdir() {
     await mkdir(dirname(this.#file), {
       recursive: true,

--- a/src/keychain/test/index.ts
+++ b/src/keychain/test/index.ts
@@ -62,6 +62,32 @@ t.test('basic behavior', async t => {
   t.equal(kc.getSync('x'), undefined)
 })
 
+t.test('keys and keysSync', async t => {
+  const { Keychain } = await getKC(t)
+  const kc = new Keychain('test/keys')
+  t.strictSame(kc.keysSync(), [])
+  t.strictSame(await kc.keys(), [])
+  kc.set('a', '1')
+  kc.set('b', '2')
+  kc.set('c', '3')
+  t.strictSame(kc.keysSync(), ['a', 'b', 'c'])
+  t.strictSame(await kc.keys(), ['a', 'b', 'c'])
+  kc.delete('b')
+  t.strictSame(kc.keysSync(), ['a', 'c'])
+  t.strictSame(await kc.keys(), ['a', 'c'])
+})
+
+t.test('keys loads data if not loaded', async t => {
+  const { Keychain } = await getKC(t)
+  const kc = new Keychain('test/keys-load')
+  kc.set('x', 'y')
+  await kc.save()
+  const kc2 = new Keychain('test/keys-load')
+  // kc2 hasn't been loaded yet; keys() should trigger load
+  const result = await kc2.keys()
+  t.strictSame(result, ['x'])
+})
+
 t.test('treat borked file as just not being there', async t => {
   const { Keychain } = await getKC(t)
   const kc = new Keychain('test/bork')

--- a/src/registry-client/src/auth.ts
+++ b/src/registry-client/src/auth.ts
@@ -2,6 +2,21 @@ import { Keychain } from '@vltpkg/keychain'
 
 export type Token = `Bearer ${string}` | `Basic ${string}`
 
+/**
+ * Normalize a registry URL into a stable key that preserves the
+ * path prefix.  The result is `origin + pathname` with trailing
+ * slashes stripped so that
+ *   `https://r.io/luke/`  and  `https://r.io/luke`
+ * both produce the same key.
+ *
+ * For plain-origin registries the result is identical to the old
+ * `new URL(url).origin` behaviour (e.g. `https://registry.npmjs.org`).
+ */
+export const normalizeRegistryKey = (url: string): string => {
+  const u = new URL(url)
+  return (u.origin + u.pathname).replace(/\/+$/, '')
+}
+
 // just exported for testing
 export const keychains = new Map<string, Keychain<Token>>()
 
@@ -12,7 +27,7 @@ export const keychains = new Map<string, Keychain<Token>>()
 export const runtimeTokens = new Map<string, Token>()
 
 export const setRuntimeToken = (registry: string, token: Token) => {
-  runtimeTokens.set(new URL(registry).origin, token)
+  runtimeTokens.set(normalizeRegistryKey(registry), token)
 }
 
 export const clearRuntimeTokens = () => {
@@ -38,7 +53,7 @@ export const deleteToken = async (
 ): Promise<void> => {
   const kc = getKC(identity)
   await kc.load()
-  kc.delete(new URL(registry).origin)
+  kc.delete(normalizeRegistryKey(registry))
   await kc.save()
 }
 
@@ -48,7 +63,7 @@ export const setToken = async (
   identity: string,
 ): Promise<void> => {
   const kc = getKC(identity)
-  return kc.set(new URL(registry).origin, token)
+  return kc.set(normalizeRegistryKey(registry), token)
 }
 
 export const getToken = async (
@@ -56,21 +71,73 @@ export const getToken = async (
   identity: string,
 ): Promise<Token | undefined> => {
   const kc = getKC(identity)
-  registry = new URL(registry).origin
+  const key = normalizeRegistryKey(registry)
 
   // Runtime tokens (e.g. from OIDC exchange) take precedence
-  const rt = runtimeTokens.get(registry)
+  const rt = runtimeTokens.get(key)
   if (rt) return rt
 
   const envReg = process.env.VLT_REGISTRY
-  if (envReg && registry === new URL(envReg).origin) {
+  if (envReg && key === normalizeRegistryKey(envReg)) {
     const envTok = process.env.VLT_TOKEN
     if (envTok) return `Bearer ${envTok}`
   }
   const tok =
-    process.env[
-      `VLT_TOKEN_${registry.replace(/[^a-zA-Z0-9]+/g, '_')}`
-    ]
+    process.env[`VLT_TOKEN_${key.replace(/[^a-zA-Z0-9]+/g, '_')}`]
   if (tok) return `Bearer ${tok}`
-  return kc.get(registry)
+  return kc.get(key)
+}
+
+/**
+ * Find the best matching token for a request URL by performing a
+ * longest-prefix match against all known registry keys (runtime
+ * tokens, env-var registries, and keychain entries).
+ *
+ * This is used by `RegistryClient.request()` which only has the
+ * full request URL — not the configured registry URL that was used
+ * to construct it.
+ */
+export const getTokenByURL = async (
+  requestUrl: string,
+  identity: string,
+): Promise<Token | undefined> => {
+  const normalized = normalizeRegistryKey(requestUrl)
+
+  // Collect all known registry keys.
+  const candidates: string[] = [...runtimeTokens.keys()]
+
+  const envReg = process.env.VLT_REGISTRY
+  if (envReg) {
+    candidates.push(normalizeRegistryKey(envReg))
+  }
+
+  const kc = getKC(identity)
+
+  // Keychain entries
+  for (const k of await kc.keys()) {
+    candidates.push(k)
+  }
+
+  // Find the longest candidate key that is a prefix of the
+  // normalized request URL.
+  let bestKey: string | undefined
+  let bestLen = 0
+  for (const candidate of candidates) {
+    if (
+      candidate.length > bestLen &&
+      (normalized === candidate ||
+        normalized.startsWith(candidate + '/'))
+    ) {
+      bestKey = candidate
+      bestLen = candidate.length
+    }
+  }
+
+  if (bestKey) {
+    return getToken(bestKey, identity)
+  }
+
+  // Fall back to origin-only match (handles VLT_TOKEN_* env vars
+  // which we can't enumerate by URL).
+  return getToken(requestUrl, identity)
 }

--- a/src/registry-client/src/index.ts
+++ b/src/registry-client/src/index.ts
@@ -18,8 +18,10 @@ import {
   deleteToken,
   getKC,
   getToken,
+  getTokenByURL,
   isToken,
   keychains,
+  normalizeRegistryKey,
   runtimeTokens,
   setRuntimeToken,
   setToken,
@@ -44,8 +46,10 @@ export {
   clearRuntimeTokens,
   deleteToken,
   getKC,
+  getTokenByURL,
   isToken,
   keychains,
+  normalizeRegistryKey,
   oidc,
   runtimeTokens,
   setRuntimeToken,
@@ -425,7 +429,6 @@ export class RegistryClient {
     ;(signal as AbortSignal | null)?.throwIfAborted()
 
     // first, try to get from the cache before making any request.
-    const { origin } = u
     const key = `${method !== 'GET' ? method + ' ' : ''}${u}`
     const buffer =
       useCache ?
@@ -483,7 +486,7 @@ export class RegistryClient {
     options.headers = addHeader(
       options.headers,
       'authorization',
-      await getToken(origin, this.identity),
+      await getTokenByURL(String(u), this.identity),
     )
 
     let response: Dispatcher.ResponseData | null = null

--- a/src/registry-client/test/auth.ts
+++ b/src/registry-client/test/auth.ts
@@ -1,5 +1,5 @@
 import t from 'tap'
-import { isToken } from '../src/auth.ts'
+import { isToken, normalizeRegistryKey } from '../src/auth.ts'
 
 const checkLog = (kc: any) => (kc as Keychain).log
 
@@ -7,6 +7,7 @@ let expectKeychainApp = 'vlt/auth'
 class Keychain {
   log: string[][] = []
   file: string
+  #data: Record<string, string> = {}
 
   constructor(app: string) {
     t.equal(app, expectKeychainApp)
@@ -23,20 +24,67 @@ class Keychain {
 
   async delete(reg: string) {
     this.log.push(['delete', reg])
+    delete this.#data[reg]
   }
 
   async set(reg: string, token: string) {
     t.equal(isToken(token), true)
     this.log.push(['set', reg, token])
+    this.#data[reg] = token
   }
 
   async get(reg: string) {
     this.log.push(['get', reg])
-    return 'Bearer stokenboken'
+    if (reg in this.#data) {
+      return this.#data[reg] as `Bearer ${string}`
+    }
+    return 'Bearer stokenboken' as const
+  }
+
+  async keys() {
+    return Object.keys(this.#data)
+  }
+
+  keysSync() {
+    return Object.keys(this.#data)
   }
 }
 
 const mocks = { '@vltpkg/keychain': { Keychain } }
+
+t.test('normalizeRegistryKey', t => {
+  // Origin-only URLs (backward compat)
+  t.equal(
+    normalizeRegistryKey('https://registry.npmjs.org/'),
+    'https://registry.npmjs.org',
+  )
+  t.equal(
+    normalizeRegistryKey('https://registry.npmjs.org'),
+    'https://registry.npmjs.org',
+  )
+  // Path-scoped registries
+  t.equal(
+    normalizeRegistryKey('https://registry.vlt.io/luke/'),
+    'https://registry.vlt.io/luke',
+  )
+  t.equal(
+    normalizeRegistryKey('https://registry.vlt.io/luke'),
+    'https://registry.vlt.io/luke',
+  )
+  // Multiple trailing slashes
+  t.equal(
+    normalizeRegistryKey('https://r.io/path///'),
+    'https://r.io/path',
+  )
+  // Port preserved
+  t.equal(
+    normalizeRegistryKey('https://foo.com:8080/'),
+    'https://foo.com:8080',
+  )
+  // Throws on invalid URL
+  t.throws(() => normalizeRegistryKey('not a url'))
+  t.end()
+})
 
 t.test('isToken', t => {
   t.equal(isToken('Bearer ok'), true)
@@ -63,6 +111,20 @@ t.test('setToken', async t => {
   typeChecks
 })
 
+t.test('setToken preserves path', async t => {
+  const { setToken, getKC } = await t.mockImport<
+    typeof import('../src/auth.ts')
+  >('../src/auth.ts', mocks)
+  await setToken(
+    'https://registry.vlt.io/luke/',
+    'Bearer luketoken',
+    '',
+  )
+  t.strictSame(checkLog(getKC('')), [
+    ['set', 'https://registry.vlt.io/luke', 'Bearer luketoken'],
+  ])
+})
+
 t.test('deleteToken', async t => {
   const { deleteToken, getKC } = await t.mockImport<
     typeof import('../src/auth.ts')
@@ -73,6 +135,18 @@ t.test('deleteToken', async t => {
     ['load'],
     ['load'],
     ['delete', 'https://x.com'],
+    ['save'],
+  ])
+})
+
+t.test('deleteToken preserves path', async t => {
+  const { deleteToken, getKC } = await t.mockImport<
+    typeof import('../src/auth.ts')
+  >('../src/auth.ts', mocks)
+  await deleteToken('https://registry.vlt.io/luke/', '')
+  t.strictSame(checkLog(getKC('')), [
+    ['load'],
+    ['delete', 'https://registry.vlt.io/luke'],
     ['save'],
   ])
 })
@@ -94,6 +168,23 @@ t.test('getToken', async t => {
   t.strictSame(
     await getToken('https://foo.com:8080/', ''),
     'Bearer foofromenv',
+  )
+})
+
+t.test('getToken with path-scoped registry', async t => {
+  const { getToken } = await t.mockImport<
+    typeof import('../src/auth.ts')
+  >('../src/auth.ts', mocks)
+  process.env.VLT_TOKEN = 'luketoken'
+  process.env.VLT_REGISTRY = 'https://registry.vlt.io/luke/'
+  t.equal(
+    await getToken('https://registry.vlt.io/luke/', ''),
+    'Bearer luketoken',
+  )
+  // Trailing slash normalization
+  t.equal(
+    await getToken('https://registry.vlt.io/luke', ''),
+    'Bearer luketoken',
   )
 })
 
@@ -120,6 +211,150 @@ t.test('runtime tokens take precedence', async t => {
   // now falls back to env
   t.equal(await getToken('https://x.com/', ''), 'Bearer fromenv')
 })
+
+t.test(
+  'runtime tokens for path-scoped registries are independent',
+  async t => {
+    const {
+      getToken,
+      setRuntimeToken,
+      clearRuntimeTokens,
+      runtimeTokens,
+    } = await t.mockImport<typeof import('../src/auth.ts')>(
+      '../src/auth.ts',
+      mocks,
+    )
+    setRuntimeToken(
+      'https://registry.vlt.io/luke/',
+      'Bearer luke-oidc',
+    )
+    setRuntimeToken('https://registry.vlt.io/vlt/', 'Bearer vlt-oidc')
+    t.equal(runtimeTokens.size, 2)
+    t.equal(
+      await getToken('https://registry.vlt.io/luke/', ''),
+      'Bearer luke-oidc',
+    )
+    t.equal(
+      await getToken('https://registry.vlt.io/vlt/', ''),
+      'Bearer vlt-oidc',
+    )
+    clearRuntimeTokens()
+  },
+)
+
+t.test('getTokenByURL longest-prefix match', async t => {
+  const { getTokenByURL, setRuntimeToken, clearRuntimeTokens } =
+    await t.mockImport<typeof import('../src/auth.ts')>(
+      '../src/auth.ts',
+      mocks,
+    )
+  setRuntimeToken(
+    'https://registry.vlt.io/luke/',
+    'Bearer luke-token',
+  )
+  setRuntimeToken('https://registry.vlt.io/vlt/', 'Bearer vlt-token')
+
+  // Request URL under /luke/ → luke-token
+  t.equal(
+    await getTokenByURL(
+      'https://registry.vlt.io/luke/@scope/pkg',
+      '',
+    ),
+    'Bearer luke-token',
+  )
+  // Request URL under /vlt/ → vlt-token
+  t.equal(
+    await getTokenByURL('https://registry.vlt.io/vlt/@scope/pkg', ''),
+    'Bearer vlt-token',
+  )
+  clearRuntimeTokens()
+})
+
+t.test('getTokenByURL exact match', async t => {
+  const { getTokenByURL, setRuntimeToken, clearRuntimeTokens } =
+    await t.mockImport<typeof import('../src/auth.ts')>(
+      '../src/auth.ts',
+      mocks,
+    )
+  setRuntimeToken('https://registry.npmjs.org/', 'Bearer npm-token')
+  t.equal(
+    await getTokenByURL('https://registry.npmjs.org/', ''),
+    'Bearer npm-token',
+  )
+  t.equal(
+    await getTokenByURL('https://registry.npmjs.org/pkg', ''),
+    'Bearer npm-token',
+  )
+  clearRuntimeTokens()
+})
+
+t.test('getTokenByURL falls back to getToken', async t => {
+  const { getTokenByURL } = await t.mockImport<
+    typeof import('../src/auth.ts')
+  >('../src/auth.ts', mocks)
+  // No runtime tokens or keychain entries; falls through to getToken
+  // which uses the mock keychain's get() returning 'Bearer stokenboken'
+  t.equal(
+    await getTokenByURL('https://unknown.com/foo', ''),
+    'Bearer stokenboken',
+  )
+})
+
+t.test('getTokenByURL prefers env registry with path', async t => {
+  const { getTokenByURL, clearRuntimeTokens } = await t.mockImport<
+    typeof import('../src/auth.ts')
+  >('../src/auth.ts', mocks)
+  clearRuntimeTokens()
+  process.env.VLT_TOKEN = 'env-path-token'
+  process.env.VLT_REGISTRY = 'https://registry.vlt.io/luke/'
+  t.equal(
+    await getTokenByURL(
+      'https://registry.vlt.io/luke/@scope/pkg',
+      '',
+    ),
+    'Bearer env-path-token',
+  )
+})
+
+t.test(
+  'getTokenByURL with keychain entries does prefix match',
+  async t => {
+    const { getTokenByURL, setToken, clearRuntimeTokens } =
+      await t.mockImport<typeof import('../src/auth.ts')>(
+        '../src/auth.ts',
+        mocks,
+      )
+    clearRuntimeTokens()
+    delete process.env.VLT_TOKEN
+    delete process.env.VLT_REGISTRY
+    // Store tokens in keychain via setToken
+    await setToken(
+      'https://registry.vlt.io/luke/',
+      'Bearer kc-luke',
+      '',
+    )
+    await setToken(
+      'https://registry.vlt.io/vlt/',
+      'Bearer kc-vlt',
+      '',
+    )
+
+    t.equal(
+      await getTokenByURL(
+        'https://registry.vlt.io/luke/@scope/pkg',
+        '',
+      ),
+      'Bearer kc-luke',
+    )
+    t.equal(
+      await getTokenByURL(
+        'https://registry.vlt.io/vlt/@scope/pkg',
+        '',
+      ),
+      'Bearer kc-vlt',
+    )
+  },
+)
 
 t.test('get a KC with a different identity', async t => {
   const { getKC } = await t.mockImport<


### PR DESCRIPTION
## Summary

Auth layer previously keyed tokens by `URL.origin`, which silently collapsed path-scoped registries on the same host. Two registries like `https://registry.vlt.io/luke/` and `https://registry.vlt.io/vlt/` would overwrite each other's tokens in the keychain because both normalize to `https://registry.vlt.io`.

## Changes

### `src/registry-client/src/auth.ts`
- Added `normalizeRegistryKey(url)` utility that produces `${origin}${pathname}` with trailing slashes stripped for stable keying
- Applied `normalizeRegistryKey` symmetrically in `setRuntimeToken`, `deleteToken`, `setToken`, `getToken`, and the env-var (`VLT_REGISTRY`) fallback
- Added `getTokenByURL()` — a longest-prefix-match lookup used by `RegistryClient.request()` that checks runtime tokens, env-var registries, and keychain entries to find the best matching token for any request URL

### `src/registry-client/src/index.ts`
- `request()` now uses `getTokenByURL()` instead of `getToken(origin, ...)` so path-scoped registries get the correct token
- Exported `normalizeRegistryKey` and `getTokenByURL` from the public API

### `src/cli-sdk/src/commands/token.ts`
- Token add/rm now uses `normalizeRegistryKey` instead of `new URL(...).origin`, so `vlt token add --registry https://r.io/luke/` stores the token under the correct key

### `src/keychain/src/index.ts`
- Added `keys()` (async) and `keysSync()` methods so the auth layer can enumerate stored registry keys for prefix matching

### `src/registry-client/src/oidc.ts`
- No changes needed — `setRuntimeToken(registry, token)` already passes the full registry URL, and `setRuntimeToken` now normalizes internally

## Test coverage
- Added `normalizeRegistryKey` unit tests (trailing slashes, ports, paths, invalid URLs)
- Added path-scoped registry tests for `setToken`, `deleteToken`, `getToken`, `setRuntimeToken`
- Added `getTokenByURL` tests: longest-prefix match, exact match, env-var fallback, keychain prefix match
- Added `Keychain.keys()/keysSync()` tests
- Added path-scoped token CLI test
- All existing tests continue to pass (backward compatible for origin-only URLs)

Closes #1599

Co-authored-by: Darcy Clarke <darcy@darcyclarke.me>