### PR TITLE
feat(query): add :vulnerable/:vuln selector

### DIFF
--- a/src/query/src/pseudo.ts
+++ b/src/query/src/pseudo.ts
@@ -62,6 +62,7 @@ import { unknown } from './pseudo/unknown.ts'
 import { unmaintained } from './pseudo/unmaintained.ts'
 import { unpopular } from './pseudo/unpopular.ts'
 import { unstable } from './pseudo/unstable.ts'
+import { vulnerable } from './pseudo/vulnerable.ts'
 import { workspace } from './pseudo/workspace.ts'
 
 import type { EdgeLike, NodeLike } from '@vltpkg/types'
@@ -364,6 +365,8 @@ const pseudoSelectors = new Map<string, ParserFn>(
     unpopular,
     unstable,
     v: semver,
+    vuln: vulnerable,
+    vulnerable,
     workspace,
   }),
 )

--- a/src/query/src/pseudo/vulnerable.ts
+++ b/src/query/src/pseudo/vulnerable.ts
@@ -1,0 +1,26 @@
+import type { ParserState } from '../types.ts'
+import {
+  assertSecurityArchive,
+  removeDanglingEdges,
+  removeNode,
+} from './helpers.ts'
+
+/**
+ * :vulnerable / :vuln Pseudo-Selector matches any package version
+ * that has at least one CVE associated with it.
+ */
+export const vulnerable = async (state: ParserState) => {
+  assertSecurityArchive(state, 'vulnerable')
+
+  for (const node of state.partial.nodes) {
+    const report = state.securityArchive.get(node.id)
+    const hasCve = report?.alerts.some(alert => alert.props?.cveId)
+    if (!hasCve) {
+      removeNode(state, node)
+    }
+  }
+
+  removeDanglingEdges(state)
+
+  return state
+}

--- a/src/query/tap-snapshots/test/pseudo/vulnerable.ts.test.cjs
+++ b/src/query/tap-snapshots/test/pseudo/vulnerable.ts.test.cjs
@@ -1,0 +1,18 @@
+/* IMPORTANT
+ * This snapshot file is auto-generated, but designed for humans.
+ * It should be checked into source control and tracked carefully.
+ * Re-generate by setting TAP_SNAPSHOT=1 and running tests.
+ * Make sure to inspect the output below.  Do not ignore changes!
+ */
+'use strict'
+exports[`test/pseudo/vulnerable.ts > TAP > selects packages with any CVE > filter out nodes without CVE alerts > must match snapshot 1`] = `
+Object {
+  "edges": Array [
+    "e",
+    "e",
+  ],
+  "nodes": Array [
+    "e",
+  ],
+}
+`

