### PR TITLE
fix(graph): update lockfile edge when dep spec moves to/from catalog

### DIFF
--- a/src/graph/src/ideal/remove-satisfied-specs.ts
+++ b/src/graph/src/ideal/remove-satisfied-specs.ts
@@ -30,6 +30,14 @@ export const removeSatisfiedSpecs = ({
         continue
       }
 
+      // If the spec type has changed (e.g., from "registry" to
+      // "catalog" or vice versa), keep it in the add list so the
+      // edge gets rebuilt with the updated spec, even if the
+      // resolved node is the same.
+      const edgeIsCatalog = edge.spec.type === 'catalog'
+      const depIsCatalog = dependency.spec.type === 'catalog'
+      if (edgeIsCatalog !== depIsCatalog) continue
+
       // If the current graph edge is already valid, then we remove that
       // dependency item from the list of items to be added to the graph
       if (

--- a/src/graph/tap-snapshots/test/ideal/remove-satisfied-specs.ts.test.cjs
+++ b/src/graph/tap-snapshots/test/ideal/remove-satisfied-specs.ts.test.cjs
@@ -19,6 +19,12 @@ exports[`test/ideal/remove-satisfied-specs.ts > TAP > graph with an actual node 
 Map {}
 `
 
+exports[`test/ideal/remove-satisfied-specs.ts > TAP > graph with an actual node > catalog spec is not removed even if node satisfies > should keep the catalog spec in the add list 1`] = `
+Map(1) {
+  'file~_d' => Map(1) { 'foo' => { spec: Spec {foo@catalog:}, type: 'prod' } }
+}
+`
+
 exports[`test/ideal/remove-satisfied-specs.ts > TAP > graph with an actual node > registry tag > should not return registry tag item if something already satisfies it 1`] = `
 Map(0) {}
 `

--- a/src/graph/test/ideal/remove-satisfied-specs.ts
+++ b/src/graph/test/ideal/remove-satisfied-specs.ts
@@ -163,6 +163,36 @@ t.test('graph with an actual node', async t => {
     )
   })
 
+  await t.test('catalog spec is not removed even if node satisfies', async t => {
+    const graph = load({
+      projectRoot,
+      scurry: new PathScurry(projectRoot),
+      monorepo: Monorepo.maybeLoad(projectRoot),
+      packageJson: new PackageJson(),
+    })
+    const add = new Map([
+      [
+        joinDepIDTuple(['file', '.']),
+        new Map(
+          Object.entries({
+            foo: asDependency({
+              spec: Spec.parse('foo', 'catalog:', {
+                catalog: { foo: '^1.0.0' },
+                catalogs: {},
+              }),
+              type: 'prod',
+            }),
+          }),
+        ),
+      ],
+    ]) as AddImportersDependenciesMap
+    removeSatisfiedSpecs({ add, graph })
+    t.matchSnapshot(
+      inspect(add, { depth: Infinity }),
+      'should keep the catalog spec in the add list',
+    )
+  })
+
   await t.test('refer to missing importer', async t => {
     const graph = new Graph({
       mainManifest: {},


### PR DESCRIPTION
## Summary

When a dependency spec changes between a direct version (e.g., `"^5.9.3"`) and a catalog reference (e.g., `"catalog:"`), the lockfile edge was not being updated. This caused `vlt ci` to fail with **"Lockfile is out of sync"** and left workspace edges recording the old literal spec instead of `catalog:`.

## Root Cause

In `removeSatisfiedSpecs()`, when the add list contains a dep whose spec changed from a direct range to `"catalog:"`, the `satisfies()` check still returns `true` because:

1. `satisfies()` calls `spec.final` which unwraps `catalog:` to the underlying version range
2. The existing node still satisfies that range
3. The dep gets removed from the add list — no lockfile update happens

This affects both root importers and workspace importers. The lockfile `options.catalog` gets updated, but the individual dep edges keep the old literal spec, making the lockfile internally inconsistent.

## Fix

Added a check in `removeSatisfiedSpecs()`: if the spec type changes between `catalog` and non-catalog, skip the satisfied check and keep the dep in the add list. This ensures the edge gets rebuilt with the correct spec source.

## Test

Added test case: "catalog spec is not removed even if node satisfies" — verifies that a `catalog:` spec stays in the add list when an existing node already satisfies the resolved version.

All existing tests pass (367 ideal tests, 233 reify tests, 52 install tests).

Fixes #1613
Fixes #1610

---
Co-authored-by: @darcyclarke