### PR TITLE
feat(cli): add --loglevel/--verbose and clearer resolve errors

### DIFF
--- a/src/cli-sdk/src/config/definition.ts
+++ b/src/cli-sdk/src/config/definition.ts
@@ -20,6 +20,7 @@ export const defaultEditor = () =>
 
 const canonicalCommands = {
   access: 'access',
+  audit: 'audit',
   bugs: 'bugs',
   build: 'build',
   cache: 'cache',
@@ -31,6 +32,7 @@ const canonicalCommands = {
   docs: 'docs',
   exec: 'exec',
   'exec-local': 'exec-local',
+  fund: 'fund',
   help: 'help',
   init: 'init',
   install: 'install',
@@ -38,6 +40,7 @@ const canonicalCommands = {
   logout: 'logout',
   list: 'list',
   ls: 'ls',
+  outdated: 'outdated',
   pack: 'pack',
   ping: 'ping',
   pkg: 'pkg',
@@ -77,6 +80,7 @@ const aliases = {
   '?': 'help',
   info: 'view',
   ls: 'list',
+  out: 'outdated',
   show: 'view',
   xc: 'exec-cache',
 } as const
@@ -633,6 +637,43 @@ export const definition = j
         'inspect',
         'silent',
       ] as const,
+    },
+  })
+
+  .opt({
+    loglevel: {
+      hint: 'level',
+      default: 'info',
+      description: `Sets the verbosity of diagnostic logging written to
+                    stderr (registry requests, warnings, etc). This is
+                    independent of \`--view\`, which controls a command's
+                    result output on stdout.
+
+                    - silent: No diagnostic logging.
+                    - error: Only errors.
+                    - warn: Errors and warnings.
+                    - info: Default. High-level progress.
+                    - verbose: Adds per-request logging (each registry URL
+                      with its cache/stale/fetch outcome and status code).
+                    - debug: Everything, including low-level detail.
+
+                    \`--verbose\` is shorthand for \`--loglevel=verbose\`.`,
+      validOptions: [
+        'silent',
+        'error',
+        'warn',
+        'info',
+        'verbose',
+        'debug',
+      ] as const,
+    },
+  })
+
+  .flag({
+    verbose: {
+      description: `Shorthand for \`--loglevel=verbose\`. Streams each
+                    registry request to stderr with its cache/fetch outcome
+                    and status code, useful for debugging request behavior.`,
     },
   })
 

