### PR TITLE
fix(token): adding a new token wasnt saving properly

### DIFF
--- a/src/registry-client/src/auth.ts
+++ b/src/registry-client/src/auth.ts
@@ -63,7 +63,9 @@ export const setToken = async (
   identity: string,
 ): Promise<void> => {
   const kc = getKC(identity)
-  return kc.set(normalizeRegistryKey(registry), token)
+  await kc.load()
+  kc.set(normalizeRegistryKey(registry), token)
+  await kc.save()
 }
 
 export const getToken = async (

--- a/src/registry-client/test/auth.ts
+++ b/src/registry-client/test/auth.ts
@@ -102,7 +102,10 @@ t.test('setToken', async t => {
   await t.rejects(setToken('not a url', 'Bearer token', ''))
   await setToken('https://x.com/', 'Bearer token', '')
   t.strictSame(checkLog(getKC('')), [
+    ['load'],
+    ['load'],
     ['set', 'https://x.com', 'Bearer token'],
+    ['save'],
   ])
   function typeChecks() {
     //@ts-expect-error
@@ -121,7 +124,9 @@ t.test('setToken preserves path', async t => {
     '',
   )
   t.strictSame(checkLog(getKC('')), [
+    ['load'],
     ['set', 'https://registry.vlt.io/luke', 'Bearer luketoken'],
+    ['save'],
   ])
 })
 


### PR DESCRIPTION
This pull request updates the behavior of the `setToken` function to ensure that credentials are properly loaded before setting and saved after updating, and adjusts the related tests to reflect these changes.

### Authentication logic improvements

* Updated `setToken` in `auth.ts` to call `load()` before setting the token and `save()` after, ensuring token changes are persisted correctly.

### Test updates

* Modified `setToken` tests in `auth.ts` to check for the new `load` and `save` calls, ensuring the function's side effects are properly validated.