### PR TITLE
feat: add --save-exact and --save-prefix options for vlt install

### DIFF
--- a/src/cli-sdk/src/commands/install.ts
+++ b/src/cli-sdk/src/commands/install.ts
@@ -41,6 +41,11 @@ export const usage: CommandUsage = () =>
         description:
           'Save installed packages with exact versions instead of a semver range.',
       },
+      'save-prefix': {
+        value: '<prefix>',
+        description:
+          'The version prefix to use when saving dependencies (e.g. ^, ~, >=, or empty string).',
+      },
       'save-optional': {
         description:
           'Save installed packages to package.json as optionalDependencies.',
@@ -162,6 +167,7 @@ export const command: CommandFn<InstallResult> = async conf => {
   const expectLockfile = conf.options['expect-lockfile']
   const lockfileOnly = conf.options['lockfile-only']
   const saveExact = conf.values['save-exact']
+  const savePrefix = conf.values['save-prefix']
   /* c8 ignore start */
   const allowScripts =
     conf.get('allow-scripts') ?
@@ -177,6 +183,7 @@ export const command: CommandFn<InstallResult> = async conf => {
       allowScripts,
       lockfileOnly,
       saveExact,
+      savePrefix,
     },
     add,
   )

--- a/src/cli-sdk/src/commands/install.ts
+++ b/src/cli-sdk/src/commands/install.ts
@@ -37,6 +37,10 @@ export const usage: CommandUsage = () =>
         description:
           'Save installed packages to package.json as devDependencies.',
       },
