### PR TITLE
fix(cli-sdk): honor -- as terminator in exec trailing option extraction

### DIFF
--- a/src/cli-sdk/src/config/definition.ts
+++ b/src/cli-sdk/src/config/definition.ts
@@ -145,10 +145,15 @@ const j = jack({
   stopAtPositionalTest: arg => {
     if (stopParsing) return true
     const a = arg as keyof Commands
-    // we stop parsing AFTER the thing, so you can do
-    // vlt run --vlt --configs scriptName --args --for --script
-    // or
-    // vlt exec --vlt --configs command --args --for --command
+    // We stop parsing AFTER the command name, so options that
+    // appear after the script/command name end up as positionals.
+    // ExecCommand.#extractTrailingOptions() then re-scans those
+    // positionals for known vlt options (--scope, --workspace,
+    // --recursive, etc.) regardless of position.  A bare `--`
+    // terminates that re-scan so flags after it are always
+    // forwarded to the script:
+    //   vlt run scriptName --scope "..." --bail  ← vlt gets both
+    //   vlt run scriptName -- --bail              ← script gets --bail
     if (stopParsingCommands.includes(commands[a])) {
       stopParsing = true
     }

--- a/src/cli-sdk/src/exec-command.ts
+++ b/src/cli-sdk/src/exec-command.ts
@@ -161,6 +161,10 @@ export class ExecCommand<B extends RunnerBG, F extends RunnerFG> {
    * Scan trailing args for known vlt options that ended up as
    * positionals due to stop-at-positional parsing. Extract them
    * and apply to conf.values so they're available via conf.get().
+   *
+   * A bare `--` terminates extraction: everything after it is
+   * passed through to the script unchanged (the `--` itself is
+   * consumed, per POSIX convention).
    */
   #extractTrailingOptions(): void {
     if (this.args.length === 0) return
@@ -173,6 +177,18 @@ export class ExecCommand<B extends RunnerBG, F extends RunnerFG> {
       const arg = this.args[i]
       /* c8 ignore next - defensive: loop condition already guards */
       if (arg === undefined) break
+
+      // A bare `--` terminates vlt option extraction.
+      // Everything after it is passed through to the script.
+      if (arg === '--') {
+        for (let j = i + 1; j < this.args.length; j++) {
+          const rest = this.args[j]
+          /* c8 ignore next - defensive: loop condition already guards */
+          if (rest === undefined) break
+          remaining.push(rest)
+        }
+        break
+      }
 
       // Handle --option=value form
       const eqIdx = arg.indexOf('=')

--- a/src/cli-sdk/test/commands/run.ts
+++ b/src/cli-sdk/test/commands/run.ts
@@ -961,3 +961,163 @@ t.test(
     t.strictSame(logs(), [])
   },
 )
+
+t.test(
+  '-- terminates vlt option extraction (flags forwarded to script)',
+  async t => {
+    // Use a script that accepts arbitrary args without failing
+    const passWithArgs = 'node -e "process.exitCode = 0" --'
+    const dir = t.testdir({
+      'vlt.json': JSON.stringify({}),
+      'package.json': JSON.stringify({
+        name: 'root',
+        version: '1.0.0',
+        scripts: {
+          hello: passWithArgs,
+        },
+      }),
+      '.git': {},
+    })
+    t.chdir(dir)
+
+    const { Config } = await t.mockImport<
+      typeof import('../../src/config/index.ts')
+    >('../../src/config/index.ts')
+    unload()
+
+    // Simulate: vlt run hello -- --bail
+    // --bail is a known vlt option but appears after --, so it
+    // should be forwarded to the script, not extracted.
+    const conf = await Config.load(t.testdirName, [
+      'run',
+      'hello',
+      '--',
+      '--bail',
+    ])
+    t.equal(conf.command, 'run')
+
+    const logs = t.capture(console, 'log').args
+    const result = await command(conf)
+
+    t.strictSame(result, {
+      command: passWithArgs,
+      args: ['--bail'],
+      cwd: dir,
+      stdout: null,
+      stderr: null,
+      status: 0,
+      signal: null,
+    })
+    t.strictSame(logs(), [])
+  },
+)
+
+t.test(
+  '-- allows forwarding multiple vlt-like flags to script',
+  async t => {
+    const passWithArgs = 'node -e "process.exitCode = 0" --'
+    const dir = t.testdir({
+      'vlt.json': JSON.stringify({}),
+      'package.json': JSON.stringify({
+        name: 'root',
+        version: '1.0.0',
+        scripts: {
+          hello: passWithArgs,
+        },
+      }),
+      '.git': {},
+    })
+    t.chdir(dir)
+
+    const { Config } = await t.mockImport<
+      typeof import('../../src/config/index.ts')
+    >('../../src/config/index.ts')
+    unload()
+
+    // Simulate: vlt run hello -- --bail --recursive --scope foo
+    // All of these are known vlt options but should be forwarded
+    const conf = await Config.load(t.testdirName, [
+      'run',
+      'hello',
+      '--',
+      '--bail',
+      '--recursive',
+      '--scope',
+      'foo',
+    ])
+    t.equal(conf.command, 'run')
+
+    const logs = t.capture(console, 'log').args
+    const result = await command(conf)
+
+    t.strictSame(result, {
+      command: passWithArgs,
+      args: ['--bail', '--recursive', '--scope', 'foo'],
+      cwd: dir,
+      stdout: null,
+      stderr: null,
+      status: 0,
+      signal: null,
+    })
+    t.strictSame(logs(), [])
+  },
+)
+
+t.test(
+  'vlt options before -- are extracted, flags after are forwarded',
+  async t => {
+    const passWithArgs = 'node -e "process.exitCode = 0" --'
+    const dir = t.testdir({
+      'vlt.json': JSON.stringify({ workspaces: 'src/*' }),
+      'package.json': JSON.stringify({
+        name: 'root',
+        version: '1.0.0',
+      }),
+      src: {
+        a: {
+          'package.json': JSON.stringify({
+            name: 'a',
+            version: '1.0.0',
+            scripts: {
+              hello: passWithArgs,
+            },
+          }),
+        },
+      },
+      '.git': {},
+    })
+    t.chdir(dir)
+
+    const { Config } = await t.mockImport<
+      typeof import('../../src/config/index.ts')
+    >('../../src/config/index.ts')
+    unload()
+
+    // Simulate: vlt run hello -w src/a -- --bail
+    // -w src/a should be extracted as a vlt option (workspace)
+    // --bail after -- should be forwarded to the script
+    const conf = await Config.load(t.testdirName, [
+      'run',
+      'hello',
+      '-w',
+      'src/a',
+      '--',
+      '--bail',
+    ])
+    t.equal(conf.command, 'run')
+
+    const logs = t.capture(console, 'log').args
+    const result = await command(conf)
+
+    t.strictSame(result, {
+      command: passWithArgs,
+      args: ['--bail'],
+      cwd: resolve(dir, 'src/a'),
+      stdout: null,
+      stderr: null,
+      status: 0,
+      signal: null,
+    })
+    t.strictSame(logs(), [])
+  },
+)

--- a/src/cli-sdk/test/exec-command.ts
+++ b/src/cli-sdk/test/exec-command.ts
@@ -37,6 +37,77 @@ t.test('basic', t => {
   t.end()
 })
 
+t.test('-- terminates trailing option extraction', t => {
+  const e = new ExecCommand(
+    {
+      projectRoot: t.testdirName,
+      positionals: ['script', '--', '--bail', '--recursive'],
+      get() {},
+      options: {
+        packageJson: {
+          read: () => ({}),
+        },
+      },
+      values: {},
+    } as unknown as LoadedConfig,
+    exec,
+    execFG,
+  )
+
+  // --bail and --recursive appear after -- so they should NOT
+  // be extracted as vlt options; they should remain as script args
+  t.strictSame(e.args, ['--bail', '--recursive'])
+  t.end()
+})
+
+t.test('-- with vlt options before it', t => {
+  const values: Record<string, unknown> = {}
+  const e = new ExecCommand(
+    {
+      projectRoot: t.testdirName,
+      positionals: ['script', '-w', 'src/a', '--', '--bail'],
+      get() {},
+      options: {
+        packageJson: {
+          read: () => ({}),
+        },
+      },
+      values,
+    } as unknown as LoadedConfig,
+    exec,
+    execFG,
+  )
+
+  // -w src/a before -- should be extracted
+  t.strictSame(values.workspace, ['src/a'])
+  // --bail after -- should be forwarded as a script arg
+  t.strictSame(e.args, ['--bail'])
+  t.end()
+})
+
+t.test('-- alone with no trailing args', t => {
+  const values: Record<string, unknown> = {}
+  const e = new ExecCommand(
+    {
+      projectRoot: t.testdirName,
+      positionals: ['script', '--'],
+      get() {},
+      options: {
+        packageJson: {
+          read: () => ({}),
+        },
+      },
+      values,
+    } as unknown as LoadedConfig,
+    exec,
+    execFG,
+  )
+
+  // -- consumed, no remaining args
+  t.strictSame(e.args, [])
+  t.end()
+})
+
 t.test('with view', t => {
   const e = new ExecCommand(
     {


### PR DESCRIPTION
## Summary

PR #1531 made vlt config flags position-independent in `vlt run` / `vlt exec` — they can appear after the script name. But there was no escape hatch: `--` didn't terminate the extraction, so scripts that accept flags sharing names with vlt config flags (like `--bail`) could never receive them.

## Changes

### `src/cli-sdk/src/exec-command.ts`
- **`#extractTrailingOptions()`**: When a bare `--` is encountered, stop scanning for vlt options. Everything after `--` is passed through to the script unchanged (the `--` itself is consumed, per POSIX convention).

### `src/cli-sdk/src/config/definition.ts`
- Updated the `stopAtPositionalTest` comment to reflect the current behavior (post-#1531) and document the `--` terminator.

### Tests
- Added 3 unit tests in `test/exec-command.ts` for direct `--` terminator behavior
- Added 3 integration tests in `test/commands/run.ts`:
  - `--` forwards known vlt flags to script
  - `--` forwards multiple flags to script
  - vlt options before `--` are extracted, flags after are forwarded

## Reproduction

```bash
# Before: --bail is intercepted by vlt
vlt run test -- --bail   # script receives ['--'], --bail consumed

# After: -- terminates extraction
vlt run test -- --bail   # script receives ['--bail']
```

Closes #1608

Co-authored-by: Luke Karrys <luke@lukekarrys.com>