### PR TITLE
feat(init): add .gitignore scaffolding and post-init install

### DIFF
--- a/src/cli-sdk/src/commands/init.ts
+++ b/src/cli-sdk/src/commands/init.ts
@@ -2,6 +2,7 @@ import { mkdirSync } from 'node:fs'
 import { relative, resolve } from 'node:path'
 import { minimatch } from 'minimatch'
 import { init } from '@vltpkg/init'
+import { install } from '@vltpkg/graph'
 import { load, save } from '@vltpkg/vlt-json'
 import { assertWSConfig, asWSConfig } from '@vltpkg/workspaces'
 import { commandUsage } from '../config/usage.ts'
@@ -130,5 +131,14 @@ export const command: CommandFn<
     return results
   }
 
-  return init({ cwd: process.cwd() })
+  const result = await init({ cwd: process.cwd() })
+
+  // Run install to create node_modules/ and vlt-lock.json,
+  // giving the user a fully functional project immediately.
+  await install({
+    ...conf.options,
+    allowScripts: ':not(*)',
+  })
+
+  return result
 }

--- a/src/cli-sdk/test/commands/init.ts
+++ b/src/cli-sdk/test/commands/init.ts
@@ -5,6 +5,7 @@ import type { LoadedConfig } from '../../src/config/index.ts'
 import type { InitFileResults } from '@vltpkg/init'
 
 const inited: string[] = []
+const installed: Record<string, unknown>[] = []
 const vltJsonData: Record<string, any> = {}
 
 const { usage, command, views } = await t.mockImport<
