### PR TITLE
fix(spec): registry path truncation resolving to wrong origin

### DIFF
--- a/src/spec/src/browser.ts
+++ b/src/spec/src/browser.ts
@@ -717,10 +717,14 @@ export class Spec implements SpecLike<Spec> {
     const { name, registry, range } = this.final
     if (!registry || !range?.isSingle) return
     const stripScope = /^@[^/]+\//
+    // resolve relative to the registry URL so that any path component
+    // (e.g. https://registry.example.com/npm/) is preserved. Using a
+    // leading `/` would make the path absolute and discard that prefix.
+    const base = registry.endsWith('/') ? registry : registry + '/'
     this.conventionalRegistryTarball = String(
       new URL(
-        `/${name}/-/${name.replace(stripScope, '')}-${range}.tgz`,
-        registry,
+        `${name}/-/${name.replace(stripScope, '')}-${range}.tgz`,
+        base,
       ),
     )
   }

--- a/src/spec/test/browser.ts
+++ b/src/spec/test/browser.ts
@@ -716,6 +716,49 @@ t.test('try to guess the conventional tarball URL', t => {
   t.end()
 })
 
+t.test(
+  'conventionalRegistryTarball preserves registry URL path',
+  async t => {
+    // when the configured registry URL includes a path component
+    // (e.g. https://registry.example.com/npm/), the conventional tarball
+    // URL must keep that path prefix rather than resolving against the
+    // host root.
+    const cases: [string, string, string][] = [
+      [
+        'https://registry.example.com/npm/',
+        'foo',
+        'https://registry.example.com/npm/foo/-/foo-1.0.0.tgz',
+      ],
+      [
+        // missing trailing slash should still work
+        'https://registry.example.com/npm',
+        'foo',
+        'https://registry.example.com/npm/foo/-/foo-1.0.0.tgz',
+      ],
+      [
+        'https://registry.example.com/npm/',
+        '@scope/foo',
+        'https://registry.example.com/npm/@scope/foo/-/foo-1.0.0.tgz',
+      ],
+      [
+        // root-path registry behaves the same as before
+        'https://registry.npmjs.org/',
+        'foo',
+        'https://registry.npmjs.org/foo/-/foo-1.0.0.tgz',
+      ],
+    ]
+    for (const [registry, name, expected] of cases) {
+      const s = Spec.parse(name, '1.0.0', { registry })
+      t.equal(
+        s.conventionalRegistryTarball,
+        expected,
+        `${registry} + ${name}`,
+      )
+    }
+    t.end()
+  },
+)
+
 t.test('git path selector must be relative', async t => {
   const nogood = [
     //can't clean up absolute in browser 'git+ssh://user@host/repo#main::path:/x',


### PR DESCRIPTION
This pull request improves how conventional tarball URLs are generated for package registries, ensuring that any path components in the registry URL are preserved. It also adds new tests to verify this behavior, especially for registries with custom path prefixes.

**Bug Fixes and Improvements to URL Generation:**
- Updated the logic in the `Spec` class (`src/spec/src/browser.ts`) to resolve tarball URLs relative to the registry base, preserving any path component (such as `/npm/`) in the registry URL. This prevents accidental omission of custom path prefixes in tarball URLs.

**Testing Enhancements:**
- Added comprehensive test cases in `src/spec/test/browser.ts` to ensure that the conventional tarball URL correctly preserves the registry's path component in various scenarios, including registries with and without trailing slashes, and scoped packages.