### PR TITLE
fix(registry-client): base paths & auth

### DIFF
--- a/src/cli-sdk/src/commands/publish.ts
+++ b/src/cli-sdk/src/commands/publish.ts
@@ -1,5 +1,9 @@
 import { error } from '@vltpkg/error-cause'
-import { RegistryClient, oidc } from '@vltpkg/registry-client'
+import {
+  RegistryClient,
+  oidc,
+  registryBase,
+} from '@vltpkg/registry-client'
 import type { CacheEntry } from '@vltpkg/registry-client'
 import { run } from '@vltpkg/run'
 import { commandUsage } from '../config/usage.ts'
@@ -205,7 +209,7 @@ const commandSingle = async (
     'dry-run': dry = false,
     otp,
   } = conf.options
-  const registryUrl = new URL(registry)
+  const registryUrl = new URL(registryBase(registry))
 
   const runOptions = {
     cwd: manifestDir,

--- a/src/cli-sdk/src/commands/token.ts
+++ b/src/cli-sdk/src/commands/token.ts
@@ -4,6 +4,7 @@ import {
   getKC,
   getToken,
   normalizeRegistryKey,
+  registryBase,
   RegistryClient,
   setToken,
 } from '@vltpkg/registry-client'
@@ -154,7 +155,7 @@ const listTokens = async (
   if (!localTok) {
     return { registry, alias, tokens: [] }
   }
-  const tokensUrl = new URL('-/npm/v1/tokens', registry)
+  const tokensUrl = new URL('-/npm/v1/tokens', registryBase(registry))
   try {
     const objects = await rc.scroll<TokenInfo>(tokensUrl, {
       useCache: false,

--- a/src/cli-sdk/test/commands/publish.ts
+++ b/src/cli-sdk/test/commands/publish.ts
@@ -3,7 +3,7 @@ import { resolve } from 'node:path'
 import { command, views, usage } from '../../src/commands/publish.ts'
 import type { CommandResultSingle } from '../../src/commands/publish.ts'
 import { PackageJson } from '@vltpkg/package-json'
-import { RegistryClient } from '@vltpkg/registry-client'
+import { RegistryClient, registryBase } from '@vltpkg/registry-client'
 import type { LoadedConfig } from '../../src/config/index.ts'
 
 interface MockResponse {
@@ -664,6 +664,7 @@ t.test('publish command with scope', async t => {
           }
         },
         oidc: async () => undefined,
+        registryBase,
       },
       '../../src/query-host-contexts.ts': {
         createHostContextsMap: async () => new Map(),
@@ -750,6 +751,7 @@ t.test('publish command with scope', async t => {
           }
         },
         oidc: async () => undefined,
+        registryBase,
       },
       '../../src/query-host-contexts.ts': {
         createHostContextsMap: async () => new Map(),

--- a/src/cli-sdk/test/commands/token.ts
+++ b/src/cli-sdk/test/commands/token.ts
@@ -8,6 +8,9 @@ const mockRegistryClient = {
     const u = new URL(url)
     return (u.origin + u.pathname).replace(/\/+$/, '')
   },
+  registryBase(url: string) {
+    return url.endsWith('/') ? url : url + '/'
+  },
   async setToken(_reg: string, _tok: Token) {},
   async deleteToken(_reg: string) {},
   async getToken(): Promise<Token | undefined> {

--- a/src/registry-client/src/auth.ts
+++ b/src/registry-client/src/auth.ts
@@ -17,6 +17,16 @@ export const normalizeRegistryKey = (url: string): string => {
   return (u.origin + u.pathname).replace(/\/+$/, '')
 }
 
+/**
+ * Ensure a registry URL ends with `/` so that `new URL(path, base)`
+ * appends under the full path instead of replacing the last segment.
+ *
+ *   registryBase('https://r.io/scope/name')
+ *   // → 'https://r.io/scope/name/'
+ */
+export const registryBase = (url: string): string =>
+  url.endsWith('/') ? url : url + '/'
+
 // just exported for testing
 export const keychains = new Map<string, Keychain<Token>>()
 

--- a/src/registry-client/src/index.ts
+++ b/src/registry-client/src/index.ts
@@ -22,6 +22,7 @@ import {
   isToken,
   keychains,
   normalizeRegistryKey,
+  registryBase,
   runtimeTokens,
   setRuntimeToken,
   setToken,
@@ -52,6 +53,7 @@ export {
   keychains,
   normalizeRegistryKey,
   oidc,
+  registryBase,
   runtimeTokens,
   setRuntimeToken,
   setToken,
@@ -298,7 +300,8 @@ export class RegistryClient {
 
     const s = tok.replace(/^(Bearer|Basic) /i, '')
 
-    const tokensUrl = new URL('-/npm/v1/tokens', registry)
+    const base = registryBase(registry)
+    const tokensUrl = new URL('-/npm/v1/tokens', base)
     const record = await this.seek<{
       key: string
       token: string
@@ -309,7 +312,7 @@ export class RegistryClient {
     if (record) {
       const { key } = record
       await this.request(
-        new URL(`-/npm/v1/tokens/token/${key}`, registry),
+        new URL(`-/npm/v1/tokens/token/${key}`, base),
         { useCache: false, method: 'DELETE' },
       )
     }
@@ -331,7 +334,7 @@ export class RegistryClient {
     // - hang on the doneUrl until done
     //
     // if that fails: fall back to couchdb login
-    const webLoginURL = new URL('-/v1/login', registry)
+    const webLoginURL = new URL('-/v1/login', registryBase(registry))
     const response = await this.request(webLoginURL, {
       method: 'POST',
       useCache: false,

--- a/src/registry-client/src/oidc.ts
+++ b/src/registry-client/src/oidc.ts
@@ -77,14 +77,13 @@ const _oidc = async ({
   const isGitLab = process.env.GITLAB_CI === 'true'
   const isCircle = process.env.CIRCLECI === 'true'
 
+  if (!isGitHub && !isGitLab && !isCircle) {
+    return undefined
+  }
+
   log(
     `CI detected: github=${isGitHub} gitlab=${isGitLab} circle=${isCircle}`,
   )
-
-  if (!isGitHub && !isGitLab && !isCircle) {
-    log('Not in a supported CI environment — skipping')
-    return undefined
-  }
 
   // NPM_ID_TOKEN is supported as an override in all CI environments
   let idToken = process.env.NPM_ID_TOKEN

--- a/src/registry-client/src/otplease.ts
+++ b/src/registry-client/src/otplease.ts
@@ -80,6 +80,13 @@ export const otplease = async (
     })
   }
 
+  if (wwwAuth.has('bearer')) {
+    throw error(
+      'Missing or invalid authentication token. Run `vlt login` or `vlt token add` to authenticate.',
+      { response },
+    )
+  }
+
   if (wwwAuth.size) {
     throw error('Unknown authentication challenge', { response })
   }

--- a/src/registry-client/test/auth.ts
+++ b/src/registry-client/test/auth.ts
@@ -1,5 +1,9 @@
 import t from 'tap'
-import { isToken, normalizeRegistryKey } from '../src/auth.ts'
+import {
+  isToken,
+  normalizeRegistryKey,
+  registryBase,
+} from '../src/auth.ts'
 
 const checkLog = (kc: any) => (kc as Keychain).log
 
@@ -83,6 +87,26 @@ t.test('normalizeRegistryKey', t => {
   )
   // Throws on invalid URL
   t.throws(() => normalizeRegistryKey('not a url'))
+  t.end()
+})
+
+t.test('registryBase', t => {
+  t.equal(
+    registryBase('https://registry.npmjs.org'),
+    'https://registry.npmjs.org/',
+  )
+  t.equal(
+    registryBase('https://registry.npmjs.org/'),
+    'https://registry.npmjs.org/',
+  )
+  t.equal(
+    registryBase('https://registry.vlt.io/vltpkg/main'),
+    'https://registry.vlt.io/vltpkg/main/',
+  )
+  t.equal(
+    registryBase('https://registry.vlt.io/vltpkg/main/'),
+    'https://registry.vlt.io/vltpkg/main/',
+  )
   t.end()
 })
 

--- a/src/registry-client/test/otplease.ts
+++ b/src/registry-client/test/otplease.ts
@@ -61,6 +61,20 @@ t.test('cannot auth if ipaddress rejected', async t => {
   )
 })
 
+t.test('bearer www-authenticate prompts to log in', async t => {
+  await t.rejects(
+    otplease(mockClient, {}, {
+      headers: {
+        'www-authenticate': 'Bearer',
+      },
+    } as unknown as Dispatcher.ResponseData),
+    {
+      message:
+        'Missing or invalid authentication token. Run `vlt login` or `vlt token add` to authenticate.',
+    },
+  )
+})
+
 t.test('unknown www-authenticate challenges', async t => {
   await t.rejects(
     otplease(mockClient, {}, {


### PR DESCRIPTION
This pull request standardizes how registry URLs are handled across the CLI and registry client packages by introducing a new utility function, `registryBase`, which ensures registry URLs always end with a trailing slash. This change prevents subtle URL construction bugs and makes code dealing with registry endpoints more robust. The update also improves error handling for authentication failures and adds tests for the new utilities.

**Registry URL handling improvements:**

* Added a new `registryBase` utility function in `src/registry-client/src/auth.ts` to ensure registry URLs always end with a trailing slash, preventing incorrect URL path joining.
* Updated all usages of registry URLs in `RegistryClient`, CLI commands (`publish.ts`, `token.ts`), and corresponding tests to use `registryBase` for consistent URL construction. 

**Authentication and error handling:**

* Improved error message for missing or invalid authentication tokens in `otplease.ts`, now prompting the user to run `vlt login` or `vlt token add` when a Bearer challenge is detected.
* Added a test in `otplease.ts` to verify the new error message is shown for Bearer authentication challenges.

**Testing and code quality:**

* Added comprehensive tests for the new `registryBase` utility in `auth.ts` and updated all relevant mocks to include the new function.

**Minor improvements:**

* Cleaned up logging in `oidc.ts` to only log CI environment detection when relevant.