### PR TITLE
fix: correct docs Vercel ignore-build condition

### DIFF
--- a/www/docs/vercel.json
+++ b/www/docs/vercel.json
@@ -1,5 +1,4 @@
 {
-  "git": {
-    "ignoredCommand": "! git diff --quiet $VERCEL_GIT_PREVIOUS_SHA $VERCEL_GIT_COMMIT_SHA -- www/docs/"
-  }
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "ignoreCommand": "git diff --quiet $VERCEL_GIT_PREVIOUS_SHA $VERCEL_GIT_COMMIT_SHA -- www/docs/"
 }


### PR DESCRIPTION
## Summary

The docs site (`docs.vlt.sh`) stopped publishing after docs changes because the Vercel ignore-build gate in `www/docs/vercel.json` was inverted.

Two problems with the previous config (added in #1674):

```json
{
  "git": {
    "ignoredCommand": "! git diff --quiet $VERCEL_GIT_PREVIOUS_SHA $VERCEL_GIT_COMMIT_SHA -- www/docs/"
  }
}
```

1. **Inverted exit code.** Vercel's contract is exit `1` = build continues, exit `0` = build canceled. `git diff --quiet` already returns `1` when there are changes and `0` when there aren't — correct on its own. The leading `!` flips it, so the docs build is **canceled exactly when `www/docs` changes** and runs when nothing changed.
2. **Non-standard key.** The documented property is a top-level [`ignoreCommand`](https://vercel.com/docs/project-configuration/vercel-json#ignorecommand), not `git.ignoredCommand`, so the intended command may have been ignored entirely.

### Fix

```json
{
  "$schema": "https://openapi.vercel.sh/vercel.json",
  "ignoreCommand": "git diff --quiet $VERCEL_GIT_PREVIOUS_SHA $VERCEL_GIT_COMMIT_SHA -- www/docs/"
}
```

Now: `www/docs` changed → exit `1` → **build**; unchanged → exit `0` → **skip**.

## Notes / follow-ups

- If the `docs` Vercel project also configures an "Ignored Build Step" in the dashboard UI, confirm it doesn't conflict with this file (prefer relying on `vercel.json`).
- The ignore command runs from the project's **Root Directory**. If that root is `www/docs`, the path should be `.` instead of `www/docs/` — worth confirming the project's Root Directory setting.

## Test plan

- [ ] Merge and push a docs-only change → Vercel `docs` deployment **builds**.
- [ ] Push a non-docs change → Vercel `docs` deployment is **skipped/ignored**.
