### PR TITLE
chore: add git-scp-url support metadata

### DIFF
--- a/src/git-scp-url/package.json
+++ b/src/git-scp-url/package.json
@@ -7,6 +7,10 @@
     "url": "git+https://github.com/vltpkg/vltpkg.git",
     "directory": "src/git-scp-url"
   },
+  "homepage": "https://github.com/vltpkg/vltpkg/tree/main/src/git-scp-url#readme",
+  "bugs": {
+    "url": "https://github.com/vltpkg/vltpkg/issues"
+  },
   "author": "vlt technology inc. <support@vlt.sh> (http://vlt.sh)",
   "devDependencies": {
     "@eslint/js": "catalog:",


### PR DESCRIPTION
## Summary
- add the npm homepage for @vltpkg/git-scp-url, pointing to its package README path
- add the package bugs URL, pointing to the upstream vltpkg issue tracker

## Validation
- npm view @vltpkg/git-scp-url@1.0.0-rc.32 homepage bugs repository --json
- node assertion for package homepage and bugs.url
- git diff --check
- npm pack --dry-run --ignore-scripts --json ./src/git-scp-url