### PR TITLE
feat(query): add dss-query agent skill

### DIFF
--- a/src/query/package.json
+++ b/src/query/package.json
@@ -60,7 +60,8 @@
     }
   },
   "files": [
-    "dist"
+    "dist",
+    "skills"
   ],
   "bugs": {
     "url": "https://github.com/vltpkg/vltpkg/issues"

--- a/src/query/skills/dss-query/REFERENCE.md
+++ b/src/query/skills/dss-query/REFERENCE.md
@@ -1,0 +1,119 @@
+# DSS Reference
+
+Compiled from https://docs.vlt.io/cli/selectors/ (source:
+`www/docs/src/content/docs/cli/selectors/`). When in doubt, check those
+docs — they are canonical.
+
+## Attribute selectors
+
+Match against `package.json` fields.
+
+| Selector | Meaning |
+| --- | --- |
+| `[attr]` | has the property |
+| `[attr=value]` | equals |
+| `[attr^=value]` | starts with |
+| `[attr$=value]` | ends with |
+| `[attr*=value]` | contains |
+| `[attr~=value]` | whitespace-separated list contains |
+| `[attr\|=value]` | equals value or starts with `value-` |
+| `[attr=value i]` | case-insensitive (`s` = case-sensitive, default) |
+
+Nested fields (e.g. `engines.node`) need `:attr()`:
+`:attr(engines, [node])`, `:attr(peerDependenciesMeta, foo, [optional=true])`.
+
+`#foo` is shorthand for `[name=foo]`.
+
+## Combinators
+
+| Combinator | Meaning |
+| --- | --- |
+| `A > B` | B is a **direct** dependency of A (chain for depth: `:root > * > *`) |
+| `A B` | B is a direct **or transitive** dependency of A |
+| `A ~ B` | B shares a parent with A (sibling) |
+
+## Pseudo-states (no arguments)
+
+Graph structure:
+
+| Selector | Matches |
+| --- | --- |
+| `:root` | top-level package.json node |
+| `:project` | root + all workspaces ("your code") |
+| `:workspace` | workspaces from vlt.json |
+| `:scope` | current selector scope (with `--scope`) |
+
+Dependency type:
+
+| Selector | Matches |
+| --- | --- |
+| `:prod` / `:dev` / `:optional` / `:peer` | by dependency type |
+| `:missing` | declared but not installed (**edges only, not nodes**) |
+| `:overridden` | has an override applied |
+
+Package properties:
+
+| Selector | Matches |
+| --- | --- |
+| `:private` | `"private": true` |
+| `:empty` | no dependencies |
+| `:link` | linked packages |
+| `:prerelease` | version has prerelease part (`1.0.0-beta.1`) |
+| `:built` | built during reify |
+| `:scanned` | has Socket security metadata |
+
+## Pseudo-classes (take arguments)
+
+| Selector | Meaning | Example |
+| --- | --- | --- |
+| `:attr(...)` | nested package.json property | `:attr(engines, [node])` |
+| `:dist(tag)` | registry dist-tag | `:dist(latest)` |
+| `:has(sel)` | has matching descendant | `:has(.peer[name=react])` |
+| `:host(name)` | switch graph context to another project | `:host(local) :malware` |
+| `:is(a, b)` | any of (forgiving list) | `:is([name=a], [name=b])` |
+| `:not(sel)` | negation | `:not([license=MIT])` |
+| `:outdated(kind?)` | newer version exists | `:outdated(major)` |
+| `:published(range)` | by publish date | `:published(">2024")` |
+| `:semver(range)` | semver comparison on installed version | `:semver(^1.0.0)` |
+| `:spec(spec)` | by declared specifier (edge) | `:spec(^1.0.0)` |
+| `:path(glob)` | workspace/file packages by path | `:path("packages/**")` |
+| `:type(kind)` | package type | `:type(git)`, `:type(registry)`, `:type(file)` |
+| `:diff(ref)` | files changed vs git ref | `:diff(main)` |
+| `:hostname(host)` | upstream hostname | `:hostname(github.com)` |
+| `:registry(name)` | configured registry name | `:registry(npm)` |
+
+## Security insights (Socket-powered, network call)
+
+Severity args accept names or numbers (`critical`/`0`, `high`/`1`,
+`medium`/`2`, `low`/`3`) and comparators: `:severity(">=medium")`.
+
+Threats: `:malware(sev?)`, `:squat(sev?)`, `:suspicious`, `:confused`.
+
+Vulnerabilities: `:vulnerable` (alias `:vuln`), `:cve(CVE-2023-1234)`,
+`:cve(*)`, `:cwe(CWE-79)`, `:severity(level)`.
+
+Licensing: `:license(type)` — types: `unlicensed`, `misc`, `restricted`,
+`ambiguous`, `copyleft`, `unknown`, `none`, `exception`.
+
+Code behavior: `:eval`, `:network`, `:fs`, `:env`, `:shell`, `:scripts`
+(install scripts), `:debug`, `:dynamic`.
+
+Obfuscation: `:obfuscated`, `:minified`, `:entropic`, `:native`,
+`:shrinkwrap`.
+
+Health: `:deprecated`, `:unmaintained` (5+ years stale), `:unpopular`,
+`:trivial` (<10 LOC), `:abandoned`, `:unknown`, `:unstable`.
+
+Other: `:tracker` (telemetry), `:undesirable`,
+`:score(rate, kind?)` — kinds: `overall` (default), `license`,
+`maintenance`, `quality`, `supplyChain`, `vulnerability`;
+e.g. `:score("<=0.5", "maintenance")`.
+
+## Audit query starters
+
+```bash
+vlt query ':malware(critical), :cve(*), :obfuscated'   # critical issues
+vlt query ':abandoned, :unmaintained, :unknown'        # supply chain risk
+vlt query ':license(copyleft), :license(unlicensed)'   # license compliance
+vlt query ':eval, :shell, :network, :fs'               # behavior audit
+```

