### PR TITLE
fix(token): list support for both remote & local tokens

### DIFF
--- a/src/cli-sdk/src/commands/token.ts
+++ b/src/cli-sdk/src/commands/token.ts
@@ -1,6 +1,8 @@
 import { error } from '@vltpkg/error-cause'
 import {
   deleteToken,
+  getKC,
+  getToken,
   normalizeRegistryKey,
   RegistryClient,
   setToken,
@@ -26,11 +28,16 @@ export type TokenInfo = {
 export type RegistryTokens = {
   registry: string
   alias?: string
+  /** Masked local keychain token, if stored */
+  localToken?: string
   tokens: TokenInfo[]
   error?: string
 }
 
-export type TokenListResult = RegistryTokens[]
+export type TokenListResult = {
+  identity: string
+  registries: RegistryTokens[]
+}
 
 export const usage: CommandUsage = () =>
   commandUsage({
@@ -40,10 +47,9 @@ export const usage: CommandUsage = () =>
     subcommands: {
       list: {
         usage: '',
-        description: `List all tokens for configured registries.
-                      Queries each registry's token API and displays
-                      token metadata including key, creation date,
-                      and permissions.`,
+        description: `List tokens for configured registries. Shows
+                      locally stored auth tokens and queries each
+                      registry's token API for remote token metadata.`,
       },
       add: {
         usage: '',
@@ -81,6 +87,12 @@ const formatDate = (iso: string): string => {
   })
 }
 
+const maskToken = (token: string): string => {
+  const bare = token.replace(/^(Bearer|Basic)\s+/i, '')
+  if (bare.length <= 8) return bare + '…'
+  return bare.slice(0, 8) + '…'
+}
+
 const formatTokenEntry = (t: TokenInfo): string => {
   const parts = [
     `key: ${t.key}`,
@@ -96,18 +108,32 @@ const formatTokenEntry = (t: TokenInfo): string => {
 
 const formatRegistryTokens = (r: RegistryTokens): string => {
   const header = r.alias ? `${r.alias} (${r.registry})` : r.registry
-  if (r.error) return `${header}\n  error: ${r.error}`
-  if (r.tokens.length === 0) return `${header}\n  (no tokens found)`
-  return [
-    header,
-    ...r.tokens.map(t => `  ${formatTokenEntry(t)}`),
-  ].join('\n')
+  const lines: string[] = [header]
+  lines.push(
+    `  local: ${r.localToken ? maskToken(r.localToken) : '(none)'}`,
+  )
+  if (!r.localToken) {
+    lines.push('  (skipped remote query — no auth token)')
+  } else if (r.error) {
+    lines.push(`  error: ${r.error}`)
+  } else if (r.tokens.length === 0) {
+    lines.push('  (no remote tokens found)')
+  } else {
+    for (const t of r.tokens) {
+      lines.push(`  ${formatTokenEntry(t)}`)
+    }
+  }
+  return lines.join('\n')
 }
 
 export const views = {
   human: (r: TokenListResult | void) => {
     if (!r) return
-    return r.map(formatRegistryTokens).join('\n\n')
+    const header =
+      r.identity ? `identity: ${r.identity}` : 'identity: (default)'
+    return [header, ...r.registries.map(formatRegistryTokens)].join(
+      '\n\n',
+    )
   },
   json: (r: TokenListResult | void) => {
     if (!r) return
@@ -118,8 +144,16 @@ export const views = {
 const listTokens = async (
   rc: RegistryClient,
   registry: string,
+  identity: string,
   alias?: string,
 ): Promise<RegistryTokens> => {
+  const localTok = await getToken(
+    normalizeRegistryKey(registry),
+    identity,
+  )
+  if (!localTok) {
+    return { registry, alias, tokens: [] }
+  }
   const tokensUrl = new URL('-/npm/v1/tokens', registry)
   try {
     const objects = await rc.scroll<TokenInfo>(tokensUrl, {
@@ -128,6 +162,7 @@ const listTokens = async (
     return {
       registry,
       alias,
+      localToken: localTok,
       tokens: objects.map(o => ({
         key: o.key,
         token: o.token,
@@ -140,6 +175,7 @@ const listTokens = async (
     return {
       registry,
       alias,
+      localToken: localTok,
       tokens: [],
       error: err instanceof Error ? err.message : String(err),
     }
@@ -153,23 +189,47 @@ export const command: CommandFn<
   switch (conf.positionals[0]) {
     case 'list': {
       const rc = new RegistryClient(conf.options)
-      const results: RegistryTokens[] = []
+      const identity = conf.options.identity
+      const registries: RegistryTokens[] = []
+      const seen = new Set<string>()
 
       // Always query the default registry first
-      results.push(
-        await listTokens(rc, conf.options.registry, 'default'),
+      const defaultReg = conf.options.registry
+      seen.add(normalizeRegistryKey(defaultReg))
+      registries.push(
+        await listTokens(rc, defaultReg, identity, 'default'),
       )
 
       // Then query all configured registry aliases
-      const registries = conf.options.registries
-      for (const [alias, registry] of Object.entries(registries)) {
-        // Skip if it's the same as the default registry
-        if (registry !== conf.options.registry) {
-          results.push(await listTokens(rc, registry, alias))
+      const configuredRegistries = conf.options.registries
+      for (const [alias, registry] of Object.entries(
+        configuredRegistries,
+      )) {
+        const key = normalizeRegistryKey(registry)
+        if (!seen.has(key)) {
+          seen.add(key)
+          registries.push(
+            await listTokens(rc, registry, identity, alias),
+          )
         }
       }
 
-      return results
+      // Also show any keychain entries for registries not
+      // already covered (e.g. added via `vlt token add --registry`)
+      const kc = getKC(identity)
+      for (const key of await kc.keys()) {
+        if (!seen.has(key)) {
+          seen.add(key)
+          const tok = await kc.get(key)
+          registries.push({
+            registry: key,
+            localToken: tok ?? undefined,
+            tokens: [],
+          })
+        }
+      }
+
+      return { identity, registries }
     }
 
     case 'add': {

--- a/src/cli-sdk/tap-snapshots/test/commands/token.ts.test.cjs
+++ b/src/cli-sdk/tap-snapshots/test/commands/token.ts.test.cjs
@@ -20,7 +20,7 @@ Manage registry authentication tokens in the vlt keychain.
 
 ### list
 
-List all tokens for configured registries. Queries each registry's token API and displays token metadata including key, creation date, and permissions.
+List tokens for configured registries. Shows locally stored auth tokens and queries each registry's token API for remote token metadata.
 
 \`\`\`
 vlt token list

--- a/src/cli-sdk/test/commands/token.ts
+++ b/src/cli-sdk/test/commands/token.ts
@@ -10,6 +10,19 @@ const mockRegistryClient = {
   },
   async setToken(_reg: string, _tok: Token) {},
   async deleteToken(_reg: string) {},
+  async getToken(): Promise<Token | undefined> {
+    return undefined
+  },
+  getKC() {
+    return {
+      async keys() {
+        return []
+      },
+      async get() {
+        return undefined
+      },
+    }
+  },
   RegistryClient: class MockRegistryClient {
     async scroll<T>(): Promise<T[]> {
       return [] as T[]
@@ -122,6 +135,9 @@ t.test('list tokens from default registry', async t => {
   >('../../src/commands/token.ts', {
     '@vltpkg/registry-client': {
       ...mockRegistryClient,
+      async getToken(): Promise<Token | undefined> {
+        return 'Bearer npm_localtoken123'
+      },
       RegistryClient: class MockRegistryClient {
         async scroll<T>(): Promise<T[]> {
           return mockTokens as T[]
@@ -134,23 +150,67 @@ t.test('list tokens from default registry', async t => {
     options: {
       registry: 'https://registry.npmjs.org/',
       registries: {},
+      identity: '',
     },
     positionals: ['list'],
   } as unknown as LoadedConfig)
 
-  t.ok(Array.isArray(result))
-  t.equal(result?.length, 1)
-  t.equal(result?.[0]?.registry, 'https://registry.npmjs.org/')
-  t.equal(result?.[0]?.alias, 'default')
-  t.equal(result?.[0]?.tokens.length, 2)
-  t.equal(result?.[0]?.tokens[0]?.key, 'abc123')
-  t.equal(result?.[0]?.tokens[0]?.token, 'npm_1234')
-  t.equal(result?.[0]?.tokens[0]?.readonly, false)
-  t.equal(result?.[0]?.tokens[1]?.key, 'def456')
-  t.equal(result?.[0]?.tokens[1]?.readonly, true)
-  t.strictSame(result?.[0]?.tokens[1]?.cidr_whitelist, [
+  t.equal(result?.identity, '')
+  t.equal(result?.registries.length, 1)
+  t.equal(
+    result?.registries[0]?.registry,
+    'https://registry.npmjs.org/',
+  )
+  t.equal(result?.registries[0]?.alias, 'default')
+  t.equal(
+    result?.registries[0]?.localToken,
+    'Bearer npm_localtoken123',
+  )
+  t.equal(result?.registries[0]?.tokens.length, 2)
+  t.equal(result?.registries[0]?.tokens[0]?.key, 'abc123')
+  t.equal(result?.registries[0]?.tokens[0]?.token, 'npm_1234')
+  t.equal(result?.registries[0]?.tokens[0]?.readonly, false)
+  t.equal(result?.registries[0]?.tokens[1]?.key, 'def456')
+  t.equal(result?.registries[0]?.tokens[1]?.readonly, true)
+  t.strictSame(result?.registries[0]?.tokens[1]?.cidr_whitelist, [
     '192.168.1.0/24',
   ])
+})
+
+t.test('list skips remote query when no local token', async t => {
+  const scrollCalled: string[] = []
+
+  const { command: cmd } = await t.mockImport<
+    typeof import('../../src/commands/token.ts')
+  >('../../src/commands/token.ts', {
+    '@vltpkg/registry-client': {
+      ...mockRegistryClient,
+      async getToken(): Promise<Token | undefined> {
+        return undefined
+      },
+      RegistryClient: class MockRegistryClient {
+        async scroll<T>(url: URL): Promise<T[]> {
+          scrollCalled.push(String(url))
+          return [] as T[]
+        }
+      },
+    },
+  })
+
+  const result = await cmd({
+    options: {
+      registry: 'https://registry.npmjs.org/',
+      registries: {},
+      identity: '',
+    },
+    positionals: ['list'],
+  } as unknown as LoadedConfig)
+
+  t.equal(result?.identity, '')
+  t.equal(result?.registries.length, 1)
+  t.equal(result?.registries[0]?.localToken, undefined)
+  t.equal(result?.registries[0]?.tokens.length, 0)
+  t.strictSame(scrollCalled, [], 'should not query registry API')
 })
 
 t.test('list tokens from multiple registries', async t => {
@@ -178,6 +238,9 @@ t.test('list tokens from multiple registries', async t => {
   >('../../src/commands/token.ts', {
     '@vltpkg/registry-client': {
       ...mockRegistryClient,
+      async getToken(): Promise<Token | undefined> {
+        return 'Bearer npm_mock'
+      },
       RegistryClient: class MockRegistryClient {
         async scroll<T>(url: URL): Promise<T[]> {
           return (scrollResults[String(url)] ?? []) as T[]
@@ -193,22 +256,123 @@ t.test('list tokens from multiple registries', async t => {
         npm: 'https://registry.npmjs.org/',
         custom: 'https://custom.registry.io/',
       },
+      identity: '',
     },
     positionals: ['list'],
   } as unknown as LoadedConfig)
 
-  t.ok(Array.isArray(result))
+  t.equal(result?.identity, '')
   // npm is same URL as default, so skipped → default + custom = 2
-  t.equal(result?.length, 2)
+  t.equal(result?.registries.length, 2)
 
-  t.equal(result?.[0]?.alias, 'default')
-  t.equal(result?.[0]?.tokens.length, 1)
-  t.equal(result?.[0]?.tokens[0]?.key, 'npm-key-1')
+  t.equal(result?.registries[0]?.alias, 'default')
+  t.equal(result?.registries[0]?.tokens.length, 1)
+  t.equal(result?.registries[0]?.tokens[0]?.key, 'npm-key-1')
 
-  t.equal(result?.[1]?.alias, 'custom')
-  t.equal(result?.[1]?.registry, 'https://custom.registry.io/')
-  t.equal(result?.[1]?.tokens.length, 1)
-  t.equal(result?.[1]?.tokens[0]?.key, 'custom-key-1')
+  t.equal(result?.registries[1]?.alias, 'custom')
+  t.equal(
+    result?.registries[1]?.registry,
+    'https://custom.registry.io/',
+  )
+  t.equal(result?.registries[1]?.tokens.length, 1)
+  t.equal(result?.registries[1]?.tokens[0]?.key, 'custom-key-1')
+})
+
+t.test('list includes keychain-only registries', async t => {
+  const { command: cmd } = await t.mockImport<
+    typeof import('../../src/commands/token.ts')
+  >('../../src/commands/token.ts', {
+    '@vltpkg/registry-client': {
+      ...mockRegistryClient,
+      async getToken(key: string): Promise<Token | undefined> {
+        if (key === 'https://registry.npmjs.org') return undefined
+        if (key === 'https://extra.registry.io')
+          return 'Bearer extra_tok'
+        return undefined
+      },
+      getKC() {
+        return {
+          async keys() {
+            return [
+              'https://registry.npmjs.org',
+              'https://extra.registry.io',
+              'https://stale.registry.io',
+            ]
+          },
+          async get(key: string) {
+            if (key === 'https://extra.registry.io')
+              return 'Bearer extra_tok'
+            // stale entry where kc.get returns undefined
+            return undefined
+          },
+        }
+      },
+      RegistryClient: class MockRegistryClient {
+        async scroll<T>(): Promise<T[]> {
+          return [] as T[]
+        }
+      },
+    },
+  })
+
+  const result = await cmd({
+    options: {
+      registry: 'https://registry.npmjs.org/',
+      registries: {},
+      identity: '',
+    },
+    positionals: ['list'],
+  } as unknown as LoadedConfig)
+
+  t.equal(result?.identity, '')
+  // default (npmjs, no local token) + extra + stale
+  t.equal(result?.registries.length, 3)
+  t.equal(
+    result?.registries[0]?.registry,
+    'https://registry.npmjs.org/',
+  )
+  t.equal(result?.registries[0]?.localToken, undefined)
+  t.equal(
+    result?.registries[1]?.registry,
+    'https://extra.registry.io',
+  )
+  t.equal(result?.registries[1]?.localToken, 'Bearer extra_tok')
+  t.equal(
+    result?.registries[2]?.registry,
+    'https://stale.registry.io',
+  )
+  t.equal(result?.registries[2]?.localToken, undefined)
+})
+
+t.test('list with named identity', async t => {
+  const { command: cmd } = await t.mockImport<
+    typeof import('../../src/commands/token.ts')
+  >('../../src/commands/token.ts', {
+    '@vltpkg/registry-client': {
+      ...mockRegistryClient,
+      async getToken(): Promise<Token | undefined> {
+        return 'Bearer corp_token123'
+      },
+      RegistryClient: class MockRegistryClient {
+        async scroll<T>(): Promise<T[]> {
+          return [] as T[]
+        }
+      },
+    },
+  })
+
+  const result = await cmd({
+    options: {
+      registry: 'https://registry.npmjs.org/',
+      registries: {},
+      identity: 'corp',
+    },
+    positionals: ['list'],
+  } as unknown as LoadedConfig)
+
+  t.equal(result?.identity, 'corp')
+  t.equal(result?.registries.length, 1)
+  t.equal(result?.registries[0]?.localToken, 'Bearer corp_token123')
 })
 
 t.test('list handles registry errors gracefully', async t => {
@@ -217,6 +381,9 @@ t.test('list handles registry errors gracefully', async t => {
   >('../../src/commands/token.ts', {
     '@vltpkg/registry-client': {
       ...mockRegistryClient,
+      async getToken(): Promise<Token | undefined> {
+        return 'Bearer npm_mock'
+      },
       RegistryClient: class MockRegistryClient {
         async scroll<T>(): Promise<T[]> {
           throw new Error('401 Unauthorized')
@@ -229,14 +396,15 @@ t.test('list handles registry errors gracefully', async t => {
     options: {
       registry: 'https://registry.npmjs.org/',
       registries: {},
+      identity: '',
     },
     positionals: ['list'],
   } as unknown as LoadedConfig)
 
-  t.ok(Array.isArray(result))
-  t.equal(result?.length, 1)
-  t.equal(result?.[0]?.tokens.length, 0)
-  t.equal(result?.[0]?.error, '401 Unauthorized')
+  t.equal(result?.registries.length, 1)
+  t.equal(result?.registries[0]?.tokens.length, 0)
+  t.equal(result?.registries[0]?.error, '401 Unauthorized')
+  t.equal(result?.registries[0]?.localToken, 'Bearer npm_mock')
 })
 
 t.test('list handles non-Error thrown gracefully', async t => {
@@ -245,6 +413,9 @@ t.test('list handles non-Error thrown gracefully', async t => {
   >('../../src/commands/token.ts', {
     '@vltpkg/registry-client': {
       ...mockRegistryClient,
+      async getToken(): Promise<Token | undefined> {
+        return 'Bearer npm_mock'
+      },
       RegistryClient: class MockRegistryClient {
         async scroll<T>(): Promise<T[]> {
           // eslint-disable-next-line @typescript-eslint/only-throw-error
@@ -258,90 +429,176 @@ t.test('list handles non-Error thrown gracefully', async t => {
     options: {
       registry: 'https://registry.npmjs.org/',
       registries: {},
+      identity: '',
     },
     positionals: ['list'],
   } as unknown as LoadedConfig)
 
-  t.ok(Array.isArray(result))
-  t.equal(result?.[0]?.error, 'string error')
+  t.equal(result?.registries[0]?.error, 'string error')
 })
 
 t.test('views', async t => {
-  t.test('human view formats token list', async t => {
-    const result = [
-      {
-        registry: 'https://registry.npmjs.org/',
-        alias: 'default',
-        tokens: [
+  t.test(
+    'human view formats token list with local token',
+    async t => {
+      const result = {
+        identity: '',
+        registries: [
           {
-            key: 'abc123',
-            token: 'npm_1234',
-            created: '2025-06-15T10:30:00.000Z',
-            readonly: false,
+            registry: 'https://registry.npmjs.org/',
+            alias: 'default',
+            localToken: 'Bearer npm_abcdef1234' as Token,
+            tokens: [
+              {
+                key: 'abc123',
+                token: 'npm_1234',
+                created: '2025-06-15T10:30:00.000Z',
+                readonly: false,
+              },
+              {
+                key: 'def456',
+                token: 'npm_5678',
+                created: '2025-01-20T08:00:00.000Z',
+                readonly: true,
+                cidr_whitelist: ['192.168.1.0/24', '10.0.0.0/8'],
+              },
+            ],
           },
           {
-            key: 'def456',
-            token: 'npm_5678',
-            created: '2025-01-20T08:00:00.000Z',
-            readonly: true,
-            cidr_whitelist: ['192.168.1.0/24', '10.0.0.0/8'],
+            registry: 'https://custom.registry.io/',
+            alias: 'custom',
+            tokens: [],
           },
         ],
-      },
-      {
-        registry: 'https://custom.registry.io/',
-        alias: 'custom',
-        tokens: [],
-      },
-    ]
-    const output = views.human(result)
-    t.type(output, 'string')
-    t.match(output, /default/)
-    t.match(output, /registry\.npmjs\.org/)
-    t.match(output, /abc123/)
-    t.match(output, /npm_1234/)
-    t.match(output, /readonly: no/)
-    t.match(output, /def456/)
-    t.match(output, /readonly: yes/)
-    t.match(output, /192\.168\.1\.0\/24/)
-    t.match(output, /10\.0\.0\.0\/8/)
-    t.match(output, /custom/)
-    t.match(output, /no tokens found/)
-  })
+      }
+      const output = views.human(result)
+      t.type(output, 'string')
+      t.match(output, /identity: \(default\)/)
+      t.match(output, /default/)
+      t.match(output, /registry\.npmjs\.org/)
+      t.match(output, /local: npm_abcd…/)
+      t.match(output, /abc123/)
+      t.match(output, /npm_1234/)
+      t.match(output, /readonly: no/)
+      t.match(output, /def456/)
+      t.match(output, /readonly: yes/)
+      t.match(output, /192\.168\.1\.0\/24/)
+      t.match(output, /10\.0\.0\.0\/8/)
+      t.match(output, /custom/)
+      t.match(output, /skipped remote query/)
+    },
+  )
 
   t.test('human view with error', async t => {
-    const result = [
-      {
-        registry: 'https://registry.npmjs.org/',
-        alias: 'default',
-        tokens: [],
-        error: '401 Unauthorized',
-      },
-    ]
+    const result = {
+      identity: '',
+      registries: [
+        {
+          registry: 'https://registry.npmjs.org/',
+          alias: 'default',
+          localToken: 'Bearer npm_tok' as Token,
+          tokens: [],
+          error: '401 Unauthorized',
+        },
+      ],
+    }
     const output = views.human(result)
     t.type(output, 'string')
     t.match(output, /error: 401 Unauthorized/)
   })
 
   t.test('human view with no alias', async t => {
-    const result = [
-      {
-        registry: 'https://registry.npmjs.org/',
-        tokens: [
-          {
-            key: 'abc123',
-            token: 'npm_1234',
-            created: '2025-06-15T10:30:00.000Z',
-            readonly: false,
-          },
-        ],
-      },
-    ]
+    const result = {
+      identity: '',
+      registries: [
+        {
+          registry: 'https://registry.npmjs.org/',
+          localToken: 'Bearer npm_abcdefghij' as Token,
+          tokens: [
+            {
+              key: 'abc123',
+              token: 'npm_1234',
+              created: '2025-06-15T10:30:00.000Z',
+              readonly: false,
+            },
+          ],
+        },
+      ],
+    }
     const output = views.human(result)
     t.type(output, 'string')
-    // Should show just the URL without alias
     t.match(output, /https:\/\/registry\.npmjs\.org\//)
     t.notMatch(output, /\(https:/)
+  })
+
+  t.test(
+    'human view with local token but no remote tokens',
+    async t => {
+      const result = {
+        identity: '',
+        registries: [
+          {
+            registry: 'https://registry.npmjs.org/',
+            alias: 'default',
+            localToken: 'Bearer npm_abcdef1234' as Token,
+            tokens: [],
+          },
+        ],
+      }
+      const output = views.human(result)
+      t.type(output, 'string')
+      t.match(output, /local: npm_abcd…/)
+      t.match(output, /no remote tokens found/)
+    },
+  )
+
+  t.test('human view with no local token', async t => {
+    const result = {
+      identity: '',
+      registries: [
+        {
+          registry: 'https://registry.npmjs.org/',
+          alias: 'default',
+          tokens: [],
+        },
+      ],
+    }
+    const output = views.human(result)
+    t.type(output, 'string')
+    t.match(output, /local: \(none\)/)
+    t.match(output, /skipped remote query/)
+  })
+
+  t.test('human view masks short tokens', async t => {
+    const result = {
+      identity: '',
+      registries: [
+        {
+          registry: 'https://registry.npmjs.org/',
+          localToken: 'Bearer ab' as Token,
+          tokens: [],
+        },
+      ],
+    }
+    const output = views.human(result)
+    t.type(output, 'string')
+    t.match(output, /local: ab…/)
+  })
+
+  t.test('human view shows named identity', async t => {
+    const result = {
+      identity: 'corp',
+      registries: [
+        {
+          registry: 'https://registry.npmjs.org/',
+          tokens: [],
+        },
+      ],
+    }
+    const output = views.human(result)
+    t.type(output, 'string')
+    t.match(output, /identity: corp/)
+    t.notMatch(output, /\(default\)/)
   })
 
   t.test('human view returns undefined for void', async t => {
@@ -350,13 +607,16 @@ t.test('views', async t => {
   })
 
   t.test('json view returns data', async t => {
-    const result = [
-      {
-        registry: 'https://registry.npmjs.org/',
-        alias: 'default',
-        tokens: [],
-      },
-    ]
+    const result = {
+      identity: '',
+      registries: [
+        {
+          registry: 'https://registry.npmjs.org/',
+          alias: 'default',
+          tokens: [],
+        },
+      ],
+    }
     t.strictSame(views.json(result), result)
   })
 

--- a/src/registry-client/src/index.ts
+++ b/src/registry-client/src/index.ts
@@ -46,6 +46,7 @@ export {
   clearRuntimeTokens,
   deleteToken,
   getKC,
+  getToken,
   getTokenByURL,
   isToken,
   keychains,
@@ -546,9 +547,15 @@ export class RegistryClient {
   ): Promise<CacheEntry> {
     if (handleCacheHitResponse(response, entry)) return entry
 
+    let consumedBody: string | undefined
     if (response.statusCode === 401) {
-      const repeatRequest = await otplease(this, options, response)
-      if (repeatRequest) return await this.request(url, repeatRequest)
+      const otpResult = await otplease(this, options, response)
+      if (otpResult && 'retry' in otpResult) {
+        return await this.request(url, otpResult.retry)
+      }
+      if (otpResult && 'bodyConsumed' in otpResult) {
+        consumedBody = otpResult.bodyConsumed
+      }
     }
 
     const h: Uint8Array[] = []
@@ -566,6 +573,16 @@ export class RegistryClient {
     }
 
     const { integrity, trustIntegrity } = options
+
+    // When otplease already consumed the body, use its length
+    // instead of the Content-Length header to size the CacheEntry
+    // buffer correctly.
+    const contentLength =
+      consumedBody !== undefined ? consumedBody.length
+      : response.headers['content-length'] ?
+        Number(response.headers['content-length'])
+      : /* c8 ignore next */ undefined
+
     const result = new CacheEntry(
       /* c8 ignore next - should always have a status code */
       response.statusCode || 200,
@@ -575,10 +592,7 @@ export class RegistryClient {
         trustIntegrity,
         'stale-while-revalidate-factor':
           this.staleWhileRevalidateFactor,
-        contentLength:
-          response.headers['content-length'] ?
-            Number(response.headers['content-length'])
-          : /* c8 ignore next */ undefined,
+        contentLength,
       },
     )
 
@@ -587,6 +601,16 @@ export class RegistryClient {
       const [nextURL, nextOptions] = redirect(options, result, url)
       if (nextOptions && nextURL) {
         return await this.request(nextURL, nextOptions)
+      }
+      return result
+    }
+
+    // If otplease already consumed the body (e.g. checking for OTP
+    // prompt on a plain 401), use the text it read rather than trying
+    // to re-read from the already-drained stream.
+    if (consumedBody !== undefined) {
+      if (consumedBody.length > 0) {
+        result.addBody(new TextEncoder().encode(consumedBody))
       }
       return result
     }

--- a/src/registry-client/src/otplease.ts
+++ b/src/registry-client/src/otplease.ts
@@ -24,11 +24,16 @@ const question = async (text: string): Promise<string> => {
 const otpChallengeNotice =
   /^Open ([^ ]+) to use your security key for authentication or enter OTP from your authenticator app/i
 
+export type OtpResult =
+  | { retry: RegistryClientRequestOptions }
+  | { bodyConsumed: string }
+  | undefined
+
 export const otplease = async (
   client: RegistryClient,
   options: RegistryClientRequestOptions,
   response: Dispatcher.ResponseData,
-): Promise<RegistryClientRequestOptions | undefined> => {
+): Promise<OtpResult> => {
   const waHeader = String(response.headers['www-authenticate'] ?? '')
   const wwwAuth = new Set(
     waHeader ? waHeader.toLowerCase().split(/,\s*/) : [],
@@ -47,8 +52,10 @@ export const otplease = async (
     )
     if (challenge) {
       return {
-        ...options,
-        otp: (await client.webAuthOpener(challenge)).token,
+        retry: {
+          ...options,
+          otp: (await client.webAuthOpener(challenge)).token,
+        },
       }
     }
 
@@ -60,8 +67,10 @@ export const otplease = async (
         await urlOpen(match[1])
         log(notice)
         return {
-          ...options,
-          otp: await question('OTP: '),
+          retry: {
+            ...options,
+            otp: await question('OTP: '),
+          },
         }
       }
     }
@@ -75,12 +84,17 @@ export const otplease = async (
     throw error('Unknown authentication challenge', { response })
   }
 
-  // see if the body is prompting for otp
+  // Consume the body to check if it's prompting for OTP.
+  // We must return the consumed text so the caller doesn't try to
+  // re-read from the already-drained stream.
   const text = await response.body.text().catch(() => '')
   if (text.toLowerCase().includes('one-time pass')) {
     return {
-      ...options,
-      otp: await question(text),
+      retry: {
+        ...options,
+        otp: await question(text),
+      },
     }
   }
+  return { bodyConsumed: text }
 }

--- a/src/registry-client/test/index.ts
+++ b/src/registry-client/test/index.ts
@@ -43,10 +43,15 @@ process.env.XDG_RUNTIME_HOME = dir
 // mock function, just sets the npm-otp header
 const otplease = async (
   _client: any,
-  options: RegistryClientRequestOptions,
-  _response: any,
-): Promise<RegistryClientRequestOptions | undefined> => {
-  if (!options.otp) return { ...options, otp: 'hello' }
+  options: RegistryClientRequestOptions & Record<string, unknown>,
+  response: any,
+) => {
+  if (response.statusCode === 401 && options.bodyConsumedTest) {
+    // Consume the real body just like the real otplease does
+    const text = await response.body.text()
+    return { bodyConsumed: text }
+  }
+  if (!options.otp) return { retry: { ...options, otp: 'hello' } }
 }
 
 let doneUrlRetry: boolean | string = false
@@ -687,6 +692,44 @@ t.test('401 prompting otplease', async t => {
     { useCache: false },
   )
   t.match(result, { statusCode: 200 })
+})
+
+t.test('401 with body consumed by otplease', async t => {
+  dropConnection = false
+  const rc = t.context.rc as RegistryClient
+  const result = await rc.request(
+    new URL('/-/401/consumed', registryURL),
+    { useCache: false, bodyConsumedTest: true } as any,
+  )
+  t.match(result, { statusCode: 401 })
+  t.strictSame(result.json(), { needs: 'otp' })
+})
+
+t.test('401 with empty body consumed by otplease', async t => {
+  dropConnection = false
+
+  const mockOtpEmpty = async (
+    _client: any,
+    options: RegistryClientRequestOptions & Record<string, unknown>,
+    _response: any,
+  ) => {
+    if (options.emptyBodyTest) {
+      return { bodyConsumed: '' }
+    }
+    if (!options.otp) return { retry: { ...options, otp: 'hello' } }
+  }
+
+  const { RegistryClient: EmptyRC } = await mockIndex(t, {
+    '../src/otplease.ts': { otplease: mockOtpEmpty },
+  })
+  const rc2 = new EmptyRC({})
+  const result = await rc2.request(
+    new URL('/-/401/empty', registryURL),
+    { useCache: false, emptyBodyTest: true } as any,
+  )
+  t.match(result, { statusCode: 401 })
+  // Body is empty since otplease consumed it and returned ''
+  t.equal(result.text(), '')
 })
 
 t.test('sending request with PUT method', async t => {

--- a/src/registry-client/test/otplease.ts
+++ b/src/registry-client/test/otplease.ts
@@ -102,7 +102,7 @@ t.test('www-authenticate otp challenge', async t => {
   } as unknown as Dispatcher.ResponseData)
   t.strictSame(doneUrlsOpened, ['done url'])
   t.strictSame(urlsOpened, ['login url'])
-  t.match(result, { otp: 'token' })
+  t.match(result, { retry: { otp: 'token' } })
 })
 
 t.test('npm-notice prompting for OTP', async t => {
@@ -122,7 +122,7 @@ t.test('npm-notice prompting for OTP', async t => {
     'Open {login-url} to use your security key for authentication or enter OTP from your authenticator app',
   ])
   t.strictSame(result, {
-    otp: 'OTP: ',
+    retry: { otp: 'OTP: ' },
   })
 })
 
@@ -133,6 +133,23 @@ t.test('body prompting for OTP', async t => {
       text: async () => 'oNe-TiME pAsS',
     },
   } as unknown as Dispatcher.ResponseData
-  const opts = await otplease(mockClient, {}, resp)
-  t.equal(opts?.otp, 'oNe-TiME pAsS')
+  const result = await otplease(mockClient, {}, resp)
+  t.ok(result && 'retry' in result)
+  if (result && 'retry' in result) {
+    t.equal(result.retry.otp, 'oNe-TiME pAsS')
+  }
+})
+
+t.test('non-OTP 401 returns consumed body', async t => {
+  const resp = {
+    headers: {},
+    body: {
+      text: async () => '{"error":"You must be logged in"}',
+    },
+  } as unknown as Dispatcher.ResponseData
+  const result = await otplease(mockClient, {}, resp)
+  t.ok(result && 'bodyConsumed' in result)
+  if (result && 'bodyConsumed' in result) {
+    t.equal(result.bodyConsumed, '{"error":"You must be logged in"}')
+  }
 })


### PR DESCRIPTION
This pull request updates the `vlt token list` command to provide a more comprehensive and user-friendly listing of registry authentication tokens. The main improvements include displaying locally stored tokens, skipping remote queries when no local token is present, showing keychain-only registries, and updating both the output format and tests to match these enhancements.

**Enhancements to token listing and output:**

- The `list` command now displays both locally stored (keychain) tokens and remote registry tokens, and outputs a top-level `identity` field and a `localToken` field per registry. It also skips remote API queries for registries with no local token.

- The output format for the human-readable view is improved: it now masks local tokens, clearly indicates when remote queries are skipped due to missing local tokens, and includes a summary header with the identity.

**Broader registry/keychain coverage:**

- The command now lists all keychain entries, including those not present in the current config (such as tokens added via `vlt token add --registry`), ensuring no stored token is missed in the output.

**Test and type updates:**

- The tests are updated and expanded to cover the new behaviors: skipping remote queries, handling keychain-only registries, error cases, and validating the new output structure. The result type for `list` is changed from an array to an object with `identity` and `registries` fields.

**Documentation:**

- The command description and CLI help text are updated to reflect the new features and improved output.

Overall, these changes make it easier for users to see all relevant tokens and understand their authentication state across all configured and stored registries.