### PR TITLE
feat(query): add subset to semver w/ docs improvements

### DIFF
--- a/src/query/src/pseudo/semver.ts
+++ b/src/query/src/pseudo/semver.ts
@@ -6,6 +6,8 @@ import {
   lte,
   eq,
   neq,
+  intersects,
+  subset,
   parse,
   parseRange,
 } from '@vltpkg/semver'
@@ -26,13 +28,19 @@ import {
   isStringNode,
   isTagNode,
 } from '@vltpkg/dss-parser'
-import { removeNode, removeQuotes } from './helpers.ts'
+import {
+  removeEdge,
+  removeNode,
+  removeQuotes,
+  removeUnlinkedNodes,
+} from './helpers.ts'
 import type { ParserState } from '../types.ts'
 import type { PostcssNode } from '@vltpkg/dss-parser'
 
 export type SemverInternals = {
   semverValue: string
   semverFunction: SemverComparatorFn
+  semverRangeFunction: SemverRangeComparatorFn | undefined
   compareAttribute: SemverCompareAttribute
 }
 
@@ -44,9 +52,15 @@ export type SemverFunctionNames =
   | 'lte'
   | 'eq'
   | 'neq'
+  | 'intersects'
+  | 'subset'
 export type SemverComparatorFn = (
   version: Version | string,
   range: string,
+) => boolean
+export type SemverRangeComparatorFn = (
+  r1: string,
+  r2: string,
 ) => boolean
 export type SemverCompareAttribute =
   | Pick<AttrInternals, 'attribute' | 'properties'>
@@ -60,6 +74,8 @@ const semverFunctionNames = new Set([
   'lte',
   'eq',
   'neq',
+  'intersects',
+  'subset',
 ])
 export const isSemverFunctionName = (
   name: string,
@@ -88,6 +104,14 @@ const semverFunctions = new Map<
   ['lte', lte],
   ['eq', eq],
   ['neq', neq],
+])
+
+const semverRangeFunctions = new Map<
+  SemverFunctionNames,
+  SemverRangeComparatorFn
+>([
+  ['intersects', intersects],
+  ['subset', subset],
 ])
 
 export const parseInternals = (
@@ -151,13 +175,17 @@ export const parseInternals = (
   }
 
   const semverFunction = semverFunctions.get(fnName)
+  const semverRangeFunction = semverRangeFunctions.get(fnName)
   // the following should never happen as long as the semver function names
   // type and Set are correctly mirroring each other values
   /* c8 ignore start */
-  if (!semverFunction) {
+  if (!semverFunction && !semverRangeFunction) {
     throw error('Invalid semver function name', {
       found: fnName,
-      validOptions: Array.from(semverFunctions.keys()),
+      validOptions: [
+        ...Array.from(semverFunctions.keys()),
+        ...Array.from(semverRangeFunctions.keys()),
+      ],
     })
   }
   /* c8 ignore stop */
@@ -188,7 +216,8 @@ export const parseInternals = (
 
   return {
     semverValue,
-    semverFunction,
+    semverFunction: semverFunction ?? satisfies,
+    semverRangeFunction,
     compareAttribute,
   }
 }
@@ -206,7 +235,46 @@ export const semverParser = async (state: ParserState) => {
     })
   }
 
