### PR TITLE
fix: registry nav improvements & CI optimizations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,21 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  changes:
+    name: Detect Changes
+    runs-on: ubuntu-latest
+    outputs:
+      src: ${{ steps.filter.outputs.src }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            src:
+              - '!www/docs/**'
+              - '!*.md'
+
   pre-check:
     name: Pre-Check
     runs-on: ubuntu-latest
@@ -190,7 +205,8 @@ jobs:
 
   test:
     name: Test - ${{ matrix.platform.name }} - ${{ matrix.node-version }}
-    needs: pre-check
+    needs: [pre-check, changes]
+    if: needs.changes.outputs.src == 'true'
     runs-on: ${{ matrix.platform.os }}
     defaults:
       run:

--- a/.github/workflows/fork_pr_benchmarks_run.yml
+++ b/.github/workflows/fork_pr_benchmarks_run.yml
@@ -3,6 +3,9 @@ name: Run Benchmarks
 on:
   pull_request:
     types: [opened, reopened, edited, synchronize]
+    paths-ignore:
+      - 'www/docs/**'
+      - '*.md'
 
 jobs:
   benchmark_fork_pr_branch:

--- a/.gitignore
+++ b/.gitignore
@@ -85,3 +85,5 @@ knip.d.ts.map
 
 **/.opencode/**
 opencode.jsonc
+.vercel
+.env*

--- a/www/docs/astro.config.mts
+++ b/www/docs/astro.config.mts
@@ -142,7 +142,7 @@ export default defineConfig({
         },
         {
           label: 'Registry',
-          collapsed: true,
+          collapsed: false,
           autogenerate: { directory: 'registry' },
         },
         {

--- a/www/docs/astro.config.mts
+++ b/www/docs/astro.config.mts
@@ -119,6 +119,16 @@ export default defineConfig({
               paths: ['cli/**'],
             },
           ],
+          /**
+           *only excludes content for llms-small.txt: abridged llm reference
+           */
+          exclude: [
+            'cli/workspaces',
+            'cli/selectors/**',
+            'packages/**',
+            'get-started/reference',
+            'get-started/concepts/**',
+          ],
           rawContent: false,
           minify: {
             customSelectors: ['.expressive-code'],

--- a/www/docs/src/components/footer/content.tsx
+++ b/www/docs/src/components/footer/content.tsx
@@ -17,17 +17,16 @@ export interface Section {
 }
 
 const products: Section = {
-  title: 'Products',
+  title: 'Platform',
   contents: [
     {
-      slug: 'Client',
-      href: 'https://vlt.io/open-source/client',
+      slug: 'registry',
+      href: 'https://www.vlt.io/platform/registry',
     },
     {
-      slug: 'Serverless Registry',
-      href: 'https://vlt.io/open-source/serverless-registry',
-    },
-  ],
+      slug: 'security',
+      href: 'https://www.vlt.io/platform/security',
+    },],
 }
 
 const resources: Section = {

--- a/www/docs/src/components/footer/content.tsx
+++ b/www/docs/src/components/footer/content.tsx
@@ -20,13 +20,14 @@ const products: Section = {
   title: 'Platform',
   contents: [
     {
-      slug: 'registry',
+      slug: 'Registry',
       href: 'https://www.vlt.io/platform/registry',
     },
     {
-      slug: 'security',
+      slug: 'Security',
       href: 'https://www.vlt.io/platform/security',
-    },],
+    },
+  ],
 }
 
 const resources: Section = {

--- a/www/docs/src/components/header/linear-menu.tsx
+++ b/www/docs/src/components/header/linear-menu.tsx
@@ -40,11 +40,12 @@ const LinearMenu = () => {
   ]
 
   return (
-    <div className="hidden items-center gap-x-2 rounded-[1rem] bg-white/95 p-2 text-[15px] text-neutral-950 shadow-[0_0_0_1px_theme(colors.black/5%)] backdrop-blur-sm dark:bg-neutral-950/75 dark:text-white dark:shadow-[0_0_0_1px_theme(colors.white/10%)] md:flex">
+    <div className="hidden items-center gap-x-2 rounded-[1rem] bg-white/95 p-2 text-body text-neutral-950  backdrop-blur-sm dark:bg-neutral-950/75 dark:text-white md:flex">
+
       {menuData.map(item =>
         item.children ?
           <MenuGroup key={item.title} item={item} />
-        : <MenuLink key={item.title} item={item} />,
+          : <MenuLink key={item.title} item={item} />,
       )}
     </div>
   )
@@ -75,27 +76,27 @@ const MenuGroup = ({ item }: { item: MenuItem }) => {
 
 const MenuLink = ({
   item,
-  className = '',
+  className,
 }: {
   item: MenuItem
   className?: string
 }) => {
   return !item.path ?
-      <span
-        className={`inline-flex items-center gap-x-3 text-nowrap px-3 py-3 ${className}`}>
-        {item.icon ?
-          <MenuLinkIcon item={item} />
+    <span
+      className={`inline-flex items-center gap-x-3 text-nowrap px-3 py-3 ${className}`}>
+      {item.icon ?
+        <MenuLinkIcon item={item} />
         : null}{' '}
-        {item.title}
-      </span>
+      {item.title}
+    </span>
     : <a
-        href={item.path}
-        className={`text-15 group inline-flex items-center gap-x-3 text-nowrap rounded-[8px] px-4 py-1.5 text-foreground no-underline hover:bg-black/5 dark:hover:bg-white/10 ${className}`}>
-        {item.icon ?
-          <MenuLinkIcon item={item} />
+      href={item.path}
+      className={`text-[15px] group inline-flex items-center gap-x-3 text-nowrap rounded-[8px] px-4 py-1.5 text-foreground no-underline hover:bg-black/5 dark:hover:bg-white/10 ${className}`}>
+      {item.icon ?
+        <MenuLinkIcon item={item} />
         : null}{' '}
-        {item.title}
-      </a>
+      {item.title}
+    </a>
 }
 
 const MenuLinkIcon = ({ item }: { item: MenuItem }) => {
@@ -103,7 +104,7 @@ const MenuLinkIcon = ({ item }: { item: MenuItem }) => {
     return null
   }
   return (
-    <span className="group-hover:border-white/3 flex size-[1.75rem] flex-shrink-0 items-center justify-center rounded-[6px] border border-black/5 bg-black/5 group-hover:bg-white/15 dark:border-white/10 dark:bg-white/10">
+    <span className="group-hover:border-white/3 flex size-[1.75rem] flex-shrink-0 items-center justify-center rounded-[6px] border border-black/5 bg-black/5 group-hover:bg-white/15 dark:bg-white/10">
       <Icon name={item.icon} className="size-[1rem] text-white" />
     </span>
   )

--- a/www/docs/src/components/header/linear-menu.tsx
+++ b/www/docs/src/components/header/linear-menu.tsx
@@ -40,12 +40,11 @@ const LinearMenu = () => {
   ]
 
   return (
-    <div className="hidden items-center gap-x-2 rounded-[1rem] bg-white/95 p-2 text-body text-neutral-950  backdrop-blur-sm dark:bg-neutral-950/75 dark:text-white md:flex">
-
+    <div className="text-body hidden items-center gap-x-2 rounded-[1rem] bg-white/95 p-2 text-neutral-950 backdrop-blur-sm dark:bg-neutral-950/75 dark:text-white md:flex">
       {menuData.map(item =>
         item.children ?
           <MenuGroup key={item.title} item={item} />
-          : <MenuLink key={item.title} item={item} />,
+        : <MenuLink key={item.title} item={item} />,
       )}
     </div>
   )
@@ -82,21 +81,21 @@ const MenuLink = ({
   className?: string
 }) => {
   return !item.path ?
-    <span
-      className={`inline-flex items-center gap-x-3 text-nowrap px-3 py-3 ${className}`}>
-      {item.icon ?
-        <MenuLinkIcon item={item} />
+      <span
+        className={`inline-flex items-center gap-x-3 text-nowrap px-3 py-3 ${className}`}>
+        {item.icon ?
+          <MenuLinkIcon item={item} />
         : null}{' '}
-      {item.title}
-    </span>
+        {item.title}
+      </span>
     : <a
-      href={item.path}
-      className={`text-[15px] group inline-flex items-center gap-x-3 text-nowrap rounded-[8px] px-4 py-1.5 text-foreground no-underline hover:bg-black/5 dark:hover:bg-white/10 ${className}`}>
-      {item.icon ?
-        <MenuLinkIcon item={item} />
+        href={item.path}
+        className={`group inline-flex items-center gap-x-3 text-nowrap rounded-[8px] px-4 py-1.5 text-[15px] text-foreground no-underline hover:bg-black/5 dark:hover:bg-white/10 ${className}`}>
+        {item.icon ?
+          <MenuLinkIcon item={item} />
         : null}{' '}
-      {item.title}
-    </a>
+        {item.title}
+      </a>
 }
 
 const MenuLinkIcon = ({ item }: { item: MenuItem }) => {

--- a/www/docs/src/components/header/theme-switcher.tsx
+++ b/www/docs/src/components/header/theme-switcher.tsx
@@ -33,7 +33,7 @@ const storeTheme = (
       resolveTo =
         window.matchMedia('(prefers-color-scheme: dark)').matches ?
           'dark'
-          : 'light'
+        : 'light'
       break
     case 'dark':
       resolveTo = 'dark'
@@ -87,15 +87,15 @@ const ThemeSwitcher = () => {
 
     return (
       theme === 'system' ? <LaptopMinimal {...themeProps} />
-        : theme === 'light' ? <Sun {...themeProps} />
-          : <Moon {...themeProps} />
+      : theme === 'light' ? <Sun {...themeProps} />
+      : <Moon {...themeProps} />
     )
   }
 
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild className="group">
-        <button className="w-auto h-[38px] [&>svg]:duration-250 duration-250 inline-flex w-[90px] cursor-default items-center justify-center gap-2 rounded-[8px] bg-transparent px-4 py-1.5 text-body font-medium text-neutral-500 ring-offset-background transition-all hover:bg-neutral-200 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 data-[state=open]:bg-neutral-200 data-[state=open]:text-foreground dark:hover:bg-secondary dark:data-[state=open]:bg-secondary [&>svg]:fill-neutral-500 [&>svg]:stroke-neutral-500 [&>svg]:transition-all [&>svg]:hover:fill-foreground [&>svg]:hover:stroke-foreground [&>svg]:data-[state=open]:fill-foreground [&>svg]:data-[state=open]:stroke-foreground">
+        <button className="[&>svg]:duration-250 duration-250 text-body inline-flex h-[38px] w-[90px] w-auto cursor-default items-center justify-center gap-2 rounded-[8px] bg-transparent px-4 py-1.5 font-medium text-neutral-500 ring-offset-background transition-all hover:bg-neutral-200 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 data-[state=open]:bg-neutral-200 data-[state=open]:text-foreground dark:hover:bg-secondary dark:data-[state=open]:bg-secondary [&>svg]:fill-neutral-500 [&>svg]:stroke-neutral-500 [&>svg]:transition-all [&>svg]:hover:fill-foreground [&>svg]:hover:stroke-foreground [&>svg]:data-[state=open]:fill-foreground [&>svg]:data-[state=open]:stroke-foreground">
           {renderIcon()}
         </button>
       </DropdownMenuTrigger>
@@ -113,7 +113,7 @@ const ThemeSwitcher = () => {
               'relative text-sm font-medium capitalize',
               t.name === theme ?
                 'bg-neutral-200/40 dark:bg-neutral-800/80'
-                : '',
+              : '',
             )}
             key={t.name}>
             {t.name}

--- a/www/docs/src/components/header/theme-switcher.tsx
+++ b/www/docs/src/components/header/theme-switcher.tsx
@@ -33,7 +33,7 @@ const storeTheme = (
       resolveTo =
         window.matchMedia('(prefers-color-scheme: dark)').matches ?
           'dark'
-        : 'light'
+          : 'light'
       break
     case 'dark':
       resolveTo = 'dark'
@@ -87,15 +87,15 @@ const ThemeSwitcher = () => {
 
     return (
       theme === 'system' ? <LaptopMinimal {...themeProps} />
-      : theme === 'light' ? <Sun {...themeProps} />
-      : <Moon {...themeProps} />
+        : theme === 'light' ? <Sun {...themeProps} />
+          : <Moon {...themeProps} />
     )
   }
 
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild className="group">
-        <button className="[&>svg]:duration-250 duration-250 inline-flex w-[90px] cursor-default items-center justify-center gap-2 rounded-[8px] bg-transparent px-4 py-1.5 text-[15px] font-medium text-neutral-500 ring-offset-background transition-all hover:bg-neutral-200 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 data-[state=open]:bg-neutral-200 data-[state=open]:text-foreground dark:hover:bg-secondary dark:data-[state=open]:bg-secondary [&>svg]:fill-neutral-500 [&>svg]:stroke-neutral-500 [&>svg]:transition-all [&>svg]:hover:fill-foreground [&>svg]:hover:stroke-foreground [&>svg]:data-[state=open]:fill-foreground [&>svg]:data-[state=open]:stroke-foreground">
+        <button className="w-auto h-[38px] [&>svg]:duration-250 duration-250 inline-flex w-[90px] cursor-default items-center justify-center gap-2 rounded-[8px] bg-transparent px-4 py-1.5 text-body font-medium text-neutral-500 ring-offset-background transition-all hover:bg-neutral-200 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 data-[state=open]:bg-neutral-200 data-[state=open]:text-foreground dark:hover:bg-secondary dark:data-[state=open]:bg-secondary [&>svg]:fill-neutral-500 [&>svg]:stroke-neutral-500 [&>svg]:transition-all [&>svg]:hover:fill-foreground [&>svg]:hover:stroke-foreground [&>svg]:data-[state=open]:fill-foreground [&>svg]:data-[state=open]:stroke-foreground">
           {renderIcon()}
         </button>
       </DropdownMenuTrigger>
@@ -113,7 +113,7 @@ const ThemeSwitcher = () => {
               'relative text-sm font-medium capitalize',
               t.name === theme ?
                 'bg-neutral-200/40 dark:bg-neutral-800/80'
-              : '',
+                : '',
             )}
             key={t.name}>
             {t.name}

--- a/www/docs/src/components/page-frame/page-frame.astro
+++ b/www/docs/src/components/page-frame/page-frame.astro
@@ -21,17 +21,17 @@ const shouldRenderSearch =
 
 <div class="flex h-full w-full grow flex-col">
   <header
-    class="sticky top-0 z-[1000] border-b-[1px] border-border/50 backdrop-blur-sm">
+    class="sticky top-0 z-50 w-full max-w-8xl border-b border-transparent bg-white will-change-auto dark:bg-black lg:mx-auto lg:rounded-lg lg:border lg:transition-all lg:ease-out">
     <nav
-      class="mx-auto -mt-1 flex w-full max-w-8xl items-center justify-between px-10 py-4 md:px-6">
+      class="max-lg:gap-3 flex h-14 w-full items-center justify-between px-4 will-change-auto lg:h-12 lg:transition-all lg:ease-out">
       <a
         href="https://www.vlt.io/"
-        class="-mt-[1px] ml-[5px] flex h-[52px] w-auto items-center no-underline">
+        class="-mt-[1px] ml-[5px] flex w-auto items-center no-underline">
         <Logo />
       </a>
 
       <div
-        class="flex w-full items-center justify-end justify-items-end gap-4">
+        class="flex w-full items-end items-center justify-end gap-4">
         {shouldRenderSearch && <Search {...Astro.props} />}
         <MobileSidebar client:load sidebar={sidebar} />
         <LinearMenu client:load />

--- a/www/docs/src/components/sidebar/data.tsx
+++ b/www/docs/src/components/sidebar/data.tsx
@@ -11,7 +11,7 @@ export const labelMap: Record<string, string> = {
   'pseudo-states': 'Pseudo-States',
 }
 
-export const majorSections = new Set(['get-started', 'registry'])
+export const majorSections = new Set(['get-started'])
 
 const allIcons = {
   ...LucideIcons,

--- a/www/docs/src/components/sidebar/sidebar-sublist.tsx
+++ b/www/docs/src/components/sidebar/sidebar-sublist.tsx
@@ -55,12 +55,20 @@ const Section = ({
 }) => {
   if (entry.type === 'link') return null
 
+  const key = entry.label.toLowerCase()
+  const iconName = iconMap[key]
+
   return (
     <div className="flex flex-col gap-2">
-      <p className="px-3 text-sm font-medium text-neutral-500">
+      <p className="flex items-center gap-2 px-3 text-sm font-medium text-neutral-500">
+        {iconName && (
+          <span className="flex size-5 items-center justify-center">
+            <Icon name={iconName} className="size-4" />
+          </span>
+        )}
         {entry.label}
       </p>
-      <div>{renderMenu(entry.entries, depth)}</div>
+      <div>{renderMenu(entry.entries, depth + 1)}</div>
     </div>
   )
 }

--- a/www/docs/src/components/sidebar/sidebar.tsx
+++ b/www/docs/src/components/sidebar/sidebar.tsx
@@ -13,6 +13,7 @@ const AppSidebar = ({ sidebar }: { sidebar: SidebarEntries }) => {
   return (
     <aside
       className="sticky top-[101px] hidden max-h-[calc(100svh-104.25px)] min-h-[calc(100svh-104.25px)] w-[260px] flex-col bg-white pl-4 pr-4 dark:bg-black md:block"
+      data-pagefind-ignore
       id="sidebar">
       <ScrollArea
         id="sidebar-scroll-area"

--- a/www/docs/src/styles/globals.css
+++ b/www/docs/src/styles/globals.css
@@ -15,12 +15,12 @@
 /* ***************************************************** */
 /** Search Button */
 button[aria-label='Search'] {
-  height: 56.25px;
+  height: 44px;
   border-radius: 1rem;
   border-width: 1px;
   box-sizing: border-box;
   width: 50px;
-  padding: 1rem 1rem;
+  padding: 1rem;
   margin-left: 1rem;
   transition-property: all;
   transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);


### PR DESCRIPTION
## Changes

### Registry nav
- Fix registry nav items not indented (Section depth not incremented)
- Add icon to registry section header
- Make registry section collapsible

### LLM text
- Exclude non-essential pages from llms-small.txt (workspaces, selectors, packages, get-started/reference, get-started/concepts)

### Intercom/Pagefind
- Add `data-pagefind-ignore` to sidebar

### Header/Footer
- Refine header layout and reduce search button size
- Update footer platform links

### CI
- Skip tests on docs-only PRs (dorny/paths-filter)
- Skip benchmarks on docs-only PRs (paths-ignore)

Closes #1660