### PR TITLE
fix(graph): custom registries not being applied properly

### DIFF
--- a/src/graph/src/actual/load.ts
+++ b/src/graph/src/actual/load.ts
@@ -350,7 +350,10 @@ const parseDir = (
       const depType = shorten(type, alias, fromNode.manifest)
       let spec = Spec.parse(alias, bareSpec, {
         ...options,
-        registry: fromNode.registry,
+        // fall back to options.registry (which the lockfile merges into)
+        // so importer-level edges don't silently revert to the default
+        // npm registry. see vltpkg/vltpkg#1580.
+        registry: fromNode.registry ?? options.registry,
       })
 
       // Check for active modifiers and replace spec if a modifier is complete
@@ -425,7 +428,7 @@ const parseDir = (
       const depType = shorten(type, name, fromNode.manifest)
       let spec = Spec.parse(name, bareSpec, {
         ...options,
-        registry: fromNode.registry,
+        registry: fromNode.registry ?? options.registry,
       })
 
       // Check for active modifiers and replace spec for missing dependencies

--- a/src/graph/src/install.ts
+++ b/src/graph/src/install.ts
@@ -228,8 +228,13 @@ export const install = async (
 
     // If lockfileOnly is enabled, skip reify and only save the lockfile
     if (options.lockfileOnly) {
-      // Save only the main lockfile, skip all filesystem operations
-      lockfile.save({ graph, modifiers })
+      // Save only the main lockfile, skip all filesystem operations.
+      // Spread `options` so that spec-level config (registry,
+      // scoped-registries, git-hosts, catalogs, etc.) round-trips
+      // through the lockfile - otherwise subsequent installs lose
+      // the configured registry and rewrite node/edge DepIDs back
+      // to the default npm registry. (See vltpkg/vltpkg#1580.)
+      lockfile.save({ ...options, graph, modifiers })
       const saveImportersPackageJson =
         /* c8 ignore next */
         add?.modifiedDependencies || remove.modifiedDependencies ?

--- a/src/graph/src/lockfile/load-edges.ts
+++ b/src/graph/src/lockfile/load-edges.ts
@@ -123,11 +123,18 @@ export const loadEdges = (
       }
     }
 
-    // Parse spec once we know the nodes are valid
-    const spec = Spec.parse(specName, valRest.substring(0, vrSplit), {
-      ...options,
-      registry: fromNode.registry,
-    })
+    // Use the merged options directly — they already carry the
+    // correct registry from the lockfile's `options` + caller config.
+    // `fromNode.registry` is not populated yet at this point (the
+    // post-load hydration loop in load.ts sets it *after* edges are
+    // loaded), so overriding here would always inject `undefined`
+    // and silently revert to the default npm registry.
+    // See vltpkg/vltpkg#1580.
+    const spec = Spec.parse(
+      specName,
+      valRest.substring(0, vrSplit),
+      options,
+    )
 
     if (useOptimizations) {
       edgeProcessingQueue.push({

--- a/src/graph/src/uninstall.ts
+++ b/src/graph/src/uninstall.ts
@@ -48,8 +48,11 @@ export const uninstall = async (
 
     // If lockfileOnly is enabled, skip reify and only save the lockfile
     if (options.lockfileOnly) {
-      // Save only the main lockfile, skip all filesystem operations
-      lockfile.save({ graph, modifiers })
+      // Save only the main lockfile, skip all filesystem operations.
+      // Spread `options` so that spec-level config (registry,
+      // scoped-registries, git-hosts, catalogs, etc.) round-trips
+      // through the lockfile. See vltpkg/vltpkg#1580.
+      lockfile.save({ ...options, graph, modifiers })
       const saveImportersPackageJson =
         /* c8 ignore next */
         remove?.modifiedDependencies ?

--- a/src/graph/test/lockfile/registry-roundtrip.ts
+++ b/src/graph/test/lockfile/registry-roundtrip.ts
@@ -1,0 +1,179 @@
+import { Spec } from '@vltpkg/spec'
+import type { SpecOptions } from '@vltpkg/spec'
+import { PackageJson } from '@vltpkg/package-json'
+import { unload } from '@vltpkg/vlt-json'
+import { existsSync, readFileSync, rmSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { PathScurry } from 'path-scurry'
+import t from 'tap'
+import type { PackageInfoClient } from '@vltpkg/package-info'
+import { Graph } from '../../src/graph.ts'
+import { save } from '../../src/lockfile/save.ts'
+import { load as loadVirtual } from '../../src/lockfile/load.ts'
+import type { AddImportersDependenciesMap } from '../../src/dependencies.ts'
+import type { InstallOptions } from '../../src/install.ts'
+
+// Reproduces vltpkg/vltpkg#1580: lockfile node/edge registry references
+// should not flip back to npm after a re-load and re-save when a custom
+// registry is configured in vlt.json.
+
+t.test(
+  'custom registry survives save -> load -> save round-trip',
+  async t => {
+    const specOptions: SpecOptions = {
+      registry: 'https://registry.vlt.io/npm/',
+    }
+    const mainManifest = {
+      name: 'my-project',
+      version: '1.0.0',
+      dependencies: {
+        foo: '^1.0.0',
+      },
+    }
+    const projectRoot = t.testdir({ 'vlt.json': '{}' })
+    t.chdir(projectRoot)
+    unload('project')
+
+    const graph = new Graph({
+      ...specOptions,
+      projectRoot,
+      mainManifest,
+    })
+    graph
+      .placePackage(
+        graph.mainImporter,
+        'prod',
+        Spec.parse('foo', '^1.0.0', specOptions),
+        {
+          name: 'foo',
+          version: '1.0.0',
+          dist: {
+            integrity: 'sha512-deadbeef==',
+            // Many registries (incl. proxies) return the upstream
+            // npmjs.org tarball URL even when serving the manifest
+            // themselves. Ensure this is faithfully round-tripped.
+            tarball: 'https://registry.npmjs.org/foo/-/foo-1.0.0.tgz',
+          },
+        },
+      )
+      ?.setResolved()
+
+    save({ ...specOptions, graph })
+    const first = readFileSync(
+      resolve(projectRoot, 'vlt-lock.json'),
+      'utf8',
+    )
+
+    // Re-load the lockfile and re-save with the same options.
+    const reloaded = loadVirtual({
+      ...specOptions,
+      projectRoot,
+      mainManifest,
+    })
+    save({ ...specOptions, graph: reloaded })
+    const second = readFileSync(
+      resolve(projectRoot, 'vlt-lock.json'),
+      'utf8',
+    )
+
+    t.equal(
+      second,
+      first,
+      'second save should be byte-identical to first save',
+    )
+  },
+)
+
+t.test(
+  'two installs in a row preserve custom registry references',
+  async t => {
+    const fooManifest = {
+      name: 'foo',
+      version: '1.0.0',
+      dist: {
+        integrity: 'sha512-deadbeef==',
+        // Registry proxies frequently rewrite (or pass through)
+        // tarball URLs; cover both cases here by using a URL that
+        // does NOT live on the configured custom registry.
+        tarball: 'https://registry.npmjs.org/foo/-/foo-1.0.0.tgz',
+      },
+    }
+
+    const packageInfo = {
+      async manifest(spec: Spec) {
+        if (spec.name === 'foo') return fooManifest
+        return null
+      },
+      async extract(spec: Spec) {
+        return { resolved: '', spec }
+      },
+    } as unknown as PackageInfoClient
+
+    const projectRoot = t.testdir({
+      'package.json': JSON.stringify({
+        name: 'my-project',
+        version: '1.0.0',
+        dependencies: { foo: '^1.0.0' },
+      }),
+      'vlt.json': '{}',
+    })
+    t.chdir(projectRoot)
+    unload('project')
+
+    const customRegistry = 'https://registry.vlt.io/npm/'
+
+    const options = {
+      projectRoot,
+      scurry: new PathScurry(projectRoot),
+      packageJson: new PackageJson(),
+      packageInfo,
+      allowScripts: ':not(*)',
+      registry: customRegistry,
+      lockfileOnly: true,
+    } as unknown as InstallOptions
+
+    const { install } = await import('../../src/install.ts')
+
+    await install(options, new Map() as AddImportersDependenciesMap)
+
+    const first = readFileSync(
+      resolve(projectRoot, 'vlt-lock.json'),
+      'utf8',
+    )
+    t.match(
+      first,
+      /registry\.vlt\.io/,
+      'first install lockfile mentions the custom registry',
+    )
+
+    // wipe the hidden lockfile to make sure the second install
+    // doesn't take any actual-graph shortcuts that paper over the bug
+    const hidden = resolve(projectRoot, 'node_modules/.vlt-lock.json')
+    if (existsSync(hidden)) rmSync(hidden)
+
+    // fresh options - simulate a brand new `vlt install` invocation
+    const options2 = {
+      ...options,
+      scurry: new PathScurry(projectRoot),
+      packageJson: new PackageJson(),
+    } as unknown as InstallOptions
+
+    await install(options2, new Map() as AddImportersDependenciesMap)
+
+    const second = readFileSync(
+      resolve(projectRoot, 'vlt-lock.json'),
+      'utf8',
+    )
+
+    t.equal(
+      second,
+      first,
+      'second install should produce an identical lockfile',
+    )
+    t.match(
+      second,
+      /registry\.vlt\.io/,
+      'second install lockfile still mentions the custom registry',
+    )
+  },
+)


### PR DESCRIPTION
This pull request fixes an important bug where custom registry settings could be lost when saving and reloading the lockfile, causing dependencies to revert to the default npm registry. The changes ensure that registry and other spec-level configuration options are consistently preserved through all lockfile operations. Additionally, new tests have been added to prevent regressions for this scenario.

**Bug fixes and registry handling improvements:**

* Updated all relevant calls to `Spec.parse` in `load.ts` and `lockfile/load-edges.ts` to correctly fall back to `options.registry` when `fromNode.registry` is undefined, preventing silent reversion to the default npm registry.

* Modified lockfile save logic in both `install.ts` and `uninstall.ts` to spread the full `options` object, ensuring that registry and other spec-level configuration round-trip through the lockfile and are not lost on subsequent installs.

**Testing and regression prevention:**

* Added a new test file `registry-roundtrip.ts` to verify that custom registry settings survive save-load-save cycles and multiple installs, ensuring byte-identical lockfile output and that the configured registry is always preserved.

Fixes: #1580