### PR TITLE
fix(build): unbuilt scripts should log each install

### DIFF
--- a/src/graph/src/reify/index.ts
+++ b/src/graph/src/reify/index.ts
@@ -147,6 +147,16 @@ export const reify = async (
       const lfData = lockfileData(options)
       saveData(lfData, scurry.resolve('vlt-lock.json'), false)
     }
+    // Even with no reify changes, report nodes that still need building.
+    // Build state is persisted in the hidden lockfile and loaded into the
+    // actual graph, so check there for pending builds.
+    const pending = [...actual.nodes.values()]
+      .filter(n => n.buildState === 'needed')
+      .map(n => n.id)
+    if (pending.length) {
+      res.buildQueue = pending
+    }
+
     done()
     return res
   }

--- a/src/graph/test/reify/index.ts
+++ b/src/graph/test/reify/index.ts
@@ -827,6 +827,95 @@ t.test('allowScripts with query selector :scripts', async t => {
   )
 })
 
+t.test(
+  'no-op reify still reports buildQueue when nodes need building',
+  async t => {
+    const dir = t.testdir({
+      cache: {},
+      project: {
+        'vlt.json': JSON.stringify({
+          cache: resolve(t.testdirName, 'cache'),
+        }),
+        'package.json': JSON.stringify({
+          name: 'test-project',
+          version: '1.0.0',
+          dependencies: {
+            lodash: '4',
+          },
+        }),
+      },
+    })
+    const projectRoot = resolve(dir, 'project')
+    const packageJson = new PackageJson()
+
+    // First install: creates node_modules and lockfiles
+    const graph = await ideal.build({
+      projectRoot,
+      packageInfo: mockPackageInfo,
+      monorepo: Monorepo.maybeLoad(projectRoot),
+      scurry: new PathScurry(projectRoot),
+      packageJson,
+      remover: new RollbackRemove(),
+    })
+    await reify({
+      projectRoot,
+      packageInfo: mockPackageInfo,
+      monorepo: Monorepo.maybeLoad(projectRoot),
+      scurry: new PathScurry(projectRoot),
+      packageJson: new PackageJson(),
+      graph,
+      allowScripts: ':not(*)',
+      remover: new RollbackRemove(),
+    })
+
+    // Load actual from disk — nodes carry buildState from hidden lockfile
+    const scurry2 = new PathScurry(projectRoot)
+    const act = actual.load({
+      projectRoot,
+      monorepo: Monorepo.maybeLoad(projectRoot),
+      scurry: scurry2,
+      packageJson: new PackageJson(),
+      loadManifests: true,
+    })
+
+    // Find a non-importer node and mark it as needing a build
+    const lodashId = joinDepIDTuple([
+      'registry',
+      '',
+      'lodash@4.17.21',
+    ])
+    const lodashNode = act.nodes.get(lodashId)
+    t.ok(lodashNode, 'lodash node exists in actual graph')
+    if (!lodashNode) throw new Error('missing lodash node')
+    lodashNode.buildState = 'needed'
+
+    // Second reify: same ideal graph, no diff changes,
+    // but actual has a node with buildState === 'needed'
+    const result = await reify({
+      projectRoot,
+      packageInfo: mockPackageInfo,
+      monorepo: Monorepo.maybeLoad(projectRoot),
+      scurry: scurry2,
+      packageJson: new PackageJson(),
+      graph,
+      actual: act,
+      allowScripts: ':not(*)',
+      remover: new RollbackRemove(),
+    })
+
+    t.equal(
+      result.diff.hasChanges(),
+      false,
+      'diff should have no changes',
+    )
+    t.ok(result.buildQueue, 'buildQueue should be present')
+    t.ok(
+      result.buildQueue?.includes(lodashId),
+      'buildQueue should include the node that needs building',
+    )
+  },
+)
+
 t.test('reify recreates deleted workspace node_modules', async t => {
   const projectRoot = t.testdir({
     cache: {},


### PR DESCRIPTION
This pull request enhances the `reify` process to ensure that nodes requiring builds are reported even when there are no dependency changes, and adds a corresponding test to verify this behavior. The main focus is on improving the accuracy of build state reporting in scenarios where the dependency graph itself hasn't changed, but some nodes still need to be built.

**Enhancements to build state reporting:**

* Updated the `reify` function in `src/graph/src/reify/index.ts` to check for nodes with `buildState === 'needed'` and include their IDs in the `buildQueue` property of the result, even when there are no dependency changes.

**Testing improvements:**

* Added a new test case in `src/graph/test/reify/index.ts` to verify that a no-op reify still reports the `buildQueue` when nodes need building, ensuring the new behavior is covered and works as expected.

Fixes: #1427