### PR TITLE
chore(token): make token subcommand aliases more consistent

### DIFF
--- a/src/cli-sdk/src/commands/token.ts
+++ b/src/cli-sdk/src/commands/token.ts
@@ -188,6 +188,7 @@ export const command: CommandFn<
 > = async conf => {
   const reg = normalizeRegistryKey(conf.options.registry)
   switch (conf.positionals[0]) {
+    case 'ls':
     case 'list': {
       const rc = new RegistryClient(conf.options)
       const identity = conf.options.identity
@@ -242,6 +243,7 @@ export const command: CommandFn<
       break
     }
 
+    case 'remove':
     case 'rm': {
       await deleteToken(reg, conf.options.identity)
       break
@@ -250,7 +252,7 @@ export const command: CommandFn<
     default: {
       throw error('Invalid token subcommand', {
         found: conf.positionals[0],
-        validOptions: ['list', 'add', 'rm'],
+        validOptions: ['list', 'ls', 'add', 'rm', 'remove'],
         code: 'EUSAGE',
       })
     }

--- a/src/cli-sdk/test/commands/token.ts
+++ b/src/cli-sdk/test/commands/token.ts
@@ -106,6 +106,59 @@ t.test('preserves path for path-scoped registry', async t => {
   ])
 })
 
+t.test('alias: ls works like list', async t => {
+  const { command: cmd } = await t.mockImport<
+    typeof import('../../src/commands/token.ts')
+  >('../../src/commands/token.ts', {
+    '@vltpkg/registry-client': {
+      ...mockRegistryClient,
+      async getToken(): Promise<Token | undefined> {
+        return undefined
+      },
+      RegistryClient: class MockRegistryClient {
+        async scroll<T>(): Promise<T[]> {
+          return [] as T[]
+        }
+      },
+    },
+  })
+
+  const result = await cmd({
+    options: {
+      registry: 'https://registry.npmjs.org/',
+      registries: {},
+      identity: '',
+    },
+    positionals: ['ls'],
+  } as unknown as LoadedConfig)
+
+  t.equal(result?.identity, '')
+  t.equal(result?.registries.length, 1)
+})
+
+t.test('alias: remove works like rm', async t => {
+  const removeLog: string[][] = []
+  const { command: cmd } = await t.mockImport<
+    typeof import('../../src/commands/token.ts')
+  >('../../src/commands/token.ts', {
+    '@vltpkg/registry-client': {
+      ...mockRegistryClient,
+      async deleteToken(reg: string) {
+        removeLog.push(['delete', reg])
+      },
+    },
+  })
+
+  await cmd({
+    options: { registry: 'https://registry.vlt.javascript/' },
+    positionals: ['remove'],
+  } as LoadedConfig)
+
+  t.strictSame(removeLog, [
+    ['delete', 'https://registry.vlt.javascript'],
+  ])
+})
+
 t.test('invalid token sub command', async t => {
   await t.rejects(
     command({


### PR DESCRIPTION
This pull request adds support for additional command aliases to the token CLI, making it more user-friendly by allowing users to use either the short or long form of commands. It also updates the error handling to reflect the new valid options and adds tests to ensure the new aliases work as intended.

**Command alias support:**

* Added `ls` as an alias for the `list` subcommand in the `command` function in `token.ts`, allowing users to use either `list` or `ls` to list tokens.
* Added `remove` as an alias for the `rm` subcommand in the `command` function in `token.ts`, so users can use either `rm` or `remove` to delete tokens.
* Updated the error message for invalid subcommands to include the new aliases (`ls` and `remove`) in the list of valid options.

**Testing improvements:**

* Added tests to verify that the `ls` and `remove` aliases behave identically to `list` and `rm`, respectively, in `token.ts` tests.

Fixes: #1635