+      'save-exact': {
+        description:
+          'Save installed packages with exact versions instead of a semver range.',
+      },
       'save-optional': {
         description:
           'Save installed packages to package.json as optionalDependencies.',
@@ -157,6 +161,7 @@ export const command: CommandFn<InstallResult> = async conf => {
   const frozenLockfile = conf.options['frozen-lockfile']
   const expectLockfile = conf.options['expect-lockfile']
   const lockfileOnly = conf.options['lockfile-only']
+  const saveExact = conf.values['save-exact']
   /* c8 ignore start */
   const allowScripts =
     conf.get('allow-scripts') ?
@@ -171,6 +176,7 @@ export const command: CommandFn<InstallResult> = async conf => {
       expectLockfile,
       allowScripts,
       lockfileOnly,
+      saveExact,
     },
     add,
   )

--- a/src/cli-sdk/src/config/definition.ts
+++ b/src/cli-sdk/src/config/definition.ts
@@ -651,6 +651,16 @@ export const definition = j
   })
 
   .opt({
+    'save-prefix': {
+      description: `The version prefix to use when saving dependencies to
+                    package.json (e.g. \`^\`, \`~\`, \`>=\`, or empty string
+                    for exact versions). Defaults to \`^\`.
+                    Ignored when \`--save-exact\` is set.`,
+      default: '^',
+    },
+  })
+
+  .opt({
     'expect-results': {
       hint: 'value',
       validate: (v: unknown) =>

--- a/src/cli-sdk/src/config/definition.ts
+++ b/src/cli-sdk/src/config/definition.ts
@@ -626,6 +626,12 @@ export const definition = j
       description: `Save installed packages to a package.json file as
                     devDependencies`,
     },
+    'save-exact': {
+      short: 'E',
+      description: `Save installed packages to package.json with an exact
+                    version rather than using the default semver range
+                    operator (e.g. \`1.2.3\` instead of \`^1.2.3\`).`,
+    },
     'save-optional': {
       short: 'O',
       description: `Save installed packages to a package.json file as

--- a/src/cli-sdk/tap-snapshots/test/commands/install.ts.test.cjs
+++ b/src/cli-sdk/tap-snapshots/test/commands/install.ts.test.cjs
@@ -42,6 +42,12 @@ appropriately.
 
       ​--save-exact
 
+    save-prefix
+      The version prefix to use when saving dependencies (e.g. ^, ~, >=, or
+      empty string).
+
+      ​--save-prefix=<prefix>
+
     save-optional
       Save installed packages to package.json as optionalDependencies.
 

--- a/src/cli-sdk/tap-snapshots/test/commands/install.ts.test.cjs
+++ b/src/cli-sdk/tap-snapshots/test/commands/install.ts.test.cjs
@@ -37,6 +37,11 @@ appropriately.
 
       ​--save-dev
 
+    save-exact
+      Save installed packages with exact versions instead of a semver range.
+
+      ​--save-exact
+
     save-optional
       Save installed packages to package.json as optionalDependencies.
 

--- a/src/cli-sdk/tap-snapshots/test/config/definition.ts.test.cjs
+++ b/src/cli-sdk/tap-snapshots/test/config/definition.ts.test.cjs
@@ -410,6 +410,11 @@ Object {
     "short": "D",
     "type": "boolean",
   },
+  "save-exact": Object {
+    "description": "Save installed packages to package.json with an exact version rather than using the default semver range operator (e.g. \`1.2.3\` instead of \`^1.2.3\`).",
+    "short": "E",
+    "type": "boolean",
+  },
   "save-optional": Object {
     "description": "Save installed packages to a package.json file as optionalDependencies",
     "short": "O",
@@ -595,6 +600,7 @@ Array [
   "--registries=<name=url>",
   "--registry=<url>",
   "--save-dev",
+  "--save-exact",
   "--save-optional",
   "--save-peer",
   "--save-prod",
@@ -657,6 +663,7 @@ Array [
   "registries",
   "registry",
   "save-dev",
+  "save-exact",
   "save-optional",
   "save-peer",
   "save-prod",

--- a/src/cli-sdk/tap-snapshots/test/config/definition.ts.test.cjs
+++ b/src/cli-sdk/tap-snapshots/test/config/definition.ts.test.cjs
@@ -424,6 +424,10 @@ Object {
     "description": "Save installed packages to a package.json file as peerDependencies",
     "type": "boolean",
   },
+  "save-prefix": Object {
+    "description": "The version prefix to use when saving dependencies to package.json (e.g. \`^\`, \`~\`, \`>=\`, or empty string for exact versions). Defaults to \`^\`. Ignored when \`--save-exact\` is set.",
+    "type": "string",
+  },
   "save-prod": Object {
     "description": "Save installed packages into dependencies specifically. This is useful if a package already exists in devDependencies or optionalDependencies, but you want to move it to be a non-optional production dependency.",
     "short": "P",
@@ -603,6 +607,7 @@ Array [
   "--save-exact",
   "--save-optional",
   "--save-peer",
+  "--save-prefix=<save-prefix>",
   "--save-prod",
   "--scope=<query>",
   "--scoped-registries=<@scope=url>",
@@ -666,6 +671,7 @@ Array [
   "save-exact",
   "save-optional",
   "save-peer",
+  "save-prefix",
   "save-prod",
   "scope",
   "scoped-registries",

--- a/src/cli-sdk/tap-snapshots/test/index.ts.test.cjs
+++ b/src/cli-sdk/tap-snapshots/test/index.ts.test.cjs
@@ -79,6 +79,7 @@ Unknown option '--unknown'. To specify a positional argument starting with a '-'
     --save-exact
     --save-optional
     --save-peer
+    --save-prefix=<save-prefix>
     --save-prod
     --scope=<query>
     --scoped-registries=<@scope=url>
@@ -145,6 +146,7 @@ Unknown config option: asdf
     save-exact
     save-optional
     save-peer
+    save-prefix
     save-prod
     scope
     scoped-registries

--- a/src/cli-sdk/tap-snapshots/test/index.ts.test.cjs
+++ b/src/cli-sdk/tap-snapshots/test/index.ts.test.cjs
@@ -76,6 +76,7 @@ Unknown option '--unknown'. To specify a positional argument starting with a '-'
     --registries=<name=url>
     --registry=<url>
     --save-dev
+    --save-exact
     --save-optional
     --save-peer
     --save-prod
@@ -141,6 +142,7 @@ Unknown config option: asdf
     registries
     registry
     save-dev
+    save-exact
     save-optional
     save-peer
     save-prod

--- a/src/graph/src/install.ts
+++ b/src/graph/src/install.ts
@@ -28,6 +28,7 @@ export type InstallOptions = LoadOptions & {
   packageInfo: PackageInfoClient
   cleanInstall?: boolean // Only set by ci command for clean install
   allowScripts: string
+  saveExact?: boolean
 }
 
 export const install = async (

--- a/src/graph/src/install.ts
+++ b/src/graph/src/install.ts
@@ -29,6 +29,7 @@ export type InstallOptions = LoadOptions & {
   cleanInstall?: boolean // Only set by ci command for clean install
   allowScripts: string
   saveExact?: boolean
+  savePrefix?: string
 }
 
 export const install = async (

--- a/src/graph/src/reify/calculate-save-value.ts
+++ b/src/graph/src/reify/calculate-save-value.ts
@@ -6,6 +6,7 @@ export const calculateSaveValue = (
   spec: Spec,
   existing: string | undefined,
   nodeVersion: string | undefined,
+  saveExact?: boolean,
 ): string => {
   // Catalog specs should always be preserved as-is in package.json.
   // The catalog reference (e.g. "catalog:dev") is the user's intent;
@@ -32,9 +33,10 @@ export const calculateSaveValue = (
       // then leave it as-is, because we just installed our pj dep
       return existing
     } else {
+      const prefix = saveExact ? '' : SAVE_PREFIX
       const finalRange =
-        (spec.final.semver && spec.final.bareSpec) ||
-        `${SAVE_PREFIX}${nodeVersion}`
+        (spec.final.semver && !saveExact && spec.final.bareSpec) ||
+        `${prefix}${nodeVersion}`
       // didn't have dep previously, or depended on a different thing
       // than what was requested. Update with the ^ range based on
       // the node that landed in the graph, but preserve alias prefix

--- a/src/graph/src/reify/calculate-save-value.ts
+++ b/src/graph/src/reify/calculate-save-value.ts
@@ -1,5 +1,6 @@
 import type { Spec } from '@vltpkg/spec'
-const SAVE_PREFIX = '^'
+
+const DEFAULT_SAVE_PREFIX = '^'
 
 export const calculateSaveValue = (
   nodeType: string,
@@ -7,6 +8,7 @@ export const calculateSaveValue = (
   existing: string | undefined,
   nodeVersion: string | undefined,
   saveExact?: boolean,
+  savePrefix?: string,
 ): string => {
   // Catalog specs should always be preserved as-is in package.json.
   // The catalog reference (e.g. "catalog:dev") is the user's intent;
@@ -33,7 +35,8 @@ export const calculateSaveValue = (
       // then leave it as-is, because we just installed our pj dep
       return existing
     } else {
-      const prefix = saveExact ? '' : SAVE_PREFIX
+      const prefix =
+        saveExact ? '' : (savePrefix ?? DEFAULT_SAVE_PREFIX)
       const finalRange =
         (spec.final.semver && !saveExact && spec.final.bareSpec) ||
         `${prefix}${nodeVersion}`

--- a/src/graph/src/reify/index.ts
+++ b/src/graph/src/reify/index.ts
@@ -97,6 +97,7 @@ export type ReifyOptions = LoadOptions & {
   remover: RollbackRemove
   update?: boolean
   saveExact?: boolean
+  savePrefix?: string
 }
 
 export type ReifyResult = {
@@ -195,6 +196,7 @@ const reify_ = async (
     scurry,
     allowScripts,
     saveExact,
+    savePrefix,
   } = options
   const saveImportersPackageJson =
     /* c8 ignore next */
@@ -205,6 +207,7 @@ const reify_ = async (
         graph: options.graph,
         packageJson,
         saveExact,
+        savePrefix,
       })
     : undefined
 

--- a/src/graph/src/reify/index.ts
+++ b/src/graph/src/reify/index.ts
@@ -96,6 +96,7 @@ export type ReifyOptions = LoadOptions & {
   modifiers?: GraphModifier
   remover: RollbackRemove
   update?: boolean
+  saveExact?: boolean
 }
 
 export type ReifyResult = {
@@ -193,6 +194,7 @@ const reify_ = async (
     packageJson,
     scurry,
     allowScripts,
+    saveExact,
   } = options
   const saveImportersPackageJson =
     /* c8 ignore next */
@@ -202,6 +204,7 @@ const reify_ = async (
         remove,
         graph: options.graph,
         packageJson,
+        saveExact,
       })
     : undefined
 

--- a/src/graph/src/reify/update-importers-package-json.ts
+++ b/src/graph/src/reify/update-importers-package-json.ts
@@ -56,6 +56,11 @@ export type UpdatePackageJsonOptions = {
    * instead of the default semver range operator (e.g. `^1.2.3`).
    */
   saveExact?: boolean
+  /**
+   * The prefix to use when saving dependency versions (e.g. `^`, `~`, `>=`, ``).
+   * Defaults to `^` if not specified. Ignored when `saveExact` is true.
+   */
+  savePrefix?: string
 }
 
 const addOrRemoveDeps = (
@@ -65,6 +70,7 @@ const addOrRemoveDeps = (
     | AddImportersDependenciesMap
     | RemoveImportersDependenciesMap,
   saveExact?: boolean,
+  savePrefix?: string,
 ): NormalizedManifest | undefined => {
   const node = graph.nodes.get(nodeId)
   if (!node) {
@@ -147,6 +153,7 @@ const addOrRemoveDeps = (
         existing,
         n.version,
         saveExact,
+        savePrefix,
       )
       dependencies[name] = saveValue
       manifestChanged = manifestChanged || saveValue !== existing
@@ -165,6 +172,7 @@ export const updatePackageJson = ({
   packageJson,
   remove,
   saveExact,
+  savePrefix,
 }: UpdatePackageJsonOptions) => {
   const manifestsToUpdate = new Set<NormalizedManifest>()
   const operations = new Set([add, remove])
@@ -180,6 +188,7 @@ export const updatePackageJson = ({
           graph,
           operation,
           saveExact,
+          savePrefix,
         )
         if (manifest) {
           manifestsToUpdate.add(manifest)

--- a/src/graph/src/reify/update-importers-package-json.ts
+++ b/src/graph/src/reify/update-importers-package-json.ts
@@ -67,8 +67,7 @@ const addOrRemoveDeps = (
   nodeId: DepID,
   graph: Graph,
   addOrRemove?:
-    | AddImportersDependenciesMap
-    | RemoveImportersDependenciesMap,
+    AddImportersDependenciesMap | RemoveImportersDependenciesMap,
   saveExact?: boolean,
   savePrefix?: string,
 ): NormalizedManifest | undefined => {

--- a/src/graph/src/reify/update-importers-package-json.ts
+++ b/src/graph/src/reify/update-importers-package-json.ts
@@ -51,13 +51,20 @@ export type UpdatePackageJsonOptions = {
    * instance used to load these `package.json` files previously.
    */
   packageJson: PackageJson
+  /**
+   * When true, save dependencies with exact versions (e.g. `1.2.3`)
+   * instead of the default semver range operator (e.g. `^1.2.3`).
+   */
+  saveExact?: boolean
 }
 
 const addOrRemoveDeps = (
   nodeId: DepID,
   graph: Graph,
   addOrRemove?:
-    AddImportersDependenciesMap | RemoveImportersDependenciesMap,
+    | AddImportersDependenciesMap
+    | RemoveImportersDependenciesMap,
+  saveExact?: boolean,
 ): NormalizedManifest | undefined => {
   const node = graph.nodes.get(nodeId)
   if (!node) {
@@ -139,6 +146,7 @@ const addOrRemoveDeps = (
         dep.spec,
         existing,
         n.version,
+        saveExact,
       )
       dependencies[name] = saveValue
       manifestChanged = manifestChanged || saveValue !== existing
@@ -156,6 +164,7 @@ export const updatePackageJson = ({
   graph,
   packageJson,
   remove,
+  saveExact,
 }: UpdatePackageJsonOptions) => {
   const manifestsToUpdate = new Set<NormalizedManifest>()
   const operations = new Set([add, remove])
@@ -166,7 +175,12 @@ export const updatePackageJson = ({
       // that are nested folders from which the user can also add new
       // dependencies to
       for (const nodeId of operation.keys()) {
-        const manifest = addOrRemoveDeps(nodeId, graph, operation)
+        const manifest = addOrRemoveDeps(
+          nodeId,
+          graph,
+          operation,
+          saveExact,
+        )
         if (manifest) {
           manifestsToUpdate.add(manifest)
         }

--- a/src/graph/test/reify/calculate-save-value.ts
+++ b/src/graph/test/reify/calculate-save-value.ts
@@ -193,3 +193,173 @@ t.test('save-exact with catalog spec', t => {
   )
   t.end()
 })
+
+// save-prefix registry cases
+// nodeVersion is always 1.2.3
+const savePrefixTildeCases: [
+  spec: string,
+  existing: string | undefined,
+  expect: string,
+  comment: string,
+][] = [
+  ['', undefined, '~1.2.3', 'new dep, no spec, use tilde prefix'],
+  [
+    '1',
+    undefined,
+    '1',
+    'range spec preserved as-is with tilde prefix',
+  ],
+  ['npm:b', undefined, 'npm:b@~1.2.3', 'alias with tilde prefix'],
+  [
+    'npm:b@',
+    undefined,
+    'npm:b@~1.2.3',
+    'alias with @ uses tilde prefix',
+  ],
+  [
+    'npm:b@npm:c',
+    undefined,
+    'npm:c@~1.2.3',
+    'chained alias shortened with tilde prefix',
+  ],
+  [
+    'jsr:@a/b@',
+    undefined,
+    'jsr:@a/b@~1.2.3',
+    'jsr alias with tilde prefix',
+  ],
+  [
+    'npm:@i/j@jsr:@a/b',
+    undefined,
+    'jsr:@a/b@~1.2.3',
+    'jsr alias shorten with tilde prefix',
+  ],
+  ['jsr:', undefined, 'jsr:~1.2.3', 'jsr tilde prefix'],
+  ['latest', 'latest', 'latest', 'spec matches manifest, unchanged'],
+  ['', 'latest', 'latest', 'spec from manifest, unchanged'],
+  ['1.2.3', 'latest', '1.2.3', 'specific version stays exact'],
+  [
+    '',
+    '1.2.3',
+    '1.2.3',
+    'manifest needs specific version, unchanged',
+  ],
+  ['1.2', '1.2', '1.2', 'got exactly what we wanted, unchanged'],
+]
+
+t.test('save-prefix ~ registry cases', t => {
+  t.plan(savePrefixTildeCases.length)
+  for (const [
+    bareSpec,
+    existing,
+    expect,
+    comment,
+  ] of savePrefixTildeCases) {
+    const spec = Spec.parse('@x/y', bareSpec)
+    t.equal(
+      calculateSaveValue(
+        'registry',
+        spec,
+        existing,
+        '1.2.3',
+        false,
+        '~',
+      ),
+      expect,
+      comment,
+    )
+  }
+})
+
+t.test('save-prefix >= registry cases', t => {
+  const spec = Spec.parse('@x/y', '')
+  t.equal(
+    calculateSaveValue(
+      'registry',
+      spec,
+      undefined,
+      '1.2.3',
+      false,
+      '>=',
+    ),
+    '>=1.2.3',
+    'new dep with >= prefix',
+  )
+  t.end()
+})
+
+t.test('save-prefix empty string registry cases', t => {
+  const spec = Spec.parse('@x/y', '')
+  t.equal(
+    calculateSaveValue(
+      'registry',
+      spec,
+      undefined,
+      '1.2.3',
+      false,
+      '',
+    ),
+    '1.2.3',
+    'new dep with empty prefix (exact version)',
+  )
+  t.end()
+})
+
+t.test('save-exact takes precedence over save-prefix', t => {
+  const spec = Spec.parse('@x/y', '')
+  t.equal(
+    calculateSaveValue(
+      'registry',
+      spec,
+      undefined,
+      '1.2.3',
+      true,
+      '~',
+    ),
+    '1.2.3',
+    'saveExact overrides savePrefix',
+  )
+  t.end()
+})
+
+t.test('save-prefix with non-registry type', t => {
+  const s = Spec.parse('x', 'github:a/b')
+  t.equal(
+    calculateSaveValue('git', s, 'a/b', '1.2.3', false, '~'),
+    'github:a/b',
+    'non-registry type unaffected by savePrefix',
+  )
+  t.end()
+})
+
+t.test('save-prefix with catalog spec', t => {
+  const s = Spec.parse('typescript', 'catalog:dev', {
+    catalog: {},
+    catalogs: { dev: { typescript: 'npm:typescript@^5.0.0' } },
+    registry: 'https://registry.npmjs.org/',
+    registries: {},
+  })
+  t.equal(
+    calculateSaveValue('registry', s, undefined, '5.9.3', false, '~'),
+    'catalog:dev',
+    'catalog spec preserved even with savePrefix',
+  )
+  t.end()
+})
+
+t.test('save-prefix defaults to ^ when undefined', t => {
+  const spec = Spec.parse('@x/y', '')
+  t.equal(
+    calculateSaveValue(
+      'registry',
+      spec,
+      undefined,
+      '1.2.3',
+      false,
+      undefined,
+    ),
+    '^1.2.3',
+    'undefined savePrefix defaults to ^',
+  )
+  t.end()
+})

--- a/src/graph/test/reify/calculate-save-value.ts
+++ b/src/graph/test/reify/calculate-save-value.ts
@@ -98,3 +98,98 @@ t.test('registry cases', t => {
     )
   }
 })
+
+// save-exact registry cases
+// nodeVersion is always 1.2.3
+const saveExactCases: [
+  spec: string,
+  existing: string | undefined,
+  expect: string,
+  comment: string,
+][] = [
+  ['', undefined, '1.2.3', 'new dep, no spec, use exact version'],
+  [
+    '1',
+    undefined,
+    '1.2.3',
+    'range spec overridden with exact version',
+  ],
+  ['npm:b', undefined, 'npm:b@1.2.3', 'alias with exact version'],
+  [
+    'npm:b@',
+    undefined,
+    'npm:b@1.2.3',
+    'alias with @ uses exact version',
+  ],
+  [
+    'npm:b@npm:c',
+    undefined,
+    'npm:c@1.2.3',
+    'chained alias shortened with exact version',
+  ],
+  [
+    'jsr:@a/b@',
+    undefined,
+    'jsr:@a/b@1.2.3',
+    'jsr alias with exact version',
+  ],
+  [
+    'npm:@i/j@jsr:@a/b',
+    undefined,
+    'jsr:@a/b@1.2.3',
+    'jsr alias shorten with exact version',
+  ],
+  ['jsr:', undefined, 'jsr:1.2.3', 'jsr exact version'],
+  ['latest', 'latest', 'latest', 'spec matches manifest, unchanged'],
+  ['', 'latest', 'latest', 'spec from manifest, unchanged'],
+  ['1.2.3', 'latest', '1.2.3', 'specific version stays exact'],
+  [
+    '',
+    '1.2.3',
+    '1.2.3',
+    'manifest needs specific version, unchanged',
+  ],
+  ['1.2', '1.2', '1.2', 'got exactly what we wanted, unchanged'],
+]
+
+t.test('save-exact registry cases', t => {
+  t.plan(saveExactCases.length)
+  for (const [
+    bareSpec,
+    existing,
+    expect,
+    comment,
+  ] of saveExactCases) {
+    const spec = Spec.parse('@x/y', bareSpec)
+    t.equal(
+      calculateSaveValue('registry', spec, existing, '1.2.3', true),
+      expect,
+      comment,
+    )
+  }
+})
+
+t.test('save-exact with non-registry type', t => {
+  const s = Spec.parse('x', 'github:a/b')
+  t.equal(
+    calculateSaveValue('git', s, 'a/b', '1.2.3', true),
+    'github:a/b',
+    'non-registry type unaffected by saveExact',
+  )
+  t.end()
+})
+
+t.test('save-exact with catalog spec', t => {
+  const s = Spec.parse('typescript', 'catalog:dev', {
+    catalog: {},
+    catalogs: { dev: { typescript: 'npm:typescript@^5.0.0' } },
+    registry: 'https://registry.npmjs.org/',
+    registries: {},
+  })
+  t.equal(
+    calculateSaveValue('registry', s, undefined, '5.9.3', true),
+    'catalog:dev',
+    'catalog spec preserved even with saveExact',
+  )
+  t.end()
+})

--- a/src/graph/test/reify/update-importers-package-json.ts
+++ b/src/graph/test/reify/update-importers-package-json.ts
@@ -682,4 +682,59 @@ t.test('updatePackageJson', async t => {
       )
     },
   )
+
+  await t.test('save-exact saves exact versions', async t => {
+    const testRootMani = {
+      name: 'exact-root',
+      version: '1.0.0',
+    }
+
+    const testGraph = new Graph({
+      mainManifest: testRootMani,
+      projectRoot: t.testdirName,
+    })
+    const testRoot = testGraph.mainImporter
+
+    // Dependency resolves to version 4.0.0
+    const abbrevMani = { name: 'abbrev', version: '4.0.0' }
+    // Bare spec with no version (like running `vlt i abbrev`)
+    const abbrevSpec = Spec.parse('abbrev')
+    const abbrev = testGraph.addNode(
+      undefined,
+      abbrevMani,
+      abbrevSpec,
+      abbrevMani.name,
+      abbrevMani.version,
+    )
+    testGraph.addEdge('prod', abbrevSpec, testRoot, abbrev)
+
+    updatePackageJson({
+      packageJson,
+      graph: testGraph,
+      saveExact: true,
+      add: new Map([
+        [
+          testRoot.id,
+          new Map([
+            [
+              'abbrev',
+              asDependency({
+                spec: abbrevSpec,
+                type: 'prod',
+              }),
+            ],
+          ]),
+        ],
+      ]) as AddImportersDependenciesMap,
+    })()
+
+    const res = retrieveManifestResult()
+    t.strictSame(res.length, 1, 'should have been called once')
+    // The key assertion: should be 4.0.0 (exact), NOT ^4.0.0 (caret)
+    t.strictSame(
+      res[0]?.[0]?.dependencies?.abbrev,
+      '4.0.0',
+      'should save exact version without caret prefix',
+    )
+  })
 })

--- a/src/graph/test/reify/update-importers-package-json.ts
+++ b/src/graph/test/reify/update-importers-package-json.ts
@@ -683,6 +683,221 @@ t.test('updatePackageJson', async t => {
     },
   )
 
+  await t.test('save-prefix ~ saves tilde versions', async t => {
+    const testRootMani = {
+      name: 'tilde-root',
+      version: '1.0.0',
+    }
+
+    const testGraph = new Graph({
+      mainManifest: testRootMani,
+      projectRoot: t.testdirName,
+    })
+    const testRoot = testGraph.mainImporter
+
+    const abbrevMani = { name: 'abbrev', version: '4.0.0' }
+    const abbrevSpec = Spec.parse('abbrev')
+    const abbrev = testGraph.addNode(
+      undefined,
+      abbrevMani,
+      abbrevSpec,
+      abbrevMani.name,
+      abbrevMani.version,
+    )
+    testGraph.addEdge('prod', abbrevSpec, testRoot, abbrev)
+
+    updatePackageJson({
+      packageJson,
+      graph: testGraph,
+      savePrefix: '~',
+      add: new Map([
+        [
+          testRoot.id,
+          new Map([
+            [
+              'abbrev',
+              asDependency({
+                spec: abbrevSpec,
+                type: 'prod',
+              }),
+            ],
+          ]),
+        ],
+      ]) as AddImportersDependenciesMap,
+    })()
+
+    const res = retrieveManifestResult()
+    t.strictSame(res.length, 1, 'should have been called once')
+    t.strictSame(
+      res[0]?.[0]?.dependencies?.abbrev,
+      '~4.0.0',
+      'should save version with tilde prefix',
+    )
+  })
+
+  await t.test('save-prefix >= saves gte versions', async t => {
+    const testRootMani = {
+      name: 'gte-root',
+      version: '1.0.0',
+    }
+
+    const testGraph = new Graph({
+      mainManifest: testRootMani,
+      projectRoot: t.testdirName,
+    })
+    const testRoot = testGraph.mainImporter
+
+    const abbrevMani = { name: 'abbrev', version: '4.0.0' }
+    const abbrevSpec = Spec.parse('abbrev')
+    const abbrev = testGraph.addNode(
+      undefined,
+      abbrevMani,
+      abbrevSpec,
+      abbrevMani.name,
+      abbrevMani.version,
+    )
+    testGraph.addEdge('prod', abbrevSpec, testRoot, abbrev)
+
+    updatePackageJson({
+      packageJson,
+      graph: testGraph,
+      savePrefix: '>=',
+      add: new Map([
+        [
+          testRoot.id,
+          new Map([
+            [
+              'abbrev',
+              asDependency({
+                spec: abbrevSpec,
+                type: 'prod',
+              }),
+            ],
+          ]),
+        ],
+      ]) as AddImportersDependenciesMap,
+    })()
+
+    const res = retrieveManifestResult()
+    t.strictSame(res.length, 1, 'should have been called once')
+    t.strictSame(
+      res[0]?.[0]?.dependencies?.abbrev,
+      '>=4.0.0',
+      'should save version with >= prefix',
+    )
+  })
+
+  await t.test(
+    'save-prefix empty string saves exact versions',
+    async t => {
+      const testRootMani = {
+        name: 'empty-prefix-root',
+        version: '1.0.0',
+      }
+
+      const testGraph = new Graph({
+        mainManifest: testRootMani,
+        projectRoot: t.testdirName,
+      })
+      const testRoot = testGraph.mainImporter
+
+      const abbrevMani = { name: 'abbrev', version: '4.0.0' }
+      const abbrevSpec = Spec.parse('abbrev')
+      const abbrev = testGraph.addNode(
+        undefined,
+        abbrevMani,
+        abbrevSpec,
+        abbrevMani.name,
+        abbrevMani.version,
+      )
+      testGraph.addEdge('prod', abbrevSpec, testRoot, abbrev)
+
+      updatePackageJson({
+        packageJson,
+        graph: testGraph,
+        savePrefix: '',
+        add: new Map([
+          [
+            testRoot.id,
+            new Map([
+              [
+                'abbrev',
+                asDependency({
+                  spec: abbrevSpec,
+                  type: 'prod',
+                }),
+              ],
+            ]),
+          ],
+        ]) as AddImportersDependenciesMap,
+      })()
+
+      const res = retrieveManifestResult()
+      t.strictSame(res.length, 1, 'should have been called once')
+      t.strictSame(
+        res[0]?.[0]?.dependencies?.abbrev,
+        '4.0.0',
+        'should save exact version with empty prefix',
+      )
+    },
+  )
+
+  await t.test(
+    'save-exact takes precedence over save-prefix',
+    async t => {
+      const testRootMani = {
+        name: 'precedence-root',
+        version: '1.0.0',
+      }
+
+      const testGraph = new Graph({
+        mainManifest: testRootMani,
+        projectRoot: t.testdirName,
+      })
+      const testRoot = testGraph.mainImporter
+
+      const abbrevMani = { name: 'abbrev', version: '4.0.0' }
+      const abbrevSpec = Spec.parse('abbrev')
+      const abbrev = testGraph.addNode(
+        undefined,
+        abbrevMani,
+        abbrevSpec,
+        abbrevMani.name,
+        abbrevMani.version,
+      )
+      testGraph.addEdge('prod', abbrevSpec, testRoot, abbrev)
+
+      updatePackageJson({
+        packageJson,
+        graph: testGraph,
+        saveExact: true,
+        savePrefix: '~',
+        add: new Map([
+          [
+            testRoot.id,
+            new Map([
+              [
+                'abbrev',
+                asDependency({
+                  spec: abbrevSpec,
+                  type: 'prod',
+                }),
+              ],
+            ]),
+          ],
+        ]) as AddImportersDependenciesMap,
+      })()
+
+      const res = retrieveManifestResult()
+      t.strictSame(res.length, 1, 'should have been called once')
+      t.strictSame(
+        res[0]?.[0]?.dependencies?.abbrev,
+        '4.0.0',
+        'save-exact takes precedence over save-prefix ~',
+      )
+    },
+  )
+
   await t.test('save-exact saves exact versions', async t => {
     const testRootMani = {
       name: 'exact-root',


### PR DESCRIPTION
## Summary

Adds two new options to `vlt install` for controlling how dependency versions are saved to `package.json`:

- **`--save-exact`** (`-E`): Saves installed packages with exact versions (e.g. `1.2.3`) instead of the default semver range (e.g. `^1.2.3`).
- **`--save-prefix=<prefix>`**: Configurable version prefix when saving dependencies (default `^`). Supports `~`, `>=`, empty string, etc. Ignored when `--save-exact` is set.

Closes #1181

## Changes

- **Config definition** (`src/cli-sdk/src/config/definition.ts`): Add `save-exact` boolean option (short: `-E`) and `save-prefix` string option (default: `^`)
- **Install command** (`src/cli-sdk/src/commands/install.ts`): Read both options from config and pass to install options; add usage docs
- **Install options** (`src/graph/src/install.ts`): Add `saveExact` and `savePrefix` to `InstallOptions`
- **Reify** (`src/graph/src/reify/index.ts`): Thread `saveExact` and `savePrefix` through to `updatePackageJson`
- **Update importers** (`src/graph/src/reify/update-importers-package-json.ts`): Pass both options to `calculateSaveValue`
- **Calculate save value** (`src/graph/src/reify/calculate-save-value.ts`): Replace hardcoded `SAVE_PREFIX` with configurable `savePrefix` parameter (defaults to `^`). `saveExact` takes precedence when both are specified.
- Catalog and non-registry specs are unaffected by either option

## Tests

- 15 save-exact test cases for `calculateSaveValue` covering registry, non-registry, alias, JSR, and catalog specs
- Save-prefix test cases covering `~`, `>=`, empty string, undefined (default `^`), and `saveExact` precedence over `savePrefix`
- Integration test for `updatePackageJson` verifying exact version save behavior
- All snapshot files updated