### PR TITLE
ci: skip tests and benchmarks on docs-only PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,21 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  changes:
+    name: Detect Changes
+    runs-on: ubuntu-latest
+    outputs:
+      src: ${{ steps.filter.outputs.src }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            src:
+              - '!www/docs/**'
+              - '!*.md'
+
   pre-check:
     name: Pre-Check
     runs-on: ubuntu-latest
@@ -190,7 +205,8 @@ jobs:
 
   test:
     name: Test - ${{ matrix.platform.name }} - ${{ matrix.node-version }}
-    needs: pre-check
+    needs: [pre-check, changes]
+    if: needs.changes.outputs.src == 'true'
     runs-on: ${{ matrix.platform.os }}
     defaults:
       run:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,9 +28,9 @@ jobs:
         with:
           filters: |
             src:
+              - '**'
               - '!www/docs/**'
-              - '!*.md'
-
+              - '!**/*.md'
   pre-check:
     name: Pre-Check
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,8 +22,8 @@ jobs:
     outputs:
       src: ${{ steps.filter.outputs.src }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: dorny/paths-filter@v3
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590 # v3.0.3
         id: filter
         with:
           filters: |

--- a/.github/workflows/fork_pr_benchmarks_run.yml
+++ b/.github/workflows/fork_pr_benchmarks_run.yml
@@ -5,7 +5,7 @@ on:
     types: [opened, reopened, edited, synchronize]
     paths-ignore:
       - 'www/docs/**'
-      - '*.md'
+      - '**/*.md'
 
 jobs:
   benchmark_fork_pr_branch:

--- a/.github/workflows/fork_pr_benchmarks_run.yml
+++ b/.github/workflows/fork_pr_benchmarks_run.yml
@@ -3,6 +3,9 @@ name: Run Benchmarks
 on:
   pull_request:
     types: [opened, reopened, edited, synchronize]
+    paths-ignore:
+      - 'www/docs/**'
+      - '*.md'
 
 jobs:
   benchmark_fork_pr_branch:


### PR DESCRIPTION
Uses `dorny/paths-filter` to detect source changes. 
Stops running unecessary benchmarks and tests whenever docs change.

- Skip test matrix (Ubuntu/macOS/Windows) when only docs change
- Skip benchmark runs when only docs change
- Lint and dependency checks still run on all PRs
- used [pinact](https://github.com/suzuki-shunsuke/pinact) locally to pin the actions I added