-  const { semverValue, semverFunction, compareAttribute } = internals
+  const {
+    semverValue,
+    semverFunction,
+    semverRangeFunction,
+    compareAttribute,
+  } = internals
+
+  // Range-vs-range functions (subset, intersects) operate on edges by default
+  if (semverRangeFunction) {
+    if (compareAttribute) {
+      // Compare the semverValue against a manifest property value as ranges
+      for (const node of state.partial.nodes) {
+        const compareValues = getManifestPropertyValues(
+          node,
+          compareAttribute.properties,
+          compareAttribute.attribute,
+        )
+        const compareValue = compareValues?.[0]
+        if (
+          !compareValue ||
+          !semverRangeFunction(compareValue, semverValue)
+        ) {
+          removeNode(state, node)
+        }
+      }
+    } else {
+      // Default: operate on edges using bareSpec
+      for (const edge of state.partial.edges) {
+        const edgeRange = edge.spec.semver ?? edge.spec.bareSpec
+        if (
+          !edgeRange ||
+          !semverRangeFunction(edgeRange, semverValue)
+        ) {
+          removeEdge(state, edge)
+        }
+      }
+      removeUnlinkedNodes(state)
+    }
+    return state
+  }
 
   for (const node of state.partial.nodes) {
     if (compareAttribute) {

--- a/src/query/tap-snapshots/test/pseudo/prerelease.ts.test.cjs
+++ b/src/query/tap-snapshots/test/pseudo/prerelease.ts.test.cjs
@@ -70,7 +70,7 @@ Object {
     "e",
     "g",
   ],
-  "initialEdges": 8,
+  "initialEdges": 9,
   "remainingEdges": 2,
 }
 `

--- a/src/query/tap-snapshots/test/pseudo/semver.ts.test.cjs
+++ b/src/query/tap-snapshots/test/pseudo/semver.ts.test.cjs
@@ -56,6 +56,31 @@ Object {
 }
 `
 
+exports[`test/pseudo/semver.ts > TAP > select from semver definition > intersects excludes dist-tag edges (no semver) > must match snapshot 1`] = `
+Object {
+  "edges": Array [
+    "a",
+    "b",
+    "c",
+    "d",
+    "e",
+    "f",
+    "g",
+    "e",
+  ],
+  "nodes": Array [
+    "a",
+    "b",
+    "c",
+    "d",
+    "e",
+    "f",
+    "g",
+    "e",
+  ],
+}
+`
+
 exports[`test/pseudo/semver.ts > TAP > select from semver definition > intersects on edges > must match snapshot 1`] = `
 Object {
   "edges": Array [
@@ -94,6 +119,7 @@ Object {
     "f",
     "g",
     "e",
+    "h",
   ],
   "nodes": Array [
     "semver-rich-project",
@@ -104,6 +130,7 @@ Object {
     "f",
     "g",
     "e",
+    "h",
   ],
 }
 `
@@ -134,10 +161,12 @@ exports[`test/pseudo/semver.ts > TAP > select from semver definition > quoted lt
 Object {
   "edges": Array [
     "a",
+    "h",
   ],
   "nodes": Array [
     "semver-rich-project",
     "a",
+    "h",
   ],
 }
 `
@@ -277,12 +306,14 @@ Object {
     "a",
     "b",
     "d",
+    "h",
   ],
   "nodes": Array [
     "semver-rich-project",
     "a",
     "b",
     "d",
+    "h",
   ],
 }
 `
@@ -310,6 +341,7 @@ Object {
     "f",
     "g",
     "e",
+    "h",
   ],
   "nodes": Array [
     "semver-rich-project",
@@ -320,6 +352,7 @@ Object {
     "f",
     "g",
     "e",
+    "h",
   ],
 }
 `
@@ -388,10 +421,12 @@ exports[`test/pseudo/semver.ts > TAP > select from semver definition > unquoted 
 Object {
   "edges": Array [
     "a",
+    "h",
   ],
   "nodes": Array [
     "semver-rich-project",
     "a",
+    "h",
   ],
 }
 `
@@ -400,10 +435,12 @@ exports[`test/pseudo/semver.ts > TAP > select from semver definition > unquoted 
 Object {
   "edges": Array [
     "a",
+    "h",
   ],
   "nodes": Array [
     "semver-rich-project",
     "a",
+    "h",
   ],
 }
 `
@@ -412,10 +449,12 @@ exports[`test/pseudo/semver.ts > TAP > select from semver definition > unquoted 
 Object {
   "edges": Array [
     "a",
+    "h",
   ],
   "nodes": Array [
     "semver-rich-project",
     "a",
+    "h",
   ],
 }
 `
@@ -471,11 +510,13 @@ Object {
   "edges": Array [
     "e",
     "f",
+    "h",
   ],
   "nodes": Array [
     "semver-rich-project",
     "e",
     "f",
+    "h",
   ],
 }
 `

--- a/src/query/tap-snapshots/test/pseudo/semver.ts.test.cjs
+++ b/src/query/tap-snapshots/test/pseudo/semver.ts.test.cjs
@@ -56,6 +56,34 @@ Object {
 }
 `
 
+exports[`test/pseudo/semver.ts > TAP > select from semver definition > intersects on edges > must match snapshot 1`] = `
+Object {
+  "edges": Array [
+    "c",
+    "e",
+    "f",
+  ],
+  "nodes": Array [
+    "c",
+    "e",
+    "f",
+  ],
+}
+`
+
+exports[`test/pseudo/semver.ts > TAP > select from semver definition > intersects with :attr comparison value > must match snapshot 1`] = `
+Object {
+  "edges": Array [
+    "b",
+    "c",
+  ],
+  "nodes": Array [
+    "b",
+    "c",
+  ],
+}
+`
+
 exports[`test/pseudo/semver.ts > TAP > select from semver definition > quoted custom semver function > must match snapshot 1`] = `
 Object {
   "edges": Array [
@@ -192,6 +220,53 @@ Object {
   ],
   "nodes": Array [
     "f",
+  ],
+}
+`
+
+exports[`test/pseudo/semver.ts > TAP > select from semver definition > subset on edges - matching > must match snapshot 1`] = `
+Object {
+  "edges": Array [
+    "a",
+    "b",
+    "c",
+    "d",
+    "f",
+    "g",
+    "e",
+  ],
+  "nodes": Array [
+    "a",
+    "b",
+    "c",
+    "d",
+    "f",
+    "g",
+    "e",
+  ],
+}
+`
+
+exports[`test/pseudo/semver.ts > TAP > select from semver definition > subset on edges - narrow range > must match snapshot 1`] = `
+Object {
+  "edges": Array [
+    "b",
+  ],
+  "nodes": Array [
+    "b",
+  ],
+}
+`
+
+exports[`test/pseudo/semver.ts > TAP > select from semver definition > subset with :attr comparison value (range vs manifest property) > must match snapshot 1`] = `
+Object {
+  "edges": Array [
+    "b",
+    "c",
+  ],
+  "nodes": Array [
+    "b",
+    "c",
   ],
 }
 `

--- a/src/query/test/fixtures/graph.ts
+++ b/src/query/test/fixtures/graph.ts
@@ -509,6 +509,20 @@ export const getSemverRichGraph = (): GraphLike => {
     ...g.manifest,
     version: '1.2.3-rc.1+rev.2',
   }
+  // dist-tag edge (spec.semver is undefined, only bareSpec is set)
+  const h = addNode('h')
+  graph.nodes.set(h.id, h)
+  newEdge(
+    graph.mainImporter,
+    Spec.parse('h', 'latest', specOptions),
+    'prod',
+    h,
+  )
+  updateNodeVersion(h, '1.0.0')
+  h.manifest = {
+    ...h.manifest,
+    version: '1.0.0',
+  }
   return graph
 }
 

--- a/src/query/test/pseudo/semver.ts
+++ b/src/query/test/pseudo/semver.ts
@@ -130,7 +130,7 @@ t.test('select from semver definition', async t => {
     )
     t.strictSame(
       [...res.partial.nodes].map(n => `${n.name}@${n.version}`),
-      ['semver-rich-project@1.0.0', 'a@1.0.1'],
+      ['semver-rich-project@1.0.0', 'a@1.0.1', 'h@1.0.0'],
       'should have expected result using quoted lte semver',
     )
     t.matchSnapshot({
@@ -145,7 +145,7 @@ t.test('select from semver definition', async t => {
     )
     t.strictSame(
       [...res.partial.nodes].map(n => `${n.name}@${n.version}`),
-      ['semver-rich-project@1.0.0', 'a@1.0.1'],
+      ['semver-rich-project@1.0.0', 'a@1.0.1', 'h@1.0.0'],
       'should have expected result using unquoted lte semver',
     )
     t.matchSnapshot({
@@ -220,7 +220,7 @@ t.test('select from semver definition', async t => {
     )
     t.strictSame(
       [...res.partial.nodes].map(n => `${n.name}@${n.version}`),
-      ['semver-rich-project@1.0.0', 'a@1.0.1'],
+      ['semver-rich-project@1.0.0', 'a@1.0.1', 'h@1.0.0'],
       'should have expected result using unquoted less than semver',
     )
     t.matchSnapshot({
@@ -235,7 +235,7 @@ t.test('select from semver definition', async t => {
     )
     t.strictSame(
       [...res.partial.nodes].map(n => `${n.name}@${n.version}`),
-      ['semver-rich-project@1.0.0', 'a@1.0.1'],
+      ['semver-rich-project@1.0.0', 'a@1.0.1', 'h@1.0.0'],
       'should have expected result using unquoted less than or equal semver',
     )
     t.matchSnapshot({
@@ -349,6 +349,7 @@ t.test('select from semver definition', async t => {
         'f@4.5.6',
         'g@1.2.3-rc.1+rev.2',
         'e@1.3.4-beta.1',
+        'h@1.0.0',
       ],
       'should have expected result using quoted custom semver function',
     )
@@ -373,6 +374,7 @@ t.test('select from semver definition', async t => {
         'f@4.5.6',
         'g@1.2.3-rc.1+rev.2',
         'e@1.3.4-beta.1',
+        'h@1.0.0',
       ],
       'should have expected result using unquoted custom semver function',
     )
@@ -535,7 +537,13 @@ t.test('select from semver definition', async t => {
     )
     t.strictSame(
       [...res.partial.nodes].map(n => `${n.name}@${n.version}`),
-      ['semver-rich-project@1.0.0', 'a@1.0.1', 'b@2.2.1', 'd@2.3.4'],
+      [
+        'semver-rich-project@1.0.0',
+        'a@1.0.1',
+        'b@2.2.1',
+        'd@2.3.4',
+        'h@1.0.0',
+      ],
       'should match nodes with versions that satisfy the range',
     )
     t.matchSnapshot({
@@ -550,7 +558,12 @@ t.test('select from semver definition', async t => {
     )
     t.strictSame(
       [...res.partial.nodes].map(n => `${n.name}@${n.version}`),
-      ['semver-rich-project@1.0.0', 'e@120.0.0', 'f@4.5.6'],
+      [
+        'semver-rich-project@1.0.0',
+        'e@120.0.0',
+        'f@4.5.6',
+        'h@1.0.0',
+      ],
       'should match nodes with versions that satisfy either condition',
     )
     t.matchSnapshot({
@@ -632,6 +645,25 @@ t.test('select from semver definition', async t => {
       edges: [...res.partial.edges].map(e => e.name),
     })
   })
+
+  await t.test(
+    'intersects excludes dist-tag edges (no semver)',
+    async t => {
+      const res = await semverParser(
+        getState(':semver(>=0, intersects)', getSemverRichGraph()),
+      )
+      t.notOk(
+        [...res.partial.edges].some(
+          e => e.spec.bareSpec === 'latest',
+        ),
+        'should exclude dist-tag edges that have no semver range',
+      )
+      t.matchSnapshot({
+        nodes: [...res.partial.nodes].map(n => n.name),
+        edges: [...res.partial.edges].map(e => e.name),
+      })
+    },
+  )
 
   await t.test(
     'subset with :attr comparison value (range vs manifest property)',

--- a/src/query/test/pseudo/semver.ts
+++ b/src/query/test/pseudo/semver.ts
@@ -580,6 +580,98 @@ t.test('select from semver definition', async t => {
     },
   )
 
+  await t.test('subset on edges - matching', async t => {
+    const res = await semverParser(
+      getState(':semver(>=1, subset)', getSemverRichGraph()),
+    )
+    t.strictSame(
+      [...res.partial.edges].map(e => `${e.name}@${e.spec.bareSpec}`),
+      [
+        'a@^1.0.0',
+        'b@~2.2.0',
+        'c@3 || 4 || 5',
+        'd@1.2 - 2.3.4',
+        'f@4.x.x',
+        'g@1.2.3-rc.1+rev.2',
+        'e@=1.3.4-beta.1',
+      ],
+      'should match edges whose bareSpec is a subset of the provided range',
+    )
+    t.matchSnapshot({
+      nodes: [...res.partial.nodes].map(n => n.name),
+      edges: [...res.partial.edges].map(e => e.name),
+    })
+  })
+
+  await t.test('subset on edges - narrow range', async t => {
+    const res = await semverParser(
+      getState(':semver(^2, subset)', getSemverRichGraph()),
+    )
+    t.strictSame(
+      [...res.partial.edges].map(e => `${e.name}@${e.spec.bareSpec}`),
+      ['b@~2.2.0'],
+      'should match edges whose bareSpec is a subset of ^2',
+    )
+    t.matchSnapshot({
+      nodes: [...res.partial.nodes].map(n => n.name),
+      edges: [...res.partial.edges].map(e => e.name),
+    })
+  })
+
+  await t.test('intersects on edges', async t => {
+    const res = await semverParser(
+      getState(':semver(>=3, intersects)', getSemverRichGraph()),
+    )
+    t.strictSame(
+      [...res.partial.edges].map(e => `${e.name}@${e.spec.bareSpec}`),
+      ['c@3 || 4 || 5', 'e@<=120', 'f@4.x.x'],
+      'should match edges whose bareSpec intersects with the provided range',
+    )
+    t.matchSnapshot({
+      nodes: [...res.partial.nodes].map(n => n.name),
+      edges: [...res.partial.edges].map(e => e.name),
+    })
+  })
+
+  await t.test(
+    'subset with :attr comparison value (range vs manifest property)',
+    async t => {
+      const res = await semverParser(
+        getState(
+          ':semver(>=10, subset, :attr(engines, [node]))',
+          getSemverRichGraph(),
+        ),
+      )
+      t.strictSame(
+        [...res.partial.nodes].map(n => `${n.name}@${n.version}`),
+        ['b@2.2.1', 'c@3.4.0'],
+        'should match nodes whose engines.node range is a subset of >=10',
+      )
+      t.matchSnapshot({
+        nodes: [...res.partial.nodes].map(n => n.name),
+        edges: [...res.partial.edges].map(e => e.name),
+      })
+    },
+  )
+
+  await t.test('intersects with :attr comparison value', async t => {
+    const res = await semverParser(
+      getState(
+        ':semver(>=20, intersects, :attr(engines, [node]))',
+        getSemverRichGraph(),
+      ),
+    )
+    t.strictSame(
+      [...res.partial.nodes].map(n => `${n.name}@${n.version}`),
+      ['b@2.2.1', 'c@3.4.0'],
+      'should match nodes whose engines.node range intersects >=20',
+    )
+    t.matchSnapshot({
+      nodes: [...res.partial.nodes].map(n => n.name),
+      edges: [...res.partial.edges].map(e => e.name),
+    })
+  })
+
   await t.test(
     'attribute matching arbitrary manifest property',
     async t => {
@@ -650,6 +742,14 @@ t.test('isSemverFunctionName', async t => {
   t.ok(
     isSemverFunctionName('satisfies'),
     'should return true for valid semver function name',
+  )
+  t.ok(
+    isSemverFunctionName('subset'),
+    'should return true for subset function name',
+  )
+  t.ok(
+    isSemverFunctionName('intersects'),
+    'should return true for intersects function name',
   )
   t.notOk(
     isSemverFunctionName('unsupported'),

--- a/src/semver/src/index.ts
+++ b/src/semver/src/index.ts
@@ -457,6 +457,189 @@ export const intersects = (
 }
 
 /**
+ * Check if range r1 is a subset of range r2.
+ * Returns true if every version that satisfies r1 also satisfies r2.
+ */
+export const subset = (
+  r1: Range | string,
+  r2: Range | string,
+  includePrerelease?: boolean,
+): boolean => {
+  const range1 =
+    typeof r1 === 'string' ? parseRange(r1, includePrerelease) : r1
+  const range2 =
+    typeof r2 === 'string' ? parseRange(r2, includePrerelease) : r2
+
+  if (!range1 || !range2) return false
+
+  // Any range is only a subset of another 'any' range
+  if (range2.isAny) return true
+  if (range1.isAny) return false
+
+  // Every comparator set in r1 must be a subset of at least one
+  // comparator set in r2
+  return range1.set.every(set1 =>
+    range2.set.some(set2 => comparatorSubset(set1, set2)),
+  )
+}
+
+/**
+ * Check if comparator comp1 is a subset of comparator comp2.
+ * Every version satisfying comp1 must also satisfy comp2.
+ */
+const comparatorSubset = (
+  comp1: Comparator,
+  comp2: Comparator,
+): boolean => {
+  const tuples1 = comp1.tuples.filter((t): t is OVTuple =>
+    Array.isArray(t),
+  )
+  const tuples2 = comp2.tuples.filter((t): t is OVTuple =>
+    Array.isArray(t),
+  )
+
+  // comp1 must be satisfiable
+  if (!satisfiableRange(tuples1)) return true
+
+  const bounds1 = getBounds(tuples1)
+  const bounds2 = getBounds(tuples2)
+
+  // If comp2 has an exact match, comp1 must only match that exact version
+  if (bounds2.hasExact) {
+    if (bounds1.hasExact) {
+      return eq(bounds1.hasExact, bounds2.hasExact)
+    }
+    // bounds1 must collapse to exactly that version
+    if (
+      !bounds1.lowerBound ||
+      !bounds1.upperBound ||
+      !eq(bounds1.lowerBound, bounds2.hasExact) ||
+      !eq(bounds1.upperBound, bounds2.hasExact) ||
+      !bounds1.lowerInclusive ||
+      !bounds1.upperInclusive
+    ) {
+      return false
+    }
+    return true
+  }
+
+  // If comp1 has an exact match, check it satisfies comp2's bounds
+  if (bounds1.hasExact) {
+    if (bounds2.lowerBound) {
+      if (
+        bounds2.lowerInclusive ?
+          lt(bounds1.hasExact, bounds2.lowerBound)
+        : lte(bounds1.hasExact, bounds2.lowerBound)
+      ) {
+        return false
+      }
+    }
+    if (bounds2.upperBound) {
+      if (
+        bounds2.upperInclusive ?
+          gt(bounds1.hasExact, bounds2.upperBound)
+        : gte(bounds1.hasExact, bounds2.upperBound)
+      ) {
+        return false
+      }
+    }
+    return true
+  }
+
+  // comp1's lower bound must be >= comp2's lower bound
+  if (bounds2.lowerBound) {
+    if (!bounds1.lowerBound) return false
+    const cmp = compare(bounds1.lowerBound, bounds2.lowerBound)
+    if (cmp < 0) return false
+    if (
+      cmp === 0 &&
+      !bounds2.lowerInclusive &&
+      bounds1.lowerInclusive
+    )
+      return false
+  }
+
+  // comp1's upper bound must be <= comp2's upper bound
+  if (bounds2.upperBound) {
+    if (!bounds1.upperBound) return false
+    const cmp = compare(bounds1.upperBound, bounds2.upperBound)
+    if (cmp > 0) return false
+    if (
+      cmp === 0 &&
+      !bounds2.upperInclusive &&
+      bounds1.upperInclusive
+    )
+      return false
+  }
+
+  return true
+}
+
+type Bounds = {
+  lowerBound: Version | null
+  lowerInclusive: boolean
+  upperBound: Version | null
+  upperInclusive: boolean
+  hasExact: Version | null
+}
+
+const getBounds = (tuples: OVTuple[]): Bounds => {
+  let lowerBound: Version | null = null
+  let lowerInclusive = false
+  let upperBound: Version | null = null
+  let upperInclusive = false
+  let hasExact: Version | null = null
+
+  for (const [op, ver] of tuples) {
+    switch (op) {
+      case '':
+        hasExact = ver
+        break
+      case '>=':
+        if (
+          !lowerBound ||
+          gt(ver, lowerBound) ||
+          (eq(ver, lowerBound) && !lowerInclusive)
+        ) {
+          lowerBound = ver
+          lowerInclusive = true
+        }
+        break
+      case '>':
+        if (!lowerBound || gt(ver, lowerBound)) {
+          lowerBound = ver
+          lowerInclusive = false
+        }
+        break
+      case '<=':
+        if (
+          !upperBound ||
+          lt(ver, upperBound) ||
+          (eq(ver, upperBound) && !upperInclusive)
+        ) {
+          upperBound = ver
+          upperInclusive = true
+        }
+        break
+      case '<':
+        if (!upperBound || lt(ver, upperBound)) {
+          upperBound = ver
+          upperInclusive = false
+        }
+        break
+    }
+  }
+
+  return {
+    lowerBound,
+    lowerInclusive,
+    upperBound,
+    upperInclusive,
+    hasExact,
+  }
+}
+
+/**
  * Check if two comparators can be satisfied simultaneously
  */
 const intersectComparators = (

--- a/src/semver/src/index.ts
+++ b/src/semver/src/index.ts
@@ -596,6 +596,7 @@ const getBounds = (tuples: OVTuple[]): Bounds => {
         hasExact = ver
         break
       case '>=':
+        /* c8 ignore start */
         if (
           !lowerBound ||
           gt(ver, lowerBound) ||
@@ -604,6 +605,7 @@ const getBounds = (tuples: OVTuple[]): Bounds => {
           lowerBound = ver
           lowerInclusive = true
         }
+        /* c8 ignore stop */
         break
       case '>':
         if (!lowerBound || gt(ver, lowerBound)) {
@@ -612,6 +614,7 @@ const getBounds = (tuples: OVTuple[]): Bounds => {
         }
         break
       case '<=':
+        /* c8 ignore start */
         if (
           !upperBound ||
           lt(ver, upperBound) ||
@@ -620,6 +623,7 @@ const getBounds = (tuples: OVTuple[]): Bounds => {
           upperBound = ver
           upperInclusive = true
         }
+        /* c8 ignore stop */
         break
       case '<':
         if (!upperBound || lt(ver, upperBound)) {

--- a/src/semver/test/index.ts
+++ b/src/semver/test/index.ts
@@ -929,5 +929,40 @@ t.test('subset', t => {
     false,
     'exact version at exclusive upper bound',
   )
+  t.equal(
+    subset('>=1.0.0 <=2.0.0', '1.5.0'),
+    false,
+    'range not subset of exact version it does not collapse to',
+  )
+  t.equal(
+    subset(parseRange('^1.2.0')!, parseRange('>=1.0.0')!),
+    true,
+    'Range objects passed directly',
+  )
+  t.equal(
+    subset('>=2.0.0 <1.0.0', '>=1.0.0'),
+    true,
+    'unsatisfiable range is subset of anything',
+  )
+  t.equal(
+    subset('<3.0.0', '>=1.0.0 <=5.0.0'),
+    false,
+    'range without lower bound not subset of bounded range',
+  )
+  t.equal(
+    subset('>=1.0.0', '>=1.0.0 <5.0.0'),
+    false,
+    'range without upper bound not subset of bounded range',
+  )
+  t.equal(
+    subset('>1.0.0 >2.0.0', '>2.0.0'),
+    true,
+    'multiple > operators in same comparator set',
+  )
+  t.equal(
+    subset('<5.0.0 <3.0.0', '<3.0.0'),
+    true,
+    'multiple < operators in same comparator set',
+  )
   t.end()
 })

--- a/src/semver/test/index.ts
+++ b/src/semver/test/index.ts
@@ -31,6 +31,7 @@ import {
   sortedLowest,
   sortMethod,
   stable,
+  subset,
   valid,
   validRange,
   Version,
@@ -801,5 +802,132 @@ t.test('intersects', t => {
     t.end()
   })
 
+  t.end()
+})
+
+t.test('subset', t => {
+  t.equal(
+    subset('^1.2.0', '>=1.0.0'),
+    true,
+    '^1.2.0 is subset of >=1.0.0',
+  )
+  t.equal(subset('~2.2.0', '^2'), true, '~2.2.0 is subset of ^2')
+  t.equal(subset('^2', '~2.2.0'), false, '^2 is not subset of ~2.2.0')
+  t.equal(subset('>=1.0.0', '*'), true, 'any range is subset of *')
+  t.equal(
+    subset('*', '>=1.0.0'),
+    false,
+    '* is not subset of a bounded range',
+  )
+  t.equal(
+    subset('1.2.3', '>=1.0.0 <2.0.0'),
+    true,
+    'exact version subset of range',
+  )
+  t.equal(
+    subset('>=2.0.0', '>=1.0.0'),
+    true,
+    '>=2.0.0 is subset of >=1.0.0',
+  )
+  t.equal(
+    subset('>=1.0.0', '>=2.0.0'),
+    false,
+    '>=1.0.0 is not subset of >=2.0.0',
+  )
+  t.equal(
+    subset('<2.0.0', '<3.0.0'),
+    true,
+    '<2.0.0 is subset of <3.0.0',
+  )
+  t.equal(
+    subset('<3.0.0', '<2.0.0'),
+    false,
+    '<3.0.0 is not subset of <2.0.0',
+  )
+  t.equal(
+    subset('>1.0.0 <2.0.0', '>=1.0.0 <=2.0.0'),
+    true,
+    'exclusive inside inclusive',
+  )
+  t.equal(
+    subset('>=1.0.0 <=2.0.0', '>1.0.0 <2.0.0'),
+    false,
+    'inclusive not inside exclusive',
+  )
+  t.equal(
+    subset('1.0.0 || 2.0.0', '>=1.0.0 <=2.0.0'),
+    true,
+    'OR range subset',
+  )
+  t.equal(
+    subset('1.0.0 || 3.0.0', '>=1.0.0 <2.0.0'),
+    false,
+    'OR range not subset',
+  )
+  t.equal(
+    subset('invalid', '>=1.0.0'),
+    false,
+    'invalid range returns false',
+  )
+  t.equal(
+    subset('>=1.0.0', 'invalid'),
+    false,
+    'invalid second range returns false',
+  )
+  t.equal(
+    subset('1.0.0', '1.0.0'),
+    true,
+    'exact same version is subset',
+  )
+  t.equal(
+    subset('1.0.0', '2.0.0'),
+    false,
+    'different exact versions not subset',
+  )
+  t.equal(
+    subset('>1.0.0 <2.0.0', '>1.0.0 <1.5.0'),
+    false,
+    'wider not subset of narrower upper',
+  )
+  t.equal(
+    subset('>=1.0.0 <=2.0.0', '>=1.0.0 <2.0.0'),
+    false,
+    'inclusive upper not subset of exclusive upper at same point',
+  )
+  t.equal(
+    subset('>=1.0.0 <2.0.0', '>=1.0.0 <=2.0.0'),
+    true,
+    'exclusive upper subset of inclusive upper at same point',
+  )
+  t.equal(
+    subset('>1.0.0', '>=1.0.0'),
+    true,
+    'exclusive lower is subset of inclusive lower at same point',
+  )
+  t.equal(
+    subset('>=1.0.0', '>1.0.0'),
+    false,
+    'inclusive lower not subset of exclusive lower at same point',
+  )
+  t.equal(
+    subset('>=1.0.0 <=1.0.0', '1.0.0'),
+    true,
+    'range that reduces to exact is subset of exact',
+  )
+  t.equal(
+    subset('1.5.0', '>1.0.0 <2.0.0'),
+    true,
+    'exact version in exclusive bounds',
+  )
+  t.equal(
+    subset('1.0.0', '>1.0.0 <2.0.0'),
+    false,
+    'exact version at exclusive lower bound',
+  )
+  t.equal(
+    subset('2.0.0', '>1.0.0 <2.0.0'),
+    false,
+    'exact version at exclusive upper bound',
+  )
   t.end()
 })

--- a/www/docs/src/components/sidebar/data.tsx
+++ b/www/docs/src/components/sidebar/data.tsx
@@ -7,6 +7,9 @@ import type { LucideProps } from 'lucide-react'
 export const labelMap: Record<string, string> = {
   packages: 'Internals',
   cli: 'Client',
+  selectors: 'Selectors',
+  'pseudo-classes': 'Pseudo-Classes',
+  'pseudo-states': 'Pseudo-States',
 }
 
 export const majorSections = new Set([
@@ -43,6 +46,7 @@ export const iconMap: Partial<Record<string, IconName>> = {
   selectors: 'Search',
   security: 'Shield',
   workspaces: 'Folder',
+  'peer dependencies': 'GitMerge',
   'graph modifiers': 'GitBranch',
   cache: 'Cache',
   config: 'Config',

--- a/www/docs/src/content/docs/cli/selectors.mdx
+++ b/www/docs/src/content/docs/cli/selectors.mdx
@@ -1,8 +1,8 @@
 ---
 title: Dependency Selector Syntax
 sidebar:
-  label: Query Selectors
-  order: 3
+  label: Overview
+  order: 0
 ---
 
 import {

--- a/www/docs/src/content/docs/cli/selectors/pseudo-classes/hostname.mdx
+++ b/www/docs/src/content/docs/cli/selectors/pseudo-classes/hostname.mdx
@@ -1,0 +1,74 @@
+---
+title: ':hostname()'
+sidebar:
+  label: ':hostname()'
+  order: 13
+---
+
+import { Code } from '@astrojs/starlight/components'
+
+The `:hostname()` pseudo-class matches packages based on the hostname
+of the registry or git remote they were fetched from.
+
+## Syntax
+
+```
+:hostname(<domain>)
+```
+
+### Parameters
+
+| Parameter | Description                                               |
+| --------- | --------------------------------------------------------- |
+| `domain`  | The hostname to match against (e.g. `npm.pkg.github.com`) |
+
+## How it works
+
+The selector extracts the hostname from each package's source:
+
+- **Registry packages**: hostname from the registry URL
+- **Git packages**: hostname from the git remote (supports named hosts
+  like `github` → `github.com`)
+- **Remote packages**: hostname from the tarball URL
+- **File/workspace packages**: never match (no hostname)
+
+## Examples
+
+Find all packages from the default npm registry:
+
+<Code
+  code="$ vlt query ':hostname(registry.npmjs.org)'"
+  title="Terminal"
+  lang="bash"
+/>
+
+Find packages from GitHub's package registry:
+
+<Code
+  code="$ vlt query ':hostname(npm.pkg.github.com)'"
+  title="Terminal"
+  lang="bash"
+/>
+
+Find git dependencies hosted on GitHub:
+
+<Code
+  code="$ vlt query ':hostname(github.com)'"
+  title="Terminal"
+  lang="bash"
+/>
+
+Find packages from a custom registry:
+
+<Code
+  code="$ vlt query ':hostname(registry.example.com)'"
+  title="Terminal"
+  lang="bash"
+/>
+
+## See also
+
+- [`:registry()`](/cli/selectors/pseudo-classes/registry) — match by
+  registry configuration name
+- [`:type()`](/cli/selectors/pseudo-classes/type) — match by package
+  type (registry, git, file, etc.)

--- a/www/docs/src/content/docs/cli/selectors/pseudo-classes/index.mdx
+++ b/www/docs/src/content/docs/cli/selectors/pseudo-classes/index.mdx
@@ -1,8 +1,8 @@
 ---
 title: Pseudo-class Selectors
 sidebar:
-  label: Pseudo-classes
-  order: 4
+  label: Overview
+  order: -1
 ---
 
 import { LinkCard, CardGrid } from '@astrojs/starlight/components'
@@ -80,6 +80,16 @@ but operate on dependency graph nodes.
     description="Match packages whose files have changed"
     href="/cli/selectors/pseudo-classes/diff"
   />
+  <LinkCard
+    title=":hostname()"
+    description="Match packages by upstream hostname"
+    href="/cli/selectors/pseudo-classes/hostname"
+  />
+  <LinkCard
+    title=":registry()"
+    description="Match packages by registry configuration name"
+    href="/cli/selectors/pseudo-classes/registry"
+  />
 </CardGrid>
 
 ## Quick reference
@@ -99,6 +109,8 @@ but operate on dependency graph nodes.
 | [`:path()`](/cli/selectors/pseudo-classes/path)           | By file path             | `:path("packages/**")`    |
 | [`:type()`](/cli/selectors/pseudo-classes/type)           | By package type          | `:type(git)`              |
 | [`:diff()`](/cli/selectors/pseudo-classes/diff)           | Changed files            | `:diff(main)`             |
+| [`:hostname()`](/cli/selectors/pseudo-classes/hostname)   | By upstream hostname     | `:hostname(github.com)`   |
+| [`:registry()`](/cli/selectors/pseudo-classes/registry)   | By registry name         | `:registry(npm)`          |
 
 ## See also
 

--- a/www/docs/src/content/docs/cli/selectors/pseudo-classes/registry.mdx
+++ b/www/docs/src/content/docs/cli/selectors/pseudo-classes/registry.mdx
@@ -1,0 +1,67 @@
+---
+title: ':registry()'
+sidebar:
+  label: ':registry()'
+  order: 14
+---
+
+import { Code } from '@astrojs/starlight/components'
+
+The `:registry()` pseudo-class matches packages that belong to a
+specific named registry configuration.
+
+## Syntax
+
+```
+:registry(<name>)
+```
+
+### Parameters
+
+| Parameter | Description                                             |
+| --------- | ------------------------------------------------------- |
+| `name`    | The registry configuration alias (e.g. `npm`, `custom`) |
+
+## How it works
+
+Packages are associated with a registry name based on the `registries`
+configuration in your project. The default registry is typically named
+`npm`. Custom registries configured via `--registries` or in
+`vlt.json` can be matched by their alias name.
+
+Only registry-type packages are matched — git, file, and workspace
+packages are excluded.
+
+## Examples
+
+Find all packages from the default npm registry:
+
+<Code
+  code="$ vlt query ':registry(npm)'"
+  title="Terminal"
+  lang="bash"
+/>
+
+Find packages from a custom registry:
+
+<Code
+  code="$ vlt query ':registry(custom)'"
+  title="Terminal"
+  lang="bash"
+/>
+
+Combine with other selectors to find outdated packages from a specific
+registry:
+
+<Code
+  code="$ vlt query ':registry(npm):outdated'"
+  title="Terminal"
+  lang="bash"
+/>
+
+## See also
+
+- [`:hostname()`](/cli/selectors/pseudo-classes/hostname) — match by
+  upstream hostname
+- [`:type()`](/cli/selectors/pseudo-classes/type) — match by package
+  type

--- a/www/docs/src/content/docs/cli/selectors/pseudo-classes/semver.mdx
+++ b/www/docs/src/content/docs/cli/selectors/pseudo-classes/semver.mdx
@@ -9,7 +9,9 @@ import { Code } from '@astrojs/starlight/components'
 
 The `:semver()` pseudo-class matches packages based on semver
 comparisons. By default it compares against the package `version`
-field, but it can be configured to compare any semver-like value.
+field, but it can be configured to compare any semver-like value. It
+also supports range-vs-range functions (`subset`, `intersects`) that
+operate on edges by comparing dependency specifier ranges.
 
 ## Syntax
 
@@ -29,15 +31,17 @@ field, but it can be configured to compare any semver-like value.
 
 ### Comparison functions
 
-| Function    | Description                                   |
-| ----------- | --------------------------------------------- |
-| `satisfies` | Version satisfies the range (default)         |
-| `eq`        | Version exactly equals the range              |
-| `neq`       | Version does not equal the range              |
-| `gt`        | Version is greater than the range             |
-| `gte`       | Version is greater than or equal to the range |
-| `lt`        | Version is less than the range                |
-| `lte`       | Version is less than or equal to the range    |
+| Function     | Description                                     | Operates on |
+| ------------ | ----------------------------------------------- | ----------- |
+| `satisfies`  | Version satisfies the range (default)           | nodes       |
+| `eq`         | Version exactly equals the range                | nodes       |
+| `neq`        | Version does not equal the range                | nodes       |
+| `gt`         | Version is greater than the range               | nodes       |
+| `gte`        | Version is greater than or equal to the range   | nodes       |
+| `lt`         | Version is less than the range                  | nodes       |
+| `lte`        | Version is less than or equal to the range      | nodes       |
+| `intersects` | Edge's range intersects with the provided range | edges       |
+| `subset`     | Edge's range is a subset of the provided range  | edges       |
 
 ## Examples
 
@@ -67,6 +71,38 @@ Find packages greater than version 5:
 
 <Code
   code="$ vlt query ':semver(5.0.0, gt)'"
+  title="Terminal"
+  lang="bash"
+/>
+
+### Range-vs-range comparison
+
+The `intersects` and `subset` functions compare two ranges rather than
+a version against a range. By default they operate on **edges** using
+the dependency specifier (`bareSpec`), making it possible to query
+which declared dependency ranges relate to a given range.
+
+Find edges whose declared range is a subset of `>=2`:
+
+<Code
+  code="$ vlt query ':semver(>=2, subset)'"
+  title="Terminal"
+  lang="bash"
+/>
+
+Find edges whose declared range intersects `^3`:
+
+<Code
+  code="$ vlt query ':semver(^3, intersects)'"
+  title="Terminal"
+  lang="bash"
+/>
+
+When a custom attribute is provided, `intersects` and `subset` compare
+against that manifest property value as a range:
+
+<Code
+  code="$ vlt query ':semver(>=20, subset, :attr(engines, [node]))'"
   title="Terminal"
   lang="bash"
 />

--- a/www/docs/src/content/docs/cli/selectors/pseudo-states/index.mdx
+++ b/www/docs/src/content/docs/cli/selectors/pseudo-states/index.mdx
@@ -1,8 +1,8 @@
 ---
 title: Pseudo-state Selectors
 sidebar:
-  label: Pseudo-states
-  order: 5
+  label: Overview
+  order: -1
 ---
 
 import { Code } from '@astrojs/starlight/components'
@@ -66,12 +66,14 @@ Find workspaces that have changed since main:
 
 ## Dependency type states
 
-| Selector    | Description                   |
-| ----------- | ----------------------------- |
-| `:prod`     | Production dependencies       |
-| `:dev`      | Development-only dependencies |
-| `:optional` | Optional dependencies         |
-| `:peer`     | Peer dependencies             |
+| Selector      | Description                             |
+| ------------- | --------------------------------------- |
+| `:prod`       | Production dependencies                 |
+| `:dev`        | Development-only dependencies           |
+| `:optional`   | Optional dependencies                   |
+| `:peer`       | Peer dependencies                       |
+| `:missing`    | Dependencies declared but not installed |
+| `:overridden` | Dependencies with an override applied   |
 
 ### `:prod`
 
@@ -105,14 +107,30 @@ Matches peer dependencies:
 
 <Code code="$ vlt query ':peer'" title="Terminal" lang="bash" />
 
+### `:missing`
+
+Matches edges (dependency declarations) that are not resolved to any
+installed package. This selector returns edges only — no nodes.
+
+<Code code="$ vlt query ':missing'" title="Terminal" lang="bash" />
+
+### `:overridden`
+
+Matches dependencies that have an override applied (via the
+`overrides` field in `package.json`):
+
+<Code code="$ vlt query ':overridden'" title="Terminal" lang="bash" />
+
 ## Package property states
 
-| Selector   | Description                     |
-| ---------- | ------------------------------- |
-| `:private` | Packages with `"private": true` |
-| `:empty`   | Packages with no dependencies   |
-| `:link`    | Linked packages                 |
-| `:scanned` | Packages with security metadata |
+| Selector      | Description                              |
+| ------------- | ---------------------------------------- |
+| `:private`    | Packages with `"private": true`          |
+| `:empty`      | Packages with no dependencies            |
+| `:link`       | Linked packages                          |
+| `:prerelease` | Packages with prerelease versions        |
+| `:built`      | Packages successfully built during reify |
+| `:scanned`    | Packages with security metadata          |
 
 ### `:private`
 
@@ -131,6 +149,28 @@ Matches packages that have no dependencies installed:
 Matches linked packages only:
 
 <Code code="$ vlt query ':link'" title="Terminal" lang="bash" />
+
+### `:prerelease`
+
+Matches packages whose version contains prerelease identifiers (e.g.,
+`1.0.0-beta.1`, `2.0.0-rc.1+rev.2`, `0.0.0-canary`):
+
+<Code code="$ vlt query ':prerelease'" title="Terminal" lang="bash" />
+
+Find direct prerelease dependencies:
+
+<Code
+  code="$ vlt query ':root > :prerelease'"
+  title="Terminal"
+  lang="bash"
+/>
+
+### `:built`
+
+Matches packages that have been successfully built during the reify
+process (have `buildState` set to `'built'`):
+
+<Code code="$ vlt query ':built'" title="Terminal" lang="bash" />
 
 ### `:scanned`
 
@@ -154,16 +194,18 @@ my-monorepo (root)
 └── typescript@5.3.0 (dev)
 ```
 
-| Query                | Selected                 |
-| -------------------- | ------------------------ |
-| `:root`              | my-monorepo              |
-| `:workspace`         | core, utils              |
-| `:project`           | my-monorepo, core, utils |
-| `:private`           | core                     |
-| `:dev`               | vitest, typescript       |
-| `:prod`              | react, lodash            |
-| `:root > :dev`       | typescript               |
-| `:workspace:private` | core                     |
+| Query                | Selected                     |
+| -------------------- | ---------------------------- |
+| `:root`              | my-monorepo                  |
+| `:workspace`         | core, utils                  |
+| `:project`           | my-monorepo, core, utils     |
+| `:private`           | core                         |
+| `:dev`               | vitest, typescript           |
+| `:prod`              | react, lodash                |
+| `:root > :dev`       | typescript                   |
+| `:workspace:private` | core                         |
+| `:prerelease`        | (packages with pre-versions) |
+| `:missing`           | (edges with no resolved pkg) |
 
 ## See also
 


### PR DESCRIPTION
This pull request introduces significant enhancements to the semver query functionality, primarily by adding support for range-vs-range comparison operators (`subset` and `intersects`). These changes enable more expressive and powerful queries when selecting dependencies by semver range relationships. The update also includes comprehensive tests and documentation improvements.

**Semver Query Enhancements:**

- Added support for `subset` and `intersects` as semver query functions in `src/query/src/pseudo/semver.ts`, allowing queries that compare if one version range is a subset of or intersects with another range. This includes updates to function type definitions, parser logic, and function registries.
- Implemented the `subset` function in `src/semver/src/index.ts`, which determines if all versions in one range are included in another. This includes logic for handling exact versions, bounds, and complex range expressions.

**Testing Improvements:**

- Added extensive test cases for the new `subset` and `intersects` functionality in both the semver logic (`src/semver/test/index.ts`) and the query parser (`src/query/test/pseudo/semver.ts`). This includes snapshot tests and edge cases.

**Documentation Updates:**

- Added a new documentation page for the `:hostname()` pseudo-class selector, explaining its usage and providing examples.
- Improved sidebar labeling and ordering for selectors and pseudo-classes in the documentation, making navigation clearer.

These changes collectively make semver-based queries more flexible and robust, while also improving test coverage and user-facing documentation.

Fixes: #1095