--- a/src/query/skills/dss-query/SKILL.md
+++ b/src/query/skills/dss-query/SKILL.md
@@ -1,0 +1,102 @@
+---
+name: dss-query
+description: Explain and compose vlt Dependency Selector Syntax (DSS) queries — CSS-selector-like strings for filtering packages in a dependency graph. Use when the user asks about DSS, `vlt query`, dependency selectors, or wants to find/filter packages (e.g. "find outdated deps", "which packages have CVEs", "select all workspaces").
+---
+
+# DSS Query Helper
+
+Run DSS queries via `vlt query '<selector>'`.
+
+## Response style
+
+**Be concise and brief.** Give the query first, then a one-line explanation.
+No long preambles, no exhaustive alternatives. Example answer shape:
+
+> ```
+> vlt query ':root > :outdated(major)'
+> ```
+> Direct dependencies with a newer major version available.
+
+## Workflow
+
+1. **Clarify intent first** if the goal is ambiguous — ask 1–2 short
+   questions, never a survey. Pin down:
+   - **What to match**: which packages? Whole graph or just direct deps?
+     Everywhere, or only under a specific workspace/package?
+   - **Expected outcome**: what does the result set look like if the query
+     works — a handful of known offenders, every workspace, one package?
+     What will they do with it (audit, remove, report)?
+   Skip this when the request is already specific — don't interrogate
+   someone who said "direct deps of root with an MIT license".
+2. **Compose the query** with the steps below. Then:
+   - Show the query.
+   - Explain each piece in one short sentence.
+   - State what the results should look like, so the user can tell whether
+     it worked.
+3. **"What does this query do?"**: decompose left to right, one line per
+   segment.
+4. **Uncertain match?** Offer to run it: `vlt query '<selector>'` (always
+   single-quote the selector in the shell).
+5. **Iterate**: compare results against the expected outcome from step 1 —
+   too broad/narrow means refine one piece at a time (add a combinator, a
+   pseudo-state, or `:not()`).
+
+## Composing a query from a goal
+
+Build left to right, in this order — each step is optional:
+
+1. **Anchor** — where in the graph? `:root` (top level), `:workspace`,
+   `:project`, `#pkg-name`, or nothing (whole graph).
+2. **Traverse** — what relationship? `>` direct deps, ` ` (space) anything
+   beneath, `~` siblings. Skip to filter the anchor itself.
+3. **Filter** — chain conditions with no space = AND: attribute
+   (`[license=MIT]`), state (`:dev`), functional (`:outdated(major)`),
+   negation (`:not(...)`).
+4. **Union** — need OR? Join complete selectors with commas.
+5. **Invert direction** — "what depends on X?" flips traversal: use
+   `:has(> #x)` (dependents of x), not `#x > *` (dependencies of x).
+
+Worked example — "prod deps of my workspaces with a copyleft license":
+`:workspace` (anchor) + `>` (direct) + `:prod:license(copyleft)` (filters)
+→ `vlt query ':workspace > :prod:license(copyleft)'`
+
+## Core syntax (mental model: CSS, but nodes are packages)
+
+| Piece | Meaning | Example |
+| --- | --- | --- |
+| `[name=foo]` / `#foo` | match by package.json field / name shortcut | `[version^=2]`, `#react` |
+| `>` | direct dependency | `:root > *` |
+| ` ` (space) | any transitive dependency | `:root [name=js-tokens]` |
+| `~` | sibling (shares a parent) | `[name=react] ~ *` |
+| `:root` `:project` `:workspace` | graph anchors | `:workspace > :dev` |
+| `:prod` `:dev` `:optional` `:peer` | dependency type | `:dev:outdated` |
+| `:has()` `:not()` `:is()` | structural filters | `:has(> :cve(*))` |
+| `:outdated()` `:semver()` `:type()` | functional filters | `:outdated(major)` |
+| `:malware` `:cve()` `:license()` | security (Socket data, network call) | `:license(copyleft)` |
+| `,` | OR — union of selectors | `:dev, :optional` |
+
+Chaining without spaces is AND: `:workspace:private` = workspace AND private.
+
+## Common recipes
+
+```bash
+vlt query ':root > *'                    # direct dependencies
+vlt query ':workspace'                   # select all workspaces
+vlt query ':root > :outdated'            # outdated direct deps
+vlt query '[name=react] *'               # everything react pulls in
+vlt query ':has(> #react)'               # packages that directly depend on react
+vlt query ':dev:eval'                    # dev deps using eval()
+vlt query ':malware, :cve(*)'            # malware or any CVE
+```
+
+## Gotchas
+
+- `:missing` matches edges (declarations), not nodes — no package output.
+- Security selectors (`:cve`, `:malware`, `:score`, …) fetch Socket data over
+  the network; expect latency.
+- Quote values with special chars: `[name^="@vltpkg"]`.
+
+## Full reference
+
+Selector-by-selector detail (all pseudo-classes, security insights, operators):
+see [REFERENCE.md](REFERENCE.md). Canonical docs: https://docs.vlt.io/cli/selectors/


### PR DESCRIPTION
Ship a DSS (Dependency Selector Syntax) skill with @vltpkg/query so coding agents can explain and compose selector queries for users unfamiliar with the syntax. Stored in-package under skills/ and added to the publish files list, matching the layout proposed in #1540 where install discovers packaged SKILL.md files and mounts them into the project's root skills/ folder.