--- a/src/cli-sdk/src/config/index.ts
+++ b/src/cli-sdk/src/config/index.ts
@@ -382,6 +382,13 @@ export class Config {
 
     Object.assign(this, p)
 
+    // `--verbose` is shorthand for `--loglevel=verbose`. Only apply it
+    // when loglevel is still at its default so an explicit `--loglevel`
+    // always wins.
+    if (p.values.verbose && p.values.loglevel === 'info') {
+      p.values.loglevel = 'verbose'
+    }
+
     /* c8 ignore start - unpossible */
     if (!isParsed(this)) throw error('failed to parse config')
     /* c8 ignore stop */

--- a/src/cli-sdk/src/output.ts
+++ b/src/cli-sdk/src/output.ts
@@ -23,6 +23,7 @@ import {
   trackCommand,
   trackError,
 } from './telemetry.ts'
+import { startRequestLog } from './verbose-log.ts'
 
 /* c8 ignore start - CI env detection is a best-effort heuristic */
 const isCI = (): boolean =>
@@ -174,6 +175,14 @@ export const outputCommand = async <T>(
   if (stderrColor) styleTextStderr = styleText
   /* c8 ignore stop */
 
+  // Stream per-request diagnostics to stderr when `--loglevel` is verbose
+  // or higher (e.g. via `--verbose`). No-op otherwise.
+  const stopRequestLog = startRequestLog(
+    conf.values.loglevel,
+    line => stderr(line),
+    styleTextStderr,
+  )
+
   const { onDone, onError } = startView(
     conf,
     // assume views will always output to stdout so use color support from there
@@ -195,6 +204,7 @@ export const outputCommand = async <T>(
     }
 
     const output = await onDone(await command(conf))
+    stopRequestLog()
 
     const duration_ms = Date.now() - start
     trackCommand(
@@ -232,6 +242,7 @@ export const outputCommand = async <T>(
     // can still exit promptly.
     await flushTelemetry()
   } catch (err) {
+    stopRequestLog()
     onError?.(err)
     process.exitCode ||= 1
 

--- a/src/cli-sdk/src/print-err.ts
+++ b/src/cli-sdk/src/print-err.ts
@@ -32,6 +32,21 @@ const isNonEmptyString = (v: unknown): v is string =>
 const formatURL = (v: unknown, format: Formatter) =>
   v instanceof URL ? v.toString() : /* c8 ignore next */ format(v)
 
+// True when `v` overrides the default `Object.prototype.toString`, i.e.
+// stringifying it yields something meaningful (like a `Spec` → `next@*`)
+// rather than `[object Object]`.
+const hasCustomToString = (
+  v: unknown,
+): v is { toString: () => string } =>
+  isObject(v) && v.toString !== Object.prototype.toString
+
+// Render a value that has a meaningful custom `toString()` (such as a
+// `Spec`, e.g. `next@*`) as a concise string rather than dumping its
+// entire internal structure via util.inspect. Falls back to `format`
+// for plain values/objects.
+const formatToString = (v: unknown, format: Formatter): string =>
+  hasCustomToString(v) ? v.toString() : format(v)
+
 const formatArray = (v: unknown, format: Formatter, joiner = ', ') =>
   Array.isArray(v) ? v.join(joiner) : /* c8 ignore next */ format(v)
 
@@ -208,7 +223,7 @@ const printCode = (
         stderr(indent(`While fetching: ${formatURL(url, format)}`))
       }
       if (spec) {
-        stderr(indent(`To satisfy: ${format(spec)}`))
+        stderr(indent(`To satisfy: ${formatToString(spec, format)}`))
       }
       if (from) {
         stderr(indent(`From: ${format(from)}`))

--- a/src/cli-sdk/src/verbose-log.ts
+++ b/src/cli-sdk/src/verbose-log.ts
@@ -1,0 +1,100 @@
+import { emitter } from '@vltpkg/output'
+import type { Events } from '@vltpkg/output'
+
+/**
+ * Diagnostic logging levels, ordered from least to most verbose.
+ * Mirrors the `loglevel` option in the config definition.
+ */
+export type LogLevel =
+  'silent' | 'error' | 'warn' | 'info' | 'verbose' | 'debug'
+
+const rank: Record<LogLevel, number> = {
+  silent: 0,
+  error: 1,
+  warn: 2,
+  info: 3,
+  verbose: 4,
+  debug: 5,
+}
+
+/** True when the given level should emit per-request logging. */
+export const isVerbose = (level: LogLevel): boolean =>
+  rank[level] >= rank.verbose
+
+const isDebug = (level: LogLevel): boolean =>
+  rank[level] >= rank.debug
+
+/** The subset of `styleText` color names this module applies. */
+export type StyleColor = 'green' | 'red' | 'gray'
+
+/**
+ * Minimal signature compatible with the `styleText` helpers exported by
+ * `./output.ts` (which accept a wider set of format names). Defaults to an
+ * identity function so this module can be tested without color support.
+ */
+export type StyleFn = (format: StyleColor, s: string) => string
+
+const identityStyle: StyleFn = (_f, s) => s
+
+const tagStyle = (
+  state: Events['request']['state'],
+  statusCode: number | undefined,
+): StyleColor => {
+  switch (state) {
+    case 'cache':
+    case 'stale':
+    case '304':
+      return 'green'
+    case 'start':
+      return 'gray'
+    case 'complete':
+      return statusCode !== undefined && statusCode >= 400 ?
+          'red'
+        : 'green'
+  }
+}
+
+/**
+ * Format a single `request` event into a human-readable log line.
+ * Exported for testing.
+ */
+export const formatRequestEvent = (
+  event: Events['request'],
+  style: StyleFn = identityStyle,
+): string => {
+  const { url, state, method = 'GET', statusCode, durationMs } = event
+  // For completed network requests show the status code rather than the
+  // literal word "complete"; everything else shows the cache/fetch state.
+  const tag = state === 'complete' ? String(statusCode ?? '') : state
+  const duration =
+    durationMs === undefined ? '' : (
+      style('gray', ` (${durationMs}ms)`)
+    )
+  return `${style(tagStyle(state, statusCode), tag.padEnd(8))} ${method} ${String(url)}${duration}`
+}
+
+/**
+ * Subscribe to registry request events and stream them to `write` when
+ * the configured `level` is `verbose` or higher. The `start` event is only
+ * logged at `debug` level to avoid duplicate lines (each network request
+ * also emits a `complete`/`304` line with its status and duration).
+ *
+ * Returns a cleanup function that detaches the subscription. When `level`
+ * is below `verbose`, nothing is subscribed and the cleanup is a no-op.
+ */
+export const startRequestLog = (
+  level: LogLevel,
+  write: (line: string) => void,
+  style: StyleFn = identityStyle,
+): (() => void) => {
+  if (!isVerbose(level)) return () => {}
+  const debug = isDebug(level)
+  const handler = (event: Events['request']) => {
+    // At verbose level, skip the `start` event so each request produces a
+    // single completion line; at debug level, show it too.
+    if (event.state === 'start' && !debug) return
+    write(formatRequestEvent(event, style))
+  }
+  emitter.on('request', handler)
+  return () => emitter.off('request', handler)
+}

--- a/src/cli-sdk/tap-snapshots/test/config/definition.ts.test.cjs
+++ b/src/cli-sdk/tap-snapshots/test/config/definition.ts.test.cjs
@@ -10,6 +10,7 @@ Object {
   "?": "help",
   "access": "access",
   "add": "install",
+  "audit": "audit",
   "b": "build",
   "bugs": "bugs",
   "build": "build",
@@ -23,6 +24,7 @@ Object {
   "exec": "exec",
   "exec-cache": "exec-cache",
   "exec-local": "exec-local",
+  "fund": "fund",
   "h": "help",
   "help": "help",
   "i": "install",
@@ -33,6 +35,8 @@ Object {
   "login": "login",
   "logout": "logout",
   "ls": "list",
+  "out": "outdated",
+  "outdated": "outdated",
   "p": "pkg",
   "pack": "pack",
   "ping": "ping",
@@ -196,6 +200,7 @@ Object {
     "type": "string",
     "validOptions": Array [
       "access",
+      "audit",
       "bugs",
       "build",
       "cache",
@@ -207,6 +212,7 @@ Object {
       "docs",
       "exec",
       "exec-local",
+      "fund",
       "help",
       "init",
       "install",
@@ -214,6 +220,7 @@ Object {
       "logout",
       "list",
       "ls",
+      "outdated",
       "pack",
       "ping",
       "pkg",
@@ -346,6 +353,30 @@ Object {
   "lockfile-only": Object {
     "description": "Only update the lockfile (vlt-lock.json) and package.json files, skip all node_modules operations including package extraction and filesystem changes.",
     "type": "boolean",
+  },
+  "loglevel": Object {
+    "description": String(
+      Sets the verbosity of diagnostic logging written to stderr (registry requests, warnings, etc). This is independent of \`--view\`, which controls a command's result output on stdout.
+      
+      - silent: No diagnostic logging.
+      - error: Only errors.
+      - warn: Errors and warnings.
+      - info: Default. High-level progress.
+      - verbose: Adds per-request logging (each registry URL with its cache/stale/fetch outcome and status code).
+      - debug: Everything, including low-level detail.
+      
+      \`--verbose\` is shorthand for \`--loglevel=verbose\`.
+    ),
+    "hint": "level",
+    "type": "string",
+    "validOptions": Array [
+      "silent",
+      "error",
+      "warn",
+      "info",
+      "verbose",
+      "debug",
+    ],
   },
   "no-bail": Object {
     "description": "When running scripts across multiple workspaces, continue on failure, running the script for all workspaces.",
@@ -514,6 +545,10 @@ Object {
     ),
     "type": "boolean",
   },
+  "verbose": Object {
+    "description": "Shorthand for \`--loglevel=verbose\`. Streams each registry request to stderr with its cache/fetch outcome and status code, useful for debugging request behavior.",
+    "type": "boolean",
+  },
   "version": Object {
     "description": "Print the version",
     "short": "v",
@@ -609,6 +644,7 @@ Array [
   "--jsr-registries=<name=url>",
   "--libc=<libc>",
   "--lockfile-only",
+  "--loglevel=<level>",
   "--no-bail",
   "--no-color",
   "--node-version=<version>",
@@ -632,6 +668,7 @@ Array [
   "--tag=<tag>",
   "--target=<query>",
   "--telemetry",
+  "--verbose",
   "--version",
   "--view=<output>",
   "--workspace=<ws>",
@@ -674,6 +711,7 @@ Array [
   "jsr-registries",
   "libc",
   "lockfile-only",
+  "loglevel",
   "no-bail",
   "no-color",
   "node-version",
@@ -697,6 +735,7 @@ Array [
   "tag",
   "target",
   "telemetry",
+  "verbose",
   "version",
   "view",
   "workspace",

--- a/src/cli-sdk/tap-snapshots/test/index.ts.test.cjs
+++ b/src/cli-sdk/tap-snapshots/test/index.ts.test.cjs
@@ -66,6 +66,7 @@ Unknown option '--unknown'. To specify a positional argument starting with a '-'
     --jsr-registries=<name=url>
     --libc=<libc>
     --lockfile-only
+    --loglevel=<level>
     --no-bail
     --no-color
     --node-version=<version>
@@ -89,6 +90,7 @@ Unknown option '--unknown'. To specify a positional argument starting with a '-'
     --tag=<tag>
     --target=<query>
     --telemetry
+    --verbose
     --version
     --view=<output>
     --workspace=<ws>
@@ -134,6 +136,7 @@ Unknown config option: asdf
     jsr-registries
     libc
     lockfile-only
+    loglevel
     no-bail
     no-color
     node-version
@@ -157,6 +160,7 @@ Unknown config option: asdf
     tag
     target
     telemetry
+    verbose
     version
     view
     workspace

--- a/src/cli-sdk/tap-snapshots/test/print-err.ts.test.cjs
+++ b/src/cli-sdk/tap-snapshots/test/print-err.ts.test.cjs
@@ -154,6 +154,51 @@ exports[`test/print-err.ts > TAP > snapshots > ERESOLVE > basic > output no file
 Resolve Error: bloopy doop
 `
 
+exports[`test/print-err.ts > TAP > snapshots > ERESOLVE > spec-object > file 1`] = `
+Error: missing tarball
+    at {STACK_LINE} {
+  [cause]: {
+    code: 'ERESOLVE',
+    spec: {
+      type: 'registry',
+      spec: 'next@*',
+      toString: [Function: toString]
+    }
+  }
+}
+`
+
+exports[`test/print-err.ts > TAP > snapshots > ERESOLVE > spec-object > output 1`] = `
+Resolve Error: missing tarball
+  To satisfy: next@*
+
+Full details written to: {CWD}/.tap/fixtures/test-print-err.ts-snapshots-ERESOLVE-spec-object/vlt/error-logs/error-123.log
+`
+
+exports[`test/print-err.ts > TAP > snapshots > ERESOLVE > spec-object > output no file 1`] = `
+Resolve Error: missing tarball
+  To satisfy: next@*
+`
+
+exports[`test/print-err.ts > TAP > snapshots > ERESOLVE > spec-plain > file 1`] = `
+Error: missing tarball
+    at {STACK_LINE} {
+  [cause]: { code: 'ERESOLVE', spec: { type: 'registry', spec: 'x@1' } }
+}
+`
+
+exports[`test/print-err.ts > TAP > snapshots > ERESOLVE > spec-plain > output 1`] = `
+Resolve Error: missing tarball
+  To satisfy: { type: 'registry', spec: 'x@1' }
+
+Full details written to: {CWD}/.tap/fixtures/test-print-err.ts-snapshots-ERESOLVE-spec-plain/vlt/error-logs/error-123.log
+`
+
+exports[`test/print-err.ts > TAP > snapshots > ERESOLVE > spec-plain > output no file 1`] = `
+Resolve Error: missing tarball
+  To satisfy: { type: 'registry', spec: 'x@1' }
+`
+
 exports[`test/print-err.ts > TAP > snapshots > ERESOLVE > url > file 1`] = `
 Error: bloopy doop
     at {STACK_LINE} {

--- a/src/cli-sdk/test/config/index.ts
+++ b/src/cli-sdk/test/config/index.ts
@@ -1049,6 +1049,45 @@ t.test('read catalogs from config file', async t => {
   )
 })
 
+t.test('--verbose is shorthand for --loglevel=verbose', async t => {
+  const dir = t.testdir({ 'vlt.json': '{}', '.git': {} })
+  t.chdir(dir)
+
+  const { Config } = await t.mockImport<
+    typeof import('../../src/config/index.ts')
+  >('../../src/config/index.ts')
+
+  clearEnv()
+  const def = await Config.load(dir, ['install'], true)
+  t.equal(def.get('loglevel'), 'info', 'defaults to info')
+  t.equal(def.get('verbose'), undefined, 'verbose unset by default')
+
+  clearEnv()
+  const verbose = await Config.load(
+    dir,
+    ['install', '--verbose'],
+    true,
+  )
+  t.equal(verbose.get('verbose'), true)
+  t.equal(
+    verbose.get('loglevel'),
+    'verbose',
+    '--verbose bumps loglevel to verbose',
+  )
+
+  clearEnv()
+  const explicit = await Config.load(
+    dir,
+    ['install', '--verbose', '--loglevel', 'debug'],
+    true,
+  )
+  t.equal(
+    explicit.get('loglevel'),
+    'debug',
+    'explicit --loglevel wins over --verbose',
+  )
+})
+
 t.test('reloadFromDisk method', async t => {
   const projectDir = t.testdir({
     'vlt.json': JSON.stringify({

--- a/src/cli-sdk/test/print-err.ts
+++ b/src/cli-sdk/test/print-err.ts
@@ -152,6 +152,29 @@ t.test('snapshots', async t => {
         response: { statusCode: 200 },
       }),
     )
+    // a spec-like object with a custom toString (like a Spec) prints
+    // concisely (e.g. `next@*`) rather than dumping its internals.
+    await testErr(
+      t,
+      'spec-object',
+      error('missing tarball', {
+        code: 'ERESOLVE',
+        spec: {
+          type: 'registry',
+          spec: 'next@*',
+          toString: () => 'next@*',
+        },
+      }),
+    )
+    // a plain spec object (no custom toString) falls back to `format`.
+    await testErr(
+      t,
+      'spec-plain',
+      error('missing tarball', {
+        code: 'ERESOLVE',
+        spec: { type: 'registry', spec: 'x@1' },
+      }),
+    )
   })
 
   t.test('ECONFIG', async t => {

--- a/src/cli-sdk/test/verbose-log.ts
+++ b/src/cli-sdk/test/verbose-log.ts
@@ -1,0 +1,129 @@
+import { emitter } from '@vltpkg/output'
+import type { Events } from '@vltpkg/output'
+import t from 'tap'
+import {
+  formatRequestEvent,
+  isVerbose,
+  startRequestLog,
+} from '../src/verbose-log.ts'
+
+// A visible style wrapper so we can assert coloring was applied.
+const style = (f: string, s: string) => `<${f}>${s}`
+
+t.test('isVerbose', async t => {
+  t.equal(isVerbose('silent'), false)
+  t.equal(isVerbose('error'), false)
+  t.equal(isVerbose('warn'), false)
+  t.equal(isVerbose('info'), false)
+  t.equal(isVerbose('verbose'), true)
+  t.equal(isVerbose('debug'), true)
+})
+
+t.test('formatRequestEvent', async t => {
+  const cases: [Events['request'], RegExp][] = [
+    [
+      { url: 'https://x/', state: 'cache' },
+      /^cache\s+GET https:\/\/x\/$/,
+    ],
+    [{ url: 'https://x/', state: 'stale' }, /^stale\s+GET/],
+    [{ url: 'https://x/', state: '304' }, /^304\s+GET/],
+    [{ url: 'https://x/', state: 'start' }, /^start\s+GET/],
+    [
+      {
+        url: 'https://x/',
+        state: 'complete',
+        method: 'HEAD',
+        statusCode: 200,
+        durationMs: 12,
+      },
+      /^200\s+HEAD https:\/\/x\/ \(12ms\)$/,
+    ],
+    [
+      { url: 'https://x/', state: 'complete', statusCode: 404 },
+      /^404\s+GET/,
+    ],
+    [{ url: 'https://x/', state: 'complete' }, /GET https:\/\/x\/$/],
+  ]
+  for (const [event, re] of cases) {
+    t.match(formatRequestEvent(event), re, event.state)
+  }
+
+  // with a style function, error statuses use red, others green/gray
+  t.match(
+    formatRequestEvent(
+      { url: 'https://x/', state: 'complete', statusCode: 500 },
+      style,
+    ),
+    /<red>/,
+    '5xx status colored red',
+  )
+  t.match(
+    formatRequestEvent(
+      { url: 'https://x/', state: 'complete', statusCode: 200 },
+      style,
+    ),
+    /<green>/,
+    '2xx status colored green',
+  )
+  t.match(
+    formatRequestEvent({ url: 'https://x/', state: 'start' }, style),
+    /<gray>/,
+    'start colored gray',
+  )
+  t.match(
+    formatRequestEvent(
+      {
+        url: 'https://x/',
+        state: 'complete',
+        statusCode: 200,
+        durationMs: 5,
+      },
+      style,
+    ),
+    /<gray> \(5ms\)/,
+    'duration colored gray',
+  )
+})
+
+t.test('startRequestLog below verbose is a no-op', async t => {
+  const lines: string[] = []
+  const stop = startRequestLog('info', l => lines.push(l))
+  emitter.emit('request', { url: 'https://x/', state: 'cache' })
+  stop()
+  t.strictSame(lines, [], 'nothing logged when loglevel < verbose')
+})
+
+t.test('startRequestLog at verbose skips start events', async t => {
+  const lines: string[] = []
+  const stop = startRequestLog('verbose', l => lines.push(l))
+  emitter.emit('request', { url: 'https://x/', state: 'start' })
+  emitter.emit('request', { url: 'https://x/', state: 'cache' })
+  emitter.emit('request', {
+    url: 'https://x/',
+    state: 'complete',
+    statusCode: 200,
+    durationMs: 3,
+  })
+  stop()
+  // start is skipped at verbose level
+  t.equal(lines.length, 2)
+  t.match(lines[0], /^cache/)
+  t.match(lines[1], /^200/)
+
+  // after stop(), no more logging
+  emitter.emit('request', { url: 'https://x/', state: 'cache' })
+  t.equal(lines.length, 2, 'cleanup detaches the subscription')
+})
+
+t.test('startRequestLog at debug includes start events', async t => {
+  const lines: string[] = []
+  const stop = startRequestLog('debug', l => lines.push(l), style)
+  emitter.emit('request', {
+    url: 'https://x/',
+    state: 'start',
+    method: 'GET',
+  })
+  stop()
+  t.equal(lines.length, 1, 'start is logged at debug level')
+  t.match(lines[0], /start/)
+})

--- a/src/output/src/index.ts
+++ b/src/output/src/index.ts
@@ -4,12 +4,21 @@ export type Events = {
   request: {
     url: URL | string
     state: 'start' | 'complete' | '304' | 'cache' | 'stale'
+    /** HTTP method for the request, when known. */
+    method?: string
+    /** HTTP status code, set on `complete`/`304` completion events. */
+    statusCode?: number
+    /** Wall-clock duration of the request in ms, set on completion. */
+    durationMs?: number
   }
   graphStep: {
     step: 'build' | 'actual' | 'reify'
     state: 'start' | 'stop'
   }
 }
+
+/** Optional diagnostic details attached to a `request` event. */
+export type RequestDetails = Omit<Events['request'], 'url' | 'state'>
 
 export class OutputEmitter {
   private emitter = new EventEmitter()
@@ -40,8 +49,9 @@ export const emitter = new OutputEmitter()
 export const logRequest = (
   url: URL | string,
   state: Events['request']['state'],
+  details: RequestDetails = {},
 ) => {
-  emitter.emit('request', { url, state })
+  emitter.emit('request', { url, state, ...details })
 }
 
 export const graphStep = (step: Events['graphStep']['step']) => {

--- a/src/output/tap-snapshots/test/index.ts.test.cjs
+++ b/src/output/tap-snapshots/test/index.ts.test.cjs
@@ -11,6 +11,18 @@ Array [
     "state": "start",
     "url": "https://example.com",
   },
+  Object {
+    "method": "GET",
+    "state": "cache",
+    "url": "https://example.com",
+  },
+  Object {
+    "durationMs": 12,
+    "method": "GET",
+    "state": "complete",
+    "statusCode": 200,
+    "url": "https://example.com",
+  },
 ]
 `
 

--- a/src/output/test/index.ts
+++ b/src/output/test/index.ts
@@ -14,6 +14,12 @@ t.test('output', async t => {
   emitter.on('graphStep', stepHandler)
 
   logRequest('https://example.com', 'start')
+  logRequest('https://example.com', 'cache', { method: 'GET' })
+  logRequest('https://example.com', 'complete', {
+    method: 'GET',
+    statusCode: 200,
+    durationMs: 12,
+  })
   graphStep('build')()
 
   emitter.off('request', reqHandler)

--- a/src/package-info/src/index.ts
+++ b/src/package-info/src/index.ts
@@ -232,7 +232,10 @@ export class PackageInfoClient {
             throw this.#resolveError(
               spec,
               options,
-              'failed to fetch tarball',
+              `Registry returned HTTP ${response.statusCode} when ` +
+                `fetching the tarball for ${spec}. The resolved version ` +
+                `may have been unpublished, or the registry may be ` +
+                `misconfigured or unreachable.`,
               {
                 url: r.resolved,
                 response,
@@ -486,7 +489,9 @@ export class PackageInfoClient {
           throw this.#resolveError(
             spec,
             options,
-            'no dist object found in manifest',
+            `The registry manifest for ${spec} has no "dist" section, ` +
+              `so no tarball can be resolved. The package version may be ` +
+              `malformed or unpublished.`,
           )
 
         const { tarball, integrity } = dist
@@ -494,7 +499,9 @@ export class PackageInfoClient {
           throw this.#resolveError(
             spec,
             options,
-            'no tarball found in manifest.dist',
+            `The registry manifest for ${spec} is missing a tarball URL ` +
+              `(dist.tarball). The package version may be malformed or ` +
+              `unpublished in this registry.`,
           )
         }
 
@@ -515,7 +522,10 @@ export class PackageInfoClient {
             throw this.#resolveError(
               spec,
               options,
-              'failed to fetch tarball',
+              `Registry returned HTTP ${response.statusCode} when ` +
+                `fetching the tarball for ${spec} at ${tarball}. The ` +
+                `version may have been unpublished, or the registry may ` +
+                `be misconfigured or unreachable.`,
               { response, url: tarball },
             )
           }

--- a/src/registry-client/src/index.ts
+++ b/src/registry-client/src/index.ts
@@ -444,18 +444,19 @@ export class RegistryClient {
 
     const entry = buffer ? CacheEntry.decode(buffer) : undefined
     if (entry?.valid) {
-      logRequest(url, 'cache')
+      logRequest(url, 'cache', { method })
       return entry
     }
 
     if (staleWhileRevalidate && entry?.staleWhileRevalidate && m) {
       // revalidate while returning the stale entry
       register(dirname(this.cache.path()), m, url)
-      logRequest(url, 'stale')
+      logRequest(url, 'stale', { method })
       return entry
     }
 
-    logRequest(url, 'start')
+    logRequest(url, 'start', { method })
+    const requestStart = Date.now()
 
     // either no cache entry, or need to revalidate before use.
     setCacheHeaders(options, entry)
@@ -522,6 +523,16 @@ export class RegistryClient {
       options,
       response,
       entry,
+    )
+
+    logRequest(
+      url,
+      response.statusCode === 304 ? '304' : 'complete',
+      {
+        method,
+        statusCode: response.statusCode,
+        durationMs: Date.now() - requestStart,
+      },
     )
 
     if (result.getHeader('integrity')) {


### PR DESCRIPTION
Add an npm-style --loglevel enum (silent|error|warn|info|verbose|debug, default info) with a --verbose shorthand that streams per-request diagnostics (method, URL, cache/stale/304/fetch outcome, status code, duration) to stderr without disturbing the stdout install UI.

Request events now carry optional method/statusCode/durationMs and the registry-client emits completion (304/complete) events. A new verbose-log subscriber writes one formatted line per request, wired into outputCommand for every command and view.

Also improve error UX: the ERESOLVE branch in print-err renders a Spec via its toString (e.g. next@*) instead of dumping the whole object, and missing-tarball/404 paths in package-info throw actionable messages including the spec, resolved URL, and HTTP status.