### PR TITLE
feat(setup): add new setup command & fix registry configs

### DIFF
--- a/.cursor/rules/registries-and-auth.mdc
+++ b/.cursor/rules/registries-and-auth.mdc
@@ -7,10 +7,49 @@ alwaysApply: false
 
 ## Registry Types
 
-1. **Default**: `--registry=<url>` (default: `https://registry.npmjs.org/`)
+1. **Default registry**: `--registry=<url>` — **no default value**; there
+   is no built-in registry URL (see bare-spec resolution below)
 2. **Named aliases**: `--registries=<name>=<url>` → use as `name:pkg@ver` in dependencies
 3. **Scope registries**: `--scoped-registries=@scope=<url>` → `@scope/*` auto-routes
-4. **Built-in aliases**: `npm:` (public npm), `jsr:` (jsr.io), `gh:` (GitHub packages)
+4. **Built-in aliases**: `jsr:` (jsr.io), `gh:` (GitHub packages). All are
+   user/service-overridable. `npm:` is **not** built-in — it has no baked
+   URL and must be configured (see below).
+
+## Bare specs & `--default-registry-alias`
+
+A bare spec (`vlt install foo`, `foo@latest`) or transitive dep with no
+explicit registry protocol resolves through, in order:
+`scoped-registries[scope]` > `--registry <url>` >
+`registries[<default-registry-alias>]`. `--default-registry-alias`
+defaults to `npm`.
+
+Because `npm` has no built-in URL, a **fresh/unconfigured** install
+(`vlt install`/`vlx`) does **not** "just work" — it errors with an
+actionable message pointing to https://www.vlt.io and `vlt setup`. This
+is the intended trade-off; a per-account vlt mirror URL isn't known ahead
+of time.
+
+## `vlt setup`
+
+Onboarding wizard (`src/cli-sdk/src/commands/setup.ts`). Authenticates
+against a vlt.io account (reusing `RegistryClient.login()` web auth) and
+writes the account's registry aliases to `vlt.json` via
+`conf.addConfigToFile`:
+
+- `registries.npm  = https://registry.vlt.io/<account>/npm/`
+- `registries.main = https://registry.vlt.io/<account>/main/`
+
+It then loops to add optional custom aliases (partner/team registries).
+Runs unattended with `vlt setup <account> --yes` (+ `--registries name=url`).
+Writes user config by default; `--config=project` targets the project.
+
+## Lockfile reproducibility
+
+Lockfiles persist the resolved `registries` map (incl. `npm`/`main`) and
+a non-default `default-registry-alias` in `options`, so a lockfile is
+self-contained. `vlt install --frozen-lockfile` / `vlt ci` error on
+config drift (`graph.optionsChanged`). Persisting these is additive —
+`LOCKFILE_VERSION` is unchanged.
 
 ## Registry Consistency
 
@@ -20,12 +59,19 @@ Child deps inherit parent's registry by default. If `foo` comes from registry X,
 
 ```json
 {
-  "registry": "https://registry.npmjs.org/",
-  "registries": { "internal": "https://npm.internal.co/" },
+  "registries": {
+    "npm": "https://registry.vlt.io/my-account/npm/",
+    "main": "https://registry.vlt.io/my-account/main/",
+    "internal": "https://npm.internal.co/"
+  },
+  "default-registry-alias": "npm",
   "scoped-registries": { "@myco": "https://npm.myco.com/" },
   "jsr-registries": { "jsr": "https://npm.jsr.io/" }
 }
 ```
+
+`registry` (scalar) may still be set to force a single registry, but the
+alias-based `registries` + `default-registry-alias` model is preferred.
 
 ## Authentication
 

--- a/.cursor/rules/spec-parsing.mdc
+++ b/.cursor/rules/spec-parsing.mdc
@@ -43,8 +43,12 @@ const s = Spec.parse('react', '^18.0.0', specOptions)
 
 ```typescript
 type SpecOptions = {
-  registry?: string              // default: 'https://registry.npmjs.org/'
-  registries?: Record<string, string>  // named registries (npm, gh, custom)
+  registry?: string              // NO default — must be configured
+  registries?: Record<string, string>  // named registries (gh; npm is
+                                        // NOT built-in, must be configured)
+  'default-registry-alias'?: string     // default: 'npm' — the alias key
+                                        // in `registries` that bare specs
+                                        // resolve through
   'jsr-registries'?: Record<string, string>
   'scoped-registries'?: Record<string, string>
   'git-hosts'?: Record<string, string>  // template: $1/$2/$committish
@@ -54,14 +58,43 @@ type SpecOptions = {
 }
 ```
 
+## Bare-spec resolution & the `npm` alias
+
+There is **no built-in default registry URL**. A bare spec (`foo`,
+`foo@latest`) or a transitive dep with no explicit registry protocol
+resolves its registry via, in precedence order:
+
+1. `scoped-registries[scope]` (if the name is scoped)
+2. `registry` (the `--registry` scalar)
+3. `registries[<default-registry-alias>]` (default alias is `npm`)
+
+If none is configured, `spec.registry === undefined` and anything that
+needs to build a registry URL fails with a missing-registry error.
+
+The `npm` alias has **no baked-in URL** — real traffic goes through a
+per-account vlt mirror whose URL isn't known ahead of time. Configure it
+via `vlt setup` (writes `registries.npm` + `registries.main`),
+`vlt login --registry=<url>`, `vlt.json`, or `--registry`. In tests,
+pass `registries: { npm: 'https://registry.npmjs.org/' }` so `npm:`
+aliases and bare specs resolve.
+
+`getOptions` merges user config **over** built-in defaults, so every
+built-in alias (`gh`, `jsr`) is user/service-overridable.
+
 ## Defaults
 
 ```typescript
-defaultRegistry = 'https://registry.npmjs.org/'
-defaultRegistries = { npm: defaultRegistry, gh: 'https://npm.pkg.github.com/' }
+defaultRegistryName = 'npm'   // DepID canonicalization constant only;
+                              // NOT a URL and NOT pre-registered
+defaultRegistries = { gh: 'https://npm.pkg.github.com/' }  // no `npm`
 defaultJsrRegistries = { jsr: 'https://npm.jsr.io/' }
 defaultScopeRegistries = { '@jsr': 'https://npm.jsr.io/' }
 ```
+
+`defaultRegistryName` stays `'npm'` because a configured mirror URL maps
+back to the `npm` alias name via `convertToKnownShortRegistryName`, so
+the mirror URL never leaks into DepIDs (empty-registry DepIDs stay
+canonical).
 
 ## Architecture
 

--- a/src/cli-sdk/src/commands/access.ts
+++ b/src/cli-sdk/src/commands/access.ts
@@ -2,7 +2,7 @@ import { error } from '@vltpkg/error-cause'
 import { RegistryClient } from '@vltpkg/registry-client'
 import type { LoadedConfig } from '../config/index.ts'
 import { commandUsage } from '../config/usage.ts'
-import { requireRegistry } from '../require-registry.ts'
+import { resolveRegistry } from '../require-registry.ts'
 import type { CommandFn, CommandUsage } from '../index.ts'
 import type { Views } from '../view.ts'
 
@@ -13,7 +13,10 @@ export const usage: CommandUsage = () =>
     command: 'access',
     usage: '<command> [<args>]',
     description: `Set or get access levels for published packages
-                  and manage team-based package permissions.`,
+                  and manage team-based package permissions.
+
+                  Target a specific configured registry by alias with
+                  \`vlt registry <alias> access <subcommand>\`.`,
     subcommands: {
       'list packages': {
         usage: '[<scope|user|org>]',
@@ -115,7 +118,7 @@ const listPackages = async (
     })
   }
   const rc = new RegistryClient(conf.options)
-  const registryUrl = new URL(requireRegistry(conf))
+  const registryUrl = new URL(await resolveRegistry(conf))
 
   // Determine who to list for — use entity arg or fall back to scope from package.json
   const scope = entity ?? getDefaultScope(conf)
@@ -146,7 +149,7 @@ const getStatus = async (
     })
   }
   const rc = new RegistryClient(conf.options)
-  const registryUrl = new URL(requireRegistry(conf))
+  const registryUrl = new URL(await resolveRegistry(conf))
   const url = new URL(
     `-/package/${encodePkgName(pkg)}/access`,
     registryUrl,
@@ -182,7 +185,7 @@ const setStatus = async (
     })
   }
   const rc = new RegistryClient(conf.options)
