### PR TITLE
feat(query): add :dist selector

### DIFF
--- a/src/query/src/pseudo.ts
+++ b/src/query/src/pseudo.ts
@@ -17,6 +17,7 @@ import { debug } from './pseudo/debug.ts'
 import { deprecated } from './pseudo/deprecated.ts'
 import { dev } from './pseudo/dev.ts'
 import { diff } from './pseudo/diff.ts'
+import { dist } from './pseudo/dist.ts'
 import { dynamic } from './pseudo/dynamic.ts'
 import { empty } from './pseudo/empty.ts'
 import { entropic } from './pseudo/entropic.ts'
@@ -313,6 +314,7 @@ const pseudoSelectors = new Map<string, ParserFn>(
     deprecated,
     dev,
     diff,
+    dist,
     dynamic,
     eval: evalParser,
     empty,

--- a/src/query/src/pseudo/dist.ts
+++ b/src/query/src/pseudo/dist.ts
@@ -1,0 +1,144 @@
+import pRetry, { AbortError } from 'p-retry'
+import { hydrate, splitDepID } from '@vltpkg/dep-id/browser'
+import { error } from '@vltpkg/error-cause'
+import {
+  asPostcssNodeWithChildren,
+  asTagNode,
+  asStringNode,
+  isTagNode,
+} from '@vltpkg/dss-parser'
+import {
+  removeDanglingEdges,
+  removeNode,
+  removeQuotes,
+} from './helpers.ts'
+import type { NodeLike, Packument } from '@vltpkg/types'
+import type { ParserState } from '../types.ts'
+
+/**
+ * Fetches the dist-tags of a package from the registry.
+ */
+export const retrieveDistTags = async (
+  node: NodeLike,
+  signal?: AbortSignal,
+): Promise<Record<string, string>> => {
+  const spec = hydrate(node.id, String(node.name), node.options)
+  if (!spec.registry || !node.name) {
+    return {}
+  }
+
+  const url = new URL(spec.registry)
+  url.pathname = `/${node.name}`
+
+  const response = await fetch(String(url), {
+    headers: {
+      Accept: 'application/vnd.npm.install-v1+json',
+    },
+    signal,
+  })
+  if (response.status === 404) {
+    throw new AbortError('Missing API')
+  }
+  if (!response.ok) {
+    throw error('Failed to fetch packument', {
+      name: node.name,
+      spec,
+      response,
+    })
+  }
+  const packument = (await response.json()) as Packument
+  return packument['dist-tags']
+}
+
+/**
+ * Checks whether a node's installed version matches the version
+ * associated with the given dist-tag. Returns the node if it should
+ * be removed (does NOT match), or undefined if it matches.
+ */
+export const queueNode = async (
+  state: ParserState,
+  node: NodeLike,
+  tagName: string,
+): Promise<NodeLike | undefined> => {
+  if (!node.name || !node.version) {
+    return node
+  }
+
+  let distTags: Record<string, string>
+  try {
+    distTags = await pRetry(
+      () => retrieveDistTags(node, state.signal),
+      {
+        retries: state.retries,
+        signal: state.signal,
+      },
+    )
+  } catch (err) {
+    // eslint-disable-next-line no-console
+    console.warn(
+      error('Could not retrieve dist-tags', {
+        name: node.name,
+        cause: err,
+      }),
+    )
+    return node
+  }
+
+  const tagVersion = distTags[tagName]
+  if (tagVersion !== node.version) {
+    return node
+  }
+
+  return undefined
+}
+
+/**
+ * :dist(tag) Pseudo-Selector, matches only nodes whose installed
+ * version corresponds to the given dist-tag in the registry.
+ *
+ * Examples:
+ * - :dist(latest) — matches packages at the `latest` dist-tag version
+ * - :dist(nightly) — matches packages at the `nightly` dist-tag version
+ * - :not(:dist(nightly)) — excludes nightly-tagged versions
+ */
+export const dist = async (state: ParserState) => {
+  const top = asPostcssNodeWithChildren(state.current)
+  const selector = asPostcssNodeWithChildren(top.nodes[0])
+  const firstChild = selector.nodes[0]
+
+  let tagName: string
+  try {
+    tagName = removeQuotes(asStringNode(firstChild).value)
+  } catch {
+    if (isTagNode(firstChild)) {
+      tagName = asTagNode(firstChild).value
+      /* c8 ignore start */
+    } else {
+      throw error('Failed to parse :dist selector', {
+        found: firstChild,
+      })
+    }
+    /* c8 ignore stop */
+  }
+
+  const queue = []
+
+  for (const node of state.partial.nodes) {
+    if (splitDepID(node.id)[0] !== 'registry') {
+      removeNode(state, node)
+      continue
+    }
+    queue.push(queueNode(state, node, tagName))
+  }
+
+  const removeNodeQueue = await Promise.all(queue)
+  for (const node of removeNodeQueue) {
+    if (node) {
+      removeNode(state, node)
+    }
+  }
+
+  removeDanglingEdges(state)
+
+  return state
+}

--- a/src/query/tap-snapshots/test/pseudo/dist.ts.test.cjs
+++ b/src/query/tap-snapshots/test/pseudo/dist.ts.test.cjs
@@ -1,0 +1,30 @@
+/* IMPORTANT
+ * This snapshot file is auto-generated, but designed for humans.
+ * It should be checked into source control and tracked carefully.
+ * Re-generate by setting TAP_SNAPSHOT=1 and running tests.
+ * Make sure to inspect the output below.  Do not ignore changes!
+ */
+'use strict'
+exports[`test/pseudo/dist.ts > TAP > :dist pseudo-selector > matches nodes at the beta dist-tag > must match snapshot 1`] = `
+Object {
+  "edges": Array [
+    "b",
+  ],
+  "nodes": Array [
+    "b",
+  ],
+}
+`
+
+exports[`test/pseudo/dist.ts > TAP > :dist pseudo-selector > matches nodes at the latest dist-tag > must match snapshot 1`] = `
+Object {
+  "edges": Array [
+    "a",
+    "f",
+  ],
+  "nodes": Array [
+    "a",
+    "f",
+  ],
+}
+`

--- a/src/query/test/pseudo/dist.ts
+++ b/src/query/test/pseudo/dist.ts
@@ -1,0 +1,215 @@
+import t from 'tap'
+import { joinDepIDTuple } from '@vltpkg/dep-id'
+import { parse, asPostcssNodeWithChildren } from '@vltpkg/dss-parser'
+import {
+  dist,
+  queueNode,
+  retrieveDistTags,
+} from '../../src/pseudo/dist.ts'
+import { getSimpleGraph } from '../fixtures/graph.ts'
+import type { NodeLike } from '@vltpkg/types'
+import type { ParserState } from '../../src/types.ts'
+
+global.fetch = (async (url: string) => {
+  if (url === 'https://registry.npmjs.org/c') {
+    return {
+      status: 404,
+      ok: false,
+    }
+  } else if (url === 'https://registry.npmjs.org/d') {
+    return {
+      ok: false,
+    }
+  } else if (url === 'https://registry.npmjs.org/e') {
+    throw new Error('ERR')
+  }
+  return {
+    ok: true,
+    json: async () => {
+      switch (url) {
+        case 'https://registry.npmjs.org/a': {
+          return {
+            'dist-tags': {
+              latest: '1.0.0',
+              nightly: '2.0.0',
+            },
+          }
+        }
+        case 'https://registry.npmjs.org/b': {
+          return {
+            'dist-tags': {
+              latest: '2.0.0',
+              beta: '1.0.0',
+            },
+          }
+        }
+        case 'https://registry.npmjs.org/f': {
+          return {
+            'dist-tags': {
+              latest: '1.0.0',
+            },
+          }
+        }
+      }
+    },
+  }
+}) as unknown as typeof global.fetch
+
+const getState = (query: string, graph = getSimpleGraph()) => {
+  const ast = parse(query)
+  const current = asPostcssNodeWithChildren(ast.first.first)
+  const state: ParserState = {
+    comment: '',
+    current,
+    initial: {
+      edges: new Set(graph.edges.values()),
+      nodes: new Set(graph.nodes.values()),
+    },
+    partial: {
+      edges: new Set(graph.edges.values()),
+      nodes: new Set(graph.nodes.values()),
+    },
+    collect: {
+      edges: new Set(),
+      nodes: new Set(),
+    },
+    cancellable: async () => {},
+    walk: async i => i,
+    retries: 0,
+    securityArchive: undefined,
+    importers: new Set(graph.importers),
+    signal: new AbortController().signal,
+    specificity: { idCounter: 0, commonCounter: 0 },
+  }
+  return state
+}
+
+t.test(':dist pseudo-selector', async t => {
+  t.capture(console, 'warn')
+
+  await t.test('matches nodes at the latest dist-tag', async t => {
+    const res = await dist(getState(':dist(latest)'))
+    const names = [...res.partial.nodes].map(n => n.name).sort()
+    t.strictSame(
+      names,
+      ['a', 'f'],
+      'should match only nodes whose version equals the latest dist-tag',
+    )
+    t.matchSnapshot({
+      nodes: names,
+      edges: [...res.partial.edges].map(e => e.name).sort(),
+    })
+  })
+
+  await t.test('matches nodes at the beta dist-tag', async t => {
+    const res = await dist(getState(':dist(beta)'))
+    const names = [...res.partial.nodes].map(n => n.name).sort()
+    t.strictSame(
+      names,
+      ['b'],
+      'should match only nodes whose version equals the beta dist-tag',
+    )
+    t.matchSnapshot({
+      nodes: names,
+      edges: [...res.partial.edges].map(e => e.name).sort(),
+    })
+  })
+
+  await t.test('matches nodes at the nightly dist-tag', async t => {
+    const res = await dist(getState(':dist(nightly)'))
+    const names = [...res.partial.nodes].map(n => n.name).sort()
+    t.strictSame(
+      names,
+      [],
+      'should match nothing since no installed version is 2.0.0',
+    )
+  })
+
+  await t.test('supports quoted tag name', async t => {
+    const res = await dist(getState(':dist("latest")'))
+    const names = [...res.partial.nodes].map(n => n.name).sort()
+    t.strictSame(
+      names,
+      ['a', 'f'],
+      'should work with quoted tag names',
+    )
+  })
+
+  await t.test('unknown dist-tag returns no matches', async t => {
+    const res = await dist(getState(':dist(nonexistent)'))
+    const names = [...res.partial.nodes].map(n => n.name).sort()
+    t.strictSame(
+      names,
+      [],
+      'should return no matches for an unknown dist-tag',
+    )
+  })
+
+  await t.test('handles empty partial state', async t => {
+    const state = getState(':dist(latest)')
+    state.partial.nodes.clear()
+    state.partial.edges.clear()
+
+    const res = await dist(state)
+    t.strictSame(
+      [...res.partial.nodes].map(n => n.name),
+      [],
+      'should return empty results from an empty partial state',
+    )
+  })
+
+  await t.test('gracefully handles fetch errors', async t => {
+    const res = await dist(getState(':dist(latest)'))
+    const names = [...res.partial.nodes].map(n => n.name).sort()
+    t.ok(
+      !names.includes('d') && !names.includes('e'),
+      'nodes with fetch errors should not be in results',
+    )
+  })
+})
+
+t.test('retrieveDistTags', async t => {
+  const missingName = {
+    id: joinDepIDTuple(['registry', '', 'a@1.0.0']),
+  } as NodeLike
+  t.strictSame(
+    await retrieveDistTags(missingName),
+    {},
+    'should return empty object if missing essential info',
+  )
+
+  await t.test('no response from registry', async t => {
+    const node = {
+      name: 'd',
+      id: joinDepIDTuple(['registry', '', 'd@1.0.0']),
+    } as NodeLike
+    await t.rejects(
+      retrieveDistTags(node),
+      /Failed to fetch packument/,
+      'should throw an internal error so that it may be retried',
+    )
+  })
+
+  await t.test('fetch error', async t => {
+    const node = {
+      name: 'e',
+      id: joinDepIDTuple(['registry', '', 'e@1.0.0']),
+    } as NodeLike
+    await t.rejects(
+      retrieveDistTags(node),
+      /ERR/,
+      'should throw the original error that will be retried',
+    )
+  })
+})
+
+t.test('queueNode', async t => {
+  const missingName = {
+    id: joinDepIDTuple(['registry', '', 'a@1.0.0']),
+  } as NodeLike
+  t.strictSame(
+    await queueNode(getState(':dist(latest)'), missingName, 'latest'),
+    missingName,
+    'should return node for removal if missing essential info',
+  )
+})

--- a/www/docs/src/content/docs/cli/selectors/pseudo-classes/dist.mdx
+++ b/www/docs/src/content/docs/cli/selectors/pseudo-classes/dist.mdx
@@ -1,0 +1,92 @@
+---
+title: ':dist()'
+sidebar:
+  label: ':dist()'
+  order: 3
+---
+
+import { Code } from '@astrojs/starlight/components'
+
+The `:dist()` pseudo-class matches packages whose installed version
+corresponds to a specific dist-tag in the registry.
+
+## Syntax
+
+```
+:dist(<tag>)
+```
+
+### Parameters
+
+| Parameter | Description                        | Default    |
+| --------- | ---------------------------------- | ---------- |
+| `tag`     | The dist-tag name to match against | (required) |
+
+## How it works
+
+When a package is published to a registry, it can be associated with
+one or more dist-tags (e.g. `latest`, `nightly`, `beta`). The
+`:dist()` selector fetches the packument for each installed package
+and checks whether the node's installed version matches the version
+pointed to by the given dist-tag.
+
+For example, given a package `foo` with:
+
+```json
+{
+  "dist-tags": {
+    "latest": "1.3.0",
+    "nightly": "1.2.1"
+  }
+}
+```
+
+- If `foo@1.3.0` is installed, `:dist(latest)` will match it.
+- If `foo@1.0.0` is installed, `:dist(latest)` will **not** match it.
+
+## Examples
+
+### Find packages at their latest version
+
+<Code code="vlt query ':dist(latest)'" title="Terminal" lang="bash" />
+
+### Find packages at a pre-release dist-tag
+
+<Code
+  code="vlt query ':dist(nightly)'"
+  title="Terminal"
+  lang="bash"
+/>
+
+### Exclude nightly-tagged packages
+
+<Code
+  code="vlt query ':not(:dist(nightly))'"
+  title="Terminal"
+  lang="bash"
+/>
+
+### Find a specific package at a dist-tag
+
+<Code
+  code="vlt query '#foo:dist(latest)'"
+  title="Terminal"
+  lang="bash"
+/>
+
+## Notes
+
+- Only registry packages are matched. File, git, workspace, and remote
+  dependencies are filtered out since they do not have dist-tags.
+- The selector makes network requests to the registry to fetch
+  dist-tag information. Results depend on the current state of the
+  registry.
+- If a dist-tag does not exist for a package, that package will not
+  match.
+
+## See also
+
+- [`:semver()`](/cli/selectors/pseudo-classes/semver) — match by
+  semver comparison
+- [`:outdated()`](/cli/selectors/pseudo-classes/outdated) — match
+  packages with newer versions available

--- a/www/docs/src/content/docs/cli/selectors/pseudo-classes/index.mdx
+++ b/www/docs/src/content/docs/cli/selectors/pseudo-classes/index.mdx
@@ -21,6 +21,11 @@ but operate on dependency graph nodes.
     href="/cli/selectors/pseudo-classes/attr"
   />
   <LinkCard
+    title=":dist()"
+    description="Match packages by registry dist-tag"
+    href="/cli/selectors/pseudo-classes/dist"
+  />
+  <LinkCard
     title=":has()"
     description="Match packages that have descendants matching a selector"
     href="/cli/selectors/pseudo-classes/has"
@@ -82,6 +87,7 @@ but operate on dependency graph nodes.
 | Selector                                                  | Description              | Example                   |
 | --------------------------------------------------------- | ------------------------ | ------------------------- |
 | [`:attr()`](/cli/selectors/pseudo-classes/attr)           | Nested property match    | `:attr(engines, [node])`  |
+| [`:dist()`](/cli/selectors/pseudo-classes/dist)           | By registry dist-tag     | `:dist(latest)`           |
 | [`:has()`](/cli/selectors/pseudo-classes/has)             | Has matching descendants | `:has(.peer[name=react])` |
 | [`:host()`](/cli/selectors/pseudo-classes/host)           | Switch graph context     | `:host(local) :malware`   |
 | [`:is()`](/cli/selectors/pseudo-classes/is)               | Match any in list        | `:is([name=a], [name=b])` |


### PR DESCRIPTION
This pull request introduces a new `:dist()` pseudo-selector for querying dependency graph nodes by their registry dist-tag (such as `latest`, `beta`, or `nightly`). The implementation includes the selector logic, comprehensive tests, documentation, and updates to the selector reference. This feature allows users to match packages whose installed version corresponds to a specific dist-tag in the registry, enhancing the flexibility and power of dependency queries.

**Core Feature: `:dist()` Pseudo-Selector**

* Added `dist` pseudo-selector to the query engine, enabling selection of packages whose installed version matches a specified registry dist-tag. This includes:
  - Implementation of the selector logic in `src/query/src/pseudo/dist.ts`, with robust error handling and support for quoted tag names.
  - Integration into the pseudo-selector registry in `src/query/src/pseudo.ts`.

**Testing**

* Added comprehensive tests for the `:dist()` selector, including cases for different tags, missing tags, fetch errors, and quoted tag names in `src/query/test/pseudo/dist.ts`.
* Added corresponding snapshot tests in `src/query/tap-snapshots/test/pseudo/dist.ts.test.cjs`.

**Documentation**

* Added a dedicated documentation page for `:dist()` explaining its syntax, usage, examples, and behavior in `www/docs/src/content/docs/cli/selectors/pseudo-classes/dist.mdx`.
* Updated the pseudo-selector index and summary table to include the new `:dist()` selector.

Fixes: #1200