### PR TITLE
feat(docs): add Registry and Why vlt links to sidebar

### DIFF
--- a/www/docs/astro.config.mts
+++ b/www/docs/astro.config.mts
@@ -113,6 +113,7 @@ export default defineConfig({
           label: 'Get Started',
           collapsed: true,
           items: [
+            'get-started/why-vlt',
             'get-started/use-cases',
             {
               label: 'Concepts',
@@ -121,6 +122,11 @@ export default defineConfig({
             },
             'get-started/reference',
           ],
+        },
+        {
+          label: 'Registry',
+          collapsed: true,
+          autogenerate: { directory: 'registry' },
         },
         {
           label: 'Client',

--- a/www/docs/src/components/sidebar/data.tsx
+++ b/www/docs/src/components/sidebar/data.tsx
@@ -27,6 +27,9 @@ const allIcons = {
 export type IconName = keyof typeof allIcons
 
 export const iconMap: Partial<Record<string, IconName>> = {
+  'get started': 'BookOpen',
+  'why vlt': 'Lightbulb',
+  registry: 'Globe',
   overview: 'Home',
   client: 'Client',
   packages: 'Package',

--- a/www/docs/src/content/docs/registry/index.mdx
+++ b/www/docs/src/content/docs/registry/index.mdx
@@ -18,12 +18,12 @@ To publish a private or public package with vlt, you first have to
    You can sign up with Github, Google (Gmail) or with an email and
    password.
 
-      <img
-  src="/images/signin.png"
-  alt="Sign up form on vlt's sign up view with first name and last name fields, and login buttons connecting to Google and Github"
-  className="border-sm"
-  style={{ maxWidth: '420px', width: '100%', height: 'auto' }}
-/>
+   <img
+     src="/images/signin.png"
+     alt="Sign up form on vlt's sign up view with first name and last name fields, and login buttons connecting to Google and Github"
+     className="border-sm"
+     style={{ maxWidth: '420px', width: '100%', height: 'auto' }}
+   />
 
 2. **Verify your email**
 
@@ -31,30 +31,30 @@ To publish a private or public package with vlt, you first have to
    one-time passcode (OTP). Paste it into the verification view to
    confirm your account.
 
-      <img
-  src="/images/otp-email.png"
-  alt="Screenshot of vlt signup one-time passcode email"
-  className="border-sm"
-  style={{ maxWidth: '420px', width: '100%', height: 'auto' }}
-/>
+   <img
+     src="/images/otp-email.png"
+     alt="Screenshot of vlt signup one-time passcode email"
+     className="border-sm"
+     style={{ maxWidth: '420px', width: '100%', height: 'auto' }}
+   />
 
 3. Set up your account
 
-      <img
-  src="/images/account-setup.png"
-  alt="Screenshot of vlt account setup view with display name and slug fields, and a grid of plans for user selection"
-  className="border-sm"
-  style={{ width: '100%', height: 'auto' }}
-/>
+   <img
+     src="/images/account-setup.png"
+     alt="Screenshot of vlt account setup view with display name and slug fields, and a grid of plans for user selection"
+     className="border-sm"
+     style={{ width: '100%', height: 'auto' }}
+   />
 
 4. You've signed up! You'll be logged into the Dashboard.
 
-      <img
-  src="/images/dashboard.png"
-  alt="Screenshot of vlt Dashboard view displaying left side side navigation where using can browse through registries and account settings "
-  className="border-sm"
-  style={{ width: '100%', height: 'auto' }}
-/>
+   <img
+     src="/images/dashboard.png"
+     alt="Screenshot of vlt Dashboard view displaying left side side navigation where using can browse through registries and account settings"
+     className="border-sm"
+     style={{ width: '100%', height: 'auto' }}
+   />
 
 </Steps>
 
@@ -67,10 +67,10 @@ To publish a private or public package with vlt, you first have to
    Log in with your email address, or continue with Github or Google.
    You can also use a passkey if you've set one up.
 
-      <img
-  src="/images/login.png"
-  alt="Login view on vlt.io with Email address input, continue button, and Github and Google login buttons. Below are links to Use passkey and a call to action to sign up if the user does not have an account"
-  style={{ maxWidth: '420px', width: '100%', height: 'auto' }}
-/>
+   <img
+     src="/images/login.png"
+     alt="Login view on vlt.io with Email address input, continue button, and Github and Google login buttons. Below are links to Use passkey and a call to action to sign up if the user does not have an account"
+     style={{ maxWidth: '420px', width: '100%', height: 'auto' }}
+   />
 
 </Steps>

--- a/www/docs/src/content/docs/registry/index.mdx
+++ b/www/docs/src/content/docs/registry/index.mdx
@@ -2,7 +2,6 @@
 title: Getting started with the registry
 sidebar:
   label: Registry
-  draft: true
 ---
 
 import { Steps } from '@astrojs/starlight/components'
@@ -19,12 +18,12 @@ To publish a private or public package with vlt, you first have to
    You can sign up with Github, Google (Gmail) or with an email and
    password.
 
-   <img
-     src="/images/signin.png"
-     alt="Sign up form on vlt's sign up view with first name and last name fields, and login buttons connecting to Google and Github"
-     className="border-sm"
-     style={{ maxWidth: '420px', width: '100%', height: 'auto' }}
-   />
+      <img
+  src="/images/signin.png"
+  alt="Sign up form on vlt's sign up view with first name and last name fields, and login buttons connecting to Google and Github"
+  className="border-sm"
+  style={{ maxWidth: '420px', width: '100%', height: 'auto' }}
+/>
 
 2. **Verify your email**
 
@@ -32,30 +31,30 @@ To publish a private or public package with vlt, you first have to
    one-time passcode (OTP). Paste it into the verification view to
    confirm your account.
 
-   <img
-     src="/images/otp-email.png"
-     alt="Screenshot of vlt signup one-time passcode email"
-     className="border-sm"
-     style={{ maxWidth: '420px', width: '100%', height: 'auto' }}
-   />
+      <img
+  src="/images/otp-email.png"
+  alt="Screenshot of vlt signup one-time passcode email"
+  className="border-sm"
+  style={{ maxWidth: '420px', width: '100%', height: 'auto' }}
+/>
 
 3. Set up your account
 
-   <img
-     src="/images/account-setup.png"
-     alt="Screenshot of vlt account setup view with display name and slug fields, and a grid of plans for user selection"
-     className="border-sm"
-     style={{ width: '100%', height: 'auto' }}
-   />
+      <img
+  src="/images/account-setup.png"
+  alt="Screenshot of vlt account setup view with display name and slug fields, and a grid of plans for user selection"
+  className="border-sm"
+  style={{ width: '100%', height: 'auto' }}
+/>
 
 4. You've signed up! You'll be logged into the Dashboard.
 
-   <img
-     src="/images/dashboard.png"
-     alt="Screenshot of vlt Dashboard view displaying left side side navigation where using can browse through registries and account settings "
-     className="border-sm"
-     style={{ width: '100%', height: 'auto' }}
-   />
+      <img
+  src="/images/dashboard.png"
+  alt="Screenshot of vlt Dashboard view displaying left side side navigation where using can browse through registries and account settings "
+  className="border-sm"
+  style={{ width: '100%', height: 'auto' }}
+/>
 
 </Steps>
 
@@ -68,10 +67,10 @@ To publish a private or public package with vlt, you first have to
    Log in with your email address, or continue with Github or Google.
    You can also use a passkey if you've set one up.
 
-   <img
-     src="/images/login.png"
-     alt="Login view on vlt.io with Email address input, continue button, and Github and Google login buttons. Below are links to Use passkey and a call to action to sign up if the user does not have an account"
-     style={{ maxWidth: '420px', width: '100%', height: 'auto' }}
-   />
+      <img
+  src="/images/login.png"
+  alt="Login view on vlt.io with Email address input, continue button, and Github and Google login buttons. Below are links to Use passkey and a call to action to sign up if the user does not have an account"
+  style={{ maxWidth: '420px', width: '100%', height: 'auto' }}
+/>
 
 </Steps>


### PR DESCRIPTION
## Summary

Adds two missing links to the docs.vlt.sh sidebar:

### Changes

1. **"Why vlt?" in Get Started section** — Added `get-started/why-vlt` to the Get Started sidebar items. The page already existed at `www/docs/src/content/docs/get-started/why-vlt.mdx` but wasn't listed in the sidebar config.

2. **Registry section** — Added a new "Registry" top-level sidebar section using `autogenerate: { directory: 'registry' }`. Removed the `draft: true` flag from `registry/index.mdx` so the page is now visible.

3. **Icon mappings** — Added icon entries in `data.tsx` for the new sidebar entries:
   - `'get started': 'BookOpen'`
   - `'why vlt': 'Lightbulb'`
   - `'registry': 'Globe'`

### Files changed

- `www/docs/astro.config.mts` — sidebar config
- `www/docs/src/components/sidebar/data.tsx` — icon mappings
- `www/docs/src/content/docs/registry/index.mdx` — removed draft flag