### PR TITLE
fix(docs): syntax broke rendering post-query selector expansion

### DIFF
--- a/www/docs/src/content/docs/cli/security.mdx
+++ b/www/docs/src/content/docs/cli/security.mdx
@@ -284,6 +284,5 @@ first query may take longer as security metadata is downloaded and
 cached locally.
 
 For more detailed information about specific security selectors, see
-the
-[Dependency Selector Syntax](/cli/selectors#security-insights-pseudo-classes--states)
+the [Dependency Selector Syntax](/cli/selectors/security-insights)
 reference.

--- a/www/docs/src/content/docs/cli/selectors/pseudo-classes/host.mdx
+++ b/www/docs/src/content/docs/cli/selectors/pseudo-classes/host.mdx
@@ -37,7 +37,7 @@ The context parameter can be:
 ### Query a specific project
 
 <Code
-  code="$ vlt query ':host(\"file:~/my-app\") :outdated'"
+  code={`$ vlt query ':host("file:~/my-app") :outdated'`}
   title="Terminal"
   lang="bash"
 />
@@ -45,7 +45,7 @@ The context parameter can be:
 ### Bump version for a remote project
 
 <Code
-  code="$ vlt version patch --scope=':host(\"file:~/tmp/test-vite\")'"
+  code={`$ vlt version patch --scope=':host("file:~/tmp/test-vite")'`}
   title="Terminal"
   lang="bash"
 />


### PR DESCRIPTION
This pull request makes minor improvements to the CLI documentation, focusing on correcting a documentation link and fixing code formatting in example commands.

- Documentation corrections:
  * Updated the link to the Dependency Selector Syntax in `security.mdx` to point to the correct section for security insights.

- Code example formatting:
  * Fixed the formatting of command examples in `host.mdx` by using template literals for the `code` prop, ensuring proper rendering of quotes in CLI examples.