### PR TITLE
fix(graph): not updating graph/resolution when config changes

### DIFF
--- a/src/graph/src/graph.ts
+++ b/src/graph/src/graph.ts
@@ -155,6 +155,13 @@ export class Graph implements GraphLike {
   peerContextForkCache = new Map<string, PeerContext>()
 
   /**
+   * Whether the options used to create this graph differ from the
+   * options stored in the lockfile it was loaded from. When true,
+   * the ideal builder must reset edges and rebuild the graph.
+   */
+  optionsChanged = false
+
+  /**
    * Tracks the current peer context index.
    */
   currentPeerContextIndex = 0

--- a/src/graph/src/ideal/refresh-ideal-graph.ts
+++ b/src/graph/src/ideal/refresh-ideal-graph.ts
@@ -111,7 +111,11 @@ export const refreshIdealGraph = async ({
   }
 
   // removes all edges to start recalculating the graph
-  if (add.modifiedDependencies || remove.modifiedDependencies) {
+  if (
+    add.modifiedDependencies ||
+    remove.modifiedDependencies ||
+    graph.optionsChanged
+  ) {
     graph.resetEdges()
   }
 

--- a/src/graph/src/install.ts
+++ b/src/graph/src/install.ts
@@ -133,9 +133,16 @@ export const install = async (
     if (
       importerSpecs.add.modifiedDependencies ||
       importerSpecs.remove.modifiedDependencies ||
-      specChanges.length > 0
+      specChanges.length > 0 ||
+      lockfileGraph.optionsChanged
     ) {
       const details: string[] = []
+
+      if (lockfileGraph.optionsChanged) {
+        details.push(
+          '  Configuration options have changed (e.g. modifiers, registries, catalogs)',
+        )
+      }
 
       if (specChanges.length > 0) {
         details.push(...specChanges)

--- a/src/graph/src/lockfile/load.ts
+++ b/src/graph/src/lockfile/load.ts
@@ -1,5 +1,14 @@
 import { error } from '@vltpkg/error-cause'
 import { PackageJson } from '@vltpkg/package-json'
+import {
+  defaultGitHostArchives,
+  defaultGitHosts,
+  defaultJsrRegistries,
+  defaultRegistries,
+  defaultRegistry,
+  defaultScopeRegistries,
+} from '@vltpkg/spec'
+import { isRecordStringString } from '@vltpkg/types'
 import { Monorepo } from '@vltpkg/workspaces'
 import { readFileSync } from 'node:fs'
 import { resolve } from 'node:path'
@@ -73,6 +82,110 @@ export const loadHidden = (options: LoadOptions): Graph => {
   )
 }
 
+/**
+ * Removes entries from `items` that match the corresponding
+ * entry in `defaultItems`, returning only non-default values.
+ */
+const removeDefaultItems = (
+  defaultItems: Record<string, string>,
+  items: Record<string, string>,
+) => {
+  const res: Record<string, string> = {}
+  for (const [key, value] of Object.entries(items)) {
+    if (!defaultItems[key] || defaultItems[key] !== value) {
+      res[key] = value
+    }
+  }
+  return res
+}
+
+/**
+ * Builds a normalized options object from the current runtime config
+ * using the same cleaning logic as `lockfile/save.ts` so that it can
+ * be compared directly against the options stored in a lockfile.
+ */
+const buildCurrentOptions = (
+  options: LoadOptions,
+): LockfileData['options'] => {
+  const hasItems = (o: Record<string, unknown> | undefined) =>
+    o && Object.keys(o).length > 0
+
+  const cleanModifiers =
+    (
+      options.modifiers &&
+      isRecordStringString(options.modifiers.config)
+    ) ?
+      options.modifiers.config
+    : undefined
+
+  const cleanRegistries =
+    isRecordStringString(options.registries) ?
+      removeDefaultItems(defaultRegistries, options.registries)
+    : undefined
+
+  const cleanScopeRegistries =
+    isRecordStringString(options['scoped-registries']) ?
+      removeDefaultItems(
+        defaultScopeRegistries,
+        options['scoped-registries'],
+      )
+    : undefined
+
+  const cleanJsrRegistries =
+    isRecordStringString(options['jsr-registries']) ?
+      removeDefaultItems(
+        defaultJsrRegistries,
+        options['jsr-registries'],
+      )
+    : undefined
+
+  const cleanGitHosts =
+    isRecordStringString(options['git-hosts']) ?
+      removeDefaultItems(defaultGitHosts, options['git-hosts'])
+    : undefined
+
+  const cleanGitHostArchives =
+    isRecordStringString(options['git-host-archives']) ?
+      removeDefaultItems(
+        defaultGitHostArchives,
+        options['git-host-archives'],
+      )
+    : undefined
+
+  return {
+    ...(hasItems(cleanModifiers) ?
+      { modifiers: cleanModifiers }
+    : {}),
+    ...(hasItems(options.catalog) ?
+      { catalog: options.catalog }
+    : {}),
+    ...(hasItems(options.catalogs) ?
+      { catalogs: options.catalogs }
+    : {}),
+    ...(hasItems(cleanScopeRegistries) ?
+      { 'scoped-registries': cleanScopeRegistries }
+    : undefined),
+    ...(hasItems(cleanJsrRegistries) ?
+      { 'jsr-registries': cleanJsrRegistries }
+    : undefined),
+    ...((
+      options.registry !== undefined &&
+      options.registry !== defaultRegistry
+    ) ?
+      { registry: options.registry }
+    : undefined),
+    ...(hasItems(cleanRegistries) ?
+      { registries: cleanRegistries }
+    : undefined),
+    ...(hasItems(cleanGitHosts) ?
+      { 'git-hosts': cleanGitHosts }
+    : undefined),
+    ...(hasItems(cleanGitHostArchives) ?
+      { 'git-host-archives': cleanGitHostArchives }
+    : undefined),
+  }
+}
+
 export const loadObject = (
   options: LoadOptions,
   lockfileData: Omit<LockfileData, 'options' | 'lockfileVersion'> &
@@ -125,6 +238,15 @@ export const loadObject = (
       }
     )['scope-registries']
 
+  // Detect whether the current config options differ from those
+  // stored in the lockfile.  When they do the ideal builder must
+  // reset edges and rebuild the graph.
+  const currentOptions = buildCurrentOptions(options)
+  /* c8 ignore next */
+  const lockfileOptions = lockfileData.options ?? {}
+  const optionsChanged =
+    JSON.stringify(currentOptions) !== JSON.stringify(lockfileOptions)
+
   // Optimize options merging - only create new objects when needed
   const mergedOptions = {
     ...options,
@@ -153,6 +275,7 @@ export const loadObject = (
     mainManifest,
     monorepo,
   })
+  graph.optionsChanged = optionsChanged
   loadNodes(
     graph,
     lockfileData.nodes,

--- a/src/graph/test/install.ts
+++ b/src/graph/test/install.ts
@@ -1821,3 +1821,74 @@ t.test(
     )
   },
 )
+
+t.test('install with frozenLockfile and changed options', async t => {
+  const dir = t.testdir({
+    'package.json': JSON.stringify({
+      name: 'test',
+      version: '1.0.0',
+      dependencies: {
+        'some-package': '^1.0.0',
+      },
+    }),
+    'vlt-lock.json': JSON.stringify({
+      lockfileVersion: 1,
+      options: {},
+      nodes: {},
+      edges: {},
+    }),
+    node_modules: {
+      'some-package': {
+        'package.json': JSON.stringify({
+          name: 'some-package',
+          version: '1.0.0',
+        }),
+      },
+    },
+  })
+
+  const options = {
+    projectRoot: dir,
+    scurry: new PathScurry(dir),
+    packageJson: new PackageJson(),
+    packageInfo: mockPackageInfo,
+    frozenLockfile: true,
+    allowScripts: ':not(*)',
+  } as unknown as InstallOptions
+
+  const { install } = await t.mockImport<
+    typeof import('../src/install.ts')
+  >('../src/install.ts', {
+    '../src/reify/index.ts': {
+      reify: async () => ({ buildQueue: {}, diff: {} }),
+    },
+    '../src/ideal/get-importer-specs.ts': {
+      getImporterSpecs: () => ({
+        add: Object.assign(new Map(), {
+          modifiedDependencies: false,
+        }),
+        remove: Object.assign(new Map(), {
+          modifiedDependencies: false,
+        }),
+      }),
+    },
+    '../src/lockfile/load.ts': {
+      load: () => ({
+        nodes: new Map(),
+        importers: [],
+        optionsChanged: true,
+        gc: () => {},
+      }),
+      loadHidden: () => ({
+        nodes: new Map(),
+        importers: [],
+      }),
+    },
+  })
+
+  await t.rejects(
+    install(options, new Map() as AddImportersDependenciesMap),
+    /Lockfile is out of sync with package\.json/,
+    'should throw when config options changed with frozen lockfile',
+  )
+})

--- a/src/graph/test/lockfile/load.ts
+++ b/src/graph/test/lockfile/load.ts
@@ -1088,3 +1088,439 @@ t.test('lockfile version validation', async t => {
     },
   )
 })
+
+t.test('optionsChanged detection', async t => {
+  const abbrevId = joinDepIDTuple(['registry', '', 'abbrev@2.0.0'])
+  const baseLockfileData = {
+    lockfileVersion: 1,
+    options: {},
+    nodes: {
+      [abbrevId]: [0, 'abbrev', 'sha512-abc=='],
+    },
+    edges: {
+      [edgeKey(['file', '.'], 'abbrev')]: `prod ^2.0.0 ${abbrevId}`,
+    },
+  } as unknown as LockfileData
+
+  t.test(
+    'optionsChanged is false when lockfile and current options match',
+    async t => {
+      const matchingLockfile: LockfileData = {
+        ...baseLockfileData,
+        options: {
+          registries: {
+            custom: 'http://example.com',
+          },
+        },
+      }
+      const projectRoot = t.testdir({
+        'vlt-lock.json': JSON.stringify(matchingLockfile),
+        'vlt.json': '{}',
+      })
+      t.chdir(projectRoot)
+      unload('project')
+      const graph = loadObject(
+        {
+          ...configData,
+          mainManifest,
+          projectRoot,
+        },
+        matchingLockfile,
+      )
+      t.equal(graph.optionsChanged, false, 'options have not changed')
+    },
+  )
+
+  t.test(
+    'optionsChanged is true when modifiers are added',
+    async t => {
+      const projectRoot = t.testdir({
+        'vlt-lock.json': JSON.stringify(baseLockfileData),
+        'vlt.json': JSON.stringify({
+          modifiers: { '#abbrev': '^3.0.0' },
+        }),
+      })
+      t.chdir(projectRoot)
+      unload('project')
+
+      const { GraphModifier } = await import('../../src/modifiers.ts')
+      const modifiers = new GraphModifier(configData)
+      const graph = loadObject(
+        {
+          ...configData,
+          mainManifest,
+          projectRoot,
+          modifiers,
+        },
+        baseLockfileData,
+      )
+      t.equal(
+        graph.optionsChanged,
+        true,
+        'options changed due to new modifiers',
+      )
+    },
+  )
+
+  t.test(
+    'optionsChanged is true when modifiers are changed',
+    async t => {
+      const lockfileWithModifiers: LockfileData = {
+        ...baseLockfileData,
+        options: {
+          modifiers: { '#abbrev': '^2.0.0' },
+        },
+      }
+      const projectRoot = t.testdir({
+        'vlt-lock.json': JSON.stringify(lockfileWithModifiers),
+        'vlt.json': JSON.stringify({
+          modifiers: { '#abbrev': '^3.0.0' },
+        }),
+      })
+      t.chdir(projectRoot)
+      unload('project')
+
+      const { GraphModifier } = await import('../../src/modifiers.ts')
+      const modifiers = new GraphModifier(configData)
+      const graph = loadObject(
+        {
+          ...configData,
+          mainManifest,
+          projectRoot,
+          modifiers,
+        },
+        lockfileWithModifiers,
+      )
+      t.equal(
+        graph.optionsChanged,
+        true,
+        'options changed due to modified modifiers',
+      )
+    },
+  )
+
+  t.test(
+    'optionsChanged is true when registry is changed',
+    async t => {
+      const lockfileWithRegistry: LockfileData = {
+        ...baseLockfileData,
+        options: {
+          registry: 'https://old-registry.example.com/',
+        },
+      }
+      const projectRoot = t.testdir({
+        'vlt-lock.json': JSON.stringify(lockfileWithRegistry),
+        'vlt.json': '{}',
+      })
+      t.chdir(projectRoot)
+      unload('project')
+      const graph = loadObject(
+        {
+          ...configData,
+          mainManifest,
+          projectRoot,
+        },
+        lockfileWithRegistry,
+      )
+      t.equal(
+        graph.optionsChanged,
+        true,
+        'options changed due to registry change',
+      )
+    },
+  )
+
+  t.test(
+    'optionsChanged is true when catalog is changed',
+    async t => {
+      const lockfileWithCatalog: LockfileData = {
+        ...baseLockfileData,
+        options: {
+          catalog: { abbrev: '^1.0.0' },
+        },
+      }
+      const projectRoot = t.testdir({
+        'vlt-lock.json': JSON.stringify(lockfileWithCatalog),
+        'vlt.json': '{}',
+      })
+      t.chdir(projectRoot)
+      unload('project')
+      const graph = loadObject(
+        {
+          ...configData,
+          mainManifest,
+          projectRoot,
+          catalog: { abbrev: '^2.0.0' },
+        },
+        lockfileWithCatalog,
+      )
+      t.equal(
+        graph.optionsChanged,
+        true,
+        'options changed due to catalog change',
+      )
+    },
+  )
+
+  t.test(
+    'optionsChanged is true when modifiers are removed',
+    async t => {
+      const lockfileWithModifiers: LockfileData = {
+        ...baseLockfileData,
+        options: {
+          modifiers: { '#abbrev': '^2.0.0' },
+        },
+      }
+      const projectRoot = t.testdir({
+        'vlt-lock.json': JSON.stringify(lockfileWithModifiers),
+        'vlt.json': '{}',
+      })
+      t.chdir(projectRoot)
+      unload('project')
+      const graph = loadObject(
+        {
+          ...configData,
+          mainManifest,
+          projectRoot,
+        },
+        lockfileWithModifiers,
+      )
+      t.equal(
+        graph.optionsChanged,
+        true,
+        'options changed due to removed modifiers',
+      )
+    },
+  )
+
+  t.test(
+    'optionsChanged detects scoped-registries change',
+    async t => {
+      const lockfileWithScoped: LockfileData = {
+        ...baseLockfileData,
+        options: {
+          'scoped-registries': {
+            '@myorg': 'https://old.example.com/',
+          },
+        },
+      }
+      const projectRoot = t.testdir({
+        'vlt-lock.json': JSON.stringify(lockfileWithScoped),
+        'vlt.json': '{}',
+      })
+      t.chdir(projectRoot)
+      unload('project')
+      const graph = loadObject(
+        {
+          ...configData,
+          mainManifest,
+          projectRoot,
+          'scoped-registries': {
+            '@myorg': 'https://new.example.com/',
+          },
+        },
+        lockfileWithScoped,
+      )
+      t.equal(
+        graph.optionsChanged,
+        true,
+        'options changed due to scoped-registries change',
+      )
+    },
+  )
+
+  t.test('optionsChanged detects jsr-registries change', async t => {
+    const lockfileWithJsr: LockfileData = {
+      ...baseLockfileData,
+      options: {
+        'jsr-registries': {
+          jsr: 'https://old-jsr.example.com/',
+        },
+      },
+    }
+    const projectRoot = t.testdir({
+      'vlt-lock.json': JSON.stringify(lockfileWithJsr),
+      'vlt.json': '{}',
+    })
+    t.chdir(projectRoot)
+    unload('project')
+    const graph = loadObject(
+      {
+        ...configData,
+        mainManifest,
+        projectRoot,
+        'jsr-registries': {
+          jsr: 'https://new-jsr.example.com/',
+        },
+      },
+      lockfileWithJsr,
+    )
+    t.equal(
+      graph.optionsChanged,
+      true,
+      'options changed due to jsr-registries change',
+    )
+  })
+
+  t.test('optionsChanged detects git-hosts change', async t => {
+    const lockfileWithGitHosts: LockfileData = {
+      ...baseLockfileData,
+      options: {
+        'git-hosts': {
+          myhost: 'https://old-git.example.com/',
+        },
+      },
+    }
+    const projectRoot = t.testdir({
+      'vlt-lock.json': JSON.stringify(lockfileWithGitHosts),
+      'vlt.json': '{}',
+    })
+    t.chdir(projectRoot)
+    unload('project')
+    const graph = loadObject(
+      {
+        ...configData,
+        mainManifest,
+        projectRoot,
+        'git-hosts': {
+          myhost: 'https://new-git.example.com/',
+        },
+      },
+      lockfileWithGitHosts,
+    )
+    t.equal(
+      graph.optionsChanged,
+      true,
+      'options changed due to git-hosts change',
+    )
+  })
+
+  t.test(
+    'optionsChanged detects git-host-archives change',
+    async t => {
+      const lockfileWithGHA: LockfileData = {
+        ...baseLockfileData,
+        options: {
+          'git-host-archives': {
+            myhost: 'https://old-archive.example.com/',
+          },
+        },
+      }
+      const projectRoot = t.testdir({
+        'vlt-lock.json': JSON.stringify(lockfileWithGHA),
+        'vlt.json': '{}',
+      })
+      t.chdir(projectRoot)
+      unload('project')
+      const graph = loadObject(
+        {
+          ...configData,
+          mainManifest,
+          projectRoot,
+          'git-host-archives': {
+            myhost: 'https://new-archive.example.com/',
+          },
+        },
+        lockfileWithGHA,
+      )
+      t.equal(
+        graph.optionsChanged,
+        true,
+        'options changed due to git-host-archives change',
+      )
+    },
+  )
+
+  t.test('optionsChanged detects catalogs change', async t => {
+    const lockfileWithCatalogs: LockfileData = {
+      ...baseLockfileData,
+      options: {
+        catalogs: {
+          testing: { vitest: '^1.0.0' },
+        },
+      },
+    }
+    const projectRoot = t.testdir({
+      'vlt-lock.json': JSON.stringify(lockfileWithCatalogs),
+      'vlt.json': '{}',
+    })
+    t.chdir(projectRoot)
+    unload('project')
+    const graph = loadObject(
+      {
+        ...configData,
+        mainManifest,
+        projectRoot,
+        catalogs: {
+          testing: { vitest: '^2.0.0' },
+        },
+      },
+      lockfileWithCatalogs,
+    )
+    t.equal(
+      graph.optionsChanged,
+      true,
+      'options changed due to catalogs change',
+    )
+  })
+
+  t.test(
+    'optionsChanged detects non-default registry in current config',
+    async t => {
+      const projectRoot = t.testdir({
+        'vlt-lock.json': JSON.stringify(baseLockfileData),
+        'vlt.json': '{}',
+      })
+      t.chdir(projectRoot)
+      unload('project')
+      const graph = loadObject(
+        {
+          ...configData,
+          mainManifest,
+          projectRoot,
+          registry: 'https://custom-registry.example.com/',
+        },
+        baseLockfileData,
+      )
+      t.equal(
+        graph.optionsChanged,
+        true,
+        'options changed due to non-default registry',
+      )
+    },
+  )
+
+  t.test('optionsChanged detects registries change', async t => {
+    const lockfileWithRegistries: LockfileData = {
+      ...baseLockfileData,
+      options: {
+        registries: {
+          custom: 'https://old-custom.example.com/',
+        },
+      },
+    }
+    const projectRoot = t.testdir({
+      'vlt-lock.json': JSON.stringify(lockfileWithRegistries),
+      'vlt.json': '{}',
+    })
+    t.chdir(projectRoot)
+    unload('project')
+    const graph = loadObject(
+      {
+        ...configData,
+        mainManifest,
+        projectRoot,
+        registries: {
+          ...configData.registries,
+          custom: 'https://new-custom.example.com/',
+        },
+      },
+      lockfileWithRegistries,
+    )
+    t.equal(
+      graph.optionsChanged,
+      true,
+      'options changed due to registries change',
+    )
+  })
+})


### PR DESCRIPTION
This pull request introduces logic to detect when configuration options (such as registries, modifiers, catalogs, etc.) have changed compared to those stored in the lockfile, and ensures the dependency graph is rebuilt accordingly. It also adds a test to verify that an install with `frozenLockfile` fails if configuration options have changed.

**Option change detection and graph rebuild:**

* Added a new `optionsChanged` property to the `Graph` class to track if runtime configuration options differ from those in the lockfile, triggering a reset and rebuild of the dependency graph when necessary.
* Implemented logic in `loadObject` (in `lockfile/load.ts`) to normalize and compare current options against those in the lockfile, setting `optionsChanged` accordingly.

**Install and refresh logic updates:**

* Updated `refreshIdealGraph` and `install` to check the new `optionsChanged` property, ensuring the graph is reset and appropriate messages are shown when configuration options have changed.

**Testing:**

* Added a test to verify that running install with `frozenLockfile` and changed options correctly throws an error, ensuring lockfile consistency.

**Supporting changes:**

* Imported default configuration values and utility functions to support option normalization and comparison in `lockfile/load.ts`.

Fixes: #1385