### PR TITLE
fix(spec): propagate configured registry through catalog specs

### DIFF
--- a/src/spec/src/browser.ts
+++ b/src/spec/src/browser.ts
@@ -397,8 +397,9 @@ export class Spec implements SpecLike<Spec> {
           validOptions: Object.keys(catalog),
         })
       }
-      this.subspec = Spec.parse(this.name, sub)
+      this.subspec = Spec.parse(this.name, sub, this.options)
       this.type = 'catalog'
+      this.registry = this.subspec.final.registry
       return
     }
 

--- a/src/spec/test/browser.ts
+++ b/src/spec/test/browser.ts
@@ -946,6 +946,25 @@ t.test('catalogs', async t => {
       spec: 'b@catalog:z',
     },
   })
+
+  t.test(
+    'propagates configured registry to catalog subspec',
+    async t => {
+      const registry = 'https://registry.example.com/'
+      const parsed = Spec.parse('a@catalog:', { ...opts, registry })
+      t.equal(parsed.type, 'catalog')
+      t.equal(
+        parsed.subspec?.registry,
+        registry,
+        'subspec inherits configured registry',
+      )
+      t.equal(
+        parsed.registry,
+        registry,
+        'catalog spec exposes registry from its subspec',
+      )
+    },
+  )
 })
 
 t.test('isSpec', async t => {


### PR DESCRIPTION
## Summary

- `catalog:` specs were re-parsing their subspec via `Spec.parse(name, sub)` without forwarding the parent options, so the subspec fell back to `defaultRegistry` (`https://registry.npmjs.org/`).
- The catalog spec itself also never assigned its own `.registry` field. Consumers reading `spec.registry` directly — notably `graph.placePackage` (`toNode.registry = spec.registry`) and `append-nodes` when parsing transitive deps — got `undefined`, and the entire transitive tree under a catalog dep inherited the npm fallback.

Fix: pass `this.options` into the subspec parse, and set `this.registry = this.subspec.final.registry` on the catalog spec.

Verified end-to-end against a project with `registry: https://registry.vlt.io/vlt/npm/` configured and several catalog entries: all 97 catalog edges and their ~565-node transitive tree now resolve through the configured registry instead of `~npm~`.

Fixes #1632