### PR TITLE
fix: publish vlt CLI to vlt registry as @vltpkg/vlt

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -401,12 +401,21 @@ jobs:
                 continue
               fi
               package_name=$(jq -r '.name' "$dir/package.json")
+              renamed=false
               if [[ "$package_name" != @vltpkg/* ]]; then
-                echo "Skipping non-@vltpkg scoped package: $package_name"
-                continue
+                scoped_name="@vltpkg/$package_name"
+                echo "Temporarily renaming $package_name → $scoped_name for vlt registry publish"
+                jq --arg n "$scoped_name" '.name = $n' "$dir/package.json" > "$dir/package.json.tmp"
+                mv "$dir/package.json.tmp" "$dir/package.json"
+                renamed=true
               fi
               echo "Publishing $dir to vlt registry..."
               (cd "$dir" && $VLT publish --access=public)
+              if [[ "$renamed" == "true" ]]; then
+                echo "Restoring original package name: $package_name"
+                jq --arg n "$package_name" '.name = $n' "$dir/package.json" > "$dir/package.json.tmp"
+                mv "$dir/package.json.tmp" "$dir/package.json"
+              fi
             fi
           done
         env:


### PR DESCRIPTION
Instead of skipping the unscoped `vlt` package when publishing to the vltpkg registry, temporarily renames it to `@vltpkg/vlt` so we can still test installing and running the CLI from our registry.

### How it works

1. Before `vlt publish`, if the package name is not `@vltpkg/*` scoped, rename it in `package.json` (e.g. `vlt` → `@vltpkg/vlt`)
2. Run `vlt publish --access=public` — the prepack step reads the (now renamed) `package.json` and bundles it with the scoped name
3. Immediately restore the original name in `package.json`

The rename is ephemeral — never committed, only exists during the publish step.

Co-authored-by: @lukekarrys