### PR TITLE
fix(cli-sdk): await telemetry flush and unref safety-net timer

### DIFF
--- a/src/cli-sdk/src/output.ts
+++ b/src/cli-sdk/src/output.ts
@@ -213,8 +213,12 @@ export const outputCommand = async <T>(
       )
     }
 
-    // Fire-and-forget flush — do not await to avoid blocking exit
-    void flushTelemetry()
+    // Await the flush so pending telemetry events are sent before
+    // the process exits.  The flush has a built-in timeout cap
+    // (SHUTDOWN_TIMEOUT_MS) so it will never block for long, and the
+    // timer is unreffed so even if this is not awaited the process
+    // can still exit promptly.
+    await flushTelemetry()
   } catch (err) {
     onError?.(err)
     process.exitCode ||= 1
@@ -252,8 +256,7 @@ export const outputCommand = async <T>(
       telemetryEnabled,
     )
 
-    // Fire-and-forget flush — do not await to avoid blocking exit
-    void flushTelemetry()
+    await flushTelemetry()
 
     printErr(err, usage, stderr, {
       ...formatOptions,

--- a/src/cli-sdk/src/telemetry.ts
+++ b/src/cli-sdk/src/telemetry.ts
@@ -5,7 +5,7 @@
  * - Generates a random UUID on first run, stored in XDG data dir.
  * - Respects opt-out via `DO_NOT_TRACK=1`, `VLT_TELEMETRY=0`,
  *   or the `--telemetry=false` config flag.
- * - Never blocks CLI exit — flush is fire-and-forget with a timeout.
+ * - Flush is awaited with a timeout cap so it never blocks CLI exit for long.
  * - Fails silently on any network or runtime error.
  * @module
  */
@@ -200,12 +200,23 @@ export const trackError = (
  * Flush pending events. Returns a promise that resolves once flushing
  * completes **or** when `SHUTDOWN_TIMEOUT_MS` elapses — whichever
  * comes first. Never rejects.
+ *
+ * The safety-net timer is unreffed so it cannot keep the process alive
+ * on its own — if the caller does not `await` this, Node will still
+ * exit promptly once all other handles are drained.
  */
 export const flush = (): Promise<void> => {
   const ph = _posthog
   if (!ph) return Promise.resolve()
+  // Clear the reference so no further events are captured and
+  // PostHog's internal timers can be garbage-collected.
+  _posthog = undefined
   return Promise.race([
     ph.shutdown().catch(() => {}),
-    new Promise<void>(r => setTimeout(r, SHUTDOWN_TIMEOUT_MS)),
+    new Promise<void>(r => {
+      const t = setTimeout(r, SHUTDOWN_TIMEOUT_MS)
+      // Unref so this timer alone won't keep the process alive.
+      if (typeof t === 'object' && 'unref' in t) t.unref()
+    }),
   ])
 }


### PR DESCRIPTION
## Problem

The telemetry flush was fire-and-forget (`void flushTelemetry()`), which could cause the Node process to hang after a command completes:

1. **Success path hang**: `outputCommand` returned without awaiting the flush. PostHog's internal `flushInterval` (10s) `setInterval` and the safety-net `setTimeout` (2s) both kept the Node event loop alive after the command completed. This blocked sequential CLI invocations — for example, the release workflow's publish loop where each `vlt publish` is a separate process that must exit before the next one starts.

2. **Ref'd timer**: The safety-net timer used a plain `setTimeout` (ref'd by default), so even after PostHog shutdown completed, the timer alone kept the process alive for up to 2 seconds per invocation.

Found while investigating the [failing v1.0.0-rc.28 release workflow](https://github.com/vltpkg/vltpkg/actions/runs/25829292407/job/75890195431).

## Changes

- **Await `flushTelemetry()`** in both the success and error paths of `outputCommand`. The 2s timeout cap ensures it never blocks for long.
- **Unref the safety-net `setTimeout`** so it cannot keep the process alive on its own.
- **Clear `_posthog` reference** on flush so PostHog's internal timers can be garbage-collected and no further events are captured after shutdown.

## Testing

```
tap test/output.ts — 27/27 passing
tsc --noEmit — clean
```
