### PR TITLE
docs: migrate footer/header links from vlt.sh to vlt.io

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,6 +67,7 @@ tmp
 /www/**/*.d.mts.map
 /www/*/node_modules
 /www/*/scripts/fixtures/
+/www/*/plans/**
 
 /scripts/*.js
 /scripts/*.js.map

--- a/www/docs/src/components/footer/content.tsx
+++ b/www/docs/src/components/footer/content.tsx
@@ -21,11 +21,11 @@ const products: Section = {
   contents: [
     {
       slug: 'Client',
-      href: 'https://www.vlt.sh/client',
+      href: 'https://vlt.io/open-source/client',
     },
     {
       slug: 'Serverless Registry',
-      href: 'https://www.vlt.sh/serverless-registry',
+      href: 'https://vlt.io/open-source/serverless-registry',
     },
   ],
 }
@@ -39,11 +39,11 @@ const resources: Section = {
     },
     {
       slug: 'Pricing',
-      href: 'https://www.vlt.sh/serverless-registry',
+      href: 'https://vlt.io/open-source/serverless-registry',
     },
     {
       slug: 'Brand Kit',
-      href: 'https://www.vlt.sh/brand',
+      href: 'https://www.vlt.io/brand-kit',
     },
   ],
 }
@@ -53,19 +53,19 @@ const company: Section = {
   contents: [
     {
       slug: 'About',
-      href: 'https://www.vlt.sh/company',
+      href: 'https://www.vlt.io/about',
     },
     {
       slug: 'Blog',
-      href: 'https://blog.vlt.sh/',
+      href: 'https://vlt.io/blog',
     },
     {
       slug: 'Privacy',
-      href: 'https://www.vlt.sh/privacy',
+      href: 'https://www.vlt.io/privacy',
     },
     {
       slug: 'Terms',
-      href: 'https://www.vlt.sh/terms',
+      href: 'https://www.vlt.io/terms',
     },
   ],
 }

--- a/www/docs/src/components/footer/theme-switcher.tsx
+++ b/www/docs/src/components/footer/theme-switcher.tsx
@@ -12,7 +12,7 @@ import { cn } from '@/lib/utils.ts'
 export type Theme = 'system' | 'light' | 'dark'
 
 const DOMAIN =
-  process.env.NODE_ENV === 'development' ? 'localhost' : '.vlt.sh'
+  process.env.NODE_ENV === 'development' ? 'localhost' : '.vlt.io'
 
 const setThemeCookie = (theme: Theme, resolveTo: Theme) => {
   const CookieDate = new Date()

--- a/www/docs/src/components/footer/waitlist.tsx
+++ b/www/docs/src/components/footer/waitlist.tsx
@@ -2,7 +2,7 @@ import { ShinyButton } from '@/components/ui/shiny-button.tsx'
 
 const Waitlist = () => {
   return (
-    <a href="https://www.vlt.sh/join">
+    <a href="https://vlt.io/sign-up">
       <ShinyButton>Join the Waitlist</ShinyButton>
     </a>
   )

--- a/www/docs/src/components/header/linear-menu.tsx
+++ b/www/docs/src/components/header/linear-menu.tsx
@@ -41,7 +41,7 @@ const LinearMenu = () => {
       {menuData.map(item =>
         item.children ?
           <MenuGroup key={item.title} item={item} />
-          : <MenuLink key={item.title} item={item} />,
+        : <MenuLink key={item.title} item={item} />,
       )}
     </div>
   )
@@ -78,21 +78,21 @@ const MenuLink = ({
   className?: string
 }) => {
   return !item.path ?
-    <span
-      className={`inline-flex items-center gap-x-3 text-nowrap px-3 py-3 ${className}`}>
-      {item.icon ?
-        <MenuLinkIcon item={item} />
+      <span
+        className={`inline-flex items-center gap-x-3 text-nowrap px-3 py-3 ${className}`}>
+        {item.icon ?
+          <MenuLinkIcon item={item} />
         : null}{' '}
-      {item.title}
-    </span>
+        {item.title}
+      </span>
     : <a
-      href={item.path}
-      className={`text-15 group inline-flex items-center gap-x-3 text-nowrap rounded-[8px] px-4 py-1.5 text-foreground no-underline hover:bg-black/5 dark:hover:bg-white/10 ${className}`}>
-      {item.icon ?
-        <MenuLinkIcon item={item} />
+        href={item.path}
+        className={`text-15 group inline-flex items-center gap-x-3 text-nowrap rounded-[8px] px-4 py-1.5 text-foreground no-underline hover:bg-black/5 dark:hover:bg-white/10 ${className}`}>
+        {item.icon ?
+          <MenuLinkIcon item={item} />
         : null}{' '}
-      {item.title}
-    </a>
+        {item.title}
+      </a>
 }
 
 const MenuLinkIcon = ({ item }: { item: MenuItem }) => {

--- a/www/docs/src/components/header/linear-menu.tsx
+++ b/www/docs/src/components/header/linear-menu.tsx
@@ -17,23 +17,23 @@ interface MenuItem {
 const LinearMenu = () => {
   const menuData: MenuItem[] = [
     {
-      title: 'Product',
+      title: 'Platform',
       children: [
         {
           icon: 'client',
           title: 'Client',
-          path: 'https://vlt.sh/client',
+          path: 'https://vlt.io/open-source/client',
         },
         {
           icon: 'serverless-registry',
           title: 'Serverless Registry',
-          path: 'https://vlt.sh/serverless-registry',
+          path: 'https://vlt.io/open-source/serverless-registry',
         },
       ],
     },
-    { title: 'Docs', path: 'https://docs.vlt.sh/' },
-    { title: 'Blog', path: 'https://blog.vlt.sh/' },
-    { title: 'Company', path: 'https://vlt.sh/company' },
+    { title: 'Docs', path: 'https://docs.vlt.io/' },
+    { title: 'Blog', path: 'https://vlt.io/blog' },
+    { title: 'Company', path: 'https://vlt.io/about' },
   ]
 
   return (
@@ -41,7 +41,7 @@ const LinearMenu = () => {
       {menuData.map(item =>
         item.children ?
           <MenuGroup key={item.title} item={item} />
-        : <MenuLink key={item.title} item={item} />,
+          : <MenuLink key={item.title} item={item} />,
       )}
     </div>
   )
@@ -78,21 +78,21 @@ const MenuLink = ({
   className?: string
 }) => {
   return !item.path ?
-      <span
-        className={`inline-flex items-center gap-x-3 text-nowrap px-3 py-3 ${className}`}>
-        {item.icon ?
-          <MenuLinkIcon item={item} />
+    <span
+      className={`inline-flex items-center gap-x-3 text-nowrap px-3 py-3 ${className}`}>
+      {item.icon ?
+        <MenuLinkIcon item={item} />
         : null}{' '}
-        {item.title}
-      </span>
+      {item.title}
+    </span>
     : <a
-        href={item.path}
-        className={`text-15 group inline-flex items-center gap-x-3 text-nowrap rounded-[8px] px-4 py-1.5 text-foreground no-underline hover:bg-black/5 dark:hover:bg-white/10 ${className}`}>
-        {item.icon ?
-          <MenuLinkIcon item={item} />
+      href={item.path}
+      className={`text-15 group inline-flex items-center gap-x-3 text-nowrap rounded-[8px] px-4 py-1.5 text-foreground no-underline hover:bg-black/5 dark:hover:bg-white/10 ${className}`}>
+      {item.icon ?
+        <MenuLinkIcon item={item} />
         : null}{' '}
-        {item.title}
-      </a>
+      {item.title}
+    </a>
 }
 
 const MenuLinkIcon = ({ item }: { item: MenuItem }) => {

--- a/www/docs/src/components/page-frame/page-frame.astro
+++ b/www/docs/src/components/page-frame/page-frame.astro
@@ -24,7 +24,7 @@ const shouldRenderSearch =
     <nav
       class="mx-auto -mt-1 flex w-full max-w-8xl items-center justify-between px-10 py-6 md:px-6">
       <a
-        href="https://www.vlt.sh/"
+        href="https://www.vlt.io/"
         class="-mt-[1px] ml-[5px] flex h-[52px] w-[104px] items-center">
         <Logo />
       </a>

--- a/www/docs/src/content/docs/cli/registries.mdx
+++ b/www/docs/src/content/docs/cli/registries.mdx
@@ -22,7 +22,7 @@ common for organizations to set up private internal registries for use
 with their non-OSS code, or to mirror public registries for
 redundancy, security, and auditing capability.
 
-[VSR](https://www.vlt.sh/serverless-registry) is a hosted serverless
+[VSR](https://vlt.io/open-source/serverless-registry) is a hosted serverless
 registry that vlt provides for this purpose.
 
 Packages that are referenced by a name and version or version range

--- a/www/docs/src/content/docs/cli/registries.mdx
+++ b/www/docs/src/content/docs/cli/registries.mdx
@@ -22,8 +22,8 @@ common for organizations to set up private internal registries for use
 with their non-OSS code, or to mirror public registries for
 redundancy, security, and auditing capability.
 
-[VSR](https://vlt.io/open-source/serverless-registry) is a hosted serverless
-registry that vlt provides for this purpose.
+[VSR](https://vlt.io/open-source/serverless-registry) is a hosted
+serverless registry that vlt provides for this purpose.
 
 Packages that are referenced by a name and version or version range
 (or a `dist-tag` like `latest`) are resolved using a registry.


### PR DESCRIPTION
Update domain references in the docs site UI (header linear menu, page frame logo, footer sections) and the registries doc page. Per-site redirects on vlt.io changed since launch, so several paths move too:

- /client              -> /open-source/client
- /serverless-registry -> /open-source/serverless-registry
- /join                -> /sign-up
- /company             -> /about
- /brand               -> /brand-kit
- blog.vlt.sh          -> vlt.io/blog
- docs.vlt.sh          -> docs.vlt.io

All targets verified to return HTTP 200.