@@ -16,6 +17,12 @@ const { usage, command, views } = await t.mockImport<
     },
     getAuthorFromGitUser() {
       return ''
+    },
+  },
+  '@vltpkg/graph': {
+    install: async (options: Record<string, unknown>) => {
+      installed.push(options)
+      return { graph: { nodes: new Map() } }
     },
   },
   '@vltpkg/vlt-json': {
@@ -30,12 +37,23 @@ t.matchSnapshot(usage().usageMarkdown())
 
 t.test('test command', async t => {
   t.chdir(t.testdir())
-  await command({ values: {} } as LoadedConfig)
+  installed.length = 0
+  await command({
+    values: {},
+    options: { projectRoot: t.testdirName },
+  } as unknown as LoadedConfig)
   t.strictSame(inited, [t.testdirName])
+  t.equal(installed.length, 1, 'install should be called once')
+  t.equal(
+    installed[0]?.allowScripts,
+    ':not(*)',
+    'install should disable scripts',
+  )
 })
 
 t.test('test command with workspace', async t => {
   const res: InitFileResults[] = []
+  const wsInstalled: Record<string, unknown>[] = []
   const { command, views } = await t.mockImport<
     typeof import('../../src/commands/init.ts')
   >('../../src/commands/init.ts', {
@@ -53,6 +71,12 @@ t.test('test command with workspace', async t => {
       },
       getAuthorFromGitUser() {
         return ''
+      },
+    },
+    '@vltpkg/graph': {
+      install: async (options: Record<string, unknown>) => {
+        wsInstalled.push(options)
+        return { graph: { nodes: new Map() } }
       },
     },
   })
@@ -94,28 +118,48 @@ t.test('test command with workspace', async t => {
       .replace(resolve(dir, 'packages/a'), 'packages/a'),
     'should output human readable message',
   )
+
+  t.equal(
+    wsInstalled.length,
+    0,
+    'install should not be called for workspace init',
+  )
 })
 
 t.test('test command with empty workspace array', async t => {
   t.chdir(t.testdir())
   inited.length = 0 // reset array
+  installed.length = 0
   await command({
     values: {
       workspace: [],
     },
+    options: { projectRoot: t.testdirName },
   } as unknown as LoadedConfig)
   t.strictSame(inited, [t.testdirName])
+  t.equal(
+    installed.length,
+    1,
+    'install should be called for empty workspace array',
+  )
 })
 
 t.test('test command with undefined workspace', async t => {
   t.chdir(t.testdir())
   inited.length = 0 // reset array
+  installed.length = 0
   await command({
     values: {
       workspace: undefined,
     },
+    options: { projectRoot: t.testdirName },
   } as unknown as LoadedConfig)
   t.strictSame(inited, [t.testdirName])
+  t.equal(
+    installed.length,
+    1,
+    'install should be called for undefined workspace',
+  )
 })
 
 t.test(

--- a/src/init/src/index.ts
+++ b/src/init/src/index.ts
@@ -3,6 +3,7 @@ import { PackageJson } from '@vltpkg/package-json'
 import type { JSONObj } from '@vltpkg/registry-client'
 import type { NormalizedManifest } from '@vltpkg/types'
 import { basename, resolve } from 'node:path'
+import { existsSync, readFileSync, writeFileSync } from 'node:fs'
 import { getAuthorFromGitUser } from './get-author-from-git-user.ts'
 import { asError, normalizeManifest } from '@vltpkg/types'
 export { getAuthorFromGitUser }
@@ -43,6 +44,35 @@ export type InitFileResults = {
   // config?: JSONFileInfo
 }
 
+/**
+ * Ensures that a `.gitignore` file exists at the given directory and
+ * contains `node_modules`. If the file does not exist, it is created.
+ * If it exists but does not contain a `node_modules` entry, the entry
+ * is appended.
+ */
+export const ensureGitignore = (cwd: string): void => {
+  const gitignorePath = resolve(cwd, '.gitignore')
+  if (existsSync(gitignorePath)) {
+    const content = readFileSync(gitignorePath, 'utf8')
+    // Check if node_modules is already listed as its own entry
+    const lines = content.split(/\r?\n/)
+    const hasNodeModules = lines.some(
+      line => line.trim() === 'node_modules',
+    )
+    if (!hasNodeModules) {
+      // Append node_modules, ensuring we start on a new line
+      const separator =
+        content.length > 0 && !content.endsWith('\n') ? '\n' : ''
+      writeFileSync(
+        gitignorePath,
+        content + separator + 'node_modules\n',
+      )
+    }
+  } else {
+    writeFileSync(gitignorePath, 'node_modules\n')
+  }
+}
+
 export const init = async ({
   cwd = process.cwd(),
   author,
@@ -75,5 +105,6 @@ export const init = async ({
 
   const indent = 2
   packageJson.write(cwd, data, indent)
+  ensureGitignore(cwd)
   return { manifest: { path, data } }
 }

--- a/src/init/test/index.ts
+++ b/src/init/test/index.ts
@@ -4,16 +4,15 @@ import t from 'tap'
 
 t.cleanSnapshot = (str: string) => str.replaceAll(/\\+/g, '/')
 
-const { init } = await t.mockImport<typeof import('../src/index.ts')>(
-  '../src/index.ts',
-  {
-    '@vltpkg/git': {
-      async getUser() {
-        return { name: 'User', email: 'foo@bar.ca' }
-      },
+const { init, ensureGitignore } = await t.mockImport<
+  typeof import('../src/index.ts')
+>('../src/index.ts', {
+  '@vltpkg/git': {
+    async getUser() {
+      return { name: 'User', email: 'foo@bar.ca' }
     },
   },
-)
+})
 
 t.test('init', async t => {
   const dir = t.testdir({
@@ -281,4 +280,110 @@ t.test('init existing partial package.json', async t => {
     },
     'should add missing author from template',
   )
+})
+
+t.test('init creates .gitignore', async t => {
+  const dir = t.testdir({
+    'my-project': {},
+  })
+  const cwd = resolve(dir, 'my-project')
+  await init({ cwd, logger: () => {} })
+  const gitignore = readFileSync(resolve(cwd, '.gitignore'), 'utf8')
+  t.equal(
+    gitignore,
+    'node_modules\n',
+    'should create .gitignore with node_modules',
+  )
+})
+
+t.test('ensureGitignore creates .gitignore when missing', t => {
+  const dir = t.testdir({})
+  ensureGitignore(dir)
+  const content = readFileSync(resolve(dir, '.gitignore'), 'utf8')
+  t.equal(content, 'node_modules\n', 'should create .gitignore')
+  t.end()
+})
+
+t.test(
+  'ensureGitignore appends to existing .gitignore without node_modules',
+  t => {
+    const dir = t.testdir({
+      '.gitignore': 'dist\n.env\n',
+    })
+    ensureGitignore(dir)
+    const content = readFileSync(resolve(dir, '.gitignore'), 'utf8')
+    t.equal(
+      content,
+      'dist\n.env\nnode_modules\n',
+      'should append node_modules',
+    )
+    t.end()
+  },
+)
+
+t.test(
+  'ensureGitignore appends with newline separator when file does not end with newline',
+  t => {
+    const dir = t.testdir({
+      '.gitignore': 'dist',
+    })
+    ensureGitignore(dir)
+    const content = readFileSync(resolve(dir, '.gitignore'), 'utf8')
+    t.equal(
+      content,
+      'dist\nnode_modules\n',
+      'should add newline before node_modules',
+    )
+    t.end()
+  },
+)
+
+t.test(
+  'ensureGitignore does not modify .gitignore that already has node_modules',
+  t => {
+    const original = 'dist\nnode_modules\n.env\n'
+    const dir = t.testdir({
+      '.gitignore': original,
+    })
+    ensureGitignore(dir)
+    const content = readFileSync(resolve(dir, '.gitignore'), 'utf8')
+    t.equal(
+      content,
+      original,
+      'should not modify file that already contains node_modules',
+    )
+    t.end()
+  },
+)
+
+t.test(
+  'ensureGitignore does not modify when node_modules has surrounding whitespace',
+  t => {
+    const original = '  node_modules  \n'
+    const dir = t.testdir({
+      '.gitignore': original,
+    })
+    ensureGitignore(dir)
+    const content = readFileSync(resolve(dir, '.gitignore'), 'utf8')
+    t.equal(
+      content,
+      original,
+      'should handle node_modules with whitespace',
+    )
+    t.end()
+  },
+)
+
+t.test('ensureGitignore handles empty .gitignore', t => {
+  const dir = t.testdir({
+    '.gitignore': '',
+  })
+  ensureGitignore(dir)
+  const content = readFileSync(resolve(dir, '.gitignore'), 'utf8')
+  t.equal(
+    content,
+    'node_modules\n',
+    'should write node_modules to empty file',
+  )
+  t.end()
 })


### PR DESCRIPTION
## Summary

`vlt init` now provides a more complete scaffolding experience:

1. **Creates a `.gitignore` file** with `node_modules` entry at the project root (only if missing or doesn't already contain `node_modules`)
2. **Runs `install()`** after creating `package.json`, creating `node_modules/` and `vlt-lock.json` — giving the user a fully functional project immediately

### Changes

- **`src/init/src/index.ts`**: Added `ensureGitignore()` function that creates or updates `.gitignore`, called during `init()`
- **`src/cli-sdk/src/commands/init.ts`**: After `init()` in the non-workspace path, calls `install()` from `@vltpkg/graph` with scripts disabled (`:not(*)`)
- **`src/init/test/index.ts`**: Added comprehensive tests for `ensureGitignore()` (7 new test cases covering create, append, no-op, edge cases)
- **`src/cli-sdk/test/commands/init.ts`**: Updated tests to mock and verify `install()` is called for non-workspace init and NOT called for workspace init

### Behavior

- **`vlt init`** (no workspace): Creates `package.json`, `.gitignore`, then runs install
- **`vlt init -w <path>`** (workspace): Creates workspace `package.json` and `.gitignore` per workspace (via `init()`), but does NOT run install (workspace init only scaffolds files)

Closes #1410

Co-authored-by: Darcy Clarke <darcy@darcyclarke.me>