### PR TITLE
fix(publish): expand publishConfig support & error handling

### DIFF
--- a/src/cli-sdk/src/commands/publish.ts
+++ b/src/cli-sdk/src/commands/publish.ts
@@ -12,6 +12,7 @@ import { packTarball } from '../pack-tarball.ts'
 import type { Views } from '../view.ts'
 import assert from 'node:assert'
 import { asError } from '@vltpkg/types'
+import type { NormalizedManifest } from '@vltpkg/types'
 import { dirname, resolve } from 'node:path'
 import prettyBytes from 'pretty-bytes'
 import { actual } from '@vltpkg/graph'
@@ -188,6 +189,24 @@ export const command: CommandFn<CommandResult> = async conf => {
   return results
 }
 
+type PublishConfig = {
+  directory?: string
+  registry?: string
+  access?: string
+  tag?: string
+}
+
+const getPublishConfig = (
+  manifest: NormalizedManifest,
+): PublishConfig | undefined => {
+  const pc: unknown = (manifest as Record<string, unknown>)
+    .publishConfig
+  if (pc && typeof pc === 'object') {
+    return pc
+  }
+  return undefined
+}
+
 const commandSingle = async (
   location: string,
   conf: LoadedConfig,
@@ -202,13 +221,11 @@ const commandSingle = async (
     error('Package has been marked as private'),
   )
 
-  const {
-    tag,
-    access,
-    registry,
-    'dry-run': dry = false,
-    otp,
-  } = conf.options
+  const { 'dry-run': dry = false, otp } = conf.options
+  const publishConfig = getPublishConfig(manifest)
+  const tag = publishConfig?.tag ?? conf.options.tag
+  const access = publishConfig?.access ?? conf.options.access
+  const registry = publishConfig?.registry ?? conf.options.registry
   const registryUrl = new URL(registryBase(registry))
 
   const runOptions = {
@@ -334,8 +351,9 @@ const commandSingle = async (
 
     if (response.statusCode !== 200 && response.statusCode !== 201) {
       let extraMsg = ''
-      // special case 404 errors to provide a better hint to the user
-      if (response.statusCode === 404) {
+      if (response.statusCode === 409) {
+        extraMsg = `.\n⚠️ ${name}@${version} already exists in the registry. Bump the version and try again.`
+      } else if (response.statusCode === 404) {
         extraMsg =
           ".\n⚠️ Make sure you're logged in and have access to publish the package."
       }

--- a/src/cli-sdk/test/commands/publish.ts
+++ b/src/cli-sdk/test/commands/publish.ts
@@ -278,6 +278,41 @@ t.test('command', async t => {
     )
   })
 
+  t.test('handles 409 conflict for existing version', async t => {
+    const dir = t.testdir({
+      'package.json': JSON.stringify({
+        name: '@test/package',
+        version: '1.2.3',
+        description: 'Test package for publish command',
+        main: 'index.js',
+      }),
+      'index.js': '// test file\nconsole.log("hello");',
+      'README.md': '# Test Package',
+      'vlt.json': '{}',
+    })
+
+    t.chdir(dir)
+
+    mockResponses.set('https://registry.npmjs.org/@test%2Fpackage', {
+      statusCode: 409,
+      text: 'Conflict',
+    })
+
+    const config = makeTestConfig({
+      projectRoot: dir,
+      options: {
+        packageJson: new PackageJson(),
+        registry: 'https://registry.npmjs.org',
+      },
+      positionals: ['publish'],
+    })
+
+    await t.rejects(
+      command(config),
+      /@test\/package@1\.2\.3 already exists in the registry\. Bump the version and try again/,
+    )
+  })
+
   t.test('uses custom tag when provided', async t => {
     const dir = t.testdir({
       'package.json': JSON.stringify({
@@ -479,6 +514,198 @@ t.test('command', async t => {
     const result = (await command(config)) as CommandResultSingle
     t.equal(result.access, 'public')
   })
+
+  t.test('uses publishConfig.tag from manifest', async t => {
+    const dir = t.testdir({
+      'package.json': JSON.stringify({
+        name: '@test/package',
+        version: '1.2.3',
+        publishConfig: {
+          tag: 'next',
+        },
+      }),
+      'index.js': '// test file',
+      'vlt.json': '{}',
+    })
+
+    t.chdir(dir)
+
+    const config = makeTestConfig({
+      projectRoot: dir,
+      options: {
+        packageJson: new PackageJson(),
+        registry: 'https://registry.npmjs.org',
+        tag: 'latest',
+      },
+      positionals: ['publish'],
+    })
+
+    const result = (await command(config)) as CommandResultSingle
+    t.equal(result.tag, 'next', 'should use publishConfig.tag')
+  })
+
+  t.test('uses publishConfig.access from manifest', async t => {
+    const dir = t.testdir({
+      'package.json': JSON.stringify({
+        name: '@test/package',
+        version: '1.2.3',
+        publishConfig: {
+          access: 'public',
+        },
+      }),
+      'index.js': '// test file',
+      'vlt.json': '{}',
+    })
+
+    t.chdir(dir)
+
+    let publishBody: string | undefined
+    const tempRequest = RegistryClient.prototype.request
+    RegistryClient.prototype.request = (async (
+      _url: URL | string,
+      opts?: { body?: string },
+    ) => {
+      publishBody = opts?.body
+      return {
+        statusCode: 201,
+        text: () => '{"ok":true}',
+        json: () => ({ ok: true }),
+        getHeader: () => undefined,
+      }
+    }) as unknown as typeof tempRequest
+    t.teardown(() => {
+      RegistryClient.prototype.request = tempRequest
+    })
+
+    const config = makeTestConfig({
+      projectRoot: dir,
+      options: {
+        packageJson: new PackageJson(),
+        registry: 'https://registry.npmjs.org',
+      },
+      positionals: ['publish'],
+    })
+
+    const result = (await command(config)) as CommandResultSingle
+    t.equal(
+      result.access,
+      'public',
+      'should use publishConfig.access',
+    )
+    t.ok(publishBody, 'should have sent a request body')
+    const metadata = JSON.parse(publishBody!)
+    t.equal(
+      metadata.access,
+      'public',
+      'publish metadata should include access from publishConfig',
+    )
+  })
+
+  t.test('uses publishConfig.registry from manifest', async t => {
+    const dir = t.testdir({
+      'package.json': JSON.stringify({
+        name: 'my-package',
+        version: '1.0.0',
+        publishConfig: {
+          registry: 'https://custom.registry.example.com/',
+        },
+      }),
+      'index.js': '// test file',
+      'vlt.json': '{}',
+    })
+
+    t.chdir(dir)
+
+    const config = makeTestConfig({
+      projectRoot: dir,
+      options: {
+        packageJson: new PackageJson(),
+        registry: 'https://registry.npmjs.org',
+      },
+      positionals: ['publish'],
+    })
+
+    const result = (await command(config)) as CommandResultSingle
+    t.equal(
+      result.registry,
+      'https://custom.registry.example.com',
+      'should use publishConfig.registry',
+    )
+  })
+
+  t.test(
+    'publishConfig takes precedence over config defaults',
+    async t => {
+      const dir = t.testdir({
+        'package.json': JSON.stringify({
+          name: '@test/package',
+          version: '1.2.3',
+          publishConfig: {
+            tag: 'next',
+            access: 'restricted',
+          },
+        }),
+        'index.js': '// test file',
+        'vlt.json': '{}',
+      })
+
+      t.chdir(dir)
+
+      const config = makeTestConfig({
+        projectRoot: dir,
+        options: {
+          packageJson: new PackageJson(),
+          registry: 'https://registry.npmjs.org',
+          tag: 'latest',
+          access: 'public',
+        },
+        positionals: ['publish'],
+      })
+
+      const result = (await command(config)) as CommandResultSingle
+      t.equal(
+        result.tag,
+        'next',
+        'publishConfig.tag takes precedence',
+      )
+      t.equal(
+        result.access,
+        'restricted',
+        'publishConfig.access takes precedence',
+      )
+    },
+  )
+
+  t.test(
+    'falls back to config when publishConfig is absent',
+    async t => {
+      const dir = t.testdir({
+        'package.json': JSON.stringify({
+          name: '@test/package',
+          version: '1.2.3',
+        }),
+        'index.js': '// test file',
+        'vlt.json': '{}',
+      })
+
+      t.chdir(dir)
+
+      const config = makeTestConfig({
+        projectRoot: dir,
+        options: {
+          packageJson: new PackageJson(),
+          registry: 'https://registry.npmjs.org',
+          tag: 'beta',
+          access: 'public',
+        },
+        positionals: ['publish'],
+      })
+
+      const result = (await command(config)) as CommandResultSingle
+      t.equal(result.tag, 'beta', 'should use config tag')
+      t.equal(result.access, 'public', 'should use config access')
+    },
+  )
 
   t.test('does not send access when not explicitly set', async t => {
     const dir = t.testdir({


### PR DESCRIPTION
This pull request enhances the `publish` command by allowing `publishConfig` fields from a package's manifest to override CLI options for `tag`, `access`, and `registry`. It also improves error handling for existing versions and adds comprehensive tests to ensure correct precedence and fallback behavior.

**Enhancements to publish configuration:**

* Added support for reading `publishConfig` (`tag`, `access`, `registry`) from the package manifest (`package.json`). These values now take precedence over CLI options if present.
* Introduced the `getPublishConfig` helper function to extract and normalize `publishConfig` from the manifest.

**Error handling improvements:**

* Improved error message for 409 Conflict responses, guiding the user to bump the version if the package already exists in the registry.

**Testing improvements:**

* Added tests to verify that `publishConfig` fields are correctly used and take precedence over CLI options, and that fallback to CLI options works when `publishConfig` is absent.
* Added a test to ensure proper handling and messaging for 409 Conflict errors when publishing an already existing version.

**Type and import updates:**

* Imported `NormalizedManifest` type from `@vltpkg/types` for improved type safety.