### PR TITLE
docs: skip Vercel deploy when docs haven't changed

### DIFF
--- a/www/docs/vercel.json
+++ b/www/docs/vercel.json
@@ -1,0 +1,5 @@
+{
+  "git": {
+    "ignoredCommand": "! git diff --quiet $VERCEL_GIT_PREVIOUS_SHA $VERCEL_GIT_COMMIT_SHA -- www/docs/"
+  }
+}


### PR DESCRIPTION
If i'm not mistaken, we deploy to vercel everytime this monorepo merges to main. 