--- a/src/query/test/pseudo/vulnerable.ts
+++ b/src/query/test/pseudo/vulnerable.ts
@@ -1,0 +1,130 @@
+import t from 'tap'
+import { joinDepIDTuple } from '@vltpkg/dep-id'
+import { asSecurityArchiveLike } from '@vltpkg/security-archive'
+import { getSimpleGraph } from '../fixtures/graph.ts'
+import type { ParserState } from '../../src/types.ts'
+import { parse } from '../../src/parser.ts'
+import { vulnerable } from '../../src/pseudo/vulnerable.ts'
+
+t.test('selects packages with any CVE', async t => {
+  const getState = (query: string, graph = getSimpleGraph()) => {
+    const ast = parse(query)
+    const current = ast.first.first
+    const state: ParserState = {
+      comment: '',
+      current,
+      initial: {
+        edges: new Set(graph.edges.values()),
+        nodes: new Set(graph.nodes.values()),
+      },
+      partial: {
+        edges: new Set(graph.edges.values()),
+        nodes: new Set(graph.nodes.values()),
+      },
+      collect: {
+        edges: new Set(),
+        nodes: new Set(),
+      },
+      cancellable: async () => {},
+      walk: async i => i,
+      securityArchive: asSecurityArchiveLike(
+        new Map([
+          [
+            joinDepIDTuple(['registry', '', 'e@1.0.0']),
+            {
+              alerts: [
+                {
+                  type: 'socketUpstreamVulnerability',
+                  severity: 'high' as const,
+                  category: 'vulnerability',
+                  key: 'some-key',
+                  props: {
+                    lastPublish: '',
+                    cveId: 'CVE-2023-1234' as const,
+                  },
+                },
+              ],
+            },
+          ],
+          [
+            joinDepIDTuple(['registry', '', 'c@1.0.0']),
+            {
+              alerts: [
+                {
+                  type: 'deprecated',
+                  severity: 'low' as const,
+                  category: 'maintenance',
+                  key: 'some-key-2',
+                },
+              ],
+            },
+          ],
+        ]),
+      ),
+      importers: new Set(graph.importers),
+      retries: 0,
+      signal: new AbortController().signal,
+      specificity: { idCounter: 0, commonCounter: 0 },
+    }
+    return state
+  }
+
+  await t.test('filter out nodes without CVE alerts', async t => {
+    const res = await vulnerable(getState(':vulnerable'))
+    t.strictSame(
+      [...res.partial.nodes].map(n => n.name),
+      ['e'],
+      'should select only packages with CVEs',
+    )
+    t.matchSnapshot({
+      nodes: [...res.partial.nodes].map(n => n.name),
+      edges: [...res.partial.edges].map(e => e.name),
+    })
+  })
+
+  await t.test('vuln alias works the same way', async t => {
+    const res = await vulnerable(getState(':vuln'))
+    t.strictSame(
+      [...res.partial.nodes].map(n => n.name),
+      ['e'],
+      'should select only packages with CVEs',
+    )
+  })
+})
+
+t.test('missing security archive', async t => {
+  const getState = (query: string) => {
+    const ast = parse(query)
+    const current = ast.first.first
+    const state: ParserState = {
+      comment: '',
+      current,
+      initial: {
+        edges: new Set(),
+        nodes: new Set(),
+      },
+      partial: {
+        edges: new Set(),
+        nodes: new Set(),
+      },
+      collect: {
+        edges: new Set(),
+        nodes: new Set(),
+      },
+      cancellable: async () => {},
+      walk: async i => i,
+      securityArchive: undefined,
+      importers: new Set(),
+      retries: 0,
+      signal: new AbortController().signal,
+      specificity: { idCounter: 0, commonCounter: 0 },
+    }
+    return state
+  }
+
+  await t.rejects(
+    vulnerable(getState(':vulnerable')),
+    { message: /Missing security archive/ },
+    'should throw an error',
+  )
+})

--- a/www/docs/src/content/docs/cli/selectors/security-insights.mdx
+++ b/www/docs/src/content/docs/cli/selectors/security-insights.mdx
@@ -76,6 +76,16 @@ Matches packages affected by manifest confusion — the published
 
 ## Vulnerabilities
 
+### `:vulnerable` / `:vuln`
+
+Matches packages that have any CVE associated with them:
+
+<Code code="$ vlt query ':vulnerable'" title="Terminal" lang="bash" />
+
+The `:vuln` alias works identically:
+
+<Code code="$ vlt query ':vuln'" title="Terminal" lang="bash" />
+
 ### `:cve(<id>)`
 
 Matches packages with a specific CVE alert:


### PR DESCRIPTION
This pull request adds a new pseudo-selector, `:vulnerable` (with alias `:vuln`), to the query system for selecting packages with associated CVEs. It includes the implementation, integration into the selector map, comprehensive tests, and documentation updates.

**New Vulnerability Selector Feature:**

* Added a new `vulnerable` pseudo-selector in `pseudo/vulnerable.ts`, which filters package nodes to only those with at least one CVE alert in the security archive. Throws an error if the security archive is missing.
* Registered `:vulnerable` and its alias `:vuln` in the `pseudoSelectors` map, making them available for queries. [[1]](diffhunk://#diff-292b5bbb2dd1597335498c71816844ee064ccc832bf80f3f5c7a1dbfe6c89125R65) [[2]](diffhunk://#diff-292b5bbb2dd1597335498c71816844ee064ccc832bf80f3f5c7a1dbfe6c89125R368-R369)

**Testing:**

* Added comprehensive tests for the `vulnerable` selector, covering normal operation, alias behavior, and error handling when the security archive is missing.
* Added a snapshot test to verify the selector outputs only packages with CVEs.

**Documentation:**

* Updated CLI documentation to describe the new `:vulnerable`/`:vuln` selectors, including usage examples.