### PR TITLE
feat(cli-sdk): add `vlt access` command

### DIFF
--- a/src/cli-sdk/src/commands/access.ts
+++ b/src/cli-sdk/src/commands/access.ts
@@ -1,0 +1,315 @@
+import { error } from '@vltpkg/error-cause'
+import { RegistryClient } from '@vltpkg/registry-client'
+import type { LoadedConfig } from '../config/index.ts'
+import { commandUsage } from '../config/usage.ts'
+import type { CommandFn, CommandUsage } from '../index.ts'
+import type { Views } from '../view.ts'
+
+export const usage: CommandUsage = () =>
+  commandUsage({
+    command: 'access',
+    usage: '<command> [<args>]',
+    description: `Set or get access levels for published packages
+                  and manage team-based package permissions.`,
+    subcommands: {
+      'list packages': {
+        usage: '[<scope|user|org>]',
+        description:
+          'List packages with access info for a scope, user, or org.',
+      },
+      'get status': {
+        usage: '<package>',
+        description: 'Get the access/visibility status of a package.',
+      },
+      'set status': {
+        usage: '<package>',
+        description: `Set the access/visibility of a package. Use --access to specify the level.`,
+      },
+      grant: {
+        usage: '<read-only|read-write> <scope:team> [<package>]',
+        description: 'Grant access to a scope:team for a package.',
+      },
+      revoke: {
+        usage: '<scope:team> [<package>]',
+        description: 'Revoke access from a scope:team for a package.',
+      },
+    },
+    options: {
+      registry: {
+        value: '<url>',
+        description: 'Registry URL to manage access on.',
+      },
+      otp: {
+        description: 'Provide an OTP for access changes.',
+        value: '<otp>',
+      },
+    },
+  })
+
+export type AccessResult =
+  | { package: string; access: string }
+  | { packages: Record<string, string> }
+  | { granted: { team: string; permissions: string } }
+  | { revoked: { team: string } }
+
+export const views = {
+  human: (result: AccessResult) => {
+    if ('packages' in result) {
+      const entries = Object.entries(result.packages)
+      if (entries.length === 0) return 'No packages found.'
+      return entries
+        .map(([name, access]) => `${name}: ${access}`)
+        .join('\n')
+    }
+    if ('granted' in result) {
+      return `Granted ${result.granted.permissions} access to ${result.granted.team}.`
+    }
+    if ('revoked' in result) {
+      return `Revoked access from ${result.revoked.team}.`
+    }
+    return `${result.package}: ${result.access}`
+  },
+  json: (r: AccessResult) => r,
+} as const satisfies Views<AccessResult>
+
+export const command: CommandFn<AccessResult> = async conf => {
+  const [sub, ...args] = conf.positionals
+  switch (sub) {
+    case 'list':
+      return listPackages(conf, args)
+    case 'get':
+      return getStatus(conf, args)
+    case 'set':
+      return setStatus(conf, args)
+    case 'grant':
+      return grant(conf, args)
+    case 'revoke':
+      return revoke(conf, args)
+    default: {
+      throw error('Invalid access subcommand', {
+        found: sub,
+        validOptions: ['list', 'get', 'set', 'grant', 'revoke'],
+        code: 'EUSAGE',
+      })
+    }
+  }
+}
+
+const encodePkgName = (name: string) =>
+  name.startsWith('@') ?
+    `@${encodeURIComponent(name.slice(1))}`
+  : encodeURIComponent(name)
+
+const listPackages = async (
+  conf: LoadedConfig,
+  args: string[],
+): Promise<AccessResult> => {
+  const [keyword, entity] = args
+  if (keyword !== 'packages') {
+    throw error('Expected `list packages [<scope|user|org>]`', {
+      found: keyword,
+      code: 'EUSAGE',
+    })
+  }
+  const rc = new RegistryClient(conf.options)
+  const registryUrl = new URL(conf.options.registry)
+
+  // Determine who to list for — use entity arg or fall back to scope from package.json
+  const scope = entity ?? getDefaultScope(conf)
+
+  const url = new URL(
+    `-/org/${encodeURIComponent(scope)}/package`,
+    registryUrl,
+  )
+  const response = await rc.request(url, { useCache: false })
+  const data = response.json() as Record<string, string>
+  return { packages: data }
+}
+
+const getStatus = async (
+  conf: LoadedConfig,
+  args: string[],
+): Promise<AccessResult> => {
+  const [keyword, pkg] = args
+  if (keyword !== 'status') {
+    throw error('Expected `get status <package>`', {
+      found: keyword,
+      code: 'EUSAGE',
+    })
+  }
+  if (!pkg) {
+    throw error('Package name is required for `get status`', {
+      code: 'EUSAGE',
+    })
+  }
+  const rc = new RegistryClient(conf.options)
+  const registryUrl = new URL(conf.options.registry)
+  const url = new URL(
+    `-/package/${encodePkgName(pkg)}/access`,
+    registryUrl,
+  )
+  const response = await rc.request(url, { useCache: false })
+  const data = response.json() as { access: string }
+  return { package: pkg, access: data.access }
+}
+
+const setStatus = async (
+  conf: LoadedConfig,
+  args: string[],
+): Promise<AccessResult> => {
+  // vlt access set status=<public|restricted> <package>
+  const [statusArg, pkg] = args
+  if (!statusArg?.startsWith('status=')) {
+    throw error(
+      'Expected `set status=<public|restricted> <package>`',
+      { found: statusArg, code: 'EUSAGE' },
+    )
+  }
+  const accessLevel = statusArg.slice('status='.length)
+  if (accessLevel !== 'public' && accessLevel !== 'restricted') {
+    throw error('Access level must be `public` or `restricted`', {
+      found: accessLevel,
+      validOptions: ['public', 'restricted'],
+      code: 'EUSAGE',
+    })
+  }
+  if (!pkg) {
+    throw error('Package name is required for `set status`', {
+      code: 'EUSAGE',
+    })
+  }
+  const rc = new RegistryClient(conf.options)
+  const registryUrl = new URL(conf.options.registry)
+  const url = new URL(
+    `-/package/${encodePkgName(pkg)}/access`,
+    registryUrl,
+  )
+  await rc.request(url, {
+    method: 'PUT',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ access: accessLevel }),
+    otp: conf.options.otp,
+    useCache: false,
+  })
+  return { package: pkg, access: accessLevel }
+}
+
+const grant = async (
+  conf: LoadedConfig,
+  args: string[],
+): Promise<AccessResult> => {
+  // vlt access grant <read-only|read-write> <scope:team> [<package>]
+  const [permissions, scopeTeam, pkg] = args
+  if (permissions !== 'read-only' && permissions !== 'read-write') {
+    throw error('Permissions must be `read-only` or `read-write`', {
+      found: permissions,
+      validOptions: ['read-only', 'read-write'],
+      code: 'EUSAGE',
+    })
+  }
+  if (!scopeTeam?.includes(':')) {
+    throw error('Team must be in the format `<scope>:<team>`', {
+      found: scopeTeam,
+      code: 'EUSAGE',
+    })
+  }
+  const [scope, team] = scopeTeam.split(':')
+  if (!scope || !team) {
+    throw error('Team must be in the format `<scope>:<team>`', {
+      found: scopeTeam,
+      code: 'EUSAGE',
+    })
+  }
+
+  const pkgName = pkg ?? getDefaultPkgName(conf)
+
+  const rc = new RegistryClient(conf.options)
+  const registryUrl = new URL(conf.options.registry)
+  const url = new URL(
+    `-/team/${encodeURIComponent(scope)}/${encodeURIComponent(team)}/package`,
+    registryUrl,
+  )
+  await rc.request(url, {
+    method: 'PUT',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({
+      package: pkgName,
+      permissions,
+    }),
+    otp: conf.options.otp,
+    useCache: false,
+  })
+  return {
+    granted: {
+      team: `${scope}:${team}`,
+      permissions,
+    },
+  }
+}
+
+const revoke = async (
+  conf: LoadedConfig,
+  args: string[],
+): Promise<AccessResult> => {
+  // vlt access revoke <scope:team> [<package>]
+  const [scopeTeam, pkg] = args
+  if (!scopeTeam?.includes(':')) {
+    throw error('Team must be in the format `<scope>:<team>`', {
+      found: scopeTeam,
+      code: 'EUSAGE',
+    })
+  }
+  const [scope, team] = scopeTeam.split(':')
+  if (!scope || !team) {
+    throw error('Team must be in the format `<scope>:<team>`', {
+      found: scopeTeam,
+      code: 'EUSAGE',
+    })
+  }
+
+  const pkgName = pkg ?? getDefaultPkgName(conf)
+
+  const rc = new RegistryClient(conf.options)
+  const registryUrl = new URL(conf.options.registry)
+  const url = new URL(
+    `-/team/${encodeURIComponent(scope)}/${encodeURIComponent(team)}/package`,
+    registryUrl,
+  )
+  await rc.request(url, {
+    method: 'DELETE',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ package: pkgName }),
+    otp: conf.options.otp,
+    useCache: false,
+  })
+  return {
+    revoked: {
+      team: `${scope}:${team}`,
+    },
+  }
+}
+
+const getDefaultScope = (conf: LoadedConfig): string => {
+  const name = conf.options.packageJson.maybeRead(
+    conf.projectRoot,
+  )?.name
+  if (name?.startsWith('@')) {
+    const scope = name.split('/')[0]
+    if (scope) return scope
+  }
+  throw error(
+    'Could not determine scope. Provide a scope, user, or org.',
+    { code: 'EUSAGE' },
+  )
+}
+
+const getDefaultPkgName = (conf: LoadedConfig): string => {
+  const name = conf.options.packageJson.maybeRead(
+    conf.projectRoot,
+  )?.name
+  if (name) return name
+  throw error(
+    'Could not determine package name. Provide a package name or run from a package directory.',
+    { code: 'EUSAGE' },
+  )
+}

