### PR TITLE
feat(cli-sdk): add `vlt token list` subcommand

### DIFF
--- a/src/cli-sdk/src/commands/token.ts
+++ b/src/cli-sdk/src/commands/token.ts
@@ -2,21 +2,68 @@ import { error } from '@vltpkg/error-cause'
 import {
   deleteToken,
   normalizeRegistryKey,
+  RegistryClient,
   setToken,
 } from '@vltpkg/registry-client'
 import { commandUsage } from '../config/usage.ts'
 import { readPassword } from '../read-password.ts'
 import type { CommandFn, CommandUsage } from '../index.ts'
+import type { Views } from '../view.ts'
+
+export type TokenInfo = {
+  /** The server-side key/id for the token */
+  key: string
+  /** A truncated prefix of the token value */
+  token: string
+  /** ISO date when the token was created */
+  created: string
+  /** Whether this token is read-only */
+  readonly: boolean
+  /** CIDR whitelist, if any */
+  cidr_whitelist?: string[]
+}
+
+export type RegistryTokens = {
+  registry: string
+  alias?: string
+  tokens: TokenInfo[]
+  error?: string
+}
+
+export type TokenListResult = RegistryTokens[]
 
 export const usage: CommandUsage = () =>
   commandUsage({
     command: 'token',
-    usage: ['add', 'rm'],
-    description: `Explicitly add or remove tokens in the vlt keychain`,
+    usage: ['list', 'add', 'rm'],
+    description: `Manage registry authentication tokens in the vlt keychain.`,
+    subcommands: {
+      list: {
+        usage: '',
+        description: `List all tokens for configured registries.
+                      Queries each registry's token API and displays
+                      token metadata including key, creation date,
+                      and permissions.`,
+      },
+      add: {
+        usage: '',
+        description: `Add a token for the specified registry.
+                      You will be prompted to paste the bearer token.`,
+      },
+      rm: {
+        usage: '',
+        description: `Remove the stored token for the specified registry.`,
+      },
+    },
     options: {
       registry: {
         value: '<url>',
         description: 'Registry URL to manage tokens for.',
+      },
+      registries: {
+        value: '<alias=url>',
+        description:
+          'Named registry aliases (used by the list subcommand).',
       },
       identity: {
         value: '<name>',
@@ -25,9 +72,106 @@ export const usage: CommandUsage = () =>
     },
   })
 
-export const command: CommandFn<void> = async conf => {
+const formatDate = (iso: string): string => {
+  const d = new Date(iso)
+  return d.toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+  })
+}
+
+const formatTokenEntry = (t: TokenInfo): string => {
+  const parts = [
+    `key: ${t.key}`,
+    `token: ${t.token}…`,
+    `created: ${formatDate(t.created)}`,
+    `readonly: ${t.readonly ? 'yes' : 'no'}`,
+  ]
+  if (t.cidr_whitelist && t.cidr_whitelist.length > 0) {
+    parts.push(`cidr: ${t.cidr_whitelist.join(', ')}`)
+  }
+  return parts.join(' │ ')
+}
+
+const formatRegistryTokens = (r: RegistryTokens): string => {
+  const header = r.alias ? `${r.alias} (${r.registry})` : r.registry
+  if (r.error) return `${header}\n  error: ${r.error}`
+  if (r.tokens.length === 0) return `${header}\n  (no tokens found)`
+  return [
+    header,
+    ...r.tokens.map(t => `  ${formatTokenEntry(t)}`),
+  ].join('\n')
+}
+
+export const views = {
+  human: (r: TokenListResult | void) => {
+    if (!r) return
+    return r.map(formatRegistryTokens).join('\n\n')
+  },
+  json: (r: TokenListResult | void) => {
+    if (!r) return
+    return r
+  },
+} as const satisfies Views<TokenListResult | void>
+
+const listTokens = async (
+  rc: RegistryClient,
+  registry: string,
+  alias?: string,
+): Promise<RegistryTokens> => {
+  const tokensUrl = new URL('-/npm/v1/tokens', registry)
+  try {
+    const objects = await rc.scroll<TokenInfo>(tokensUrl, {
+      useCache: false,
+    })
+    return {
+      registry,
+      alias,
+      tokens: objects.map(o => ({
+        key: o.key,
+        token: o.token,
+        created: o.created,
+        readonly: o.readonly,
+        cidr_whitelist: o.cidr_whitelist,
+      })),
+    }
+  } catch (err) {
+    return {
+      registry,
+      alias,
+      tokens: [],
+      error: err instanceof Error ? err.message : String(err),
+    }
+  }
+}
+
+export const command: CommandFn<
+  TokenListResult | void
+> = async conf => {
   const reg = normalizeRegistryKey(conf.options.registry)
   switch (conf.positionals[0]) {
+    case 'list': {
+      const rc = new RegistryClient(conf.options)
+      const results: RegistryTokens[] = []
+
+      // Always query the default registry first
+      results.push(
+        await listTokens(rc, conf.options.registry, 'default'),
+      )
+
+      // Then query all configured registry aliases
+      const registries = conf.options.registries
+      for (const [alias, registry] of Object.entries(registries)) {
+        // Skip if it's the same as the default registry
+        if (registry !== conf.options.registry) {
+          results.push(await listTokens(rc, registry, alias))
+        }
+      }
+
+      return results
+    }
+
     case 'add': {
       await setToken(
         reg,
@@ -45,7 +189,7 @@ export const command: CommandFn<void> = async conf => {
     default: {
       throw error('Invalid token subcommand', {
         found: conf.positionals[0],
-        validOptions: ['add', 'rm'],
+        validOptions: ['list', 'add', 'rm'],
         code: 'EUSAGE',
       })
     }

--- a/src/cli-sdk/tap-snapshots/test/commands/token.ts.test.cjs
+++ b/src/cli-sdk/tap-snapshots/test/commands/token.ts.test.cjs
@@ -9,11 +9,38 @@ exports[`test/commands/token.ts > TAP > must match snapshot 1`] = `
 Usage:
 
 \`\`\`
+vlt token list
 vlt token add
 vlt token rm
 \`\`\`
 
-Explicitly add or remove tokens in the vlt keychain
+Manage registry authentication tokens in the vlt keychain.
+
+## Subcommands
+
+### list
+
+List all tokens for configured registries. Queries each registry's token API and displays token metadata including key, creation date, and permissions.
+
+\`\`\`
+vlt token list
+\`\`\`
+
+### add
+
+Add a token for the specified registry. You will be prompted to paste the bearer token.
+
+\`\`\`
+vlt token add
+\`\`\`
+
+### rm
+
+Remove the stored token for the specified registry.
+
+\`\`\`
+vlt token rm
+\`\`\`
 
 ## Options
 
@@ -23,6 +50,14 @@ Registry URL to manage tokens for.
 
 \`\`\`
 --registry=<url>
+\`\`\`
+
+### registries
+
+Named registry aliases (used by the list subcommand).
+
+\`\`\`
+--registries=<alias=url>
 \`\`\`
 
 ### identity

--- a/src/cli-sdk/test/commands/token.ts
+++ b/src/cli-sdk/test/commands/token.ts
@@ -1,16 +1,28 @@
 import type { Token } from '@vltpkg/registry-client'
 import t from 'tap'
 import type { LoadedConfig } from '../../src/config/index.ts'
+import type { TokenInfo } from '../../src/commands/token.ts'
+
+const mockRegistryClient = {
+  normalizeRegistryKey(url: string) {
+    const u = new URL(url)
+    return (u.origin + u.pathname).replace(/\/+$/, '')
+  },
+  async setToken(_reg: string, _tok: Token) {},
+  async deleteToken(_reg: string) {},
+  RegistryClient: class MockRegistryClient {
+    async scroll<T>(): Promise<T[]> {
+      return [] as T[]
+    }
+  },
+}
 
 const log: string[][] = []
-const { usage, command } = await t.mockImport<
+const { usage, command, views } = await t.mockImport<
   typeof import('../../src/commands/token.ts')
 >('../../src/commands/token.ts', {
   '@vltpkg/registry-client': {
-    normalizeRegistryKey(url: string) {
-      const u = new URL(url)
-      return (u.origin + u.pathname).replace(/\/+$/, '')
-    },
+    ...mockRegistryClient,
     async setToken(reg: string, tok: Token) {
       log.push(['add', reg, tok])
     },
@@ -50,10 +62,7 @@ t.test('preserves path for path-scoped registry', async t => {
     typeof import('../../src/commands/token.ts')
   >('../../src/commands/token.ts', {
     '@vltpkg/registry-client': {
-      normalizeRegistryKey(url: string) {
-        const u = new URL(url)
-        return (u.origin + u.pathname).replace(/\/+$/, '')
-      },
+      ...mockRegistryClient,
       async setToken(reg: string, tok: Token) {
         pathLog.push(['add', reg, tok])
       },
@@ -89,4 +98,270 @@ t.test('invalid token sub command', async t => {
     } as LoadedConfig),
     { cause: { code: 'EUSAGE' } },
   )
+})
+
+t.test('list tokens from default registry', async t => {
+  const mockTokens: TokenInfo[] = [
+    {
+      key: 'abc123',
+      token: 'npm_1234',
+      created: '2025-06-15T10:30:00.000Z',
+      readonly: false,
+    },
+    {
+      key: 'def456',
+      token: 'npm_5678',
+      created: '2025-01-20T08:00:00.000Z',
+      readonly: true,
+      cidr_whitelist: ['192.168.1.0/24'],
+    },
+  ]
+
+  const { command: cmd } = await t.mockImport<
+    typeof import('../../src/commands/token.ts')
+  >('../../src/commands/token.ts', {
+    '@vltpkg/registry-client': {
+      ...mockRegistryClient,
+      RegistryClient: class MockRegistryClient {
+        async scroll<T>(): Promise<T[]> {
+          return mockTokens as T[]
+        }
+      },
+    },
+  })
+
+  const result = await cmd({
+    options: {
+      registry: 'https://registry.npmjs.org/',
+      registries: {},
+    },
+    positionals: ['list'],
+  } as unknown as LoadedConfig)
+
+  t.ok(Array.isArray(result))
+  t.equal(result?.length, 1)
+  t.equal(result?.[0]?.registry, 'https://registry.npmjs.org/')
+  t.equal(result?.[0]?.alias, 'default')
+  t.equal(result?.[0]?.tokens.length, 2)
+  t.equal(result?.[0]?.tokens[0]?.key, 'abc123')
+  t.equal(result?.[0]?.tokens[0]?.token, 'npm_1234')
+  t.equal(result?.[0]?.tokens[0]?.readonly, false)
+  t.equal(result?.[0]?.tokens[1]?.key, 'def456')
+  t.equal(result?.[0]?.tokens[1]?.readonly, true)
+  t.strictSame(result?.[0]?.tokens[1]?.cidr_whitelist, [
+    '192.168.1.0/24',
+  ])
+})
+
+t.test('list tokens from multiple registries', async t => {
+  const scrollResults: Record<string, TokenInfo[]> = {
+    'https://registry.npmjs.org/-/npm/v1/tokens': [
+      {
+        key: 'npm-key-1',
+        token: 'npm_aaaa',
+        created: '2025-03-10T12:00:00.000Z',
+        readonly: false,
+      },
+    ],
+    'https://custom.registry.io/-/npm/v1/tokens': [
+      {
+        key: 'custom-key-1',
+        token: 'npm_bbbb',
+        created: '2025-04-20T15:00:00.000Z',
+        readonly: true,
+      },
+    ],
+  }
+
+  const { command: cmd } = await t.mockImport<
+    typeof import('../../src/commands/token.ts')
+  >('../../src/commands/token.ts', {
+    '@vltpkg/registry-client': {
+      ...mockRegistryClient,
+      RegistryClient: class MockRegistryClient {
+        async scroll<T>(url: URL): Promise<T[]> {
+          return (scrollResults[String(url)] ?? []) as T[]
+        }
+      },
+    },
+  })
+
+  const result = await cmd({
+    options: {
+      registry: 'https://registry.npmjs.org/',
+      registries: {
+        npm: 'https://registry.npmjs.org/',
+        custom: 'https://custom.registry.io/',
+      },
+    },
+    positionals: ['list'],
+  } as unknown as LoadedConfig)
+
+  t.ok(Array.isArray(result))
+  // npm is same URL as default, so skipped → default + custom = 2
+  t.equal(result?.length, 2)
+
+  t.equal(result?.[0]?.alias, 'default')
+  t.equal(result?.[0]?.tokens.length, 1)
+  t.equal(result?.[0]?.tokens[0]?.key, 'npm-key-1')
+
+  t.equal(result?.[1]?.alias, 'custom')
+  t.equal(result?.[1]?.registry, 'https://custom.registry.io/')
+  t.equal(result?.[1]?.tokens.length, 1)
+  t.equal(result?.[1]?.tokens[0]?.key, 'custom-key-1')
+})
+
+t.test('list handles registry errors gracefully', async t => {
+  const { command: cmd } = await t.mockImport<
+    typeof import('../../src/commands/token.ts')
+  >('../../src/commands/token.ts', {
+    '@vltpkg/registry-client': {
+      ...mockRegistryClient,
+      RegistryClient: class MockRegistryClient {
+        async scroll<T>(): Promise<T[]> {
+          throw new Error('401 Unauthorized')
+        }
+      },
+    },
+  })
+
+  const result = await cmd({
+    options: {
+      registry: 'https://registry.npmjs.org/',
+      registries: {},
+    },
+    positionals: ['list'],
+  } as unknown as LoadedConfig)
+
+  t.ok(Array.isArray(result))
+  t.equal(result?.length, 1)
+  t.equal(result?.[0]?.tokens.length, 0)
+  t.equal(result?.[0]?.error, '401 Unauthorized')
+})
+
+t.test('list handles non-Error thrown gracefully', async t => {
+  const { command: cmd } = await t.mockImport<
+    typeof import('../../src/commands/token.ts')
+  >('../../src/commands/token.ts', {
+    '@vltpkg/registry-client': {
+      ...mockRegistryClient,
+      RegistryClient: class MockRegistryClient {
+        async scroll<T>(): Promise<T[]> {
+          // eslint-disable-next-line @typescript-eslint/only-throw-error
+          throw 'string error'
+        }
+      },
+    },
+  })
+
+  const result = await cmd({
+    options: {
+      registry: 'https://registry.npmjs.org/',
+      registries: {},
+    },
+    positionals: ['list'],
+  } as unknown as LoadedConfig)
+
+  t.ok(Array.isArray(result))
+  t.equal(result?.[0]?.error, 'string error')
+})
+
+t.test('views', async t => {
+  t.test('human view formats token list', async t => {
+    const result = [
+      {
+        registry: 'https://registry.npmjs.org/',
+        alias: 'default',
+        tokens: [
+          {
+            key: 'abc123',
+            token: 'npm_1234',
+            created: '2025-06-15T10:30:00.000Z',
+            readonly: false,
+          },
+          {
+            key: 'def456',
+            token: 'npm_5678',
+            created: '2025-01-20T08:00:00.000Z',
+            readonly: true,
+            cidr_whitelist: ['192.168.1.0/24', '10.0.0.0/8'],
+          },
+        ],
+      },
+      {
+        registry: 'https://custom.registry.io/',
+        alias: 'custom',
+        tokens: [],
+      },
+    ]
+    const output = views.human(result)
+    t.type(output, 'string')
+    t.match(output, /default/)
+    t.match(output, /registry\.npmjs\.org/)
+    t.match(output, /abc123/)
+    t.match(output, /npm_1234/)
+    t.match(output, /readonly: no/)
+    t.match(output, /def456/)
+    t.match(output, /readonly: yes/)
+    t.match(output, /192\.168\.1\.0\/24/)
+    t.match(output, /10\.0\.0\.0\/8/)
+    t.match(output, /custom/)
+    t.match(output, /no tokens found/)
+  })
+
+  t.test('human view with error', async t => {
+    const result = [
+      {
+        registry: 'https://registry.npmjs.org/',
+        alias: 'default',
+        tokens: [],
+        error: '401 Unauthorized',
+      },
+    ]
+    const output = views.human(result)
+    t.type(output, 'string')
+    t.match(output, /error: 401 Unauthorized/)
+  })
+
+  t.test('human view with no alias', async t => {
+    const result = [
+      {
+        registry: 'https://registry.npmjs.org/',
+        tokens: [
+          {
+            key: 'abc123',
+            token: 'npm_1234',
+            created: '2025-06-15T10:30:00.000Z',
+            readonly: false,
+          },
+        ],
+      },
+    ]
+    const output = views.human(result)
+    t.type(output, 'string')
+    // Should show just the URL without alias
+    t.match(output, /https:\/\/registry\.npmjs\.org\//)
+    t.notMatch(output, /\(https:/)
+  })
+
+  t.test('human view returns undefined for void', async t => {
+    const output = views.human(undefined)
+    t.equal(output, undefined)
+  })
+
+  t.test('json view returns data', async t => {
+    const result = [
+      {
+        registry: 'https://registry.npmjs.org/',
+        alias: 'default',
+        tokens: [],
+      },
+    ]
+    t.strictSame(views.json(result), result)
+  })
+
+  t.test('json view returns undefined for void', async t => {
+    const output = views.json(undefined)
+    t.equal(output, undefined)
+  })
 })

--- a/www/docs/src/content/docs/cli/commands/token.mdx
+++ b/www/docs/src/content/docs/cli/commands/token.mdx
@@ -9,10 +9,34 @@ import { Code } from '@astrojs/starlight/components'
 Usage:
 
 <Code
-  code="$ vlt token add
+  code="$ vlt token list
+$ vlt token add
 $ vlt token rm"
   title="Terminal"
   lang="bash"
 />
 
-Explicitly add or remove tokens in the vlt keychain
+Manage registry authentication tokens in the vlt keychain.
+
+## Subcommands
+
+### list
+
+List all tokens for configured registries. Queries each registry's
+token API and displays token metadata including key, creation date,
+and permissions.
+
+<Code code="$ vlt token list" title="Terminal" lang="bash" />
+
+### add
+
+Add a token for the specified registry. You will be prompted to paste
+the bearer token.
+
+<Code code="$ vlt token add" title="Terminal" lang="bash" />
+
+### rm
+
+Remove the stored token for the specified registry.
+
+<Code code="$ vlt token rm" title="Terminal" lang="bash" />


### PR DESCRIPTION
## Summary

Adds a `list` subcommand to `vlt token` that queries configured registries for token metadata using the `/-/npm/v1/tokens` endpoint.

### Features

- **Multi-registry support**: Lists tokens from the default registry and all configured registry aliases
- **Token metadata**: Displays token key, prefix, creation date, readonly status, and CIDR whitelist
- **Human-readable & JSON views**: Supports both output formats via the standard views pattern
- **Graceful error handling**: Per-registry errors are captured and reported without failing the entire command

### Usage

```bash
# List tokens for all configured registries
vlt token list
```

### Example Output

```
default (https://registry.npmjs.org/)
  key: abc123 │ token: npm_1234… │ created: Jun 15, 2025 │ readonly: no

custom (https://custom.registry.io/)
  key: def456 │ token: npm_5678… │ created: Jan 20, 2025 │ readonly: yes │ cidr: 192.168.1.0/24
```

### Changes

- `src/cli-sdk/src/commands/token.ts`: Added `list` subcommand with multi-registry token listing, human/JSON views
- `src/cli-sdk/test/commands/token.ts`: Comprehensive tests (50 assertions, 100% coverage)
- `src/cli-sdk/tap-snapshots/test/commands/token.ts.test.cjs`: Updated snapshot
- `www/docs/src/content/docs/cli/commands/token.mdx`: Updated documentation

Closes #1598

Co-authored-by: Darcy Clarke <darcy@darcyclarke.me>