-  const registryUrl = new URL(requireRegistry(conf))
+  const registryUrl = new URL(await resolveRegistry(conf))
   const url = new URL(
     `-/package/${encodePkgName(pkg)}/access`,
     registryUrl,
@@ -227,7 +230,7 @@ const grant = async (
   const pkgName = pkg ?? getDefaultPkgName(conf)
 
   const rc = new RegistryClient(conf.options)
-  const registryUrl = new URL(requireRegistry(conf))
+  const registryUrl = new URL(await resolveRegistry(conf))
   const url = new URL(
     `-/team/${encodeURIComponent(scope)}/${encodeURIComponent(team)}/package`,
     registryUrl,
@@ -273,7 +276,7 @@ const revoke = async (
   const pkgName = pkg ?? getDefaultPkgName(conf)
 
   const rc = new RegistryClient(conf.options)
-  const registryUrl = new URL(requireRegistry(conf))
+  const registryUrl = new URL(await resolveRegistry(conf))
   const url = new URL(
     `-/team/${encodeURIComponent(scope)}/${encodeURIComponent(team)}/package`,
     registryUrl,

--- a/src/cli-sdk/src/commands/deprecate.ts
+++ b/src/cli-sdk/src/commands/deprecate.ts
@@ -6,7 +6,7 @@ import { satisfies } from '@vltpkg/semver'
 import { asError } from '@vltpkg/types'
 import type { Manifest } from '@vltpkg/types'
 import { commandUsage } from '../config/usage.ts'
-import { requireRegistry } from '../require-registry.ts'
+import { resolveRegistry } from '../require-registry.ts'
 import type { CommandFn, CommandUsage } from '../index.ts'
 import type { Views } from '../view.ts'
 
@@ -92,7 +92,7 @@ export const command: CommandFn<CommandResult> = async conf => {
   }
 
   const { otp } = conf.options
-  const registry = requireRegistry(conf)
+  const registry = await resolveRegistry(conf)
   const registryUrl = new URL(registry)
 
   // Fetch the current packument

--- a/src/cli-sdk/src/commands/dist-tag.ts
+++ b/src/cli-sdk/src/commands/dist-tag.ts
@@ -2,7 +2,7 @@ import { error } from '@vltpkg/error-cause'
 import { RegistryClient } from '@vltpkg/registry-client'
 import { Spec } from '@vltpkg/spec'
 import { commandUsage } from '../config/usage.ts'
-import { requireRegistry } from '../require-registry.ts'
+import { resolveRegistry } from '../require-registry.ts'
 import type { CommandFn, CommandUsage } from '../index.ts'
 import type { Views } from '../view.ts'
 
@@ -139,7 +139,7 @@ export const command: CommandFn<CommandResult> = async conf => {
   }
 
   const rc = new RegistryClient(conf.options)
-  const registry = requireRegistry(conf)
+  const registry = await resolveRegistry(conf)
 
   switch (sub) {
     case 'add': {

--- a/src/cli-sdk/src/commands/logout.ts
+++ b/src/cli-sdk/src/commands/logout.ts
@@ -1,6 +1,6 @@
 import { RegistryClient } from '@vltpkg/registry-client'
 import { commandUsage } from '../config/usage.ts'
-import { requireRegistry } from '../require-registry.ts'
+import { resolveRegistry } from '../require-registry.ts'
 import type { CommandFn, CommandUsage } from '../index.ts'
 
 export const needsRegistry = true
@@ -10,7 +10,10 @@ export const usage: CommandUsage = () =>
     command: 'logout',
     usage: [''],
     description: `Log out of the default registry, deleting the token from
-                  the local keychain, as well as destroying it on the server.`,
+                  the local keychain, as well as destroying it on the server.
+
+                  Target a specific configured registry by alias with
+                  \`vlt registry <alias> logout\`.`,
     options: {
       registry: {
         value: '<url>',
@@ -26,5 +29,5 @@ export const usage: CommandUsage = () =>
 
 export const command: CommandFn<void> = async conf => {
   const rc = new RegistryClient(conf.options)
-  await rc.logout(requireRegistry(conf))
+  await rc.logout(await resolveRegistry(conf))
 }

--- a/src/cli-sdk/src/commands/profile.ts
+++ b/src/cli-sdk/src/commands/profile.ts
@@ -3,7 +3,7 @@ import { RegistryClient } from '@vltpkg/registry-client'
 import type { JSONField } from '@vltpkg/types'
 import type { LoadedConfig } from '../config/index.ts'
 import { commandUsage } from '../config/usage.ts'
-import { requireRegistry } from '../require-registry.ts'
+import { resolveRegistry } from '../require-registry.ts'
 import type { CommandFn, CommandUsage } from '../index.ts'
 import type { Views } from '../view.ts'
 
@@ -89,7 +89,7 @@ const getProfile = async (
   args: string[],
 ): Promise<ProfileResult> => {
   const rc = new RegistryClient(conf.options)
-  const registryUrl = new URL(requireRegistry(conf))
+  const registryUrl = new URL(await resolveRegistry(conf))
   const url = new URL('-/npm/v1/user', registryUrl)
   const response = await rc.request(url, { useCache: false })
   const data = response.json()
@@ -120,7 +120,7 @@ const setProfile = async (
     })
   }
   const rc = new RegistryClient(conf.options)
-  const registryUrl = new URL(requireRegistry(conf))
+  const registryUrl = new URL(await resolveRegistry(conf))
   const url = new URL('-/npm/v1/user', registryUrl)
   const response = await rc.request(url, {
     method: 'POST',

--- a/src/cli-sdk/src/commands/publish.ts
+++ b/src/cli-sdk/src/commands/publish.ts
@@ -20,7 +20,7 @@ import { Query } from '@vltpkg/query'
 import type { LoadedConfig } from '../config/index.ts'
 import { createHostContextsMap } from '../query-host-contexts.ts'
 import { minimatch } from 'minimatch'
-import { requireRegistry } from '../require-registry.ts'
+import { resolveRegistry } from '../require-registry.ts'
 
 export const needsRegistry = true
 
@@ -227,7 +227,8 @@ const commandSingle = async (
   const publishConfig = getPublishConfig(manifest)
   const tag = publishConfig?.tag ?? conf.options.tag
   const access = publishConfig?.access ?? conf.options.access
-  const registry = publishConfig?.registry ?? requireRegistry(conf)
+  const registry =
+    publishConfig?.registry ?? (await resolveRegistry(conf))
   const registryUrl = new URL(registryBase(registry))
 
   const runOptions = {

--- a/src/cli-sdk/src/commands/registry.ts
+++ b/src/cli-sdk/src/commands/registry.ts
@@ -1,0 +1,126 @@
+import { error } from '@vltpkg/error-cause'
+import { getCommand } from '../config/definition.ts'
+import { commandUsage } from '../config/usage.ts'
+import { resolveRegistry } from '../require-registry.ts'
+import type { Commands, LoadedConfig } from '../config/index.ts'
+import type { CommandFn, CommandUsage } from '../index.ts'
+import type { Views } from '../view.ts'
+
+/**
+ * The account/auth commands that can be scoped to a named registry
+ * alias via `vlt registry <alias> <command>`.
+ */
+export const registrySubcommands = [
+  'whoami',
+  'logout',
+  'login',
+  'token',
+  'access',
+  'publish',
+  'unpublish',
+  'deprecate',
+  'dist-tag',
+  'profile',
+  'ping',
+] as const satisfies Commands[keyof Commands][]
+
+const isRegistrySubcommand = (
+  s: string | undefined,
+): s is (typeof registrySubcommands)[number] => {
+  const canonical = getCommand(s)
+  return (
+    canonical !== undefined &&
+    (registrySubcommands as readonly string[]).includes(canonical)
+  )
+}
+
+export const usage: CommandUsage = () =>
+  commandUsage({
+    command: 'registry',
+    usage: '<alias> <command> [<args>]',
+    description: `Run an account command against a specific configured
+                  registry, selected by its \`registries\` alias instead
+                  of a full URL.
+
+                  For example, \`vlt registry main whoami\` runs \`whoami\`
+                  against the registry configured as \`main\`. Omit the
+                  alias (e.g. \`vlt registry whoami\`) to be prompted to
+                  choose from the configured registries, or to fall back
+                  to \`--default-registry-alias\` when non-interactive.
+
+                  \`<command>\` is one of:
+                  ${registrySubcommands.join(', ')}.`,
+  })
+
+export const views = {
+  human: () => {},
+} as const satisfies Views<void>
+
+/**
+ * Resolve `vlt registry <alias> <command>` in place: determine the
+ * target subcommand and registry, then rewrite `conf` so the outer
+ * runner dispatches the real command with the resolved registry
+ * injected. When invoked with `--help` or without a subcommand, `conf`
+ * is left untouched so the `registry` usage/error is shown instead.
+ *
+ * Streams / interactivity are injectable for tests.
+ */
+export const dispatchRegistry = async (
+  conf: LoadedConfig,
+  {
+    interactive,
+    input,
+    output,
+  }: {
+    interactive?: boolean
+    input?: NodeJS.ReadableStream
+    output?: NodeJS.WritableStream
+  } = {},
+): Promise<void> => {
+  if (conf.get('help')) return
+
+  const [first, ...restArgs] = conf.positionals
+  if (first === undefined) return
+
+  let alias: string | undefined
+  let subRaw: string | undefined
+  let args: string[]
+  if (isRegistrySubcommand(first)) {
+    subRaw = first
+    args = restArgs
+  } else {
+    alias = first
+    subRaw = restArgs[0]
+    args = restArgs.slice(1)
+  }
+
+  if (!isRegistrySubcommand(subRaw)) {
+    throw error('Unknown registry subcommand', {
+      found: subRaw,
+      validOptions: [...registrySubcommands],
+      code: 'EUSAGE',
+    })
+  }
+
+  const registry = await resolveRegistry(conf, {
+    alias,
+    interactive,
+    input,
+    output,
+  })
+
+  conf.options.registry = registry
+  conf.values.registry = registry
+  conf.command = subRaw
+  conf.positionals = args
+}
+
+export const command: CommandFn<void> = async conf => {
+  // Reached only when dispatchRegistry did not rewrite conf, i.e. no
+  // subcommand was provided (help is handled by the runner earlier).
+  throw error('Missing registry subcommand', {
+    found: conf.positionals[0],
+    validOptions: [...registrySubcommands],
+    code: 'EUSAGE',
+  })
+}

--- a/src/cli-sdk/src/commands/setup.ts
+++ b/src/cli-sdk/src/commands/setup.ts
@@ -1,0 +1,197 @@
+import { error } from '@vltpkg/error-cause'
+import { RegistryClient } from '@vltpkg/registry-client'
+import { defaultRegistries } from '@vltpkg/spec'
+import { createInterface } from 'node:readline/promises'
+import { commandUsage } from '../config/usage.ts'
+import { stdout } from '../output.ts'
+import type { CommandFn, CommandUsage } from '../index.ts'
+import type { Views } from '../view.ts'
+
+/** Where users sign up for / log into a vlt.io account. */
+export const VLT_SIGNUP_URL = 'https://www.vlt.io'
+/** Base URL that per-account registries live under. */
+export const VLT_REGISTRY_BASE = 'https://registry.vlt.io'
+
+/**
+ * The registry aliases that every vlt.io account is provisioned with.
+ * `npm` is the {@link https://docs.vlt.sh | default bare-spec alias}.
+ */
+export const accountRegistries = ['npm', 'main'] as const
+
+/** Build the per-account registry URL for a given registry name. */
+export const accountRegistryURL = (
+  account: string,
+  name: string,
+): string =>
+  `${VLT_REGISTRY_BASE}/${encodeURIComponent(account)}/${name}/`
+
+/** Ensure a registry URL ends with a single trailing slash. */
+const normalizeRegistryURL = (url: string): string =>
+  url.endsWith('/') ? url : `${url}/`
+
+export type SetupResult = {
+  /** the account slug the registries were built for */
+  account: string
+  /** which config file the registries were written to */
+  which: 'user' | 'project'
+  /** the alias -> url map that was staged into config */
+  registries: Record<string, string>
+}
+
+export const views = {
+  human: (result: SetupResult): string => {
+    const lines = [
+      `Configured ${Object.keys(result.registries).length} registry ${
+        Object.keys(result.registries).length === 1 ?
+          'alias'
+        : 'aliases'
+      } for "${result.account}" in ${result.which} config:`,
+    ]
+    for (const [name, url] of Object.entries(result.registries)) {
+      lines.push(`  ${name} -> ${url}`)
+    }
+    lines.push(
+      '',
+      'You can now install packages, e.g.:',
+      '  vlt install <pkg>',
+    )
+    return lines.join('\n')
+  },
+} as const satisfies Views<SetupResult>
+
+export const usage: CommandUsage = () =>
+  commandUsage({
+    command: 'setup',
+    usage: '[<account>]',
+    description: `Configure the registry aliases for your vlt.io account so
+                  that \`vlt install\` and \`vlx\` work out of the box.
+
+                  Sign up or log in at ${VLT_SIGNUP_URL} first. The wizard
+                  authenticates against your account and writes the
+                  \`npm\` and \`main\` registry aliases (and any additional
+                  aliases you add) to your user \`vlt.json\`.`,
+    options: {
+      config: {
+        value: '<user | project>',
+        description:
+          'Which config file to write to. Defaults to `user`; pass ' +
+          '`--config=project` to write to the project `vlt.json`.',
+      },
+      registries: {
+        value: '<name=url>',
+        description:
+          'Additional registry aliases to stage non-interactively. ' +
+          'Combine with `--yes` to run setup unattended.',
+      },
+      yes: {
+        description:
+          'Skip interactive prompts (requires <account> and does not ' +
+          'open a browser for authentication).',
+      },
+    },
+  })
+
+export const command: CommandFn<SetupResult> = async conf => {
+  const yes = !!conf.get('yes')
+  const which: 'user' | 'project' =
+    conf.get('config') === 'project' ? 'project' : 'user'
+
+  let rl: ReturnType<typeof createInterface> | undefined
+  const ask = async (question: string): Promise<string> => {
+    rl ??= createInterface(process.stdin, process.stdout)
+    return (await rl.question(question)).trim()
+  }
+
+  try {
+    stdout(
+      `Sign up or log in at ${VLT_SIGNUP_URL} before continuing.`,
+    )
+
+    // 1. resolve the account slug
+    let account = conf.positionals[0]?.trim()
+    if (!account) {
+      if (yes) {
+        throw error(
+          'An account slug is required in non-interactive mode. ' +
+            'Pass it as an argument: `vlt setup <account> --yes`.',
+          { code: 'ECONFIG' },
+        )
+      }
+      account = await ask('vlt.io account or organization slug: ')
+      if (!account) {
+        throw error('No account slug provided.', { code: 'ECONFIG' })
+      }
+    }
+
+    // 2. stage the two known account registries
+    const registries: Record<string, string> = {}
+    for (const name of accountRegistries) {
+      registries[name] = accountRegistryURL(account, name)
+    }
+
+    // 3. merge any user-supplied registry aliases (skip built-in defaults)
+    const builtinRegistries = defaultRegistries as Record<
+      string,
+      string
+    >
+    for (const [name, url] of Object.entries(
+      conf.options.registries,
+    )) {
+      if (builtinRegistries[name] === url) continue
+      registries[name] = normalizeRegistryURL(url)
+    }
+
+    const rc = new RegistryClient(conf.options)
+
+    // 4. authenticate against the account registries (interactive only)
+    if (!yes) {
+      const doAuth = await ask(
+        'Authenticate with your vlt.io account now? (Y/n) ',
+      )
+      if (!/^n/i.test(doAuth)) {
+        for (const name of accountRegistries) {
+          stdout(`Authenticating against the "${name}" registry...`)
+          await rc.login(accountRegistryURL(account, name))
+        }
+      }
+
+      // 5. offer to add further custom aliases
+      for (;;) {
+        const more = await ask('Add another registry alias? (y/N) ')
+        if (!/^y/i.test(more)) break
+        const name = await ask('  alias name: ')
+        if (!name) {
+          stdout('  alias name is required, skipping.')
+          continue
+        }
+        if (name in registries) {
+          stdout(`  alias "${name}" is already staged, skipping.`)
+          continue
+        }
+        const url = await ask('  registry url: ')
+        if (!url) {
+          stdout('  registry url is required, skipping.')
+          continue
+        }
+        const normalized = normalizeRegistryURL(url)
+        registries[name] = normalized
+        const auth = await ask(
+          `  authenticate against "${name}" now? (y/N) `,
+        )
+        if (/^y/i.test(auth)) {
+          await rc.login(normalized)
+        }
+      }
+    }
+
+    // 6. persist the staged registries (merged, not clobbered)
+    await conf.addConfigToFile(which, { registries })
+
+    return { account, which, registries }
+  } finally {
+    if (rl) {
+      rl.close()
+      process.stdin.pause()
+    }
+  }
+}

--- a/src/cli-sdk/src/commands/token.ts
+++ b/src/cli-sdk/src/commands/token.ts
@@ -47,7 +47,10 @@ export const usage: CommandUsage = () =>
   commandUsage({
     command: 'token',
     usage: ['list', 'add', 'rm'],
-    description: `Manage registry authentication tokens in the vlt keychain.`,
+    description: `Manage registry authentication tokens in the vlt keychain.
+
+                  Target a specific configured registry by alias with
+                  \`vlt registry <alias> token <subcommand>\`.`,
     subcommands: {
       list: {
         usage: '',

--- a/src/cli-sdk/src/commands/unpublish.ts
+++ b/src/cli-sdk/src/commands/unpublish.ts
@@ -3,7 +3,7 @@ import { RegistryClient } from '@vltpkg/registry-client'
 import { Spec } from '@vltpkg/spec'
 import { asError } from '@vltpkg/types'
 import { commandUsage } from '../config/usage.ts'
-import { requireRegistry } from '../require-registry.ts'
+import { resolveRegistry } from '../require-registry.ts'
 import type { CommandFn, CommandUsage } from '../index.ts'
 import type { Views } from '../view.ts'
 
@@ -76,7 +76,7 @@ export const command: CommandFn<CommandResult> = async conf => {
   }
 
   const { otp, force } = conf.options
-  const registry = requireRegistry(conf)
+  const registry = await resolveRegistry(conf)
   const registryUrl = new URL(registry)
 
   const spec = Spec.parseArgs(specArg, conf.options)

--- a/src/cli-sdk/src/commands/whoami.ts
+++ b/src/cli-sdk/src/commands/whoami.ts
@@ -1,7 +1,7 @@
 import { RegistryClient } from '@vltpkg/registry-client'
 import type { JSONField } from '@vltpkg/types'
 import { commandUsage } from '../config/usage.ts'
-import { requireRegistry } from '../require-registry.ts'
+import { resolveRegistry } from '../require-registry.ts'
 import type { CommandFn, CommandUsage } from '../index.ts'
 import type { Views } from '../view.ts'
 
@@ -12,7 +12,10 @@ export const usage: CommandUsage = () =>
     command: 'whoami',
     usage: [''],
     description: `Look up the username for the currently active token,
-                  when logged into a registry.`,
+                  when logged into a registry.
+
+                  Target a specific configured registry by alias with
+                  \`vlt registry <alias> whoami\`.`,
     options: {
       registry: {
         value: '<url>',
@@ -39,7 +42,7 @@ export const views = {
 export const command: CommandFn<CommandResult> = async conf => {
   const rc = new RegistryClient(conf.options)
   const response = await rc.request(
-    new URL('-/whoami', requireRegistry(conf)),
+    new URL('-/whoami', await resolveRegistry(conf)),
     { useCache: false },
   )
   const { username } = response.json()

--- a/src/cli-sdk/src/config/README.md
+++ b/src/cli-sdk/src/config/README.md
@@ -55,13 +55,21 @@ environment, or options specified on the command line.
 `vlt.json` file, `VLT_REGISTRY`, or `--registry`. Command modules that
 resolve or fetch packages export `needsRegistry = true`, and
 `outputCommand()` throws an `ECONFIG` error before invoking them when
-nothing is configured. `--help` is still answered first, so usage is
-readable with nothing set up. Inside a command, use the
+nothing is configured (neither `--registry` nor the
+`--default-registry-alias` alias). `--help` is still answered first,
+so usage is readable with nothing set up. Inside a command, use the
 `requireRegistry(conf)` helper rather than a non-null assertion.
 
-Note that this only removes the _unnamed_ default. Named registry
-aliases (`npm:`, `gh:`, `jsr:`) and the `@jsr` scope mapping keep
-their built-in URLs.
+### The `npm` alias is no longer built in
+
+Bare specifiers (`foo`, `foo@latest`) and transitive dependencies
+without an explicit registry protocol resolve through the registry
+alias named by `--default-registry-alias` (`npm` by default). The
+`npm` alias itself has **no** built-in URL -- run `vlt setup` (which
+points it at your vlt.io account registry) or configure
+`registries.npm` yourself. Only the `gh:` and `jsr:` aliases (and the
+`@jsr` scope mapping) keep built-in URLs; all aliases are
+user-overridable.
 
 ## Configuration Definitions and Patterns
 

--- a/src/cli-sdk/src/config/definition.ts
+++ b/src/cli-sdk/src/config/definition.ts
@@ -44,9 +44,11 @@ const canonicalCommands = {
   profile: 'profile',
   publish: 'publish',
   query: 'query',
+  registry: 'registry',
   repo: 'repo',
   'run-exec': 'run-exec',
   run: 'run',
+  setup: 'setup',
   token: 'token',
   uninstall: 'uninstall',
   unpublish: 'unpublish',
@@ -193,17 +195,32 @@ export const definition = j
                     For example, \`express@latest\` will be resolved by looking
                     up the metadata from this registry.
 
-                    There is **no default**. A registry must be configured in
-                    \`vlt.json\`, with this flag, or via the \`VLT_REGISTRY\`
-                    environment variable. Commands that need a registry fail
-                    with a config error when none is set; \`vlt login\` will
-                    configure one for you.
-
-                    Note that alias specifiers starting with \`npm:\` will
-                    still map to \`https://registry.npmjs.org/\`, unless a new
-                    mapping is created via the \`--registries\` option.
+                    There is **no default**. When unset, bare specifiers fall
+                    back to the registry alias named by
+                    \`--default-registry-alias\` (\`npm\` by default). If that
+                    alias is also unconfigured, commands that need a registry
+                    fail with a config error. Run \`vlt setup\` (or
+                    \`vlt login\`) to configure one.
 
                     See https://docs.vlt.sh/cli
+      `,
+    },
+
+    'default-registry-alias': {
+      hint: 'name',
+      default: 'npm',
+      description: `The name of the registry alias (a key in
+                    \`--registries\`) that bare specifiers (e.g.
+                    \`express@latest\`) and transitive dependencies without an
+                    explicit registry protocol resolve through, when neither
+                    \`--registry\` nor a matching \`--scoped-registries\` entry
+                    applies.
+
+                    Defaults to \`npm\`. Note that the \`npm\` alias has **no**
+                    built-in URL -- it must be configured (for example via
+                    \`vlt setup\`, which points it at your vlt.io registry),
+                    otherwise bare specifiers will have no registry to resolve
+                    against.
       `,
     },
   })
@@ -211,9 +228,9 @@ export const definition = j
   .optList({
     registries: {
       hint: 'name=url',
-      description: `Specify named registry hosts by their prefix. To set the
-                    default registry used for non-namespaced specifiers,
-                    use the \`--registry\` option.
+      description: `Specify named registry hosts by their prefix. To choose
+                    which alias is used for non-namespaced specifiers, use the
+                    \`--default-registry-alias\` option.
 
                     Prefixes can be used as a package alias. For example:
 
@@ -221,9 +238,10 @@ export const definition = j
                     vlt --registries loc=http://reg.local install foo@loc:foo@1.x
                     \`\`\`
 
-                    By default, the public npm registry is registered to the
-                    \`npm:\` prefix. It is not recommended to change this
-                    mapping in most cases.
+                    There is **no** built-in \`npm\` registry URL; the \`npm\`
+                    alias must be configured (e.g. via \`vlt setup\`) before it
+                    can be used. The \`gh\` and \`jsr\` aliases have built-in
+                    defaults that can be overridden here.
                     `,
     },
 

--- a/src/cli-sdk/src/custom-help.ts
+++ b/src/cli-sdk/src/custom-help.ts
@@ -218,6 +218,14 @@ const allCommands = [
     defaultOrder: 3,
   },
   {
+    name: 'registry',
+    aliases: [],
+    args: '<alias> <command>',
+    desc: 'Run an account command against a named registry',
+    showByDefault: true,
+    defaultOrder: 9,
+  },
+  {
     name: 'repo',
     aliases: [],
     args: '[<spec>]',
@@ -238,6 +246,14 @@ const allCommands = [
     args: '<script>',
     desc: 'Run a script &/or fallback to executing a binary',
     showByDefault: false,
+  },
+  {
+    name: 'setup',
+    aliases: [],
+    args: '[<account>]',
+    desc: 'Configure your vlt.io account registries',
+    showByDefault: true,
+    defaultOrder: 0,
   },
   {
     name: 'token',

--- a/src/cli-sdk/src/index.ts
+++ b/src/cli-sdk/src/index.ts
@@ -103,6 +103,12 @@ const run = async () => {
     return process.exit(process.exitCode || 1)
   }
 
+  if (vlt.command === 'registry') {
+    const { dispatchRegistry } =
+      await import('./commands/registry.ts')
+    await dispatchRegistry(vlt)
+  }
+
   const command = await loadCommand(vlt.command)
   await outputCommand(command, vlt, { start, vltVersion: version })
 }

--- a/src/cli-sdk/src/output.ts
+++ b/src/cli-sdk/src/output.ts
@@ -8,7 +8,10 @@ import { defaultView } from './config/definition.ts'
 import type { LoadedConfig } from './config/index.ts'
 import type { Command } from './index.ts'
 import { printErr, formatOptions } from './print-err.ts'
-import { missingRegistryError } from './require-registry.ts'
+import {
+  hasConfiguredRegistry,
+  missingRegistryError,
+} from './require-registry.ts'
 import type { View, ViewOptions, Views } from './view.ts'
 import { isViewClass } from './view.ts'
 import {
@@ -187,14 +190,8 @@ export const outputCommand = async <T>(
     // error is rendered, tracked and exited like any other command
     // error, and so that the `--help` return above still works when
     // nothing is configured.
-    if (needsRegistry) {
-      const alias = conf.options['default-registry-alias']
-      const hasRegistry =
-        !!conf.options.registry ||
-        (!!alias && !!conf.options.registries[alias])
-      if (!hasRegistry) {
-        throw missingRegistryError()
-      }
+    if (needsRegistry && !hasConfiguredRegistry(conf)) {
+      throw missingRegistryError()
     }
 
     const output = await onDone(await command(conf))

--- a/src/cli-sdk/src/output.ts
+++ b/src/cli-sdk/src/output.ts
@@ -187,8 +187,14 @@ export const outputCommand = async <T>(
     // error is rendered, tracked and exited like any other command
     // error, and so that the `--help` return above still works when
     // nothing is configured.
-    if (needsRegistry && !conf.options.registry) {
-      throw missingRegistryError()
+    if (needsRegistry) {
+      const alias = conf.options['default-registry-alias']
+      const hasRegistry =
+        !!conf.options.registry ||
+        (!!alias && !!conf.options.registries[alias])
+      if (!hasRegistry) {
+        throw missingRegistryError()
+      }
     }
 
     const output = await onDone(await command(conf))

--- a/src/cli-sdk/src/require-registry.ts
+++ b/src/cli-sdk/src/require-registry.ts
@@ -1,4 +1,5 @@
 import { error } from '@vltpkg/error-cause'
+import { defaultRegistries } from '@vltpkg/spec'
 import { selectRegistry } from './select-registry.ts'
 import type { RegistryCandidate } from './select-registry.ts'
 import type { LoadedConfig } from './config/index.ts'
@@ -60,15 +61,36 @@ export const resolveRegistryAlias = (
 }
 
 /**
- * The configured registries the user could act against, when no
- * explicit `--registry` URL is set. Order follows the `registries`
- * config (which preserves insertion order).
+ * The registries the user has actually configured, when no explicit
+ * `--registry` URL is set. Order follows the `registries` config (which
+ * preserves insertion order).
+ *
+ * Built-in defaults (eg `gh`) are excluded so they don't implicitly
+ * satisfy "a registry is configured" for account/auth commands. A
+ * built-in alias the user has overridden to a different URL counts as
+ * configured. Built-in aliases can still be targeted explicitly via
+ * `vlt registry <alias> <cmd>` (which resolves through
+ * {@link resolveRegistryAlias}).
  */
-const gatherCandidates = (conf: LoadedConfig): RegistryCandidate[] =>
-  Object.entries(conf.options.registries).map(([alias, url]) => ({
-    alias,
-    url,
-  }))
+const gatherCandidates = (
+  conf: LoadedConfig,
+): RegistryCandidate[] => {
+  const builtins = defaultRegistries as Record<string, string>
+  return Object.entries(conf.options.registries)
+    .filter(([alias, url]) => builtins[alias] !== url)
+    .map(([alias, url]) => ({ alias, url }))
+}
+
+/**
+ * Whether the current config provides a registry a `needsRegistry`
+ * command could act against without prompting for setup. True when an
+ * explicit `--registry` URL is set or the user has configured at least
+ * one non-default registry alias. Kept consistent with
+ * {@link resolveRegistry} so the pre-command gate never rejects a config
+ * the resolver would otherwise accept or prompt for.
+ */
+export const hasConfiguredRegistry = (conf: LoadedConfig): boolean =>
+  !!conf.options.registry || gatherCandidates(conf).length > 0
 
 /**
  * Synchronous, non-interactive registry resolution used by

--- a/src/cli-sdk/src/require-registry.ts
+++ b/src/cli-sdk/src/require-registry.ts
@@ -1,4 +1,6 @@
 import { error } from '@vltpkg/error-cause'
+import { selectRegistry } from './select-registry.ts'
+import type { RegistryCandidate } from './select-registry.ts'
 import type { LoadedConfig } from './config/index.ts'
 
 /**
@@ -7,20 +9,125 @@ import type { LoadedConfig } from './config/index.ts'
  */
 export const missingRegistryError = (): Error =>
   error(
-    `Missing registry configuration. Run 'vlt login --registry=<url>', ` +
-      `set "registry" in vlt.json, or pass --registry. ` +
-      `See https://docs.vlt.sh/cli`,
+    [
+      'Missing registry configuration.',
+      '',
+      'vlt has no default registry. Run `vlt setup` to get configured.',
+      '',
+      'See https://docs.vlt.sh/cli for other ways to set a registry.',
+    ].join('\n'),
     { code: 'ECONFIG' },
   )
 
 /**
- * Read `conf.options.registry`, throwing the `ECONFIG` error if it is
- * not set. Commands marked `needsRegistry` are already checked in
- * `outputCommand()`, but this keeps the invariant honest for TypeScript
- * and for programmatic callers.
+ * Multiple registries are configured and none was selected. Used in
+ * non-interactive contexts where we cannot prompt and there is no
+ * `default-registry-alias` to fall back to.
  */
-export const requireRegistry = (conf: LoadedConfig): string => {
+export const ambiguousRegistryError = (
+  candidates: RegistryCandidate[],
+): Error =>
+  error(
+    [
+      'Multiple registries are configured; specify which one to use.',
+      '',
+      'Run `vlt registry <alias> <command>` with one of:',
+      ...candidates.map(c => `  ${c.alias} -> ${c.url}`),
+    ].join('\n'),
+    {
+      code: 'ECONFIG',
+      validOptions: candidates.map(c => c.alias),
+    },
+  )
+
+/**
+ * Resolve a named registry alias to its URL, throwing an `ECONFIG`
+ * error (listing the known aliases) when the alias is not configured.
+ */
+export const resolveRegistryAlias = (
+  conf: LoadedConfig,
+  alias: string,
+): string => {
+  const url = conf.options.registries[alias]
+  if (!url) {
+    throw error(`Unknown registry alias: ${alias}`, {
+      code: 'ECONFIG',
+      found: alias,
+      validOptions: Object.keys(conf.options.registries),
+    })
+  }
+  return url
+}
+
+/**
+ * The configured registries the user could act against, when no
+ * explicit `--registry` URL is set. Order follows the `registries`
+ * config (which preserves insertion order).
+ */
+const gatherCandidates = (conf: LoadedConfig): RegistryCandidate[] =>
+  Object.entries(conf.options.registries).map(([alias, url]) => ({
+    alias,
+    url,
+  }))
+
+/**
+ * Synchronous, non-interactive registry resolution used by
+ * programmatic callers. Precedence: explicit alias > `--registry`
+ * scalar > single configured alias > `default-registry-alias`. Throws
+ * when nothing is configured or the choice is ambiguous.
+ */
+export const requireRegistry = (
+  conf: LoadedConfig,
+  alias?: string,
+): string => {
+  if (alias !== undefined) return resolveRegistryAlias(conf, alias)
   const { registry } = conf.options
-  if (!registry) throw missingRegistryError()
-  return registry
+  if (registry) return registry
+  const candidates = gatherCandidates(conf)
+  const [first, second] = candidates
+  if (!first) throw missingRegistryError()
+  if (!second) return first.url
+  const defaultUrl =
+    conf.options.registries[conf.options['default-registry-alias']]
+  if (defaultUrl) return defaultUrl
+  throw ambiguousRegistryError(candidates)
+}
+
+/**
+ * Resolve the registry a command should act against.
+ *
+ * Precedence: explicit `alias` (from `vlt registry <alias> <cmd>`) >
+ * `--registry` URL scalar > the single configured alias. When multiple
+ * aliases are configured and none was chosen, prompt interactively on a
+ * TTY, otherwise fall back to `default-registry-alias`, else error.
+ */
+export const resolveRegistry = async (
+  conf: LoadedConfig,
+  {
+    alias,
+    interactive = process.stdin.isTTY,
+    input,
+    output,
+  }: {
+    alias?: string
+    interactive?: boolean
+    input?: NodeJS.ReadableStream
+    output?: NodeJS.WritableStream
+  } = {},
+): Promise<string> => {
+  if (alias !== undefined) return resolveRegistryAlias(conf, alias)
+  const { registry } = conf.options
+  if (registry) return registry
+  const candidates = gatherCandidates(conf)
+  const [first, second] = candidates
+  if (!first) throw missingRegistryError()
+  if (!second) return first.url
+
+  const defaultAlias = conf.options['default-registry-alias']
+  if (interactive) {
+    return selectRegistry(candidates, { defaultAlias, input, output })
+  }
+  const defaultUrl = conf.options.registries[defaultAlias]
+  if (defaultUrl) return defaultUrl
+  throw ambiguousRegistryError(candidates)
 }

--- a/src/cli-sdk/src/select-registry.ts
+++ b/src/cli-sdk/src/select-registry.ts
@@ -1,0 +1,72 @@
+import { error } from '@vltpkg/error-cause'
+import { createInterface } from 'node:readline/promises'
+
+/** A configured registry the user can act against. */
+export type RegistryCandidate = {
+  /** the configured alias name (a key in `registries`) */
+  alias: string
+  /** the resolved registry URL */
+  url: string
+}
+
+export type SelectStreams = {
+  input: NodeJS.ReadableStream
+  output: NodeJS.WritableStream
+}
+
+/**
+ * Interactively prompt the user to choose one of the configured
+ * registries. `defaultAlias` (when present in `candidates`) is
+ * pre-selected so pressing enter accepts it.
+ *
+ * Streams are injectable so tests can drive the prompt deterministically.
+ */
+export const selectRegistry = async (
+  candidates: RegistryCandidate[],
+  {
+    defaultAlias,
+    input = process.stdin,
+    output = process.stdout,
+  }: {
+    defaultAlias?: string
+    input?: NodeJS.ReadableStream
+    output?: NodeJS.WritableStream
+  } = {},
+): Promise<string> => {
+  const defaultIndex = Math.max(
+    candidates.findIndex(c => c.alias === defaultAlias),
+    0,
+  )
+  const fallback = candidates[defaultIndex] ?? candidates[0]
+  if (!fallback) {
+    throw error('No registries to select from', { code: 'ECONFIG' })
+  }
+
+  const rl = createInterface({ input, output })
+  try {
+    output.write('Multiple registries are configured. Select one:\n')
+    for (const [i, c] of candidates.entries()) {
+      const marker = i === defaultIndex ? ' (default)' : ''
+      output.write(`  ${i + 1}) ${c.alias} -> ${c.url}${marker}\n`)
+    }
+
+    const answer = (
+      await rl.question(`Registry [${defaultIndex + 1}]: `)
+    ).trim()
+
+    if (!answer) return fallback.url
+
+    const choice = Number(answer)
+    const picked = candidates[choice - 1]
+    if (!Number.isInteger(choice) || !picked) {
+      throw error('Invalid registry selection', {
+        found: answer,
+        validOptions: candidates.map((_, i) => String(i + 1)),
+        code: 'EUSAGE',
+      })
+    }
+    return picked.url
+  } finally {
+    rl.close()
+  }
+}

--- a/src/cli-sdk/tap-snapshots/test/commands/access.ts.test.cjs
+++ b/src/cli-sdk/tap-snapshots/test/commands/access.ts.test.cjs
@@ -14,6 +14,8 @@ vlt access <command> [<args>]
 
 Set or get access levels for published packages and manage team-based package permissions.
 
+Target a specific configured registry by alias with \`vlt registry <alias> access <subcommand>\`.
+
 ## Subcommands
 
 ### list packages

--- a/src/cli-sdk/tap-snapshots/test/commands/help.ts.test.cjs
+++ b/src/cli-sdk/tap-snapshots/test/commands/help.ts.test.cjs
@@ -44,9 +44,12 @@ pub,     publish                     Publish package to registry
 
 q,       query       <selector>      Query for packages in the project
 
+         registry    <alias> <comm...Run an account command against a named registry
          repo        [<spec>]        Open the repository page for a package
 r,       run         <script>        Run a script defined in package.json
 rx,      run-exec    <script>        Run a script &/or fallback to executing a binary
+
+         setup       [<account>]     Configure your vlt.io account registries
 
          token       [add|rm]        Manage authentication tokens
 
@@ -88,6 +91,7 @@ USAGE
 
 COMMON COMMANDS
 
+       setup     [<account>]     Configure your vlt.io account registries
        init                      Initialize a new project
   i,   install   [<package>...]  Install dependencies
   q,   query     <selector>      Query for packages in the project
@@ -96,6 +100,7 @@ COMMON COMMANDS
   x,   exec      <executable>    Execute a package bin
   p,   pkg       <command>       Manage package metadata
   pub, publish                   Publish package to registry
+       registry  <alias> <command>Run an account command against a named registry
  
 COMPANION BINS
 

--- a/src/cli-sdk/tap-snapshots/test/commands/logout.ts.test.cjs
+++ b/src/cli-sdk/tap-snapshots/test/commands/logout.ts.test.cjs
@@ -14,6 +14,8 @@ vlt logout
 
 Log out of the default registry, deleting the token from the local keychain, as well as destroying it on the server.
 
+Target a specific configured registry by alias with \`vlt registry <alias> logout\`.
+
 ## Options
 
 ### registry

--- a/src/cli-sdk/tap-snapshots/test/commands/registry.ts.test.cjs
+++ b/src/cli-sdk/tap-snapshots/test/commands/registry.ts.test.cjs
@@ -1,0 +1,21 @@
+/* IMPORTANT
+ * This snapshot file is auto-generated, but designed for humans.
+ * It should be checked into source control and tracked carefully.
+ * Re-generate by setting TAP_SNAPSHOT=1 and running tests.
+ * Make sure to inspect the output below.  Do not ignore changes!
+ */
+'use strict'
+exports[`test/commands/registry.ts > TAP > usage > must match snapshot 1`] = `
+Usage:
+
+\`\`\`
+vlt registry <alias> <command> [<args>]
+\`\`\`
+
+Run an account command against a specific configured registry, selected by its \`registries\` alias instead of a full URL.
+
+For example, \`vlt registry main whoami\` runs \`whoami\` against the registry configured as \`main\`. Omit the alias (e.g. \`vlt registry whoami\`) to be prompted to choose from the configured registries, or to fall back to \`--default-registry-alias\` when non-interactive.
+
+\`<command>\` is one of: whoami, logout, login, token, access, publish, unpublish, deprecate, dist-tag, profile, ping.
+
+`

--- a/src/cli-sdk/tap-snapshots/test/commands/setup.ts.test.cjs
+++ b/src/cli-sdk/tap-snapshots/test/commands/setup.ts.test.cjs
@@ -1,0 +1,45 @@
+/* IMPORTANT
+ * This snapshot file is auto-generated, but designed for humans.
+ * It should be checked into source control and tracked carefully.
+ * Re-generate by setting TAP_SNAPSHOT=1 and running tests.
+ * Make sure to inspect the output below.  Do not ignore changes!
+ */
+'use strict'
+exports[`test/commands/setup.ts > TAP > usage > must match snapshot 1`] = `
+Usage:
+
+\`\`\`
+vlt setup [<account>]
+\`\`\`
+
+Configure the registry aliases for your vlt.io account so that \`vlt install\` and \`vlx\` work out of the box.
+
+Sign up or log in at https://www.vlt.io first. The wizard authenticates against your account and writes the \`npm\` and \`main\` registry aliases (and any additional aliases you add) to your user \`vlt.json\`.
+
+## Options
+
+### config
+
+Which config file to write to. Defaults to \`user\`; pass \`--config=project\` to write to the project \`vlt.json\`.
+
+\`\`\`
+--config=<user | project>
+\`\`\`
+
+### registries
+
+Additional registry aliases to stage non-interactively. Combine with \`--yes\` to run setup unattended.
+
+\`\`\`
+--registries=<name=url>
+\`\`\`
+
+### yes
+
+Skip interactive prompts (requires <account> and does not open a browser for authentication).
+
+\`\`\`
+--yes
+\`\`\`
+
+`

--- a/src/cli-sdk/tap-snapshots/test/commands/token.ts.test.cjs
+++ b/src/cli-sdk/tap-snapshots/test/commands/token.ts.test.cjs
@@ -16,6 +16,8 @@ vlt token rm
 
 Manage registry authentication tokens in the vlt keychain.
 
+Target a specific configured registry by alias with \`vlt registry <alias> token <subcommand>\`.
+
 ## Subcommands
 
 ### list

--- a/src/cli-sdk/tap-snapshots/test/commands/whoami.ts.test.cjs
+++ b/src/cli-sdk/tap-snapshots/test/commands/whoami.ts.test.cjs
@@ -14,6 +14,8 @@ vlt whoami
 
 Look up the username for the currently active token, when logged into a registry.
 
+Target a specific configured registry by alias with \`vlt registry <alias> whoami\`.
+
 ## Options
 
 ### registry

--- a/src/cli-sdk/tap-snapshots/test/config/definition.ts.test.cjs
+++ b/src/cli-sdk/tap-snapshots/test/config/definition.ts.test.cjs
@@ -43,12 +43,14 @@ Object {
   "q": "query",
   "query": "query",
   "r": "run",
+  "registry": "registry",
   "repo": "repo",
   "rm": "uninstall",
   "run": "run",
   "run-exec": "run-exec",
   "run-script": "run",
   "rx": "run-exec",
+  "setup": "setup",
   "show": "view",
   "token": "token",
   "u": "update",
@@ -140,6 +142,15 @@ Object {
     "multiple": true,
     "type": "string",
   },
+  "default-registry-alias": Object {
+    "description": String(
+      The name of the registry alias (a key in \`--registries\`) that bare specifiers (e.g. \`express@latest\`) and transitive dependencies without an explicit registry protocol resolve through, when neither \`--registry\` nor a matching \`--scoped-registries\` entry applies.
+      
+      Defaults to \`npm\`. Note that the \`npm\` alias has **no** built-in URL -- it must be configured (for example via \`vlt setup\`, which points it at your vlt.io registry), otherwise bare specifiers will have no registry to resolve against.
+    ),
+    "hint": "name",
+    "type": "string",
+  },
   "dry-run": Object {
     "description": "Run command without making any changes",
     "type": "boolean",
@@ -209,9 +220,11 @@ Object {
       "profile",
       "publish",
       "query",
+      "registry",
       "repo",
       "run-exec",
       "run",
+      "setup",
       "token",
       "uninstall",
       "unpublish",
@@ -380,7 +393,7 @@ Object {
   },
   "registries": Object {
     "description": String(
-      Specify named registry hosts by their prefix. To set the default registry used for non-namespaced specifiers, use the \`--registry\` option.
+      Specify named registry hosts by their prefix. To choose which alias is used for non-namespaced specifiers, use the \`--default-registry-alias\` option.
       
       Prefixes can be used as a package alias. For example:
       
@@ -388,7 +401,7 @@ Object {
       ​vlt --registries loc=http://reg.local install foo@loc:foo@1.x
       \`\`\`
       
-      By default, the public npm registry is registered to the \`npm:\` prefix. It is not recommended to change this mapping in most cases.
+      There is **no** built-in \`npm\` registry URL; the \`npm\` alias must be configured (e.g. via \`vlt setup\`) before it can be used. The \`gh\` and \`jsr\` aliases have built-in defaults that can be overridden here.
     ),
     "hint": "name=url",
     "multiple": true,
@@ -400,9 +413,7 @@ Object {
       
       For example, \`express@latest\` will be resolved by looking up the metadata from this registry.
       
-      There is **no default**. A registry must be configured in \`vlt.json\`, with this flag, or via the \`VLT_REGISTRY\` environment variable. Commands that need a registry fail with a config error when none is set; \`vlt login\` will configure one for you.
-      
-      Note that alias specifiers starting with \`npm:\` will still map to \`https://registry.npmjs.org/\`, unless a new mapping is created via the \`--registries\` option.
+      There is **no default**. When unset, bare specifiers fall back to the registry alias named by \`--default-registry-alias\` (\`npm\` by default). If that alias is also unconfigured, commands that need a registry fail with a config error. Run \`vlt setup\` (or \`vlt login\`) to configure one.
       
       See https://docs.vlt.sh/cli
     ),
@@ -577,6 +588,7 @@ Array [
   "--color",
   "--config=<all | user | project>",
   "--dashboard-root=<path>",
+  "--default-registry-alias=<name>",
   "--dry-run",
   "--editor=<program>",
   "--expect-lockfile",
@@ -641,6 +653,7 @@ Array [
   "color",
   "config",
   "dashboard-root",
+  "default-registry-alias",
   "dry-run",
   "editor",
   "expect-lockfile",

--- a/src/cli-sdk/tap-snapshots/test/config/index.ts.test.cjs
+++ b/src/cli-sdk/tap-snapshots/test/config/index.ts.test.cjs
@@ -19,11 +19,9 @@ exports[`test/config/index.ts > TAP > load both configs, project writes over use
   catalogs: undefined,
   'jsr-registries': { jsr: 'https://npm.jsr.io/' },
   registry: undefined,
+  'default-registry-alias': 'npm',
   'scoped-registries': {},
-  registries: {
-    npm: 'https://registry.npmjs.org/',
-    gh: 'https://npm.pkg.github.com/'
-  },
+  registries: { gh: 'https://npm.pkg.github.com/' },
   'git-host-archives': {
     github: 'https://api.github.com/repos/$1/$2/tarball/$committish',
     bitbucket: 'https://bitbucket.org/$1/$2/get/$committish.tar.gz',

--- a/src/cli-sdk/tap-snapshots/test/index.ts.test.cjs
+++ b/src/cli-sdk/tap-snapshots/test/index.ts.test.cjs
@@ -45,6 +45,7 @@ Unknown option '--unknown'. To specify a positional argument starting with a '-'
     --color
     --config=<all | user | project>
     --dashboard-root=<path>
+    --default-registry-alias=<name>
     --dry-run
     --editor=<program>
     --expect-lockfile
@@ -112,6 +113,7 @@ Unknown config option: asdf
     color
     config
     dashboard-root
+    default-registry-alias
     dry-run
     editor
     expect-lockfile

--- a/src/cli-sdk/test/commands/deprecate.ts
+++ b/src/cli-sdk/test/commands/deprecate.ts
@@ -1,4 +1,5 @@
 import t from 'tap'
+import { defaultRegistries } from '@vltpkg/spec'
 import type { LoadedConfig } from '../../src/config/index.ts'
 import type { Packument } from '@vltpkg/types'
 
@@ -240,6 +241,7 @@ t.test('error: unknown package name', async t => {
       },
     },
     '@vltpkg/spec': {
+      defaultRegistries,
       Spec: {
         parseArgs: () => ({
           name: '(unknown)',

--- a/src/cli-sdk/test/commands/dist-tag.ts
+++ b/src/cli-sdk/test/commands/dist-tag.ts
@@ -1,4 +1,5 @@
 import t from 'tap'
+import { defaultRegistries } from '@vltpkg/spec'
 import type { LoadedConfig } from '../../src/config/index.ts'
 
 let requestLog: {
@@ -37,6 +38,7 @@ const Command = await t.mockImport<
     },
   },
   '@vltpkg/spec': {
+    defaultRegistries,
     Spec: {
       parseArgs(spec: string) {
         const at = spec.lastIndexOf('@')

--- a/src/cli-sdk/test/commands/registry.ts
+++ b/src/cli-sdk/test/commands/registry.ts
@@ -1,0 +1,130 @@
+import t from 'tap'
+import type { LoadedConfig } from '../../src/config/index.ts'
+
+const load = async (answers: string[] = []) => {
+  const queue = [...answers]
+  return t.mockImport<
+    typeof import('../../src/commands/registry.ts')
+  >('../../src/commands/registry.ts', {
+    'node:readline/promises': {
+      createInterface: () => ({
+        question: async () => queue.shift() ?? '',
+        close: () => {},
+      }),
+    },
+  })
+}
+
+type Opts = {
+  registry?: string
+  registries?: Record<string, string>
+  'default-registry-alias'?: string
+}
+
+const mkConf = (
+  positionals: string[],
+  options: Opts = {},
+  help = false,
+): LoadedConfig => {
+  const values: Record<string, unknown> = { help }
+  return {
+    positionals,
+    values,
+    options: {
+      registries: {},
+      'default-registry-alias': 'npm',
+      ...options,
+    },
+    command: undefined,
+    get: (k: string) => (k === 'help' ? help : values[k]),
+  } as unknown as LoadedConfig
+}
+
+t.test('usage', async t => {
+  const mod = await load()
+  t.matchSnapshot(mod.usage().usageMarkdown())
+  t.equal(mod.views.human(), undefined)
+})
+
+t.test('help is a no-op (renders registry usage)', async t => {
+  const mod = await load()
+  const conf = mkConf(['main', 'whoami'], {}, true)
+  await mod.dispatchRegistry(conf)
+  t.equal(conf.command, undefined)
+  t.strictSame(conf.positionals, ['main', 'whoami'])
+})
+
+t.test('no positional is a no-op', async t => {
+  const mod = await load()
+  const conf = mkConf([])
+  await mod.dispatchRegistry(conf)
+  t.equal(conf.command, undefined)
+})
+
+t.test('alias + subcommand dispatch', async t => {
+  const mod = await load()
+  const conf = mkConf(['main', 'token', 'list'], {
+    registries: { main: 'https://m/' },
+  })
+  await mod.dispatchRegistry(conf, { interactive: false })
+  t.equal(conf.command, 'token')
+  t.strictSame(conf.positionals, ['list'])
+  t.equal(conf.options.registry, 'https://m/')
+  t.equal(conf.values.registry, 'https://m/')
+})
+
+t.test('subcommand without alias resolves default', async t => {
+  const mod = await load()
+  const conf = mkConf(['whoami'], {
+    registries: { npm: 'https://n/' },
+  })
+  await mod.dispatchRegistry(conf, { interactive: false })
+  t.equal(conf.command, 'whoami')
+  t.strictSame(conf.positionals, [])
+  t.equal(conf.options.registry, 'https://n/')
+})
+
+t.test('subcommand without alias prompts interactively', async t => {
+  const mod = await load(['2'])
+  const conf = mkConf(['logout'], {
+    registries: { npm: 'https://n/', main: 'https://m/' },
+  })
+  await mod.dispatchRegistry(conf, {
+    interactive: true,
+    output: { write: () => true } as never,
+  })
+  t.equal(conf.command, 'logout')
+  t.equal(conf.options.registry, 'https://m/')
+})
+
+t.test('unknown subcommand throws', async t => {
+  const mod = await load()
+  await t.rejects(
+    mod.dispatchRegistry(
+      mkConf(['main', 'frobnicate'], {
+        registries: { main: 'https://m/' },
+      }),
+    ),
+    { cause: { code: 'EUSAGE' } },
+  )
+})
+
+t.test('alias with no subcommand throws', async t => {
+  const mod = await load()
+  await t.rejects(
+    mod.dispatchRegistry(
+      mkConf(['main'], { registries: { main: 'https://m/' } }),
+    ),
+    { cause: { code: 'EUSAGE' } },
+  )
+})
+
+t.test(
+  'command() throws when reached without a subcommand',
+  async t => {
+    const mod = await load()
+    await t.rejects(mod.command(mkConf([])), {
+      cause: { code: 'EUSAGE' },
+    })
+  },
+)

--- a/src/cli-sdk/test/commands/setup.ts
+++ b/src/cli-sdk/test/commands/setup.ts
@@ -1,0 +1,215 @@
+import t from 'tap'
+import { defaultRegistries } from '@vltpkg/spec'
+import type { LoadedConfig } from '../../src/config/index.ts'
+
+type Added = [string, Record<string, unknown>]
+
+// Build a mocked setup module with injectable readline answers and a
+// RegistryClient stub that records the registries it logs in against.
+const loadSetup = async (answers: string[]) => {
+  const loginCalls: string[] = []
+  const questions: string[] = []
+  const queue = [...answers]
+  const mod = await t.mockImport<
+    typeof import('../../src/commands/setup.ts')
+  >('../../src/commands/setup.ts', {
+    '@vltpkg/registry-client': {
+      RegistryClient: class {
+        async login(registry: string) {
+          loginCalls.push(registry)
+        }
+      },
+    },
+    'node:readline/promises': {
+      createInterface: () => ({
+        question: async (q: string) => {
+          questions.push(q)
+          return queue.shift() ?? ''
+        },
+        close: () => {},
+      }),
+    },
+  })
+  return { mod, loginCalls, questions }
+}
+
+const makeConf = (
+  opts: {
+    yes?: boolean
+    config?: string
+    positionals?: string[]
+    registries?: Record<string, string>
+  },
+  added: Added[],
+): LoadedConfig =>
+  ({
+    positionals: opts.positionals ?? [],
+    get: (k: string) =>
+      k === 'yes' ? opts.yes
+      : k === 'config' ? opts.config
+      : undefined,
+    options: { registries: opts.registries ?? {} },
+    addConfigToFile: async (
+      which: string,
+      values: Record<string, unknown>,
+    ) => {
+      added.push([which, values])
+    },
+  }) as unknown as LoadedConfig
+
+t.test('usage', async t => {
+  const { mod } = await loadSetup([])
+  t.matchSnapshot(mod.usage().usageMarkdown())
+})
+
+t.test('url + view helpers', async t => {
+  const { mod } = await loadSetup([])
+  t.equal(
+    mod.accountRegistryURL('acme', 'npm'),
+    'https://registry.vlt.io/acme/npm/',
+  )
+  t.equal(
+    mod.accountRegistryURL('a/b', 'main'),
+    'https://registry.vlt.io/a%2Fb/main/',
+  )
+  t.match(
+    mod.views.human({
+      account: 'acme',
+      which: 'user',
+      registries: { npm: 'u' },
+    }),
+    /1 registry alias/,
+  )
+  t.match(
+    mod.views.human({
+      account: 'acme',
+      which: 'user',
+      registries: { npm: 'u', main: 'm' },
+    }),
+    /2 registry aliases/,
+  )
+})
+
+t.test('non-interactive with account + extras', async t => {
+  const added: Added[] = []
+  const { mod, loginCalls } = await loadSetup([])
+  const result = await mod.command(
+    makeConf(
+      {
+        yes: true,
+        positionals: ['acme'],
+        // gh matches the built-in default -> skipped; loc is custom;
+        // slashless url gets normalized.
+        registries: {
+          gh: defaultRegistries.gh,
+          loc: 'http://reg.local',
+          slashed: 'http://slash.local/',
+        },
+      },
+      added,
+    ),
+  )
+  t.strictSame(
+    loginCalls,
+    [],
+    'no browser auth in non-interactive mode',
+  )
+  t.equal(added.length, 1)
+  t.equal(added[0]?.[0], 'user')
+  t.strictSame(added[0]?.[1], {
+    registries: {
+      npm: 'https://registry.vlt.io/acme/npm/',
+      main: 'https://registry.vlt.io/acme/main/',
+      loc: 'http://reg.local/',
+      slashed: 'http://slash.local/',
+    },
+  })
+  t.equal(result.account, 'acme')
+  t.equal(result.which, 'user')
+})
+
+t.test('non-interactive requires an account', async t => {
+  const added: Added[] = []
+  const { mod } = await loadSetup([])
+  await t.rejects(mod.command(makeConf({ yes: true }, added)), {
+    cause: { code: 'ECONFIG' },
+  })
+  t.strictSame(added, [])
+})
+
+t.test('non-interactive writes to project config', async t => {
+  const added: Added[] = []
+  const { mod } = await loadSetup([])
+  const result = await mod.command(
+    makeConf(
+      { yes: true, config: 'project', positionals: ['x'] },
+      added,
+    ),
+  )
+  t.equal(result.which, 'project')
+  t.equal(added[0]?.[0], 'project')
+})
+
+t.test('interactive: prompt account, auth, add alias', async t => {
+  const added: Added[] = []
+  const { mod, loginCalls } = await loadSetup([
+    'acme', // account slug
+    'y', // authenticate now
+    'y', // add another alias?
+    'partner', // alias name
+    'https://partner.example.com', // url
+    'y', // authenticate against partner?
+    'n', // add another alias?
+  ])
+  const result = await mod.command(makeConf({}, added))
+  t.strictSame(loginCalls, [
+    'https://registry.vlt.io/acme/npm/',
+    'https://registry.vlt.io/acme/main/',
+    'https://partner.example.com/',
+  ])
+  t.strictSame(result.registries, {
+    npm: 'https://registry.vlt.io/acme/npm/',
+    main: 'https://registry.vlt.io/acme/main/',
+    partner: 'https://partner.example.com/',
+  })
+  t.equal(added[0]?.[0], 'user')
+})
+
+t.test(
+  'interactive: skip auth and handle bad alias input',
+  async t => {
+    const added: Added[] = []
+    const { mod, loginCalls } = await loadSetup([
+      'n', // skip account auth
+      'y', // add another alias?
+      '', // empty name -> skip
+      'y', // add another alias?
+      'npm', // already staged -> skip
+      'y', // add another alias?
+      'good', // name
+      '', // empty url -> skip
+      'y', // add another alias?
+      'good', // name
+      'http://good.example', // url
+      'n', // don't authenticate this one
+      'n', // stop adding
+    ])
+    const result = await mod.command(
+      makeConf({ positionals: ['acme'] }, added),
+    )
+    t.strictSame(loginCalls, [], 'never authenticated')
+    t.strictSame(result.registries, {
+      npm: 'https://registry.vlt.io/acme/npm/',
+      main: 'https://registry.vlt.io/acme/main/',
+      good: 'http://good.example/',
+    })
+  },
+)
+
+t.test('interactive: empty account slug rejects', async t => {
+  const added: Added[] = []
+  const { mod } = await loadSetup([''])
+  await t.rejects(mod.command(makeConf({}, added)), {
+    cause: { code: 'ECONFIG' },
+  })
+})

--- a/src/cli-sdk/test/index.ts
+++ b/src/cli-sdk/test/index.ts
@@ -297,3 +297,24 @@ t.test('registry config resolution', async t => {
     t.equal(config.options.registry, 'https://registry.npmjs.org/')
   })
 })
+
+t.test('vlt registry <alias> <cmd> dispatch', async t => {
+  const cwd = t.testdir({
+    'vlt.json': JSON.stringify({
+      config: { registries: { npm: 'https://npm.example/' } },
+    }),
+    'package.json': JSON.stringify({ name: 'x', version: '1.0.0' }),
+  })
+  const { error, config } = await run(t, {
+    argv: ['registry', 'npm', 'whoami'],
+    cwd,
+  })
+  t.equal(error, null)
+  t.equal(config.command, 'whoami', 'rewrote command to whoami')
+  t.strictSame(config.positionals, [], 'consumed alias + subcommand')
+  t.equal(
+    config.options.registry,
+    'https://npm.example/',
+    'injected resolved registry',
+  )
+})

--- a/src/cli-sdk/test/output.ts
+++ b/src/cli-sdk/test/output.ts
@@ -258,6 +258,21 @@ t.test('outputCommand', async t => {
       } as LoadedConfig)
       t.strictSame(logs(), [['true']])
     })
+
+    t.test(
+      'runs when the default-registry-alias is configured',
+      async t => {
+        const logs = t.capture(console, 'log').args
+        await outputCommand(registryCommand, {
+          values: { view: 'json' },
+          options: {
+            'default-registry-alias': 'npm',
+            registries: { npm: 'https://registry.npmjs.org/' },
+          },
+        } as unknown as LoadedConfig)
+        t.strictSame(logs(), [['true']])
+      },
+    )
   })
 
   t.test('view class success', async t => {

--- a/src/cli-sdk/test/output.ts
+++ b/src/cli-sdk/test/output.ts
@@ -224,22 +224,29 @@ t.test('outputCommand', async t => {
       needsRegistry: true,
     }
 
-    t.test('ECONFIG when no registry is configured', async t => {
-      errsPrinted.length = 0
-      const { exitCode = 0 } = process
-      const exits = t.capture(process, 'exit').args
-      t.teardown(() => {
-        if (t.passing()) process.exitCode = exitCode
-      })
-      await outputCommand(registryCommand, {
-        values: { view: 'json' },
-        options: {},
-      } as LoadedConfig)
-      t.strictSame(exits(), [[1]])
-      t.equal(process.exitCode, 1)
-      t.match(errsPrinted[0], { cause: { code: 'ECONFIG' } })
-      t.match(String(errsPrinted[0]), /docs\.vlt\.sh\/cli/)
-    })
+    t.test(
+      'ECONFIG when only built-in defaults are configured',
+      async t => {
+        errsPrinted.length = 0
+        const { exitCode = 0 } = process
+        const exits = t.capture(process, 'exit').args
+        t.teardown(() => {
+          if (t.passing()) process.exitCode = exitCode
+        })
+        // a built-in default (gh) left at its default URL does not
+        // count as the user having configured a registry
+        await outputCommand(registryCommand, {
+          values: { view: 'json' },
+          options: {
+            registries: { gh: 'https://npm.pkg.github.com/' },
+          },
+        } as unknown as LoadedConfig)
+        t.strictSame(exits(), [[1]])
+        t.equal(process.exitCode, 1)
+        t.match(errsPrinted[0], { cause: { code: 'ECONFIG' } })
+        t.match(String(errsPrinted[0]), /docs\.vlt\.sh\/cli/)
+      },
+    )
 
     t.test('--help is answered before the check', async t => {
       const logs = t.capture(console, 'log').args
@@ -273,6 +280,35 @@ t.test('outputCommand', async t => {
         t.strictSame(logs(), [['true']])
       },
     )
+
+    t.test(
+      'runs when only a non-default alias is configured',
+      async t => {
+        // the default alias (npm) is not configured, but a single
+        // user-configured alias is enough for resolveRegistry to pick
+        const logs = t.capture(console, 'log').args
+        await outputCommand(registryCommand, {
+          values: { view: 'json' },
+          options: {
+            'default-registry-alias': 'npm',
+            registries: { main: 'https://example.com/' },
+          },
+        } as unknown as LoadedConfig)
+        t.strictSame(logs(), [['true']])
+      },
+    )
+
+    t.test('runs when a built-in alias is overridden', async t => {
+      // gh overridden to a non-default URL counts as user-configured
+      const logs = t.capture(console, 'log').args
+      await outputCommand(registryCommand, {
+        values: { view: 'json' },
+        options: {
+          registries: { gh: 'https://custom.example.com/' },
+        },
+      } as unknown as LoadedConfig)
+      t.strictSame(logs(), [['true']])
+    })
   })
 
   t.test('view class success', async t => {

--- a/src/cli-sdk/test/require-registry.ts
+++ b/src/cli-sdk/test/require-registry.ts
@@ -183,3 +183,79 @@ t.test('resolveRegistry (interactive prompt)', async t => {
   )
   t.equal(url, 'https://m/', 'prompt selection honored')
 })
+
+const ghDefaultURL = 'https://npm.pkg.github.com/'
+
+t.test('built-in defaults are not candidates', async t => {
+  const mod = await load()
+
+  // gh left at its default URL is a built-in default, not something
+  // the user configured, so it does not satisfy resolution
+  await t.rejects(
+    mod.resolveRegistry(
+      mkConf({ registries: { gh: ghDefaultURL } }),
+      {
+        interactive: false,
+      },
+    ),
+    { message: /Missing registry configuration/ },
+    'only built-in gh -> missing',
+  )
+
+  // a single user-configured alias resolves even when the built-in gh
+  // default is also present
+  t.equal(
+    await mod.resolveRegistry(
+      mkConf({
+        registries: { gh: ghDefaultURL, main: 'https://m/' },
+      }),
+      { interactive: false },
+    ),
+    'https://m/',
+    'gh default ignored, single user alias resolves',
+  )
+
+  // overriding a built-in alias to a non-default URL counts as
+  // user-configured
+  t.equal(
+    await mod.resolveRegistry(
+      mkConf({ registries: { gh: 'https://custom/' } }),
+      { interactive: false },
+    ),
+    'https://custom/',
+    'overridden gh counts as configured',
+  )
+})
+
+t.test('hasConfiguredRegistry', async t => {
+  const mod = await load()
+
+  t.notOk(
+    mod.hasConfiguredRegistry(mkConf({})),
+    'no registries -> false',
+  )
+  t.notOk(
+    mod.hasConfiguredRegistry(
+      mkConf({ registries: { gh: ghDefaultURL } }),
+    ),
+    'only built-in gh default -> false',
+  )
+  t.ok(
+    mod.hasConfiguredRegistry(
+      mkConf({ registry: 'https://scalar/' }),
+    ),
+    'registry scalar -> true',
+  )
+  t.ok(
+    mod.hasConfiguredRegistry(
+      mkConf({ registries: { main: 'https://m/' } }),
+    ),
+    'non-default alias -> true',
+  )
+  t.ok(
+    mod.hasConfiguredRegistry(
+      mkConf({ registries: { gh: 'https://custom/' } }),
+    ),
+    'overridden built-in alias -> true',
+  )
+})

--- a/src/cli-sdk/test/require-registry.ts
+++ b/src/cli-sdk/test/require-registry.ts
@@ -1,0 +1,185 @@
+import t from 'tap'
+import type { LoadedConfig } from '../src/config/index.ts'
+
+type Opts = {
+  registry?: string
+  registries?: Record<string, string>
+  'default-registry-alias'?: string
+}
+
+const mkConf = (options: Opts): LoadedConfig =>
+  ({
+    options: {
+      registries: {},
+      'default-registry-alias': 'npm',
+      ...options,
+    },
+  }) as unknown as LoadedConfig
+
+// Load require-registry with a mocked readline so the interactive
+// branch of resolveRegistry is deterministic.
+const load = async (answers: string[] = []) => {
+  const queue = [...answers]
+  return t.mockImport<typeof import('../src/require-registry.ts')>(
+    '../src/require-registry.ts',
+    {
+      'node:readline/promises': {
+        createInterface: () => ({
+          question: async () => queue.shift() ?? '',
+          close: () => {},
+        }),
+      },
+    },
+  )
+}
+
+t.test('missingRegistryError / ambiguousRegistryError', async t => {
+  const mod = await load()
+  t.match(mod.missingRegistryError(), {
+    message: /Missing registry configuration/,
+    cause: { code: 'ECONFIG' },
+  })
+  t.match(
+    mod.ambiguousRegistryError([
+      { alias: 'npm', url: 'https://n/' },
+      { alias: 'main', url: 'https://m/' },
+    ]),
+    {
+      message: /Multiple registries are configured/,
+      cause: { code: 'ECONFIG', validOptions: ['npm', 'main'] },
+    },
+  )
+})
+
+t.test('resolveRegistryAlias', async t => {
+  const mod = await load()
+  const conf = mkConf({ registries: { main: 'https://m/' } })
+  t.equal(mod.resolveRegistryAlias(conf, 'main'), 'https://m/')
+  t.throws(() => mod.resolveRegistryAlias(conf, 'nope'), {
+    cause: { code: 'ECONFIG', found: 'nope', validOptions: ['main'] },
+  })
+})
+
+t.test('requireRegistry (sync, non-interactive)', async t => {
+  const mod = await load()
+
+  t.equal(
+    mod.requireRegistry(
+      mkConf({ registries: { main: 'https://m/' } }),
+      'main',
+    ),
+    'https://m/',
+    'explicit alias wins',
+  )
+
+  t.equal(
+    mod.requireRegistry(mkConf({ registry: 'https://scalar/' })),
+    'https://scalar/',
+    'registry scalar',
+  )
+
+  t.equal(
+    mod.requireRegistry(
+      mkConf({ registries: { npm: 'https://n/' } }),
+    ),
+    'https://n/',
+    'single configured alias',
+  )
+
+  t.equal(
+    mod.requireRegistry(
+      mkConf({
+        registries: { npm: 'https://n/', main: 'https://m/' },
+        'default-registry-alias': 'main',
+      }),
+    ),
+    'https://m/',
+    'multiple -> default alias',
+  )
+
+  t.throws(
+    () =>
+      mod.requireRegistry(
+        mkConf({
+          registries: { a: 'https://a/', b: 'https://b/' },
+          'default-registry-alias': 'zz',
+        }),
+      ),
+    { cause: { code: 'ECONFIG', validOptions: ['a', 'b'] } },
+    'multiple, no default -> ambiguous',
+  )
+
+  t.throws(() => mod.requireRegistry(mkConf({})), {
+    message: /Missing registry configuration/,
+  })
+})
+
+t.test('resolveRegistry (async)', async t => {
+  const mod = await load()
+
+  t.equal(
+    await mod.resolveRegistry(
+      mkConf({ registries: { main: 'https://m/' } }),
+      { alias: 'main' },
+    ),
+    'https://m/',
+    'explicit alias',
+  )
+
+  t.equal(
+    await mod.resolveRegistry(
+      mkConf({ registry: 'https://scalar/' }),
+    ),
+    'https://scalar/',
+    'registry scalar',
+  )
+
+  t.equal(
+    await mod.resolveRegistry(
+      mkConf({ registries: { npm: 'https://n/' } }),
+      { interactive: false },
+    ),
+    'https://n/',
+    'single alias',
+  )
+
+  t.equal(
+    await mod.resolveRegistry(
+      mkConf({
+        registries: { npm: 'https://n/', main: 'https://m/' },
+        'default-registry-alias': 'npm',
+      }),
+      { interactive: false },
+    ),
+    'https://n/',
+    'multiple, non-interactive -> default',
+  )
+
+  await t.rejects(
+    mod.resolveRegistry(
+      mkConf({
+        registries: { a: 'https://a/', b: 'https://b/' },
+        'default-registry-alias': 'zz',
+      }),
+      { interactive: false },
+    ),
+    { cause: { code: 'ECONFIG' } },
+    'multiple, non-interactive, no default -> ambiguous',
+  )
+
+  await t.rejects(
+    mod.resolveRegistry(mkConf({}), { interactive: false }),
+    { message: /Missing registry configuration/ },
+  )
+})
+
+t.test('resolveRegistry (interactive prompt)', async t => {
+  const mod = await load(['2'])
+  const url = await mod.resolveRegistry(
+    mkConf({
+      registries: { npm: 'https://n/', main: 'https://m/' },
+    }),
+    { interactive: true, output: { write: () => true } as never },
+  )
+  t.equal(url, 'https://m/', 'prompt selection honored')
+})

--- a/src/cli-sdk/test/select-registry.ts
+++ b/src/cli-sdk/test/select-registry.ts
@@ -1,0 +1,88 @@
+import t from 'tap'
+import type { RegistryCandidate } from '../src/select-registry.ts'
+
+const candidates: RegistryCandidate[] = [
+  { alias: 'npm', url: 'https://n/' },
+  { alias: 'main', url: 'https://m/' },
+]
+
+const load = async (answers: string[]) => {
+  const queue = [...answers]
+  const questions: string[] = []
+  const written: string[] = []
+  const mod = await t.mockImport<
+    typeof import('../src/select-registry.ts')
+  >('../src/select-registry.ts', {
+    'node:readline/promises': {
+      createInterface: () => ({
+        question: async (q: string) => {
+          questions.push(q)
+          return queue.shift() ?? ''
+        },
+        close: () => {},
+      }),
+    },
+  })
+  const output = {
+    write: (s: string) => {
+      written.push(s)
+      return true
+    },
+  } as unknown as NodeJS.WritableStream
+  return { mod, questions, written, output }
+}
+
+t.test('numbered selection', async t => {
+  const { mod, output } = await load(['2'])
+  t.equal(
+    await mod.selectRegistry(candidates, {
+      defaultAlias: 'npm',
+      output,
+    }),
+    'https://m/',
+  )
+})
+
+t.test('empty answer uses default alias', async t => {
+  const { mod, output, written } = await load([''])
+  t.equal(
+    await mod.selectRegistry(candidates, {
+      defaultAlias: 'main',
+      output,
+    }),
+    'https://m/',
+  )
+  t.match(written.join(''), /main -> https:\/\/m\/ \(default\)/)
+})
+
+t.test('missing default falls back to first', async t => {
+  const { mod, output } = await load([''])
+  t.equal(
+    await mod.selectRegistry(candidates, {
+      defaultAlias: 'nope',
+      output,
+    }),
+    'https://n/',
+  )
+})
+
+t.test('invalid selection throws', async t => {
+  const { mod, output } = await load(['9'])
+  await t.rejects(mod.selectRegistry(candidates, { output }), {
+    cause: { code: 'EUSAGE' },
+  })
+})
+
+t.test('non-numeric selection throws', async t => {
+  const { mod, output } = await load(['abc'])
+  await t.rejects(mod.selectRegistry(candidates, { output }), {
+    cause: { code: 'EUSAGE' },
+  })
+})
+
+t.test('empty candidate list throws', async t => {
+  const { mod, output } = await load([])
+  await t.rejects(mod.selectRegistry([], { output }), {
+    cause: { code: 'ECONFIG' },
+  })
+})

--- a/src/dep-id/test/index.ts
+++ b/src/dep-id/test/index.ts
@@ -48,6 +48,7 @@ t.test('valid specs', t => {
     'x@registry:https://c.example.com/#asfd@1.2.3', // <- not configured
   ]
   const registries = {
+    npm: defaultRegistry,
     a: 'https://a.example.com/',
     b: 'https://b.example.com/',
   }
@@ -93,7 +94,7 @@ t.test('valid specs', t => {
   ]
   for (const s of scopedSpecs) {
     t.test(s, t => {
-      const spec = Spec.parse(s)
+      const spec = Spec.parse(s, options)
       const tuple = getTuple(spec, scopedMani)
       const id = getId(spec, scopedMani)
       t.matchSnapshot([id, tuple])
@@ -150,30 +151,40 @@ t.test('hydrate only', t => {
 
 t.test('hydrate from memoized entry', t => {
   resetCaches()
-  const options = getOptions({ registry: defaultRegistry })
+  const options = getOptions({
+    registry: defaultRegistry,
+    registries: { npm: defaultRegistry },
+  })
   const id = `${delimiter}${delimiter}x@1.2.3` as DepID
-  t.equal(String(hydrate(id, 'x', options)), 'x@1.2.3')
-  t.equal(String(hydrate(id, 'x', options)), 'x@1.2.3')
+  const first = hydrate(id, 'x', options)
+  const second = hydrate(id, 'x', options)
+  t.equal(String(first), 'x@1.2.3')
+  t.equal(first, second, 'returns the memoized instance')
   t.end()
 })
 
 t.test('hydrate with no configured registry', t => {
   // there is no default registry, so a `~npm~` id is hydrated through
-  // the `npm:` alias instead of as a plain semver spec
+  // the `npm:` alias. When the `npm` alias is not configured, the spec
+  // keeps the literal `npm:` form but cannot resolve to a URL.
   resetCaches()
   const options = getOptions({})
   t.equal(options.registry, undefined, 'no registry filled in')
   const id = `${delimiter}${delimiter}x@1.2.3` as DepID
   const spec = hydrate(id, 'x', options)
   t.equal(String(spec), 'x@npm:x@1.2.3')
-  t.equal(spec.namedRegistry, 'npm')
-  t.ok(spec.subspec, 'gains a subspec')
+  t.equal(
+    spec.namedRegistry,
+    undefined,
+    'npm alias is not recognized when unconfigured',
+  )
+  t.notOk(spec.subspec, 'no subspec without a configured npm alias')
   t.equal(
     spec.final.registry,
-    'https://registry.npmjs.org/',
-    'still resolves against npm via the kept alias',
+    undefined,
+    'cannot resolve to a URL without a configured npm alias',
   )
-  // round-trips back to the equivalent id, via namedRegistry
+  // round-trips back to the equivalent id via the `npm:` prefix
   t.equal(
     getId(spec, { name: 'x', version: '1.2.3' }),
     `${delimiter}npm${delimiter}x@1.2.3`,
@@ -181,9 +192,27 @@ t.test('hydrate with no configured registry', t => {
   // and is no longer flagged as a confused package name
   t.equal(isPackageNameConfused(spec, 'x'), false)
 
-  // with a registry configured, the plain form is preserved
+  // with the npm alias configured, it resolves through the mirror URL
   resetCaches()
-  const configured = getOptions({ registry: defaultRegistry })
+  const withNpm = getOptions({
+    registries: { npm: defaultRegistry },
+  })
+  const resolved = hydrate(id, 'x', withNpm)
+  t.equal(String(resolved), 'x@npm:x@1.2.3')
+  t.equal(resolved.namedRegistry, 'npm')
+  t.ok(
+    resolved.subspec,
+    'gains a subspec once the alias is configured',
+  )
+  t.equal(resolved.final.registry, defaultRegistry)
+
+  // with the npm alias pointing at the configured registry, the plain
+  // form is preserved (the id's registry matches the default alias)
+  resetCaches()
+  const configured = getOptions({
+    registry: defaultRegistry,
+    registries: { npm: defaultRegistry },
+  })
   t.equal(String(hydrate(id, 'x', configured)), 'x@1.2.3')
   t.end()
 })
@@ -633,9 +662,14 @@ t.test('isPackageNameConfused', t => {
 
   t.test('getTuple', t => {
     t.strictSame(
-      getTuple(Spec.parse('bar', 'npm:foo@^1.0.0'), {
-        version: '1.0.0',
-      }),
+      getTuple(
+        Spec.parse('bar', 'npm:foo@^1.0.0', {
+          registries: { npm: defaultRegistry },
+        }),
+        {
+          version: '1.0.0',
+        },
+      ),
       ['registry', 'npm', 'foo@1.0.0', undefined],
       'should normalize npm named registry to empty string',
     )
@@ -645,7 +679,9 @@ t.test('isPackageNameConfused', t => {
   t.test('aliased and non-aliased generate same DepID', t => {
     const manifest = { name: 'abbrev', version: '4.0.0' }
     const direct = Spec.parse('abbrev', '^4.0.0')
-    const aliased = Spec.parse('foo', 'npm:abbrev@^4.0.0')
+    const aliased = Spec.parse('foo', 'npm:abbrev@^4.0.0', {
+      registries: { npm: defaultRegistry },
+    })
 
     t.equal(
       getId(direct, manifest),

--- a/src/graph/src/lockfile/load.ts
+++ b/src/graph/src/lockfile/load.ts
@@ -5,6 +5,7 @@ import {
   defaultGitHosts,
   defaultJsrRegistries,
   defaultRegistries,
+  defaultRegistryName,
   defaultScopeRegistries,
 } from '@vltpkg/spec'
 import { isRecordStringString } from '@vltpkg/types'
@@ -170,6 +171,12 @@ const buildCurrentOptions = (
     ...(options.registry !== undefined ?
       { registry: options.registry }
     : undefined),
+    ...((
+      options['default-registry-alias'] !== undefined &&
+      options['default-registry-alias'] !== defaultRegistryName
+    ) ?
+      { 'default-registry-alias': options['default-registry-alias'] }
+    : undefined),
     ...(hasItems(cleanRegistries) ?
       { registries: cleanRegistries }
     : undefined),
@@ -221,6 +228,7 @@ export const loadObject = (
     'scoped-registries': scopedRegistriesOption,
     registry,
     registries,
+    'default-registry-alias': defaultRegistryAlias,
     'git-hosts': gitHosts,
     'git-host-archives': gitHostArchives,
     /* c8 ignore next */
@@ -253,6 +261,8 @@ export const loadObject = (
         { ...options['scoped-registries'], ...scopeRegistries }
       : options['scoped-registries'],
     registry: registry ?? options.registry,
+    'default-registry-alias':
+      defaultRegistryAlias ?? options['default-registry-alias'],
     registries:
       registries ?
         { ...options.registries, ...registries }

--- a/src/graph/src/lockfile/save.ts
+++ b/src/graph/src/lockfile/save.ts
@@ -7,6 +7,7 @@ import {
   defaultGitHosts,
   defaultJsrRegistries,
   defaultRegistries,
+  defaultRegistryName,
   defaultScopeRegistries,
 } from '@vltpkg/spec'
 import { mkdirSync, writeFileSync } from 'node:fs'
@@ -180,6 +181,7 @@ export const lockfileData = ({
   modifiers,
   registry,
   registries,
+  'default-registry-alias': defaultRegistryAlias,
   saveManifests,
   saveBuildData,
   'scoped-registries': scopeRegistries,
@@ -227,6 +229,12 @@ export const lockfileData = ({
         { 'jsr-registries': cleanJsrRegistries }
       : undefined),
       ...(registry !== undefined ? { registry } : undefined),
+      ...((
+        defaultRegistryAlias !== undefined &&
+        defaultRegistryAlias !== defaultRegistryName
+      ) ?
+        { 'default-registry-alias': defaultRegistryAlias }
+      : undefined),
       ...(hasItems(cleanRegistries) ?
         { registries: cleanRegistries }
       : undefined),

--- a/src/graph/src/transfer-data/load.ts
+++ b/src/graph/src/transfer-data/load.ts
@@ -4,6 +4,7 @@ import {
   defaultGitHostArchives,
   defaultGitHosts,
   defaultRegistries,
+  defaultRegistryName,
   defaultScopeRegistries,
 } from '@vltpkg/spec/browser'
 import { stringifyNode } from '../stringify-node.ts'
@@ -28,6 +29,7 @@ const loadSpecOptions = (
     catalogs = {},
     registries,
     registry,
+    'default-registry-alias': defaultRegistryAlias,
     'git-hosts': gitHosts,
     'git-host-archives': gitHostArchives,
     'scoped-registries': scopedRegistriesOption,
@@ -46,6 +48,8 @@ const loadSpecOptions = (
     catalogs,
     registries: { ...defaultRegistries, ...registries },
     registry,
+    'default-registry-alias':
+      defaultRegistryAlias ?? defaultRegistryName,
     'jsr-registries': { ...jsrRegistries },
     'git-hosts': { ...defaultGitHosts, ...gitHosts },
     'git-host-archives': {

--- a/src/graph/tap-snapshots/test/graph.ts.test.cjs
+++ b/src/graph/tap-snapshots/test/graph.ts.test.cjs
@@ -12,7 +12,10 @@ exports[`test/graph.ts > TAP > Graph > should print with special tag name 1`] = 
 exports[`test/graph.ts > TAP > using placePackage > should add a type=git package 1`] = `
 @vltpkg/graph.Graph {
   lockfileVersion: 1,
-  options: { registry: 'https://registry.npmjs.org/' },
+  options: {
+    registry: 'https://registry.npmjs.org/',
+    registries: { npm: 'https://registry.npmjs.org/' }
+  },
   nodes: {
     '~npm~bar@1.0.0': [
       0,
@@ -43,7 +46,10 @@ exports[`test/graph.ts > TAP > using placePackage > should add a type=git packag
 exports[`test/graph.ts > TAP > using placePackage > should find and fix nameless spec packages 1`] = `
 @vltpkg/graph.Graph {
   lockfileVersion: 1,
-  options: { registry: 'https://registry.npmjs.org/' },
+  options: {
+    registry: 'https://registry.npmjs.org/',
+    registries: { npm: 'https://registry.npmjs.org/' }
+  },
   nodes: {
     '~npm~bar@1.0.0': [
       0,
@@ -73,7 +79,10 @@ exports[`test/graph.ts > TAP > using placePackage > should find and fix nameless
 exports[`test/graph.ts > TAP > using placePackage > should have removed baz from the graph 1`] = `
 @vltpkg/graph.Graph {
   lockfileVersion: 1,
-  options: { registry: 'https://registry.npmjs.org/' },
+  options: {
+    registry: 'https://registry.npmjs.org/',
+    registries: { npm: 'https://registry.npmjs.org/' }
+  },
   nodes: {
     '~npm~bar@1.0.0': [
       0,
@@ -101,7 +110,10 @@ exports[`test/graph.ts > TAP > using placePackage > should have removed baz from
 exports[`test/graph.ts > TAP > using placePackage > the graph 1`] = `
 @vltpkg/graph.Graph {
   lockfileVersion: 1,
-  options: { registry: 'https://registry.npmjs.org/' },
+  options: {
+    registry: 'https://registry.npmjs.org/',
+    registries: { npm: 'https://registry.npmjs.org/' }
+  },
   nodes: {
     '~npm~bar@1.0.0': [
       0,
@@ -182,6 +194,7 @@ Set {
           "options": Object {
             "catalog": Object {},
             "catalogs": Object {},
+            "default-registry-alias": "npm",
             "git-host-archives": Object {
               "bitbucket": "https://bitbucket.org/$1/$2/get/$committish.tar.gz",
               "gist": "https://codeload.github.com/gist/$1/tar.gz/$committish",
@@ -306,6 +319,7 @@ Set {
           "options": Object {
             "catalog": Object {},
             "catalogs": Object {},
+            "default-registry-alias": "npm",
             "git-host-archives": Object {
               "bitbucket": "https://bitbucket.org/$1/$2/get/$committish.tar.gz",
               "gist": "https://codeload.github.com/gist/$1/tar.gz/$committish",

--- a/src/graph/tap-snapshots/test/ideal/append-nodes.ts.test.cjs
+++ b/src/graph/tap-snapshots/test/ideal/append-nodes.ts.test.cjs
@@ -41,7 +41,10 @@ Array [
 exports[`test/ideal/append-nodes.ts > TAP > append different type of dependencies > should install different type of deps on different conditions 1`] = `
 @vltpkg/graph.Graph {
   lockfileVersion: 1,
-  options: { registry: 'https://registry.npmjs.org/' },
+  options: {
+    registry: 'https://registry.npmjs.org/',
+    registries: { npm: 'https://registry.npmjs.org/' }
+  },
   nodes: {
     '~npm~bar@1.0.0': [ 1, 'bar', <3 empty items>, { name: 'bar', version: '1.0.0' } ],
     '~npm~foo@1.0.0': [

--- a/src/graph/tap-snapshots/test/ideal/build.ts.test.cjs
+++ b/src/graph/tap-snapshots/test/ideal/build.ts.test.cjs
@@ -31,7 +31,6 @@ exports[`test/ideal/build.ts > TAP > build from lockfile > should build an ideal
       Edge spec(foo@^1.0.0) -prod-> to: Node {
         id: '~npm~foo@1.0.0',
         location: './node_modules/.vlt/~npm~foo@1.0.0/node_modules/foo',
-        resolved: 'https://registry.npmjs.org/foo/-/foo-1.0.0.tgz',
         integrity: 'sha512-URO90jLnKPqX+P7OLnJkiIQfMX4I6gEdGZ1T84drQLtRPw6uNKYLZfB6K3hjWIrj0VZB1kh2cTFdeq01i6XIYQ=='
       }
     ]

--- a/src/graph/tap-snapshots/test/ideal/refresh-ideal-graph.ts.test.cjs
+++ b/src/graph/tap-snapshots/test/ideal/refresh-ideal-graph.ts.test.cjs
@@ -116,8 +116,7 @@ exports[`test/ideal/refresh-ideal-graph.ts > TAP > refreshIdealGraph with worksp
     edgesOut: [
       Edge spec(baz@^1.0.0) -prod-> to: Node {
         id: '~npm~baz@1.0.0',
-        location: './node_modules/.vlt/~npm~baz@1.0.0/node_modules/baz',
-        resolved: 'https://registry.npmjs.org/baz/-/baz-1.0.0.tgz'
+        location: './node_modules/.vlt/~npm~baz@1.0.0/node_modules/baz'
       }
     ]
   },

--- a/src/graph/tap-snapshots/test/install.ts.test.cjs
+++ b/src/graph/tap-snapshots/test/install.ts.test.cjs
@@ -15,8 +15,7 @@ exports[`test/install.ts > TAP > install > should call build adding new dependen
       Edge spec(abbrev@latest) -dev-> to: Node {
         id: '~npm~abbrev@2.0.0',
         location: './node_modules/.vlt/~npm~abbrev@2.0.0/node_modules/abbrev',
-        dev: true,
-        resolved: 'https://registry.npmjs.org/abbrev/-/abbrev-2.0.0.tgz'
+        dev: true
       }
     ]
   }

--- a/src/graph/tap-snapshots/test/lockfile/load-nodes.ts.test.cjs
+++ b/src/graph/tap-snapshots/test/lockfile/load-nodes.ts.test.cjs
@@ -78,7 +78,7 @@ Array [
     "optional": false,
     "platform": undefined,
     "projectRoot": "{ROOT}",
-    "resolved": "https://registry.npmjs.org/foo/-/foo-1.0.0.tgz",
+    "resolved": undefined,
     "version": "1.0.0",
   },
   Object {
@@ -129,7 +129,7 @@ Array [
     "optional": false,
     "platform": undefined,
     "projectRoot": "{ROOT}",
-    "resolved": "https://registry.npmjs.org/baz/-/baz-1.0.0.tgz",
+    "resolved": undefined,
     "version": "1.0.0",
   },
   Object {
@@ -199,7 +199,7 @@ Object {
     "name": "test",
     "version": "1.0.0",
   },
-  "resolved": "https://registry.npmjs.org/foo/-/foo-1.0.0.tgz",
+  "resolved": undefined,
   "version": "1.0.0",
 }
 `
@@ -307,7 +307,7 @@ Array [
     "optional": true,
     "platform": undefined,
     "projectRoot": "{ROOT}",
-    "resolved": "https://registry.npmjs.org/bar/-/bar-1.0.0.tgz",
+    "resolved": undefined,
     "version": "1.0.0",
   },
   Object {
@@ -330,7 +330,7 @@ Array [
     "optional": false,
     "platform": undefined,
     "projectRoot": "{ROOT}",
-    "resolved": "https://registry.npmjs.org/foo/-/foo-1.0.0.tgz",
+    "resolved": undefined,
     "version": "1.0.0",
   },
   Object {
@@ -397,7 +397,7 @@ Array [
     "integrity": undefined,
     "name": "standalone",
     "optional": false,
-    "resolved": "https://registry.npmjs.org/standalone/-/standalone-1.0.0.tgz",
+    "resolved": undefined,
     "version": "1.0.0",
   },
 ]

--- a/src/graph/tap-snapshots/test/lockfile/load.ts.test.cjs
+++ b/src/graph/tap-snapshots/test/lockfile/load.ts.test.cjs
@@ -57,6 +57,7 @@ Spec {
   "options": Object {
     "catalog": Object {},
     "catalogs": Object {},
+    "default-registry-alias": "npm",
     "git-host-archives": Object {
       "bitbucket": "https://bitbucket.org/$1/$2/get/$committish.tar.gz",
       "example": "git+ssh://example.com/$1/$2/archive/$3.tar.gz",
@@ -139,6 +140,7 @@ Spec {
   "options": Object {
     "catalog": Object {},
     "catalogs": Object {},
+    "default-registry-alias": "npm",
     "git-host-archives": Object {
       "bitbucket": "https://bitbucket.org/$1/$2/get/$committish.tar.gz",
       "gist": "https://codeload.github.com/gist/$1/tar.gz/$committish",

--- a/src/graph/tap-snapshots/test/lockfile/save.ts.test.cjs
+++ b/src/graph/tap-snapshots/test/lockfile/save.ts.test.cjs
@@ -11,6 +11,7 @@ exports[`test/lockfile/save.ts > TAP > confused manifest > should save lockfile 
   "options": {
     "registry": "https://registry.npmjs.org/",
     "registries": {
+      "npm": "https://registry.npmjs.org/",
       "custom": "http://example.com"
     }
   },
@@ -133,12 +134,28 @@ exports[`test/lockfile/save.ts > TAP > overrides default registries > must match
 }
 `
 
+exports[`test/lockfile/save.ts > TAP > persists a non-default default-registry-alias > must match snapshot 1`] = `
+{
+  "lockfileVersion": 1,
+  "options": {
+    "default-registry-alias": "internal",
+    "registries": {
+      "npm": "https://registry.npmjs.org/",
+      "internal": "https://internal.example.com/"
+    }
+  },
+  "nodes": {},
+  "edges": {}
+}
+`
+
 exports[`test/lockfile/save.ts > TAP > save > must match snapshot 1`] = `
 {
   "lockfileVersion": 1,
   "options": {
     "registry": "https://registry.npmjs.org/",
     "registries": {
+      "npm": "https://registry.npmjs.org/",
       "custom": "http://example.com"
     }
   },
@@ -162,6 +179,7 @@ exports[`test/lockfile/save.ts > TAP > save > save hidden (yes manifests) > must
   "options": {
     "registry": "https://registry.npmjs.org/",
     "registries": {
+      "npm": "https://registry.npmjs.org/",
       "custom": "http://example.com"
     }
   },
@@ -220,6 +238,7 @@ exports[`test/lockfile/save.ts > TAP > save > save normal (no manifests) > must 
   "options": {
     "registry": "https://registry.npmjs.org/",
     "registries": {
+      "npm": "https://registry.npmjs.org/",
       "custom": "http://example.com"
     }
   },
@@ -243,6 +262,7 @@ exports[`test/lockfile/save.ts > TAP > save buildState data > save with saveBuil
   "options": {
     "registry": "https://registry.npmjs.org/",
     "registries": {
+      "npm": "https://registry.npmjs.org/",
       "custom": "http://example.com"
     }
   },
@@ -304,6 +324,7 @@ exports[`test/lockfile/save.ts > TAP > save buildState data > save without saveB
   "options": {
     "registry": "https://registry.npmjs.org/",
     "registries": {
+      "npm": "https://registry.npmjs.org/",
       "custom": "http://example.com"
     }
   },
@@ -344,6 +365,7 @@ exports[`test/lockfile/save.ts > TAP > save buildState data > save() and saveHid
   "options": {
     "registry": "https://registry.npmjs.org/",
     "registries": {
+      "npm": "https://registry.npmjs.org/",
       "custom": "http://example.com"
     }
   },
@@ -405,6 +427,7 @@ exports[`test/lockfile/save.ts > TAP > save buildState data > save() and saveHid
   "options": {
     "registry": "https://registry.npmjs.org/",
     "registries": {
+      "npm": "https://registry.npmjs.org/",
       "custom": "http://example.com"
     }
   },
@@ -493,6 +516,7 @@ exports[`test/lockfile/save.ts > TAP > save platform data for optional dependenc
   "options": {
     "registry": "https://registry.npmjs.org/",
     "registries": {
+      "npm": "https://registry.npmjs.org/",
       "custom": "http://example.com"
     }
   },
@@ -550,6 +574,7 @@ exports[`test/lockfile/save.ts > TAP > saveManifests with normalized author and 
   "options": {
     "registry": "https://registry.npmjs.org/",
     "registries": {
+      "npm": "https://registry.npmjs.org/",
       "custom": "http://example.com"
     }
   },
@@ -611,6 +636,7 @@ Object {
   "options": Object {
     "registries": Object {
       "custom": "http://example.com",
+      "npm": "https://registry.npmjs.org/",
     },
     "registry": "https://registry.npmjs.org/",
   },
@@ -633,6 +659,7 @@ Object {
   "options": Object {
     "registries": Object {
       "custom": "http://example.com",
+      "npm": "https://registry.npmjs.org/",
     },
     "registry": "https://registry.npmjs.org/",
   },
@@ -655,6 +682,7 @@ Object {
   "options": Object {
     "registries": Object {
       "custom": "http://example.com",
+      "npm": "https://registry.npmjs.org/",
     },
     "registry": "https://registry.npmjs.org/",
   },
@@ -677,6 +705,7 @@ Object {
   "options": Object {
     "registries": Object {
       "custom": "http://example.com",
+      "npm": "https://registry.npmjs.org/",
     },
     "registry": "https://registry.npmjs.org/",
   },
@@ -692,6 +721,7 @@ exports[`test/lockfile/save.ts > TAP > store modifiers > with valid modifiers > 
     },
     "registry": "https://registry.npmjs.org/",
     "registries": {
+      "npm": "https://registry.npmjs.org/",
       "custom": "http://example.com"
     }
   },
@@ -711,6 +741,7 @@ exports[`test/lockfile/save.ts > TAP > workspaces > save manifests > must match 
   "options": {
     "registry": "https://registry.npmjs.org/",
     "registries": {
+      "npm": "https://registry.npmjs.org/",
       "custom": "http://example.com"
     }
   },
@@ -730,6 +761,7 @@ exports[`test/lockfile/save.ts > TAP > workspaces > should save lockfile with wo
   "options": {
     "registry": "https://registry.npmjs.org/",
     "registries": {
+      "npm": "https://registry.npmjs.org/",
       "custom": "http://example.com"
     }
   },

--- a/src/graph/tap-snapshots/test/reify/update-importers-package-json.ts.test.cjs
+++ b/src/graph/tap-snapshots/test/reify/update-importers-package-json.ts.test.cjs
@@ -9,7 +9,7 @@ exports[`test/reify/update-importers-package-json.ts > TAP > updatePackageJson >
 Array [
   Object {
     "dependencies": Object {
-      "b": "npm:a@1.0.0",
+      "b": "^1.0.0",
       "becomeprod": "1.0.0",
       "git": "github:a/b",
     },

--- a/src/graph/tap-snapshots/test/visualization/json-output.ts.test.cjs
+++ b/src/graph/tap-snapshots/test/visualization/json-output.ts.test.cjs
@@ -480,13 +480,13 @@ exports[`test/visualization/json-output.ts > TAP > aliased package > should prin
   {
     "name": "a",
     "fromID": "file~_d",
-    "spec": "a@npm:@myscope/foo@^1.0.0",
+    "spec": "a@github:npm:@myscope/foo@^1.0.0",
     "type": "optional",
     "to": {
-      "id": "~npm~@myscope+foo@1.0.0",
+      "id": "git~github_cnpm_c@myscope+foo@^1.0.0~",
       "name": "@myscope/foo",
       "version": "1.0.0",
-      "location": "./node_modules/.vlt/~npm~@myscope+foo@1.0.0/node_modules/@myscope/foo",
+      "location": "./node_modules/.vlt/git~github_cnpm_c@myscope+foo@^1.0.0~/node_modules/@myscope/foo",
       "importer": false,
       "manifest": {
         "name": "@myscope/foo",

--- a/src/graph/test/fixtures/reify.ts
+++ b/src/graph/test/fixtures/reify.ts
@@ -30,7 +30,14 @@ import {
 import { basename, resolve } from 'node:path'
 import { extract } from 'tar'
 
-const realPackageInfo = new PackageInfoClient({})
+// the `npm` alias is no longer a built-in default, so it must be
+// configured explicitly for `npm:` aliased specs to collapse to their
+// resolved target (which is how the fixture maps are keyed).
+const specOptions = {
+  registries: { npm: 'https://registry.npmjs.org/' },
+}
+
+const realPackageInfo = new PackageInfoClient(specOptions)
 export const fixtureDir = resolve(import.meta.dirname, 'reify')
 
 const fixtureMapFile = resolve(fixtureDir, 'map.json')
@@ -62,14 +69,15 @@ export const fixtureManifest = (name: string) =>
     ),
   )
 
-const actualPackageInfo = new PackageInfoClient()
+const actualPackageInfo = new PackageInfoClient(specOptions)
 
 export const mockPackageInfo = {
   resolve: async (
     spec: string | Spec,
     options: PackageInfoClientRequestOptions = {},
   ): Promise<Resolution> => {
-    spec = typeof spec === 'string' ? Spec.parse(spec) : spec
+    spec =
+      typeof spec === 'string' ? Spec.parse(spec, specOptions) : spec
     if (spec.type === 'file') {
       return actualPackageInfo.resolve(spec, options)
     }
@@ -88,7 +96,7 @@ export const mockPackageInfo = {
     spec: string | Spec,
     options: PackageInfoClientRequestOptions = {},
   ) => {
-    spec = Spec.parse(String(spec)).final
+    spec = Spec.parse(String(spec), specOptions).final
     if (spec.type === 'file') {
       return actualPackageInfo.manifest(spec, options)
     }
@@ -108,7 +116,7 @@ export const mockPackageInfo = {
     target: string,
     options: PackageInfoClientRequestOptions = {},
   ): Promise<Resolution> => {
-    spec = Spec.parse(String(spec)).final
+    spec = Spec.parse(String(spec), specOptions).final
     if (spec.type === 'file') {
       return actualPackageInfo.extract(spec, target, options)
     }

--- a/src/graph/test/ideal/build.ts
+++ b/src/graph/test/ideal/build.ts
@@ -252,6 +252,12 @@ t.test(
 
     const graph = await build({
       ...specOptions,
+      // the `npm` alias is no longer built in; configure it so the
+      // `npm:foo` alias resolves
+      registries: {
+        ...specOptions.registries,
+        npm: 'https://registry.npmjs.org/',
+      },
       scurry: new PathScurry(projectRoot),
       monorepo: Monorepo.maybeLoad(projectRoot),
       packageJson: new PackageJson(),

--- a/src/graph/test/lockfile/load.ts
+++ b/src/graph/test/lockfile/load.ts
@@ -1109,9 +1109,11 @@ t.test('optionsChanged detection', async t => {
         ...baseLockfileData,
         options: {
           // the configured registry is always recorded now that there
-          // is no default to elide it against
+          // is no default to elide it against; the `npm` alias is also
+          // persisted now that it is no longer a built-in default
           registry: 'https://registry.npmjs.org/',
           registries: {
+            npm: 'https://registry.npmjs.org/',
             custom: 'http://example.com',
           },
         },
@@ -1198,6 +1200,90 @@ t.test('optionsChanged detection', async t => {
         graph.optionsChanged,
         true,
         'options changed due to modified modifiers',
+      )
+    },
+  )
+
+  t.test(
+    'default-registry-alias round-trips without drift',
+    async t => {
+      const lockfileWithAlias: LockfileData = {
+        ...baseLockfileData,
+        // key order must mirror buildCurrentOptions / save.ts
+        // (default-registry-alias before registries) since the drift
+        // check is a JSON string comparison
+        options: {
+          'default-registry-alias': 'internal',
+          registries: {
+            npm: 'https://registry.npmjs.org/',
+            internal: 'https://internal.example.com/',
+          },
+        },
+      }
+      const projectRoot = t.testdir({
+        'vlt-lock.json': JSON.stringify(lockfileWithAlias),
+        'vlt.json': '{}',
+      })
+      t.chdir(projectRoot)
+      unload('project')
+      const graph = loadObject(
+        {
+          ...configData,
+          registry: undefined,
+          registries: {
+            npm: 'https://registry.npmjs.org/',
+            internal: 'https://internal.example.com/',
+          },
+          'default-registry-alias': 'internal',
+          mainManifest,
+          projectRoot,
+        },
+        lockfileWithAlias,
+      )
+      t.equal(
+        graph.optionsChanged,
+        false,
+        'matching non-default alias does not trip drift',
+      )
+    },
+  )
+
+  t.test(
+    'optionsChanged is true when default-registry-alias is changed',
+    async t => {
+      const lockfileWithAlias: LockfileData = {
+        ...baseLockfileData,
+        options: {
+          registries: {
+            npm: 'https://registry.npmjs.org/',
+            internal: 'https://internal.example.com/',
+          },
+          'default-registry-alias': 'internal',
+        },
+      }
+      const projectRoot = t.testdir({
+        'vlt-lock.json': JSON.stringify(lockfileWithAlias),
+        'vlt.json': '{}',
+      })
+      t.chdir(projectRoot)
+      unload('project')
+      const graph = loadObject(
+        {
+          ...configData,
+          registry: undefined,
+          registries: {
+            npm: 'https://registry.npmjs.org/',
+            internal: 'https://internal.example.com/',
+          },
+          mainManifest,
+          projectRoot,
+        },
+        lockfileWithAlias,
+      )
+      t.equal(
+        graph.optionsChanged,
+        true,
+        'options changed due to default-registry-alias change',
       )
     },
   )

--- a/src/graph/test/lockfile/save.ts
+++ b/src/graph/test/lockfile/save.ts
@@ -288,6 +288,40 @@ t.test('overrides default registries', async t => {
   t.matchSnapshot(JSON.stringify(lockfile, null, 2))
 })
 
+t.test('persists a non-default default-registry-alias', async t => {
+  const mainManifest = {
+    name: 'my-project',
+    version: '1.0.0',
+    dependencies: {
+      foo: '^1.0.0',
+    },
+  }
+  const specOptions = {
+    registries: {
+      npm: 'https://registry.npmjs.org/',
+      internal: 'https://internal.example.com/',
+      // matches a built-in default, so it is stripped from the lockfile
+      gh: 'https://npm.pkg.github.com/',
+    },
+    'default-registry-alias': 'internal',
+  }
+  const projectRoot = t.testdir({ 'vlt.json': '{}' })
+  t.chdir(projectRoot)
+  unload('project')
+  const graph = new Graph({
+    projectRoot,
+    ...specOptions,
+    mainManifest,
+  })
+  const lockfile = lockfileData({ ...specOptions, graph })
+  t.equal(
+    lockfile.options['default-registry-alias'],
+    'internal',
+    'non-default alias is persisted',
+  )
+  t.matchSnapshot(JSON.stringify(lockfile, null, 2))
+})
+
 t.test('workspaces', async t => {
   const mainManifest = {
     name: 'my-project',

--- a/src/graph/test/reify/add-nodes.ts
+++ b/src/graph/test/reify/add-nodes.ts
@@ -41,7 +41,12 @@ const node = (props: Record<string, any>) => ({
     scurry.cwd.resolve(props.location).fullpath(),
 })
 
-const configData = { registry: 'https://registry.npmjs.org/' }
+const configData = {
+  registry: 'https://registry.npmjs.org/',
+  // the `npm` alias is no longer built in; configure it so the default
+  // registry DepID hydrates back to the `npm` alias name
+  registries: { npm: 'https://registry.npmjs.org/' },
+}
 
 const specOptions = getOptions(configData)
 

--- a/src/graph/test/reify/calculate-save-value.ts
+++ b/src/graph/test/reify/calculate-save-value.ts
@@ -2,6 +2,12 @@ import { Spec } from '@vltpkg/spec'
 import t from 'tap'
 import { calculateSaveValue } from '../../src/reify/calculate-save-value.ts'
 
+// the `npm` alias is no longer built in; configure it so `npm:` specs
+// resolve in these cases.
+const specOptions = {
+  registries: { npm: 'https://registry.npmjs.org/' },
+}
+
 t.test('non-registry type, just saved as-is', t => {
   const s = Spec.parse('x', 'github:a/b')
   t.equal(calculateSaveValue('git', s, 'a/b', '1.2.3'), 'github:a/b')
@@ -90,7 +96,7 @@ t.test('catalog spec preserved as-is', t => {
 t.test('registry cases', t => {
   t.plan(cases.length)
   for (const [bareSpec, existing, expect, comment] of cases) {
-    const spec = Spec.parse('@x/y', bareSpec)
+    const spec = Spec.parse('@x/y', bareSpec, specOptions)
     t.equal(
       calculateSaveValue('registry', spec, existing, '1.2.3'),
       expect,
@@ -160,7 +166,7 @@ t.test('save-exact registry cases', t => {
     expect,
     comment,
   ] of saveExactCases) {
-    const spec = Spec.parse('@x/y', bareSpec)
+    const spec = Spec.parse('@x/y', bareSpec, specOptions)
     t.equal(
       calculateSaveValue('registry', spec, existing, '1.2.3', true),
       expect,
@@ -255,7 +261,7 @@ t.test('save-prefix ~ registry cases', t => {
     expect,
     comment,
   ] of savePrefixTildeCases) {
-    const spec = Spec.parse('@x/y', bareSpec)
+    const spec = Spec.parse('@x/y', bareSpec, specOptions)
     t.equal(
       calculateSaveValue(
         'registry',

--- a/src/graph/test/reify/extract-node.ts
+++ b/src/graph/test/reify/extract-node.ts
@@ -10,7 +10,12 @@ import type { Diff } from '../../src/diff.ts'
 import type { Node } from '../../src/node.ts'
 import { extractNode } from '../../src/reify/extract-node.ts'
 
-const configData = { registry: 'https://registry.npmjs.org/' }
+const configData = {
+  registry: 'https://registry.npmjs.org/',
+  // the `npm` alias is no longer built in; configure it so the default
+  // registry DepID hydrates back to the `npm` alias name
+  registries: { npm: 'https://registry.npmjs.org/' },
+}
 
 const removed: string[] = []
 const mockRemover = {

--- a/src/graph/test/reify/index.ts
+++ b/src/graph/test/reify/index.ts
@@ -50,6 +50,10 @@ const createMockPackageInfo = (
 
 const mockPackageInfo = createMockPackageInfo()
 
+// the `npm` alias is no longer a built-in default; configure it so bare
+// specs resolve and default-registry DepIDs canonicalize to `~npm~...`.
+const registries = { npm: 'https://registry.npmjs.org/' }
+
 t.test('super basic reification', async t => {
   const dir = t.testdir({
     cache: {},
@@ -72,6 +76,7 @@ t.test('super basic reification', async t => {
     projectRoot,
     registry: 'https://registry.npmjs.org/',
     packageInfo: mockPackageInfo,
+    registries,
     monorepo: Monorepo.maybeLoad(projectRoot),
     scurry: new PathScurry(projectRoot),
     packageJson,
@@ -81,6 +86,7 @@ t.test('super basic reification', async t => {
     projectRoot,
     registry: 'https://registry.npmjs.org/',
     packageInfo: mockPackageInfo,
+    registries,
     monorepo: Monorepo.maybeLoad(projectRoot),
     scurry: new PathScurry(projectRoot),
     packageJson: new PackageJson(),
@@ -103,7 +109,10 @@ t.test('super basic reification', async t => {
 
   const expectLockfileData: LockfileData = {
     lockfileVersion: 1,
-    options: { registry: 'https://registry.npmjs.org/' },
+    options: {
+      registry: 'https://registry.npmjs.org/',
+      registries: { npm: 'https://registry.npmjs.org/' },
+    },
     nodes: {
       [joinDepIDTuple(['registry', '', 'lodash@4.17.21'])]: [
         0,
@@ -170,6 +179,7 @@ t.test('super basic reification', async t => {
   await reify({
     projectRoot,
     packageInfo: mockPackageInfo,
+    registries,
     monorepo: Monorepo.maybeLoad(projectRoot),
     scurry: new PathScurry(projectRoot),
     packageJson: new PackageJson(),
@@ -216,6 +226,7 @@ t.test('super basic reification', async t => {
     add,
     projectRoot,
     packageInfo: mockPackageInfo,
+    registries,
     monorepo: Monorepo.maybeLoad(projectRoot),
     scurry: new PathScurry(projectRoot),
     packageJson,
@@ -241,6 +252,7 @@ t.test('super basic reification', async t => {
     remove,
     projectRoot,
     packageInfo: mockPackageInfo,
+    registries,
     monorepo: Monorepo.maybeLoad(projectRoot),
     scurry: new PathScurry(projectRoot),
     packageJson,
@@ -281,11 +293,13 @@ t.test('reify with a bin', async t => {
     scurry: new PathScurry(projectRoot),
     packageJson: new PackageJson(),
     packageInfo: mockPackageInfo,
+    registries,
     remover: new RollbackRemove(),
   })
   await reify({
     projectRoot,
     packageInfo: mockPackageInfo,
+    registries,
     graph,
     monorepo: Monorepo.maybeLoad(projectRoot),
     scurry: new PathScurry(projectRoot),
@@ -330,6 +344,7 @@ t.test('failure rolls back', async t => {
   const graph = await ideal.build({
     projectRoot,
     packageInfo: mockPackageInfo,
+    registries,
     monorepo: Monorepo.maybeLoad(projectRoot),
     scurry: new PathScurry(projectRoot),
     packageJson: new PackageJson(),
@@ -348,6 +363,7 @@ t.test('failure rolls back', async t => {
     reify({
       projectRoot,
       packageInfo: mockPackageInfo,
+      registries,
       graph,
       allowScripts: '*',
       packageJson: new PackageJson(),
@@ -397,6 +413,7 @@ t.test('failure of optional node just deletes it', async t => {
 
   const before = actual.load({
     projectRoot,
+    registries,
     monorepo: Monorepo.maybeLoad(projectRoot),
     scurry: new PathScurry(projectRoot),
     packageJson: new PackageJson(),
@@ -404,6 +421,7 @@ t.test('failure of optional node just deletes it', async t => {
   const graph = await ideal.build({
     projectRoot,
     packageInfo: mockPackageInfo,
+    registries,
     monorepo: Monorepo.maybeLoad(projectRoot),
     scurry: new PathScurry(projectRoot),
     packageJson: new PackageJson(),
@@ -419,6 +437,7 @@ t.test('failure of optional node just deletes it', async t => {
 
   await reify({
     projectRoot,
+    registries,
     monorepo: Monorepo.maybeLoad(projectRoot),
     scurry: new PathScurry(projectRoot),
     packageJson: new PackageJson(),
@@ -442,6 +461,7 @@ t.test('failure of optional node just deletes it', async t => {
 
   const after = actual.load({
     projectRoot,
+    registries,
     monorepo: Monorepo.maybeLoad(projectRoot),
     scurry: new PathScurry(projectRoot),
     packageJson: new PackageJson(),
@@ -534,6 +554,7 @@ t.test('early termination when no changes are needed', async t => {
   const result = await testReify({
     projectRoot,
     packageInfo: mockPackageInfo,
+    registries,
     monorepo: Monorepo.maybeLoad(projectRoot),
     scurry: new PathScurry(projectRoot),
     packageJson: new PackageJson(),
@@ -600,6 +621,7 @@ t.test('early termination when no changes are needed', async t => {
   await testReify({
     projectRoot,
     packageInfo: mockPackageInfo,
+    registries,
     monorepo: Monorepo.maybeLoad(projectRoot),
     scurry: scurry2,
     packageJson: new PackageJson(),
@@ -637,6 +659,7 @@ t.test('checkNeededBuild is called during reification', async t => {
   const graph = await ideal.build({
     projectRoot,
     packageInfo: mockPackageInfo,
+    registries,
     monorepo: Monorepo.maybeLoad(projectRoot),
     scurry: new PathScurry(projectRoot),
     packageJson,
@@ -646,6 +669,7 @@ t.test('checkNeededBuild is called during reification', async t => {
   const result = await reify({
     projectRoot,
     packageInfo: mockPackageInfo,
+    registries,
     monorepo: Monorepo.maybeLoad(projectRoot),
     scurry: new PathScurry(projectRoot),
     packageJson: new PackageJson(),
@@ -688,6 +712,7 @@ t.test(
     const graph = await ideal.build({
       projectRoot,
       packageInfo: mockPackageInfo,
+      registries,
       monorepo: Monorepo.maybeLoad(projectRoot),
       scurry: new PathScurry(projectRoot),
       packageJson,
@@ -697,6 +722,7 @@ t.test(
     const result = await reify({
       projectRoot,
       packageInfo: mockPackageInfo,
+      registries,
       monorepo: Monorepo.maybeLoad(projectRoot),
       scurry: new PathScurry(projectRoot),
       packageJson: new PackageJson(),
@@ -739,6 +765,7 @@ t.test(
     const graph = await ideal.build({
       projectRoot,
       packageInfo: mockPackageInfo,
+      registries,
       monorepo: Monorepo.maybeLoad(projectRoot),
       scurry: new PathScurry(projectRoot),
       packageJson,
@@ -749,6 +776,7 @@ t.test(
     const result = await reify({
       projectRoot,
       packageInfo: mockPackageInfo,
+      registries,
       monorepo: Monorepo.maybeLoad(projectRoot),
       scurry: new PathScurry(projectRoot),
       packageJson: new PackageJson(),
@@ -789,6 +817,7 @@ t.test('allowScripts with query selector :scripts', async t => {
   const graph = await ideal.build({
     projectRoot,
     packageInfo: mockPackageInfo,
+    registries,
     monorepo: Monorepo.maybeLoad(projectRoot),
     scurry: new PathScurry(projectRoot),
     packageJson,
@@ -799,6 +828,7 @@ t.test('allowScripts with query selector :scripts', async t => {
   const result = await reify({
     projectRoot,
     packageInfo: mockPackageInfo,
+    registries,
     monorepo: Monorepo.maybeLoad(projectRoot),
     scurry: new PathScurry(projectRoot),
     packageJson: new PackageJson(),
@@ -854,6 +884,7 @@ t.test(
     const graph = await ideal.build({
       projectRoot,
       packageInfo: mockPackageInfo,
+      registries,
       monorepo: Monorepo.maybeLoad(projectRoot),
       scurry: new PathScurry(projectRoot),
       packageJson,
@@ -862,6 +893,7 @@ t.test(
     await reify({
       projectRoot,
       packageInfo: mockPackageInfo,
+      registries,
       monorepo: Monorepo.maybeLoad(projectRoot),
       scurry: new PathScurry(projectRoot),
       packageJson: new PackageJson(),
@@ -896,6 +928,7 @@ t.test(
     const result = await reify({
       projectRoot,
       packageInfo: mockPackageInfo,
+      registries,
       monorepo: Monorepo.maybeLoad(projectRoot),
       scurry: scurry2,
       packageJson: new PackageJson(),
@@ -957,6 +990,7 @@ t.test('reify recreates deleted workspace node_modules', async t => {
   const graph = await ideal.build({
     projectRoot,
     packageInfo: mockPackageInfo,
+    registries,
     monorepo,
     scurry,
     packageJson,
@@ -965,6 +999,7 @@ t.test('reify recreates deleted workspace node_modules', async t => {
   await reify({
     projectRoot,
     packageInfo: mockPackageInfo,
+    registries,
     monorepo,
     scurry,
     packageJson: new PackageJson(),
@@ -997,6 +1032,7 @@ t.test('reify recreates deleted workspace node_modules', async t => {
   const graph2 = await ideal.build({
     projectRoot,
     packageInfo: mockPackageInfo,
+    registries,
     monorepo: monorepo2,
     scurry: scurry2,
     packageJson: new PackageJson(),
@@ -1005,6 +1041,7 @@ t.test('reify recreates deleted workspace node_modules', async t => {
   await reify({
     projectRoot,
     packageInfo: mockPackageInfo,
+    registries,
     monorepo: monorepo2,
     scurry: scurry2,
     packageJson: new PackageJson(),
@@ -1061,12 +1098,14 @@ t.test('reify with workspace bin script', async t => {
     scurry: new PathScurry(projectRoot),
     packageJson: new PackageJson(),
     packageInfo: mockPackageInfo,
+    registries,
     remover: new RollbackRemove(),
   })
 
   await reify({
     projectRoot,
     packageInfo: mockPackageInfo,
+    registries,
     graph,
     monorepo,
     scurry: new PathScurry(projectRoot),

--- a/src/graph/test/reify/internal-hoist.ts
+++ b/src/graph/test/reify/internal-hoist.ts
@@ -550,6 +550,9 @@ t.test('hoisting with aliased dependencies', async t => {
     scurry,
     packageJson,
     monorepo: Monorepo.load(projectRoot),
+    // the `npm` alias is no longer built in; configure it so the
+    // `npm:bar` aliased deps resolve
+    registries: { npm: 'https://registry.npmjs.org/' },
   })
 
   await internalHoist(

--- a/src/graph/test/reify/update-importers-package-json.ts
+++ b/src/graph/test/reify/update-importers-package-json.ts
@@ -14,6 +14,9 @@ import { updatePackageJson } from '../../src/reify/update-importers-package-json
 const specOptions = {
   registry: 'https://registry.npmjs.org',
   registries: {
+    // the `npm` alias is no longer built in; configure it so `npm:`
+    // aliased specs resolve
+    npm: 'https://registry.npmjs.org/',
     custom: 'http://example.com',
   },
 }
@@ -506,7 +509,7 @@ t.test('updatePackageJson', async t => {
 
   await t.test('aliased install from dist-tag', async t => {
     const aliasedMani = { name: 'a', version: '1.0.0' }
-    const aliasedSpec = Spec.parse('b', 'npm:a@latest')
+    const aliasedSpec = Spec.parse('b', 'npm:a@latest', specOptions)
     const aliased = graph.addNode(
       undefined,
       aliasedMani,

--- a/src/pick-manifest/test/index.ts
+++ b/src/pick-manifest/test/index.ts
@@ -153,7 +153,9 @@ t.test('do not be confused by subspecs', t => {
   } as unknown as Packument
   const manifest = pickManifest(
     metadata,
-    Spec.parse('foo@npm:bar@^1.0.0'),
+    Spec.parse('foo@npm:bar@^1.0.0', {
+      registries: { npm: 'https://registry.npmjs.org/' },
+    }),
   )
   t.equal(
     manifest?.version,
@@ -828,7 +830,9 @@ t.test('handles complex Spec objects with subspecs correctly', t => {
   } as unknown as Packument
 
   // Create a nested spec: foo@npm:bar@npm:baz@^1.0.0
-  const nestedSpec = Spec.parse('foo@npm:bar@npm:baz@^1.0.0')
+  const nestedSpec = Spec.parse('foo@npm:bar@npm:baz@^1.0.0', {
+    registries: { npm: 'https://registry.npmjs.org/' },
+  })
 
   // Verify it's recognized correctly
   t.equal(
@@ -854,6 +858,7 @@ t.test('handles complex Spec objects with subspecs correctly', t => {
   // Create a more deeply nested spec
   const deeplyNestedSpec = Spec.parse(
     'pkg1@npm:pkg2@npm:pkg3@npm:baz@^1.0.0',
+    { registries: { npm: 'https://registry.npmjs.org/' } },
   )
   const manifestFromDeeplyNestedSpec = pickManifest(
     metadata,

--- a/src/query/test/pseudo/outdated.ts
+++ b/src/query/test/pseudo/outdated.ts
@@ -12,7 +12,15 @@ import {
   getSimpleGraph,
 } from '../fixtures/graph.ts'
 import type { NodeLike } from '@vltpkg/types'
+import type { SpecOptions } from '@vltpkg/spec'
 import type { ParserState } from '../../src/types.ts'
+
+// the `npm` alias is no longer built in; configure it so the
+// default-registry DepIDs hydrate to the npm registry URL. Typed as
+// SpecOptions so the surrounding `as NodeLike` casts stay valid.
+const npmSpecOptions: SpecOptions = {
+  registries: { npm: 'https://registry.npmjs.org/' },
+}
 
 global.fetch = (async (url: string) => {
   if (url === 'https://registry.npmjs.org/h') {
@@ -288,6 +296,7 @@ t.test('retrieveRemoveVersions', async t => {
     const missingName = {
       name: 'h',
       id: joinDepIDTuple(['registry', '', 'h@1.0.0']),
+      options: npmSpecOptions,
     } as NodeLike
     await t.rejects(
       retrieveRemoteVersions(missingName),
@@ -300,6 +309,7 @@ t.test('retrieveRemoveVersions', async t => {
     const missingName = {
       name: 'i',
       id: joinDepIDTuple(['registry', '', 'i@1.0.0']),
+      options: npmSpecOptions,
     } as NodeLike
     await t.rejects(
       retrieveRemoteVersions(missingName),

--- a/src/query/test/pseudo/published.ts
+++ b/src/query/test/pseudo/published.ts
@@ -12,7 +12,15 @@ import {
   getSimpleGraph,
 } from '../fixtures/graph.ts'
 import type { NodeLike } from '@vltpkg/types'
+import type { SpecOptions } from '@vltpkg/spec'
 import type { ParserState } from '../../src/types.ts'
+
+// the `npm` alias is no longer built in; configure it so the
+// default-registry DepIDs hydrate to the npm registry URL. Typed as
+// SpecOptions so the surrounding `as NodeLike` casts stay valid.
+const npmSpecOptions: SpecOptions = {
+  registries: { npm: 'https://registry.npmjs.org/' },
+}
 
 global.fetch = (async (url: string) => {
   if (url === 'https://registry.npmjs.org/h') {
@@ -332,6 +340,7 @@ t.test('retrieveRemoteDate', async t => {
       name: 'h',
       version: '1.0.0',
       id: joinDepIDTuple(['registry', '', 'h@1.0.0']),
+      options: npmSpecOptions,
     } as NodeLike
     await t.rejects(
       retrieveRemoteDate(node),
@@ -344,6 +353,7 @@ t.test('retrieveRemoteDate', async t => {
     const node = {
       name: 'i',
       id: joinDepIDTuple(['registry', '', 'i@1.0.0']),
+      options: npmSpecOptions,
     } as NodeLike
     t.strictSame(
       await retrieveRemoteDate(node),
@@ -357,6 +367,7 @@ t.test('retrieveRemoteDate', async t => {
       name: 'c',
       version: '1.0.0',
       id: joinDepIDTuple(['registry', '', 'c@1.0.0']),
+      options: npmSpecOptions,
     } as NodeLike
     await t.rejects(
       retrieveRemoteDate(node),

--- a/src/satisfies/test/index.ts
+++ b/src/satisfies/test/index.ts
@@ -101,7 +101,11 @@ t.test('ids that satisfy the spec', t => {
     ],
     [Spec.parse('a@file:a'), joinDepIDTuple(['file', './a'])],
     [
-      Spec.parse('a@registry:https://registry.npmjs.org/#a@1.x'),
+      // the `npm` alias is no longer a built-in default; configure it so
+      // the default-registry DepID resolves to the npm registry URL
+      Spec.parse('a@registry:https://registry.npmjs.org/#a@1.x', {
+        registries: { npm: 'https://registry.npmjs.org/' },
+      }),
       joinDepIDTuple(['registry', '', 'a@1.2.3']),
     ],
     [

--- a/src/security-archive/test/fixtures/graph.ts
+++ b/src/security-archive/test/fixtures/graph.ts
@@ -9,6 +9,10 @@ import type { SpecLike } from '@vltpkg/spec/browser'
 
 export const specOptions = getOptions({
   registries: {
+    // the `npm` alias is no longer a built-in default; configure it so
+    // bare specs resolve to the npm registry (and register as `npm`
+    // ecosystem packages for the security API)
+    npm: 'https://registry.npmjs.org/',
     custom: 'http://example.com',
   },
 })

--- a/src/spec/src/browser.ts
+++ b/src/spec/src/browser.ts
@@ -17,7 +17,6 @@ export const kCustomInspect = Symbol.for('nodejs.util.inspect.custom')
 export const defaultRegistryName = 'npm'
 
 export const defaultRegistries = {
-  npm: 'https://registry.npmjs.org/',
   gh: 'https://npm.pkg.github.com/',
 }
 
@@ -63,11 +62,14 @@ export const getOptions = (
   catalog: {},
   catalogs: {},
   ...options,
+  // built-in aliases are user/service-overridable: user config wins
   'jsr-registries': {
-    ...(options?.['jsr-registries'] ?? {}),
     ...defaultJsrRegistries,
+    ...(options?.['jsr-registries'] ?? {}),
   },
   registry: options?.registry,
+  'default-registry-alias':
+    options?.['default-registry-alias'] ?? defaultRegistryName,
   'scoped-registries': options?.['scoped-registries'] ?? {},
   'git-hosts':
     options?.['git-hosts'] ?
@@ -77,8 +79,8 @@ export const getOptions = (
       }
     : defaultGitHosts,
   registries: {
-    ...(options?.registries ?? {}),
     ...defaultRegistries,
+    ...(options?.registries ?? {}),
   },
   'git-host-archives':
     options?.['git-host-archives'] ?
@@ -642,9 +644,14 @@ export class Spec implements SpecLike<Spec> {
       this.distTag = this.bareSpec
     }
     this.registrySpec = this.bareSpec
-    const { 'scoped-registries': scopeRegs, registry } = this.options
+    const {
+      'scoped-registries': scopeRegs,
+      registry,
+      registries,
+      'default-registry-alias': defaultAlias,
+    } = this.options
     const scopeReg = this.scope && scopeRegs[this.scope]
-    this.registry = scopeReg ?? registry
+    this.registry = scopeReg ?? registry ?? registries[defaultAlias]
     // no guessing the tarball for JSR registries
     for (const r of Object.values(this.options['jsr-registries'])) {
       if (this.registry === r) return

--- a/src/spec/src/types.ts
+++ b/src/spec/src/types.ts
@@ -13,9 +13,24 @@ export type SpecOptionsFilled = {
    * There is **no default**. If no registry is configured, registry-type
    * specs parsed without one will have `spec.registry === undefined`, and
    * anything that needs to build a registry URL will fail. Named registry
-   * aliases (`npm:`, `gh:`, `jsr:`) and `scoped-registries` are unaffected.
+   * aliases (`gh:`, `jsr:`) and `scoped-registries` are unaffected.
+   *
+   * For bare specs, this takes precedence over the
+   * `default-registry-alias` lookup but not over a matching
+   * `scoped-registries` entry.
    */
   registry?: string
+  /**
+   * The name of the registry alias (a key in `registries`) that bare specs
+   * (e.g. `foo@latest`) and transitive deps without an explicit registry
+   * protocol resolve through, when no `registry` or `scoped-registries`
+   * entry applies.
+   *
+   * Defaults to `'npm'`. The `npm` alias itself has **no** built-in URL --
+   * it must be configured (e.g. via `vlt setup`), otherwise bare specs
+   * resolve with `spec.registry === undefined`.
+   */
+  'default-registry-alias': string
   /** shorthand prefix names for known registries */
   registries: Record<string, string>
   /** shorthand prefix names for known git hosts */

--- a/src/spec/tap-snapshots/test/browser.ts.test.cjs
+++ b/src/spec/tap-snapshots/test/browser.ts.test.cjs
@@ -7756,6 +7756,7 @@ Object {
     "jsr": "https://npm.jsr.io/",
   },
   "registry": undefined,
+  "default-registry-alias": "npm",
   "scoped-registries": Object {},
   "git-hosts": Object {
     "github": "git+ssh://git@github.com:$1/$2.git",
@@ -7764,7 +7765,6 @@ Object {
     "gist": "git+ssh://git@gist.github.com/$1.git",
   },
   "registries": Object {
-    "npm": "https://registry.npmjs.org/",
     "gh": "https://npm.pkg.github.com/",
   },
   "git-host-archives": Object {

--- a/src/spec/test/browser.ts
+++ b/src/spec/test/browser.ts
@@ -12,8 +12,13 @@ import {
 } from '../src/browser.ts'
 
 // there is no default registry any more; most of these cases predate
-// that change, so keep exercising them against the npm registry.
-const defaultOptions = { registry: 'https://registry.npmjs.org/' }
+// that change, so keep exercising them against the npm registry. The
+// `npm` alias is also no longer built in, so configure it explicitly for
+// the many cases that rely on `npm:` specs.
+const defaultOptions = {
+  registry: 'https://registry.npmjs.org/',
+  registries: { npm: 'https://registry.npmjs.org/' },
+}
 
 Object.assign(Spec.prototype, {
   [kCustomInspect](
@@ -453,10 +458,9 @@ t.test('no default registry', t => {
   t.strictSame(
     getOptions({}).registries,
     {
-      npm: 'https://registry.npmjs.org/',
       gh: 'https://npm.pkg.github.com/',
     },
-    'named registry aliases are kept',
+    'only built-in aliases (gh) are kept; npm is not pre-registered',
   )
 
   const s = Spec.parse('foo@latest', {})
@@ -477,8 +481,16 @@ t.test('no default registry', t => {
 
   t.equal(
     Spec.parse('foo@npm:foo@1.2.3', {}).final.registry,
+    undefined,
+    'the npm: alias no longer resolves without configuration',
+  )
+
+  t.equal(
+    Spec.parse('foo@npm:foo@1.2.3', {
+      registries: { npm: 'https://registry.npmjs.org/' },
+    }).final.registry,
     'https://registry.npmjs.org/',
-    'the npm: alias still resolves',
+    'the npm: alias resolves once configured',
   )
 
   t.equal(
@@ -492,10 +504,26 @@ t.test('no default registry', t => {
 })
 
 t.test(
-  'setting default registry does not sets npm: alias',
+  'setting default registry does not configure the npm: alias',
   async t => {
+    // with only --registry set, `npm:` is not a configured alias, so it
+    // is not recognized as a named-registry spec (no subspec/namedRegistry).
     const s = Spec.parse('a@npm:a@1', { registry: 'https://a.com/' })
     t.matchStrict(s, {
+      type: 'registry',
+      spec: 'a@npm:a@1',
+      name: 'a',
+      bareSpec: 'npm:a@1',
+      namedRegistry: undefined,
+      subspec: undefined,
+    })
+
+    // configuring the alias explicitly makes it resolve.
+    const configured = Spec.parse('a@npm:a@1', {
+      registry: 'https://a.com/',
+      registries: { npm: 'https://registry.npmjs.org/' },
+    })
+    t.matchStrict(configured, {
       type: 'registry',
       spec: 'a@npm:a@1',
       name: 'a',
@@ -612,7 +640,7 @@ t.test('invalid workspace specs', t => {
 })
 
 t.test('get final subspec in chain', t => {
-  const subby = Spec.parse('x@npm:y@npm:z@latest')
+  const subby = Spec.parse('x@npm:y@npm:z@latest', defaultOptions)
   const final = subby.final
   t.not(subby, final, 'final is not the alias spec')
   t.not(subby.subspec, final, 'final is not the first alias value')
@@ -622,7 +650,10 @@ t.test('get final subspec in chain', t => {
 })
 
 t.test('simplify in the toString result', t => {
-  const spec = Spec.parse('x@npm:y@npm:z@npm:a@npm:b@latest')
+  const spec = Spec.parse(
+    'x@npm:y@npm:z@npm:a@npm:b@latest',
+    defaultOptions,
+  )
   t.equal(spec.toString(), 'x@npm:b@latest')
   // test the memoization
   t.equal(spec.toString(), 'x@npm:b@latest')
@@ -752,6 +783,7 @@ t.test('try to guess the conventional tarball URL', t => {
   const options = {
     ...defaultOptions,
     registries: {
+      npm: 'https://registry.npmjs.org/',
       vlt: 'https://registry.vlt.sh',
     },
   }
@@ -883,7 +915,11 @@ t.test('gh: registry support (basic functionality)', async t => {
 
 t.test('gh: registry support (additional test cases)', async t => {
   // Test multiple subspecs
-  const spec1 = Spec.parse('test', 'npm:foo@gh:@octocat/bar@1.0.0')
+  const spec1 = Spec.parse(
+    'test',
+    'npm:foo@gh:@octocat/bar@1.0.0',
+    defaultOptions,
+  )
   t.equal(spec1.type, 'registry', 'should be registry type')
   t.equal(spec1.namedRegistry, 'npm', 'should use npm registry')
   t.equal(spec1.name, 'test', 'should preserve package name')
@@ -931,7 +967,11 @@ t.test('gh: registry support (additional test cases)', async t => {
 t.test('catalogs', async t => {
   const catalog = { a: '1.2.3' }
   const catalogs = { x: { a: '1.2.3' }, y: { a: '2.3.4' } }
-  const opts = { catalog, catalogs }
+  const opts = {
+    catalog,
+    catalogs,
+    registries: { npm: 'https://registry.npmjs.org/' },
+  }
 
   t.match(Spec.parse('a@catalog:', opts), {
     name: 'a',

--- a/src/spec/test/index.ts
+++ b/src/spec/test/index.ts
@@ -19,8 +19,13 @@ const { Spec } = await t.mockImport<typeof import('../src/index.ts')>(
 )
 
 // there is no default registry any more; most of these cases predate
-// that change, so keep exercising them against the npm registry.
-const defaultOptions = { registry: 'https://registry.npmjs.org/' }
+// that change, so keep exercising them against the npm registry. The
+// `npm` alias is also no longer built in, so configure it explicitly for
+// the many cases that rely on `npm:` specs.
+const defaultOptions = {
+  registry: 'https://registry.npmjs.org/',
+  registries: { npm: 'https://registry.npmjs.org/' },
+}
 
 t.strictSame(Spec.parseGitSelector(''), [{}])
 
@@ -447,7 +452,7 @@ t.test('invalid workspace specs', t => {
 })
 
 t.test('get final subspec in chain', t => {
-  const subby = Spec.parse('x@npm:y@npm:z@latest')
+  const subby = Spec.parse('x@npm:y@npm:z@latest', defaultOptions)
   const final = subby.final
   t.not(subby, final, 'final is not the alias spec')
   t.not(subby.subspec, final, 'final is not the first alias value')
@@ -457,7 +462,10 @@ t.test('get final subspec in chain', t => {
 })
 
 t.test('simplify in the toString result', t => {
-  const spec = Spec.parse('x@npm:y@npm:z@npm:a@npm:b@latest')
+  const spec = Spec.parse(
+    'x@npm:y@npm:z@npm:a@npm:b@latest',
+    defaultOptions,
+  )
   t.equal(spec.toString(), 'x@npm:b@latest')
   // test the memoization
   t.equal(spec.toString(), 'x@npm:b@latest')
@@ -587,6 +595,7 @@ t.test('try to guess the conventional tarball URL', t => {
   const options = {
     ...defaultOptions,
     registries: {
+      npm: 'https://registry.npmjs.org/',
       vlt: 'https://registry.vlt.sh',
     },
   }

--- a/vlt-lock.json
+++ b/vlt-lock.json
@@ -30,7 +30,10 @@
       "typescript": "5.7.3",
       "walk-up-path": "^4.0.0"
     },
-    "registry": "https://registry.npmjs.org/"
+    "registry": "https://registry.npmjs.org/",
+    "registries": {
+      "npm": "https://registry.npmjs.org/"
+    }
   },
   "nodes": {
     "~jsr~@jsr+std____semver@1.0.8": [2,"@jsr/std__semver","sha512-YhkykPU2Majz66e+rQbP0okYc7kKv+U32aguLPCXZZAL+vEVmBA+khHjPHhLBpWR073gzU3WHqGRgB7a/aXCjg==","https://npm.jsr.io/~/11/@jsr/std__semver/1.0.8.tgz"],

--- a/vlt.json
+++ b/vlt.json
@@ -31,6 +31,9 @@
   },
   "config": {
     "registry": "https://registry.npmjs.org/",
+    "registries": {
+      "npm": "https://registry.npmjs.org/"
+    },
     "allow-scripts": "#tailwindcss, #esbuild, #node-pty"
   }
 }

--- a/www/docs/src/content/docs/cli/auth.mdx
+++ b/www/docs/src/content/docs/cli/auth.mdx
@@ -8,6 +8,17 @@ sidebar:
 import { Code } from '@astrojs/starlight/components'
 
 The vlt client supports logging into multiple different registries.
+When more than one is configured, scope an auth command to a specific
+one with
+[`vlt registry <alias> <command>`](/cli/commands/registry) (for example
+`vlt registry main whoami`). See
+[Targeting a specific registry](/cli/registries#targeting-a-specific-registry).
+
+If you're setting up a vlt.io account for the first time, start with
+[`vlt setup`](/cli/registries#getting-started-with-vlt-setup) — it
+authenticates and configures your account's registry aliases in one
+step. The commands below cover logging into individual registries
+directly.
 
 ## npm Web Login
 

--- a/www/docs/src/content/docs/cli/auth.mdx
+++ b/www/docs/src/content/docs/cli/auth.mdx
@@ -9,9 +9,8 @@ import { Code } from '@astrojs/starlight/components'
 
 The vlt client supports logging into multiple different registries.
 When more than one is configured, scope an auth command to a specific
-one with
-[`vlt registry <alias> <command>`](/cli/commands/registry) (for example
-`vlt registry main whoami`). See
+one with [`vlt registry <alias> <command>`](/cli/commands/registry)
+(for example `vlt registry main whoami`). See
 [Targeting a specific registry](/cli/registries#targeting-a-specific-registry).
 
 If you're setting up a vlt.io account for the first time, start with

--- a/www/docs/src/content/docs/cli/commands/install.mdx
+++ b/www/docs/src/content/docs/cli/commands/install.mdx
@@ -55,6 +55,12 @@ described above.
 
 ### Registry packages
 
+Installing by name (a **bare spec**) requires a registry to be
+configured — the `npm` alias has no built-in URL. Run
+[`vlt setup`](/cli/registries#getting-started-with-vlt-setup) once to
+configure your account's registries, otherwise these commands fail
+with a missing-registry error.
+
 <Code
   code={`# Latest version
 $ vlt install express

--- a/www/docs/src/content/docs/cli/commands/logout.mdx
+++ b/www/docs/src/content/docs/cli/commands/logout.mdx
@@ -12,3 +12,7 @@ Usage:
 
 Log out of the default registry, deleting the token from the local
 keychain, as well as destroying it on the server.
+
+To target a specific configured registry by alias, use
+[`vlt registry <alias> logout`](/cli/commands/registry). See
+[Targeting a specific registry](/cli/registries#targeting-a-specific-registry).

--- a/www/docs/src/content/docs/cli/commands/registry.mdx
+++ b/www/docs/src/content/docs/cli/commands/registry.mdx
@@ -1,0 +1,71 @@
+---
+title: vlt registry
+sidebar:
+  label: registry
+---
+
+import { Code } from '@astrojs/starlight/components'
+
+Usage:
+
+<Code
+  code="$ vlt registry <alias> <command> [<args>]"
+  title="Terminal"
+  lang="bash"
+/>
+
+Run an account command against a specific configured registry, selected
+by its [`registries`](/cli/registries) alias instead of a full URL.
+
+vlt has no default registry, so account and authentication commands need
+to know _which_ registry to act against. `vlt registry <alias> <command>`
+scopes any of those commands to the registry configured under `<alias>`
+in your `vlt.json` — handy when you have more than one (for example the
+`npm` and `main` aliases created by [`vlt setup`](/cli/commands/setup)).
+
+## Groupable commands
+
+`<command>` is any of the account/authentication commands:
+
+`whoami`, `logout`, `login`, `token`, `access`, `publish`, `unpublish`,
+`deprecate`, `dist-tag`, `profile`, `ping`.
+
+## Alias resolution
+
+The registry is resolved in this order:
+
+1. A `--registry=<url>` on the command line always wins.
+2. An explicit `<alias>` (as in `vlt registry main whoami`) is looked up
+   in `registries`; an unknown alias is an error.
+3. With no explicit target and a single configured registry, that one is
+   used.
+4. With multiple configured registries and no explicit target:
+   - on an interactive terminal you are prompted to pick one (the
+     [`--default-registry-alias`](/cli/registries#bare-specs-and---default-registry-alias)
+     is pre-selected);
+   - otherwise (CI, pipes) it falls back to `--default-registry-alias`,
+     erroring if that alias is not configured.
+
+The same resolution applies to the top-level commands, so
+`vlt whoami` behaves like `vlt registry whoami`.
+
+## Examples
+
+Check who you are on the `main` registry:
+
+<Code code="$ vlt registry main whoami" title="Terminal" lang="bash" />
+
+List tokens for the `npm` registry:
+
+<Code code="$ vlt registry npm token list" title="Terminal" lang="bash" />
+
+Omit the alias to choose interactively (or fall back to the default
+alias when non-interactive):
+
+<Code code="$ vlt registry whoami" title="Terminal" lang="bash" />
+
+## See also
+
+- [Working with Named Registries](/cli/registries)
+- [`vlt setup`](/cli/commands/setup)
+- [Authentication](/cli/auth)

--- a/www/docs/src/content/docs/cli/commands/registry.mdx
+++ b/www/docs/src/content/docs/cli/commands/registry.mdx
@@ -14,50 +14,61 @@ Usage:
   lang="bash"
 />
 
-Run an account command against a specific configured registry, selected
-by its [`registries`](/cli/registries) alias instead of a full URL.
+Run an account command against a specific configured registry,
+selected by its [`registries`](/cli/registries) alias instead of a
+full URL.
 
-vlt has no default registry, so account and authentication commands need
-to know _which_ registry to act against. `vlt registry <alias> <command>`
-scopes any of those commands to the registry configured under `<alias>`
-in your `vlt.json` — handy when you have more than one (for example the
-`npm` and `main` aliases created by [`vlt setup`](/cli/commands/setup)).
+vlt has no default registry, so account and authentication commands
+need to know _which_ registry to act against.
+`vlt registry <alias> <command>` scopes any of those commands to the
+registry configured under `<alias>` in your `vlt.json` — handy when
+you have more than one (for example the `npm` and `main` aliases
+created by [`vlt setup`](/cli/commands/setup)).
 
 ## Groupable commands
 
 `<command>` is any of the account/authentication commands:
 
-`whoami`, `logout`, `login`, `token`, `access`, `publish`, `unpublish`,
-`deprecate`, `dist-tag`, `profile`, `ping`.
+`whoami`, `logout`, `login`, `token`, `access`, `publish`,
+`unpublish`, `deprecate`, `dist-tag`, `profile`, `ping`.
 
 ## Alias resolution
 
 The registry is resolved in this order:
 
 1. A `--registry=<url>` on the command line always wins.
-2. An explicit `<alias>` (as in `vlt registry main whoami`) is looked up
-   in `registries`; an unknown alias is an error.
-3. With no explicit target and a single configured registry, that one is
-   used.
+2. An explicit `<alias>` (as in `vlt registry main whoami`) is looked
+   up in `registries`; an unknown alias is an error.
+3. With no explicit target and a single configured registry, that one
+   is used.
 4. With multiple configured registries and no explicit target:
    - on an interactive terminal you are prompted to pick one (the
      [`--default-registry-alias`](/cli/registries#bare-specs-and---default-registry-alias)
      is pre-selected);
-   - otherwise (CI, pipes) it falls back to `--default-registry-alias`,
-     erroring if that alias is not configured.
+   - otherwise (CI, pipes) it falls back to
+     `--default-registry-alias`, erroring if that alias is not
+     configured.
 
-The same resolution applies to the top-level commands, so
-`vlt whoami` behaves like `vlt registry whoami`.
+The same resolution applies to the top-level commands, so `vlt whoami`
+behaves like `vlt registry whoami`.
 
 ## Examples
 
 Check who you are on the `main` registry:
 
-<Code code="$ vlt registry main whoami" title="Terminal" lang="bash" />
+<Code
+  code="$ vlt registry main whoami"
+  title="Terminal"
+  lang="bash"
+/>
 
 List tokens for the `npm` registry:
 
-<Code code="$ vlt registry npm token list" title="Terminal" lang="bash" />
+<Code
+  code="$ vlt registry npm token list"
+  title="Terminal"
+  lang="bash"
+/>
 
 Omit the alias to choose interactively (or fall back to the default
 alias when non-interactive):

--- a/www/docs/src/content/docs/cli/commands/setup.mdx
+++ b/www/docs/src/content/docs/cli/commands/setup.mdx
@@ -1,0 +1,72 @@
+---
+title: vlt setup
+sidebar:
+  label: setup
+---
+
+import { Code } from '@astrojs/starlight/components'
+
+Usage:
+
+<Code code="$ vlt setup [<account>]" title="Terminal" lang="bash" />
+
+Configure the registry aliases for your vlt.io account so that
+`vlt install` and `vlx` work out of the box.
+
+The `npm` registry alias has no built-in URL, so a fresh project can't
+resolve bare specifiers (like `vlt install express`) until a registry
+is configured. `vlt setup` is the guided way to do that: sign up or log
+in at [https://www.vlt.io](https://www.vlt.io) first, then run the
+wizard.
+
+## What it does
+
+1. Prompts for your vlt.io account (or organization) slug if not passed
+   as an argument.
+2. Stages the two registry aliases every account is provisioned with:
+   - `npm` → `https://registry.vlt.io/<account>/npm/` (the default
+     [bare-spec alias](/cli/registries#bare-specs-and---default-registry-alias))
+   - `main` → `https://registry.vlt.io/<account>/main/` (your account's
+     primary private registry)
+3. Optionally authenticates against those registries via the browser
+   web-login flow.
+4. Loops to let you add any additional custom aliases (for partner or
+   team registries), optionally authenticating against each.
+5. Writes the staged aliases into your user `vlt.json` (merging with,
+   not clobbering, existing entries).
+
+## Options
+
+| Flag                     | Description                                                                          |
+| ------------------------ | ------------------------------------------------------------------------------------ |
+| `--config=<user\|project>` | Which config file to write to. Defaults to `user`; use `project` for the project. |
+| `--registries=<name=url>` | Additional registry aliases to stage non-interactively. Can be set multiple times.  |
+| `--yes`                  | Skip interactive prompts. Requires `<account>` and does not open a browser.          |
+
+## Examples
+
+Interactive setup for an account:
+
+<Code code="$ vlt setup my-account" title="Terminal" lang="bash" />
+
+Unattended setup (for CI or setup scripts):
+
+<Code
+  code="$ vlt setup my-account --yes --registries team=https://registry.example.com/"
+  title="Terminal"
+  lang="bash"
+/>
+
+Write to the project's `vlt.json` instead of your user config:
+
+<Code
+  code="$ vlt setup my-account --config=project"
+  title="Terminal"
+  lang="bash"
+/>
+
+## See also
+
+- [Working with Named Registries](/cli/registries)
+- [Authentication](/cli/auth)
+- [`vlt login`](/cli/commands/login)

--- a/www/docs/src/content/docs/cli/commands/setup.mdx
+++ b/www/docs/src/content/docs/cli/commands/setup.mdx
@@ -15,19 +15,19 @@ Configure the registry aliases for your vlt.io account so that
 
 The `npm` registry alias has no built-in URL, so a fresh project can't
 resolve bare specifiers (like `vlt install express`) until a registry
-is configured. `vlt setup` is the guided way to do that: sign up or log
-in at [https://www.vlt.io](https://www.vlt.io) first, then run the
+is configured. `vlt setup` is the guided way to do that: sign up or
+log in at [https://www.vlt.io](https://www.vlt.io) first, then run the
 wizard.
 
 ## What it does
 
-1. Prompts for your vlt.io account (or organization) slug if not passed
-   as an argument.
+1. Prompts for your vlt.io account (or organization) slug if not
+   passed as an argument.
 2. Stages the two registry aliases every account is provisioned with:
    - `npm` → `https://registry.vlt.io/<account>/npm/` (the default
      [bare-spec alias](/cli/registries#bare-specs-and---default-registry-alias))
-   - `main` → `https://registry.vlt.io/<account>/main/` (your account's
-     primary private registry)
+   - `main` → `https://registry.vlt.io/<account>/main/` (your
+     account's primary private registry)
 3. Optionally authenticates against those registries via the browser
    web-login flow.
 4. Loops to let you add any additional custom aliases (for partner or
@@ -37,11 +37,11 @@ wizard.
 
 ## Options
 
-| Flag                     | Description                                                                          |
-| ------------------------ | ------------------------------------------------------------------------------------ |
-| `--config=<user\|project>` | Which config file to write to. Defaults to `user`; use `project` for the project. |
-| `--registries=<name=url>` | Additional registry aliases to stage non-interactively. Can be set multiple times.  |
-| `--yes`                  | Skip interactive prompts. Requires `<account>` and does not open a browser.          |
+| Flag                       | Description                                                                        |
+| -------------------------- | ---------------------------------------------------------------------------------- |
+| `--config=<user\|project>` | Which config file to write to. Defaults to `user`; use `project` for the project.  |
+| `--registries=<name=url>`  | Additional registry aliases to stage non-interactively. Can be set multiple times. |
+| `--yes`                    | Skip interactive prompts. Requires `<account>` and does not open a browser.        |
 
 ## Examples
 

--- a/www/docs/src/content/docs/cli/commands/token.mdx
+++ b/www/docs/src/content/docs/cli/commands/token.mdx
@@ -18,6 +18,10 @@ $ vlt token rm"
 
 Manage registry authentication tokens in the vlt keychain.
 
+To target a specific configured registry by alias, use
+[`vlt registry <alias> token <subcommand>`](/cli/commands/registry). See
+[Targeting a specific registry](/cli/registries#targeting-a-specific-registry).
+
 ## Subcommands
 
 ### list

--- a/www/docs/src/content/docs/cli/commands/token.mdx
+++ b/www/docs/src/content/docs/cli/commands/token.mdx
@@ -19,7 +19,8 @@ $ vlt token rm"
 Manage registry authentication tokens in the vlt keychain.
 
 To target a specific configured registry by alias, use
-[`vlt registry <alias> token <subcommand>`](/cli/commands/registry). See
+[`vlt registry <alias> token <subcommand>`](/cli/commands/registry).
+See
 [Targeting a specific registry](/cli/registries#targeting-a-specific-registry).
 
 ## Subcommands

--- a/www/docs/src/content/docs/cli/commands/whoami.mdx
+++ b/www/docs/src/content/docs/cli/commands/whoami.mdx
@@ -12,3 +12,7 @@ Usage:
 
 Look up the username for the currently active token, when logged into
 a registry.
+
+To target a specific configured registry by alias, use
+[`vlt registry <alias> whoami`](/cli/commands/registry). See
+[Targeting a specific registry](/cli/registries#targeting-a-specific-registry).

--- a/www/docs/src/content/docs/cli/configuring.mdx
+++ b/www/docs/src/content/docs/cli/configuring.mdx
@@ -65,24 +65,26 @@ There is **no default**. A registry must be configured in `vlt.json`,
 with this flag, or via the `VLT_REGISTRY` environment variable.
 Commands that need a registry fail with a config error when none is
 set; [`vlt setup`](/cli/registries#getting-started-with-vlt-setup) or
-[`vlt login`](/cli/commands/login) will configure one for you.
-See [Registries](/cli/registries).
+[`vlt login`](/cli/commands/login) will configure one for you. See
+[Registries](/cli/registries).
 
 Bare specifiers (like `express@latest`) resolve through the
-`--default-registry-alias` (default `npm`) when this scalar is not set.
+`--default-registry-alias` (default `npm`) when this scalar is not
+set.
 
 ### `--default-registry-alias=<name>`
 
 The name of the entry in `--registries` that **bare specifiers** — and
-transitive dependencies without an explicit registry protocol — resolve
-through, when neither a `scoped-registries` entry nor the `--registry`
-scalar applies. Precedence is `scoped-registries` > `--registry` >
-`registries[<default-registry-alias>]`.
+transitive dependencies without an explicit registry protocol —
+resolve through, when neither a `scoped-registries` entry nor the
+`--registry` scalar applies. Precedence is `scoped-registries` >
+`--registry` > `registries[<default-registry-alias>]`.
 
 Defaults to `npm`. The `npm` alias itself has **no built-in URL** — it
 must be configured (for example via
 [`vlt setup`](/cli/registries#getting-started-with-vlt-setup)),
-otherwise bare specs cannot resolve. See [Registries](/cli/registries).
+otherwise bare specs cannot resolve. See
+[Registries](/cli/registries).
 
 ### `--registries=<name=url>`
 

--- a/www/docs/src/content/docs/cli/configuring.mdx
+++ b/www/docs/src/content/docs/cli/configuring.mdx
@@ -64,12 +64,25 @@ metadata from this registry.
 There is **no default**. A registry must be configured in `vlt.json`,
 with this flag, or via the `VLT_REGISTRY` environment variable.
 Commands that need a registry fail with a config error when none is
-set; [`vlt login`](/cli/commands/login) will configure one for you.
+set; [`vlt setup`](/cli/registries#getting-started-with-vlt-setup) or
+[`vlt login`](/cli/commands/login) will configure one for you.
 See [Registries](/cli/registries).
 
-Note that alias specifiers starting with `npm:` will still map to
-`https://registry.npmjs.org/`, unless a new mapping is created via the
-`--registries` option.
+Bare specifiers (like `express@latest`) resolve through the
+`--default-registry-alias` (default `npm`) when this scalar is not set.
+
+### `--default-registry-alias=<name>`
+
+The name of the entry in `--registries` that **bare specifiers** — and
+transitive dependencies without an explicit registry protocol — resolve
+through, when neither a `scoped-registries` entry nor the `--registry`
+scalar applies. Precedence is `scoped-registries` > `--registry` >
+`registries[<default-registry-alias>]`.
+
+Defaults to `npm`. The `npm` alias itself has **no built-in URL** — it
+must be configured (for example via
+[`vlt setup`](/cli/registries#getting-started-with-vlt-setup)),
+otherwise bare specs cannot resolve. See [Registries](/cli/registries).
 
 ### `--registries=<name=url>`
 
@@ -85,8 +98,10 @@ Prefixes can be used as a package alias. For example:
   lang="bash"
 />
 
-By default, the public npm registry is registered to the `npm:`
-prefix. It is not recommended to change this mapping in most cases.
+The `npm:` prefix is **not** pre-registered to any URL — configure it
+(for example with `vlt setup`) before bare specs or `npm:` aliases can
+resolve. The built-in `gh:` and `jsr:` prefixes are pre-registered but
+remain overridable here.
 
 Can be set multiple times
 

--- a/www/docs/src/content/docs/cli/migration/from-npm.mdx
+++ b/www/docs/src/content/docs/cli/migration/from-npm.mdx
@@ -31,11 +31,19 @@ Unlike npm, **vlt has no default registry**. Commands that resolve or
 fetch packages fail with a config error until one is set:
 
 ```
-Config Error: Missing registry configuration. Run 'vlt login --registry=<url>',
-set "registry" in vlt.json, or pass --registry. See https://docs.vlt.sh/cli
+Config Error: Missing registry configuration.
+
+vlt has no default registry. Run `vlt setup` to get configured.
+
+See https://docs.vlt.sh/cli for other ways to set a registry.
 ```
 
-To keep npm's behavior, point it at the public npm registry:
+If you have a vlt.io account, the guided path is
+[`vlt setup`](/cli/registries#getting-started-with-vlt-setup), which
+configures your account's registry aliases for you.
+
+To instead keep npm's behavior, point the registry at the public npm
+registry:
 
 <Code
   code={`$ vlt config set registry=https://registry.npmjs.org/`}

--- a/www/docs/src/content/docs/cli/migration/from-pnpm.mdx
+++ b/www/docs/src/content/docs/cli/migration/from-pnpm.mdx
@@ -13,9 +13,21 @@ import { Code } from '@astrojs/starlight/components'
   code={`# Install vlt globally
 $ npm install -g vlt
 
+# Configure a registry -- vlt has no default
+
+$ vlt config set registry=https://registry.npmjs.org/
+
 # In your existing project, run:
 
 $ vlt install $ vlt build`} title="Terminal" lang="bash" />
+
+Unlike pnpm, **vlt has no default registry** — commands that resolve
+or fetch packages fail with a config error until one is set. The
+snippet above points it at the public npm registry; if you have a
+vlt.io account, run
+[`vlt setup`](/cli/registries#getting-started-with-vlt-setup) instead
+to configure your account's registry aliases. See
+[Registries](/cli/registries).
 
 vlt reads your existing `package.json` files and resolves
 dependencies. The `pnpm-lock.yaml` file is not migrated — vlt performs

--- a/www/docs/src/content/docs/cli/migration/from-yarn.mdx
+++ b/www/docs/src/content/docs/cli/migration/from-yarn.mdx
@@ -16,9 +16,21 @@ v2+ (berry)**. Key differences are called out where they apply.
   code={`# Install vlt globally
 $ npm install -g vlt
 
+# Configure a registry -- vlt has no default
+
+$ vlt config set registry=https://registry.npmjs.org/
+
 # In your existing project, run:
 
 $ vlt install $ vlt build`} title="Terminal" lang="bash" />
+
+Unlike yarn, **vlt has no default registry** — commands that resolve
+or fetch packages fail with a config error until one is set. The
+snippet above points it at the public npm registry; if you have a
+vlt.io account, run
+[`vlt setup`](/cli/registries#getting-started-with-vlt-setup) instead
+to configure your account's registry aliases. See
+[Registries](/cli/registries).
 
 vlt reads your existing `package.json` files and resolves
 dependencies. The `yarn.lock` file is not migrated — vlt performs a

--- a/www/docs/src/content/docs/cli/registries.mdx
+++ b/www/docs/src/content/docs/cli/registries.mdx
@@ -39,12 +39,19 @@ resolves or fetches packages, you have to say which registry to use.
 Commands that need one and do not have one fail with a config error:
 
 ```
-Config Error: Missing registry configuration. Run 'vlt login --registry=<url>',
-set "registry" in vlt.json, or pass --registry. See https://docs.vlt.sh/cli
+Config Error: Missing registry configuration.
+
+vlt has no default registry. Run `vlt setup` to get configured.
+
+See https://docs.vlt.sh/cli for other ways to set a registry.
 ```
 
-There are three ways to configure it, in increasing order of
-precedence:
+The guided path is [`vlt setup`](#getting-started-with-vlt-setup),
+which configures your account's registry aliases so that
+`vlt install <pkg>` and `vlx` work out of the box.
+
+There are three ways to configure the registry directly, in increasing
+order of precedence:
 
 1. **A `vlt.json` file**, either in your project or in your user
    config directory. Either write it by hand:
@@ -92,10 +99,94 @@ internal registry is used for all fetches, it effectively must serve
 _all_ packages, meaning it has to be a caching proxy, as well as the
 repository for any of your organization's internal code.
 
-Note that the named registry aliases (`npm:`, `gh:`, `jsr:`) and the
-`@jsr` scope mapping still have built-in URLs — only the unnamed
-default was removed. `foo@npm:foo@1.2.3` always resolves against
-`https://registry.npmjs.org/`, no matter what `registry` is set to.
+Note that the built-in registry aliases (`gh:`, `jsr:`) and the `@jsr`
+scope mapping still have built-in URLs. The `npm:` alias, however, is
+**no longer built-in** — it has no baked-in URL and must be configured
+(see [The `npm:` alias](#npm) below). All built-in aliases are
+user/service-overridable.
+
+## Bare specs and `--default-registry-alias`
+
+A **bare spec** — a dependency written without a registry protocol,
+like `vlt install foo` or `"foo": "^1.0.0"` in `package.json`, as well
+as any transitive dependency that omits a registry — resolves its
+registry in the following order of precedence:
+
+1. a matching `scoped-registries` entry (for scoped names)
+2. the `registry` scalar (`--registry` / `VLT_REGISTRY`)
+3. `registries[<default-registry-alias>]`
+
+`--default-registry-alias` defaults to `npm`, so by default a bare
+`foo` resolves through your configured `registries.npm`. Change it to
+route bare specs (including transitive deps without an explicit
+registry) through a different alias:
+
+```bash
+vlt config set default-registry-alias=main
+```
+
+Because the `npm` alias has no built-in URL, a fresh, unconfigured
+project cannot resolve bare specs until you configure one — the
+guided way to do that is `vlt setup`.
+
+## Getting started with `vlt setup`
+
+`vlt setup` is the onboarding wizard for a vlt.io account. Sign up or
+log in at [https://www.vlt.io](https://www.vlt.io) first, then run:
+
+```bash
+vlt setup
+```
+
+It authenticates against your account and writes the two account
+registry aliases into your user `vlt.json`:
+
+```json
+{
+  "registries": {
+    "npm": "https://registry.vlt.io/<account>/npm/",
+    "main": "https://registry.vlt.io/<account>/main/"
+  }
+}
+```
+
+- `npm` is the default bare-spec alias, so `vlt install <pkg>` and
+  `vlx` work immediately.
+- `main` is your account's primary private registry (named `main:` to
+  match the service).
+
+The wizard then loops to let you add any additional custom aliases
+(for partner or team registries), optionally authenticating against
+each. To run it unattended (for example in CI or a setup script):
+
+```bash
+vlt setup my-account --yes --registries team=https://registry.example.com/
+```
+
+Pass `--config=project` to write to the project's `vlt.json` instead of
+your user config.
+
+## Targeting a specific registry
+
+Account and authentication commands (`whoami`, `logout`, `login`,
+`token`, `access`, `publish`, `unpublish`, `deprecate`, `dist-tag`,
+`profile`, `ping`) need to know which registry to act against. When you
+have more than one configured, scope a command to a single alias with
+[`vlt registry <alias> <command>`](/cli/commands/registry):
+
+```bash
+# act against the registry configured as `main`
+vlt registry main whoami
+
+# list tokens for the `npm` registry
+vlt registry npm token list
+```
+
+You can also run the top-level command directly (`vlt whoami`). Either
+way, when the target is ambiguous vlt prompts you to pick a registry on
+an interactive terminal, and otherwise falls back to
+[`--default-registry-alias`](#bare-specs-and---default-registry-alias).
+A `--registry=<url>` on the command line always takes precedence.
 
 ## Named Scope Registries (npm Compatibility)
 
@@ -182,15 +273,24 @@ $ vlt install bar:bloo@1.2
 
 #### `npm:`
 
-For backwards compatibility with npm (and existing packages on the
-public npm registry), the `npm:` alias is set by default to the public
-npm registry.
+The `npm:` alias is the default bare-spec alias (see
+[`--default-registry-alias`](#bare-specs-and---default-registry-alias)),
+but it has **no built-in URL** — you must configure it. This is because
+real traffic is expected to flow through a per-account vlt mirror whose
+URL isn't known ahead of time.
 
-If the `registry` config is set to another value, for example a
-caching proxy in your organization's network, then the `npm:` alias
-will default to that value as well, in order to maintain compatibility
-with existing packages that might be getting proxied through the
-internal registry.
+The easiest way to configure it is [`vlt setup`](#getting-started-with-vlt-setup),
+which points `registries.npm` at your account's mirror. You can also
+set it directly, for example to the public npm registry or an internal
+caching proxy:
+
+```bash
+vlt config set registries=npm=https://registry.npmjs.org/
+```
+
+Until `npm` is configured, bare specs like `foo@1.2.3` and
+`foo@npm:bar@1.2.3` have no registry to resolve against and will fail
+with the missing-registry error.
 
 #### `jsr:`
 
@@ -204,9 +304,15 @@ this:
 $ vlt install jsr:@am/neuralNetwork@1.0.0
 ```
 
-Like the `npm:` alias, the `jsr:` alias can be supressed by setting
-the `registry` config option to a different value, such as a caching
-proxy in your organization's network.
+The `jsr:` alias has a built-in URL (`https://npm.jsr.io/`). Unlike a
+bare spec, it is resolved from its own alias map and is _not_ affected
+by the `registry` scalar; to point it at a different host (such as a
+caching proxy in your organization's network), override it with
+`--jsr-registries`:
+
+```bash
+vlt config set jsr-registries=jsr=https://jsr.local/
+```
 
 #### `gh:`
 
@@ -221,7 +327,8 @@ $ vlt install gh:@octocat/hello-world@1.0.0
 ```
 
 This will fetch the package from `https://npm.pkg.github.com/` instead
-of using the default registry.
+of the registry a bare spec would use. Like `jsr:`, the built-in `gh:`
+URL can be overridden via `--registries`.
 
 ### Registry Consistency
 
@@ -250,8 +357,8 @@ contains this:
 }
 ```
 
-On the public default npm registry a _different_ package by the name
-of `bar` exist, which is _not_ compatible with `foo`'s usage.
+On the public npm registry a _different_ package by the name of `bar`
+exists, which is _not_ compatible with `foo`'s usage.
 
 So the concern is, if I do `vlt install foo:foo@1.2.3`, then it'll
 fetch the `foo` package from the `foo` registry just fine. So far so
@@ -268,8 +375,8 @@ down the resolution process.
 
 ### Caution: Registry Aliases Are Not For Published Packages
 
-Except for the default `npm:` alias, it is generally _not_ advised to
-use registry alias specifiers in published package dependencies.
+Except for the `npm:` alias, it is generally _not_ advised to use
+registry alias specifiers in published package dependencies.
 
 At the time of this writing, only the vlt client supports arbitrary
 registry alias specifiers, and there is no broad consensus on which

--- a/www/docs/src/content/docs/cli/registries.mdx
+++ b/www/docs/src/content/docs/cli/registries.mdx
@@ -126,8 +126,8 @@ vlt config set default-registry-alias=main
 ```
 
 Because the `npm` alias has no built-in URL, a fresh, unconfigured
-project cannot resolve bare specs until you configure one — the
-guided way to do that is `vlt setup`.
+project cannot resolve bare specs until you configure one — the guided
+way to do that is `vlt setup`.
 
 ## Getting started with `vlt setup`
 
@@ -163,16 +163,16 @@ each. To run it unattended (for example in CI or a setup script):
 vlt setup my-account --yes --registries team=https://registry.example.com/
 ```
 
-Pass `--config=project` to write to the project's `vlt.json` instead of
-your user config.
+Pass `--config=project` to write to the project's `vlt.json` instead
+of your user config.
 
 ## Targeting a specific registry
 
 Account and authentication commands (`whoami`, `logout`, `login`,
 `token`, `access`, `publish`, `unpublish`, `deprecate`, `dist-tag`,
-`profile`, `ping`) need to know which registry to act against. When you
-have more than one configured, scope a command to a single alias with
-[`vlt registry <alias> <command>`](/cli/commands/registry):
+`profile`, `ping`) need to know which registry to act against. When
+you have more than one configured, scope a command to a single alias
+with [`vlt registry <alias> <command>`](/cli/commands/registry):
 
 ```bash
 # act against the registry configured as `main`
@@ -183,8 +183,8 @@ vlt registry npm token list
 ```
 
 You can also run the top-level command directly (`vlt whoami`). Either
-way, when the target is ambiguous vlt prompts you to pick a registry on
-an interactive terminal, and otherwise falls back to
+way, when the target is ambiguous vlt prompts you to pick a registry
+on an interactive terminal, and otherwise falls back to
 [`--default-registry-alias`](#bare-specs-and---default-registry-alias).
 A `--registry=<url>` on the command line always takes precedence.
 
@@ -275,13 +275,14 @@ $ vlt install bar:bloo@1.2
 
 The `npm:` alias is the default bare-spec alias (see
 [`--default-registry-alias`](#bare-specs-and---default-registry-alias)),
-but it has **no built-in URL** — you must configure it. This is because
-real traffic is expected to flow through a per-account vlt mirror whose
-URL isn't known ahead of time.
+but it has **no built-in URL** — you must configure it. This is
+because real traffic is expected to flow through a per-account vlt
+mirror whose URL isn't known ahead of time.
 
-The easiest way to configure it is [`vlt setup`](#getting-started-with-vlt-setup),
-which points `registries.npm` at your account's mirror. You can also
-set it directly, for example to the public npm registry or an internal
+The easiest way to configure it is
+[`vlt setup`](#getting-started-with-vlt-setup), which points
+`registries.npm` at your account's mirror. You can also set it
+directly, for example to the public npm registry or an internal
 caching proxy:
 
 ```bash

--- a/www/docs/src/content/docs/cli/selectors/pseudo-classes/registry.mdx
+++ b/www/docs/src/content/docs/cli/selectors/pseudo-classes/registry.mdx
@@ -34,7 +34,8 @@ packages are excluded.
 
 ## Examples
 
-Find all packages from the default npm registry:
+Find all packages from the `npm` registry alias (the default bare-spec
+alias):
 
 <Code
   code="$ vlt query ':registry(npm)'"


### PR DESCRIPTION
This pull request introduces significant improvements to registry selection and configuration in the CLI, moving from a hardcoded default registry model to a more flexible, alias-based approach. It also adds a new `registry` command to let users easily target specific registries by alias for all account and package management subcommands. Additionally, the PR updates all relevant commands to use the new registry resolution logic, ensuring consistent behavior and better error handling when registries are not configured.

**Registry selection and configuration overhaul:**

* The CLI no longer assumes a built-in default registry URL. Instead, registry resolution now uses a prioritized order: `scoped-registries`, then the `--registry` scalar, then the configured alias in `registries[<default-registry-alias>]` (which defaults to `npm`). If nothing is configured, commands fail with a clear error. (`.cursor/rules/registries-and-auth.mdc` [[1]](diffhunk://#diff-0393dd3ef8dd09d4c3919774edfd3d237508a095ba4a2deb877de273e8c65a57L10-R52) [[2]](diffhunk://#diff-0393dd3ef8dd09d4c3919774edfd3d237508a095ba4a2deb877de273e8c65a57L23-R75); `.cursor/rules/spec-parsing.mdc` [[3]](diffhunk://#diff-d11c634be963d1b775e353a7e51c57999bd0f295d2a379680320975774375f6bL46-R51) [[4]](diffhunk://#diff-d11c634be963d1b775e353a7e51c57999bd0f295d2a379680320975774375f6bR61-R98)

* The `vlt setup` command is documented as the primary way to configure registry aliases (such as `npm` and `main`) for a user or account, ensuring that lockfiles remain reproducible and configuration is explicit. (`.cursor/rules/registries-and-auth.mdc` [.cursor/rules/registries-and-auth.mdcL10-R52](diffhunk://#diff-0393dd3ef8dd09d4c3919774edfd3d237508a095ba4a2deb877de273e8c65a57L10-R52))

**New registry command and subcommand dispatch:**

* Adds a new `src/cli-sdk/src/commands/registry.ts` command, allowing users to run any account or package management command (e.g., `whoami`, `logout`, `publish`, etc.) against a specific configured registry alias. The command rewrites CLI arguments to dispatch the correct subcommand with the resolved registry. (`src/cli-sdk/src/commands/registry.ts` [src/cli-sdk/src/commands/registry.tsR1-R126](diffhunk://#diff-eda1071a29a7e71070bc7301e921e7ddcb2a0db2e840c4de896d2a26a38bafdbR1-R126))

**Command updates for registry resolution:**

* Refactors all commands that previously used `requireRegistry` to instead use the new async `resolveRegistry`, which supports registry alias resolution and interactive selection. This affects `access`, `deprecate`, `dist-tag`, `logout`, `profile`, and `publish` commands. (`src/cli-sdk/src/commands/access.ts` [[1]](diffhunk://#diff-fc0396267d35bbad07b101f2f59b31842c46c92aae93b2ddb2414e3b5f3370f0L5-R5) [[2]](diffhunk://#diff-fc0396267d35bbad07b101f2f59b31842c46c92aae93b2ddb2414e3b5f3370f0L118-R121) [[3]](diffhunk://#diff-fc0396267d35bbad07b101f2f59b31842c46c92aae93b2ddb2414e3b5f3370f0L149-R152) [[4]](diffhunk://#diff-fc0396267d35bbad07b101f2f59b31842c46c92aae93b2ddb2414e3b5f3370f0L185-R188) [[5]](diffhunk://#diff-fc0396267d35bbad07b101f2f59b31842c46c92aae93b2ddb2414e3b5f3370f0L230-R233) [[6]](diffhunk://#diff-fc0396267d35bbad07b101f2f59b31842c46c92aae93b2ddb2414e3b5f3370f0L276-R279); `src/cli-sdk/src/commands/deprecate.ts` [[7]](diffhunk://#diff-e3ce62c945516133317a6098020f4e63a5a58b5e529b88412b2316f82a3e24c2L9-R9) [[8]](diffhunk://#diff-e3ce62c945516133317a6098020f4e63a5a58b5e529b88412b2316f82a3e24c2L95-R95); `src/cli-sdk/src/commands/dist-tag.ts` [[9]](diffhunk://#diff-bb13212cdb75f61a1ae2fc8482099b7f30c4d83d3956b0d39e1d0d2363e79645L5-R5) [[10]](diffhunk://#diff-bb13212cdb75f61a1ae2fc8482099b7f30c4d83d3956b0d39e1d0d2363e79645L142-R142); `src/cli-sdk/src/commands/logout.ts` [[11]](diffhunk://#diff-e73bb28a29dcd7751f1d8a586a4010576c829a00d2284527d97d6efac176d47fL3-R3) [[12]](diffhunk://#diff-e73bb28a29dcd7751f1d8a586a4010576c829a00d2284527d97d6efac176d47fL13-R16) [[13]](diffhunk://#diff-e73bb28a29dcd7751f1d8a586a4010576c829a00d2284527d97d6efac176d47fL29-R32); `src/cli-sdk/src/commands/profile.ts` [[14]](diffhunk://#diff-05c9ee1e877de71c620a191cde37c14b6bdb62916978a532d79c1d1d4aaa018fL6-R6) [[15]](diffhunk://#diff-05c9ee1e877de71c620a191cde37c14b6bdb62916978a532d79c1d1d4aaa018fL92-R92) [[16]](diffhunk://#diff-05c9ee1e877de71c620a191cde37c14b6bdb62916978a532d79c1d1d4aaa018fL123-R123); `src/cli-sdk/src/commands/publish.ts` [[17]](diffhunk://#diff-e7f04d683570d0a101a3ab5e1fadd700d4966497760a98adc845324c870b8deaL23-R23) [[18]](diffhunk://#diff-e7f04d683570d0a101a3ab5e1fadd700d4966497760a98adc845324c870b8deaL230-R231)

**Documentation and usage improvements:**

* Updates usage strings for relevant commands to inform users about the new registry alias targeting feature (e.g., "Target a specific configured registry by alias with `vlt registry <alias> <command>`"). (`src/cli-sdk/src/commands/access.ts` [[1]](diffhunk://#diff-fc0396267d35bbad07b101f2f59b31842c46c92aae93b2ddb2414e3b5f3370f0L16-R19); `src/cli-sdk/src/commands/logout.ts` [[2]](diffhunk://#diff-e73bb28a29dcd7751f1d8a586a4010576c829a00d2284527d97d6efac176d47fL13-R16)

These changes make registry configuration explicit, support multiple registries seamlessly, and improve the user experience when working with custom or per-account registry mirrors.