--- a/src/cli-sdk/src/config/definition.ts
+++ b/src/cli-sdk/src/config/definition.ts
@@ -19,6 +19,7 @@ export const defaultEditor = () =>
   : 'vi')
 
 const canonicalCommands = {
+  access: 'access',
   bugs: 'bugs',
   build: 'build',
   cache: 'cache',

--- a/src/cli-sdk/tap-snapshots/test/commands/access.ts.test.cjs
+++ b/src/cli-sdk/tap-snapshots/test/commands/access.ts.test.cjs
@@ -1,0 +1,77 @@
+/* IMPORTANT
+ * This snapshot file is auto-generated, but designed for humans.
+ * It should be checked into source control and tracked carefully.
+ * Re-generate by setting TAP_SNAPSHOT=1 and running tests.
+ * Make sure to inspect the output below.  Do not ignore changes!
+ */
+'use strict'
+exports[`test/commands/access.ts > TAP > usage > must match snapshot 1`] = `
+Usage:
+
+\`\`\`
+vlt access <command> [<args>]
+\`\`\`
+
+Set or get access levels for published packages and manage team-based package permissions.
+
+## Subcommands
+
+### list packages
+
+List packages with access info for a scope, user, or org.
+
+\`\`\`
+vlt access list packages [<scope|user|org>]
+\`\`\`
+
+### get status
+
+Get the access/visibility status of a package.
+
+\`\`\`
+vlt access get status <package>
+\`\`\`
+
+### set status
+
+Set the access/visibility of a package. Use --access to specify the level.
+
+\`\`\`
+vlt access set status <package>
+\`\`\`
+
+### grant
+
+Grant access to a scope:team for a package.
+
+\`\`\`
+vlt access grant <read-only|read-write> <scope:team> [<package>]
+\`\`\`
+
+### revoke
+
+Revoke access from a scope:team for a package.
+
+\`\`\`
+vlt access revoke <scope:team> [<package>]
+\`\`\`
+
+## Options
+
+### registry
+
+Registry URL to manage access on.
+
+\`\`\`
+--registry=<url>
+\`\`\`
+
+### otp
+
+Provide an OTP for access changes.
+
+\`\`\`
+--otp=<otp>
+\`\`\`
+
+`

--- a/src/cli-sdk/tap-snapshots/test/config/definition.ts.test.cjs
+++ b/src/cli-sdk/tap-snapshots/test/config/definition.ts.test.cjs
@@ -8,6 +8,7 @@
 exports[`test/config/definition.ts > TAP > commands 1`] = `
 Object {
   "?": "help",
+  "access": "access",
   "add": "install",
   "b": "build",
   "bugs": "bugs",
@@ -181,6 +182,7 @@ Object {
     "hint": "command",
     "type": "string",
     "validOptions": Array [
+      "access",
       "bugs",
       "build",
       "cache",

--- a/src/cli-sdk/test/commands/access.ts
+++ b/src/cli-sdk/test/commands/access.ts
@@ -1,0 +1,661 @@
+import t from 'tap'
+import type { LoadedConfig } from '../../src/config/index.ts'
+import type { AccessResult } from '../../src/commands/access.ts'
+
+type RequestLog = {
+  url: string
+  method?: string
+  body?: string
+  otp?: string
+}
+
+const makeRequestLog = () => {
+  const log: RequestLog[] = []
+  return { log }
+}
+
+const makeMockModule = (
+  log: RequestLog[],
+  responseData: Record<string, unknown> = {},
+) => ({
+  '@vltpkg/registry-client': {
+    RegistryClient: class {
+      async request(
+        url: string | URL,
+        opts?: {
+          method?: string
+          body?: string
+          otp?: string
+          useCache?: false
+        },
+      ) {
+        log.push({
+          url: String(url),
+          method: opts?.method,
+          body: opts?.body,
+          otp: opts?.otp,
+        })
+        return {
+          json: () => responseData,
+        }
+      }
+    },
+  },
+})
+
+const makeConfig = (
+  positionals: string[],
+  overrides: Partial<{
+    registry: string
+    otp: string
+    access: string
+    packageJson: {
+      maybeRead: (root: string) => { name: string } | undefined
+    }
+    projectRoot: string
+  }> = {},
+): LoadedConfig =>
+  ({
+    positionals,
+    projectRoot: overrides.projectRoot ?? '/test',
+    options: {
+      registry: overrides.registry ?? 'https://registry.npmjs.org/',
+      otp: overrides.otp,
+      access: overrides.access,
+      packageJson: overrides.packageJson ?? {
+        maybeRead: () => ({ name: '@scope/my-pkg' }),
+      },
+    },
+    get: (key: string) => {
+      if (key === 'access') return overrides.access
+      return undefined
+    },
+  }) as unknown as LoadedConfig
+
+t.test('usage', async t => {
+  const { usage } = await t.mockImport<
+    typeof import('../../src/commands/access.ts')
+  >('../../src/commands/access.ts', makeMockModule([]))
+  t.matchSnapshot(usage().usageMarkdown())
+})
+
+t.test('invalid subcommand', async t => {
+  const { command } = await t.mockImport<
+    typeof import('../../src/commands/access.ts')
+  >('../../src/commands/access.ts', makeMockModule([]))
+  await t.rejects(command(makeConfig(['invalid'])), {
+    cause: { code: 'EUSAGE' },
+  })
+})
+
+t.test('missing subcommand', async t => {
+  const { command } = await t.mockImport<
+    typeof import('../../src/commands/access.ts')
+  >('../../src/commands/access.ts', makeMockModule([]))
+  await t.rejects(command(makeConfig([])), {
+    cause: { code: 'EUSAGE' },
+  })
+})
+
+t.test('list packages', async t => {
+  t.test('with explicit entity', async t => {
+    const { log } = makeRequestLog()
+    const { command } = await t.mockImport<
+      typeof import('../../src/commands/access.ts')
+    >(
+      '../../src/commands/access.ts',
+      makeMockModule(log, {
+        '@scope/pkg-a': 'read-write',
+        '@scope/pkg-b': 'read-only',
+      }),
+    )
+    const result = await command(
+      makeConfig(['list', 'packages', '@scope']),
+    )
+    t.strictSame(result, {
+      packages: {
+        '@scope/pkg-a': 'read-write',
+        '@scope/pkg-b': 'read-only',
+      },
+    })
+    t.equal(log.length, 1)
+    t.equal(
+      log[0]!.url,
+      'https://registry.npmjs.org/-/org/%40scope/package',
+    )
+  })
+
+  t.test('falls back to scope from package.json', async t => {
+    const { log } = makeRequestLog()
+    const { command } = await t.mockImport<
+      typeof import('../../src/commands/access.ts')
+    >('../../src/commands/access.ts', makeMockModule(log, {}))
+    const result = await command(makeConfig(['list', 'packages']))
+    t.strictSame(result, { packages: {} })
+    t.equal(log.length, 1)
+    t.equal(
+      log[0]!.url,
+      'https://registry.npmjs.org/-/org/%40scope/package',
+    )
+  })
+
+  t.test('errors when no scope available', async t => {
+    const { command } = await t.mockImport<
+      typeof import('../../src/commands/access.ts')
+    >('../../src/commands/access.ts', makeMockModule([]))
+    await t.rejects(
+      command(
+        makeConfig(['list', 'packages'], {
+          packageJson: {
+            maybeRead: () => ({ name: 'unscoped-pkg' }),
+          },
+        }),
+      ),
+      { cause: { code: 'EUSAGE' } },
+    )
+  })
+
+  t.test('errors when package.json has no name', async t => {
+    const { command } = await t.mockImport<
+      typeof import('../../src/commands/access.ts')
+    >('../../src/commands/access.ts', makeMockModule([]))
+    await t.rejects(
+      command(
+        makeConfig(['list', 'packages'], {
+          packageJson: { maybeRead: () => undefined },
+        }),
+      ),
+      { cause: { code: 'EUSAGE' } },
+    )
+  })
+
+  t.test('errors with wrong keyword', async t => {
+    const { command } = await t.mockImport<
+      typeof import('../../src/commands/access.ts')
+    >('../../src/commands/access.ts', makeMockModule([]))
+    await t.rejects(command(makeConfig(['list', 'wrong'])), {
+      cause: { code: 'EUSAGE' },
+    })
+  })
+})
+
+t.test('get status', async t => {
+  t.test('gets status of a package', async t => {
+    const { log } = makeRequestLog()
+    const { command } = await t.mockImport<
+      typeof import('../../src/commands/access.ts')
+    >(
+      '../../src/commands/access.ts',
+      makeMockModule(log, { access: 'public' }),
+    )
+    const result = await command(
+      makeConfig(['get', 'status', '@scope/my-pkg']),
+    )
+    t.strictSame(result, {
+      package: '@scope/my-pkg',
+      access: 'public',
+    })
+    t.equal(log.length, 1)
+    t.equal(
+      log[0]!.url,
+      'https://registry.npmjs.org/-/package/@scope%2Fmy-pkg/access',
+    )
+  })
+
+  t.test('errors with wrong keyword', async t => {
+    const { command } = await t.mockImport<
+      typeof import('../../src/commands/access.ts')
+    >('../../src/commands/access.ts', makeMockModule([]))
+    await t.rejects(command(makeConfig(['get', 'wrong', 'pkg'])), {
+      cause: { code: 'EUSAGE' },
+    })
+  })
+
+  t.test('errors without package name', async t => {
+    const { command } = await t.mockImport<
+      typeof import('../../src/commands/access.ts')
+    >('../../src/commands/access.ts', makeMockModule([]))
+    await t.rejects(command(makeConfig(['get', 'status'])), {
+      cause: { code: 'EUSAGE' },
+    })
+  })
+})
+
+t.test('set status', async t => {
+  t.test('sets package to public', async t => {
+    const { log } = makeRequestLog()
+    const { command } = await t.mockImport<
+      typeof import('../../src/commands/access.ts')
+    >('../../src/commands/access.ts', makeMockModule(log))
+    const result = await command(
+      makeConfig(['set', 'status=public', '@scope/my-pkg']),
+    )
+    t.strictSame(result, {
+      package: '@scope/my-pkg',
+      access: 'public',
+    })
+    t.equal(log.length, 1)
+    t.equal(log[0]!.method, 'PUT')
+    t.equal(log[0]!.body, JSON.stringify({ access: 'public' }))
+  })
+
+  t.test('sets package to restricted', async t => {
+    const { log } = makeRequestLog()
+    const { command } = await t.mockImport<
+      typeof import('../../src/commands/access.ts')
+    >('../../src/commands/access.ts', makeMockModule(log))
+    const result = await command(
+      makeConfig(['set', 'status=restricted', '@scope/my-pkg']),
+    )
+    t.strictSame(result, {
+      package: '@scope/my-pkg',
+      access: 'restricted',
+    })
+  })
+
+  t.test('passes otp when provided', async t => {
+    const { log } = makeRequestLog()
+    const { command } = await t.mockImport<
+      typeof import('../../src/commands/access.ts')
+    >('../../src/commands/access.ts', makeMockModule(log))
+    await command(
+      makeConfig(['set', 'status=public', '@scope/my-pkg'], {
+        otp: '123456',
+      }),
+    )
+    t.equal(log[0]!.otp, '123456')
+  })
+
+  t.test('errors with invalid access level', async t => {
+    const { command } = await t.mockImport<
+      typeof import('../../src/commands/access.ts')
+    >('../../src/commands/access.ts', makeMockModule([]))
+    await t.rejects(
+      command(makeConfig(['set', 'status=invalid', '@scope/my-pkg'])),
+      { cause: { code: 'EUSAGE' } },
+    )
+  })
+
+  t.test('errors without status= prefix', async t => {
+    const { command } = await t.mockImport<
+      typeof import('../../src/commands/access.ts')
+    >('../../src/commands/access.ts', makeMockModule([]))
+    await t.rejects(
+      command(makeConfig(['set', 'public', '@scope/my-pkg'])),
+      { cause: { code: 'EUSAGE' } },
+    )
+  })
+
+  t.test('errors without package name', async t => {
+    const { command } = await t.mockImport<
+      typeof import('../../src/commands/access.ts')
+    >('../../src/commands/access.ts', makeMockModule([]))
+    await t.rejects(command(makeConfig(['set', 'status=public'])), {
+      cause: { code: 'EUSAGE' },
+    })
+  })
+
+  t.test('errors with no args', async t => {
+    const { command } = await t.mockImport<
+      typeof import('../../src/commands/access.ts')
+    >('../../src/commands/access.ts', makeMockModule([]))
+    await t.rejects(command(makeConfig(['set'])), {
+      cause: { code: 'EUSAGE' },
+    })
+  })
+})
+
+t.test('grant', async t => {
+  t.test(
+    'grants read-write to a team with explicit package',
+    async t => {
+      const { log } = makeRequestLog()
+      const { command } = await t.mockImport<
+        typeof import('../../src/commands/access.ts')
+      >('../../src/commands/access.ts', makeMockModule(log))
+      const result = await command(
+        makeConfig([
+          'grant',
+          'read-write',
+          'myorg:myteam',
+          '@scope/my-pkg',
+        ]),
+      )
+      t.strictSame(result, {
+        granted: {
+          team: 'myorg:myteam',
+          permissions: 'read-write',
+        },
+      })
+      t.equal(log.length, 1)
+      t.equal(log[0]!.method, 'PUT')
+      t.equal(
+        log[0]!.url,
+        'https://registry.npmjs.org/-/team/myorg/myteam/package',
+      )
+      t.equal(
+        log[0]!.body,
+        JSON.stringify({
+          package: '@scope/my-pkg',
+          permissions: 'read-write',
+        }),
+      )
+    },
+  )
+
+  t.test('grants read-only to a team', async t => {
+    const { log } = makeRequestLog()
+    const { command } = await t.mockImport<
+      typeof import('../../src/commands/access.ts')
+    >('../../src/commands/access.ts', makeMockModule(log))
+    const result = await command(
+      makeConfig([
+        'grant',
+        'read-only',
+        'myorg:myteam',
+        '@scope/my-pkg',
+      ]),
+    )
+    t.strictSame(result, {
+      granted: {
+        team: 'myorg:myteam',
+        permissions: 'read-only',
+      },
+    })
+  })
+
+  t.test('falls back to package.json name', async t => {
+    const { log } = makeRequestLog()
+    const { command } = await t.mockImport<
+      typeof import('../../src/commands/access.ts')
+    >('../../src/commands/access.ts', makeMockModule(log))
+    const result = await command(
+      makeConfig(['grant', 'read-write', 'myorg:myteam']),
+    )
+    t.strictSame(result, {
+      granted: {
+        team: 'myorg:myteam',
+        permissions: 'read-write',
+      },
+    })
+    t.equal(
+      log[0]!.body,
+      JSON.stringify({
+        package: '@scope/my-pkg',
+        permissions: 'read-write',
+      }),
+    )
+  })
+
+  t.test('errors with invalid permissions', async t => {
+    const { command } = await t.mockImport<
+      typeof import('../../src/commands/access.ts')
+    >('../../src/commands/access.ts', makeMockModule([]))
+    await t.rejects(
+      command(
+        makeConfig([
+          'grant',
+          'invalid',
+          'myorg:myteam',
+          '@scope/my-pkg',
+        ]),
+      ),
+      { cause: { code: 'EUSAGE' } },
+    )
+  })
+
+  t.test('errors without team', async t => {
+    const { command } = await t.mockImport<
+      typeof import('../../src/commands/access.ts')
+    >('../../src/commands/access.ts', makeMockModule([]))
+    await t.rejects(command(makeConfig(['grant', 'read-write'])), {
+      cause: { code: 'EUSAGE' },
+    })
+  })
+
+  t.test('errors with malformed team (no colon)', async t => {
+    const { command } = await t.mockImport<
+      typeof import('../../src/commands/access.ts')
+    >('../../src/commands/access.ts', makeMockModule([]))
+    await t.rejects(
+      command(makeConfig(['grant', 'read-write', 'badteam', 'pkg'])),
+      { cause: { code: 'EUSAGE' } },
+    )
+  })
+
+  t.test('errors with malformed team (empty parts)', async t => {
+    const { command } = await t.mockImport<
+      typeof import('../../src/commands/access.ts')
+    >('../../src/commands/access.ts', makeMockModule([]))
+    await t.rejects(
+      command(makeConfig(['grant', 'read-write', ':team', 'pkg'])),
+      { cause: { code: 'EUSAGE' } },
+    )
+  })
+
+  t.test('errors when no package name available', async t => {
+    const { command } = await t.mockImport<
+      typeof import('../../src/commands/access.ts')
+    >('../../src/commands/access.ts', makeMockModule([]))
+    await t.rejects(
+      command(
+        makeConfig(['grant', 'read-write', 'myorg:myteam'], {
+          packageJson: { maybeRead: () => undefined },
+        }),
+      ),
+      { cause: { code: 'EUSAGE' } },
+    )
+  })
+
+  t.test('passes otp when provided', async t => {
+    const { log } = makeRequestLog()
+    const { command } = await t.mockImport<
+      typeof import('../../src/commands/access.ts')
+    >('../../src/commands/access.ts', makeMockModule(log))
+    await command(
+      makeConfig(
+        ['grant', 'read-write', 'myorg:myteam', '@scope/my-pkg'],
+        { otp: '654321' },
+      ),
+    )
+    t.equal(log[0]!.otp, '654321')
+  })
+})
+
+t.test('revoke', async t => {
+  t.test('revokes team access with explicit package', async t => {
+    const { log } = makeRequestLog()
+    const { command } = await t.mockImport<
+      typeof import('../../src/commands/access.ts')
+    >('../../src/commands/access.ts', makeMockModule(log))
+    const result = await command(
+      makeConfig(['revoke', 'myorg:myteam', '@scope/my-pkg']),
+    )
+    t.strictSame(result, {
+      revoked: { team: 'myorg:myteam' },
+    })
+    t.equal(log.length, 1)
+    t.equal(log[0]!.method, 'DELETE')
+    t.equal(
+      log[0]!.url,
+      'https://registry.npmjs.org/-/team/myorg/myteam/package',
+    )
+    t.equal(
+      log[0]!.body,
+      JSON.stringify({ package: '@scope/my-pkg' }),
+    )
+  })
+
+  t.test('falls back to package.json name', async t => {
+    const { log } = makeRequestLog()
+    const { command } = await t.mockImport<
+      typeof import('../../src/commands/access.ts')
+    >('../../src/commands/access.ts', makeMockModule(log))
+    const result = await command(
+      makeConfig(['revoke', 'myorg:myteam']),
+    )
+    t.strictSame(result, {
+      revoked: { team: 'myorg:myteam' },
+    })
+    t.equal(
+      log[0]!.body,
+      JSON.stringify({ package: '@scope/my-pkg' }),
+    )
+  })
+
+  t.test('errors without team', async t => {
+    const { command } = await t.mockImport<
+      typeof import('../../src/commands/access.ts')
+    >('../../src/commands/access.ts', makeMockModule([]))
+    await t.rejects(command(makeConfig(['revoke'])), {
+      cause: { code: 'EUSAGE' },
+    })
+  })
+
+  t.test('errors with malformed team (no colon)', async t => {
+    const { command } = await t.mockImport<
+      typeof import('../../src/commands/access.ts')
+    >('../../src/commands/access.ts', makeMockModule([]))
+    await t.rejects(
+      command(makeConfig(['revoke', 'badteam', 'pkg'])),
+      { cause: { code: 'EUSAGE' } },
+    )
+  })
+
+  t.test('errors with malformed team (empty scope)', async t => {
+    const { command } = await t.mockImport<
+      typeof import('../../src/commands/access.ts')
+    >('../../src/commands/access.ts', makeMockModule([]))
+    await t.rejects(command(makeConfig(['revoke', ':team', 'pkg'])), {
+      cause: { code: 'EUSAGE' },
+    })
+  })
+
+  t.test('errors when no package name available', async t => {
+    const { command } = await t.mockImport<
+      typeof import('../../src/commands/access.ts')
+    >('../../src/commands/access.ts', makeMockModule([]))
+    await t.rejects(
+      command(
+        makeConfig(['revoke', 'myorg:myteam'], {
+          packageJson: { maybeRead: () => undefined },
+        }),
+      ),
+      { cause: { code: 'EUSAGE' } },
+    )
+  })
+
+  t.test('passes otp when provided', async t => {
+    const { log } = makeRequestLog()
+    const { command } = await t.mockImport<
+      typeof import('../../src/commands/access.ts')
+    >('../../src/commands/access.ts', makeMockModule(log))
+    await command(
+      makeConfig(['revoke', 'myorg:myteam', '@scope/my-pkg'], {
+        otp: '999999',
+      }),
+    )
+    t.equal(log[0]!.otp, '999999')
+  })
+})
+
+t.test('views', async t => {
+  const { views } = await t.mockImport<
+    typeof import('../../src/commands/access.ts')
+  >('../../src/commands/access.ts', makeMockModule([]))
+
+  t.test('human view - packages list', async t => {
+    const result: AccessResult = {
+      packages: {
+        '@scope/pkg-a': 'read-write',
+        '@scope/pkg-b': 'read-only',
+      },
+    }
+    const output = views.human(result)
+    t.equal(
+      output,
+      '@scope/pkg-a: read-write\n@scope/pkg-b: read-only',
+    )
+  })
+
+  t.test('human view - empty packages list', async t => {
+    const result: AccessResult = { packages: {} }
+    const output = views.human(result)
+    t.equal(output, 'No packages found.')
+  })
+
+  t.test('human view - granted', async t => {
+    const result: AccessResult = {
+      granted: {
+        team: 'myorg:myteam',
+        permissions: 'read-write',
+      },
+    }
+    const output = views.human(result)
+    t.equal(output, 'Granted read-write access to myorg:myteam.')
+  })
+
+  t.test('human view - revoked', async t => {
+    const result: AccessResult = {
+      revoked: { team: 'myorg:myteam' },
+    }
+    const output = views.human(result)
+    t.equal(output, 'Revoked access from myorg:myteam.')
+  })
+
+  t.test('human view - package status', async t => {
+    const result: AccessResult = {
+      package: '@scope/my-pkg',
+      access: 'public',
+    }
+    const output = views.human(result)
+    t.equal(output, '@scope/my-pkg: public')
+  })
+
+  t.test('json view', async t => {
+    const result: AccessResult = {
+      package: '@scope/my-pkg',
+      access: 'public',
+    }
+    t.strictSame(views.json(result), result)
+  })
+})
+
+t.test('get status - unscoped package', async t => {
+  const { log } = makeRequestLog()
+  const { command } = await t.mockImport<
+    typeof import('../../src/commands/access.ts')
+  >(
+    '../../src/commands/access.ts',
+    makeMockModule(log, { access: 'restricted' }),
+  )
+  const result = await command(
+    makeConfig(['get', 'status', 'unscoped-pkg']),
+  )
+  t.strictSame(result, {
+    package: 'unscoped-pkg',
+    access: 'restricted',
+  })
+  t.equal(
+    log[0]!.url,
+    'https://registry.npmjs.org/-/package/unscoped-pkg/access',
+  )
+})
+
+t.test('set status - unscoped package', async t => {
+  const { log } = makeRequestLog()
+  const { command } = await t.mockImport<
+    typeof import('../../src/commands/access.ts')
+  >('../../src/commands/access.ts', makeMockModule(log))
+  const result = await command(
+    makeConfig(['set', 'status=public', 'unscoped-pkg']),
+  )
+  t.strictSame(result, {
+    package: 'unscoped-pkg',
+    access: 'public',
+  })
+  t.equal(
+    log[0]!.url,
+    'https://registry.npmjs.org/-/package/unscoped-pkg/access',
+  )
+})


### PR DESCRIPTION
## Summary

Implements the `vlt access` CLI command for managing package access levels and team permissions on npm registries. Similar to `npm access`.

### Subcommands

- `vlt access list packages [<scope|user|org>]` — list packages with access info
- `vlt access get status <package>` — get the access/visibility status of a package
- `vlt access set status=<public|restricted> <package>` — set access/visibility of a package
- `vlt access grant <read-only|read-write> <scope:team> [<package>]` — grant access to a team
- `vlt access revoke <scope:team> [<package>]` — revoke access from a team

### Implementation Details

- Follows existing command patterns (see `token.ts`, `whoami.ts`, `publish.ts`)
- Uses `RegistryClient` to interact with the npm registry access API
- Supports OTP for write operations
- Falls back to `package.json` scope/name when arguments are omitted
- Human and JSON view output
- 100% test coverage (317/317 statements, 73/73 branches, 12/12 functions)

### Files Changed

- `src/cli-sdk/src/commands/access.ts` — command implementation
- `src/cli-sdk/src/config/definition.ts` — register `access` command
- `src/cli-sdk/test/commands/access.ts` — tests (63 assertions)
- Snapshot files updated

Closes #1224

Co-authored-by: Darcy Clarke <darcy@darcyclarke.me>