### PR TITLE
feat(commands) combined

### DIFF
--- a/src/cli-sdk/src/commands/audit.ts
+++ b/src/cli-sdk/src/commands/audit.ts
@@ -1,0 +1,465 @@
+import { actual, GraphModifier } from '@vltpkg/graph'
+import { Query } from '@vltpkg/query'
+import { SecurityArchive } from '@vltpkg/security-archive'
+import { styleText as utilStyleText } from 'node:util'
+import { commandUsage } from '../config/usage.ts'
+import type { Graph } from '@vltpkg/graph'
+import type { NodeLike } from '@vltpkg/types'
+import type { Insights, QueryResponseNode } from '@vltpkg/query'
+import type { CommandFn, CommandUsage } from '../index.ts'
+import type { Views, ViewOptions } from '../view.ts'
+
+export const needsRegistry = true
+
+export const usage: CommandUsage = () =>
+  commandUsage({
+    command: 'audit',
+    usage: ['', '<query> --view=<human | json>'],
+    description: `Run a security audit of the installed dependency graph.
+
+      Uses the vlt Dependency Selector Syntax (the same engine that powers
+      \`vlt query\`) together with the Socket security database to surface
+      packages that may need attention: known malware, published
+      vulnerabilities (CVEs), typosquats, license problems, unmaintained or
+      deprecated packages, and more.
+
+      By default it scans every package that has security metadata and reports
+      any finding with a severity of moderate or higher. Provide a DSS query as
+      a positional argument to audit a specific subset of the graph (for
+      example ':workspace > *' to only audit your workspaces' direct
+      dependencies).`,
+
+    examples: {
+      '': {
+        description: 'Audit all installed dependencies',
+      },
+      [`':workspace > *'`]: {
+        description:
+          'Only audit direct dependencies of your workspaces',
+      },
+      '--view=json': {
+        description: 'Emit the audit report as JSON for tooling / CI',
+      },
+      '--all': {
+        description:
+          'Include low-severity findings such as behavioral capabilities',
+      },
+    },
+    options: {
+      all: {
+        description:
+          'Include low-severity findings (behavioral capabilities, minor hygiene issues).',
+      },
+      view: {
+        value: '[human | json]',
+        description:
+          'Output format. Defaults to human-readable, or json if there is no tty.',
+      },
+    },
+  })
+
+/**
+ * Severity buckets, ordered from most to least severe.
+ */
+export type AuditSeverity = 'critical' | 'high' | 'medium' | 'low'
+
+const severityRank: Record<AuditSeverity, number> = {
+  critical: 0,
+  high: 1,
+  medium: 2,
+  low: 3,
+}
+
+/**
+ * A single security concern found on a package.
+ */
+export type AuditFinding = {
+  severity: AuditSeverity
+  category: string
+  description: string
+}
+
+/**
+ * The collected findings for a single package.
+ */
+export type AuditPackageReport = {
+  id: string
+  name: string
+  version?: string | null
+  location?: string
+  worst: AuditSeverity
+  findings: AuditFinding[]
+}
+
+export type AuditResult = {
+  reports: AuditPackageReport[]
+  summary: Record<AuditSeverity, number> & { total: number }
+  packagesAffected: number
+  packagesScanned: number
+  queryString: string
+  showAll: boolean
+}
+
+/**
+ * Turn a node's structured {@link Insights} into a flat list of findings.
+ */
+export const insightsToFindings = (
+  insights: Insights,
+): AuditFinding[] => {
+  const findings: AuditFinding[] = []
+  const add = (
+    severity: AuditSeverity,
+    category: string,
+    description: string,
+  ) => findings.push({ severity, category, description })
+
+  // known & AI-detected malware
+  const malware = insights.malware
+  if (malware?.critical) add('critical', 'malware', 'known malware')
+  if (malware?.high) add('high', 'malware', 'AI-detected malware')
+  if (malware?.medium)
+    add('medium', 'malware', 'AI-flagged security issue')
+  if (malware?.low) add('low', 'malware', 'AI-flagged anomaly')
+
+  // published vulnerabilities, keyed to the most severe band present
+  const severity = insights.severity
+  const cves =
+    insights.cve?.length ? ` (${insights.cve.join(', ')})` : ''
+  if (severity?.critical)
+    add('critical', 'vulnerability', `critical severity CVE${cves}`)
+  else if (severity?.high)
+    add('high', 'vulnerability', `high severity CVE${cves}`)
+  else if (severity?.medium)
+    add('medium', 'vulnerability', `potential vulnerability${cves}`)
+  else if (severity?.low)
+    add('low', 'vulnerability', `low severity CVE${cves}`)
+  else if (insights.cve?.length)
+    add('high', 'vulnerability', `known CVE${cves}`)
+
+  // typosquat suspicion
+  if (insights.squat?.critical)
+    add('high', 'typosquat', 'likely typosquat')
+  else if (insights.squat?.medium)
+    add('medium', 'typosquat', 'possible typosquat')
+
+  // supply-chain integrity / trust
+  if (insights.confused)
+    add('high', 'integrity', 'manifest confusion')
+  if (insights.obfuscated) add('medium', 'code', 'obfuscated code')
+  if (insights.suspicious)
+    add('medium', 'trust', 'suspicious activity')
+  if (insights.undesirable)
+    add('medium', 'trust', 'flagged as undesirable')
+  if (insights.entropic) add('low', 'code', 'high-entropy strings')
+  if (insights.minified) add('low', 'code', 'minified, no source')
+
+  // license compliance
+  const license = insights.license
+  if (license?.copyleft) add('medium', 'license', 'copyleft license')
+  if (license?.restricted)
+    add('medium', 'license', 'non-permissive license')
+  if (license?.unlicensed) add('medium', 'license', 'unlicensed')
+  if (license?.none) add('medium', 'license', 'no license found')
+  if (license?.misc) add('low', 'license', 'license issues')
+  if (license?.ambiguous) add('low', 'license', 'ambiguous license')
+  if (license?.unknown) add('low', 'license', 'unidentified license')
+
+  // maintenance / hygiene
+  if (insights.deprecated) add('medium', 'maintenance', 'deprecated')
+  if (insights.abandoned)
+    add('medium', 'maintenance', 'abandoned (missing author)')
+  if (insights.unmaintained)
+    add('medium', 'maintenance', 'unmaintained (5+ years)')
+  if (insights.unpopular) add('low', 'maintenance', 'unpopular')
+  if (insights.unstable)
+    add('low', 'maintenance', 'unstable ownership')
+  if (insights.unknown)
+    add('low', 'maintenance', 'new / unknown author')
+  if (insights.trivial) add('low', 'maintenance', 'trivial package')
+
+  // behavioral capabilities (informational, low severity)
+  if (insights.eval) add('low', 'capability', 'uses eval')
+  if (insights.shell) add('low', 'capability', 'shell access')
+  if (insights.network) add('low', 'capability', 'network access')
+  if (insights.fs) add('low', 'capability', 'filesystem access')
+  if (insights.env) add('low', 'capability', 'reads env vars')
+  if (insights.dynamic) add('low', 'capability', 'dynamic require')
+  if (insights.debug) add('low', 'capability', 'debug access')
+  if (insights.native) add('low', 'capability', 'native code')
+  if (insights.tracker) add('low', 'capability', 'telemetry')
+  if (insights.scripts) add('low', 'capability', 'install scripts')
+  if (insights.shrinkwrap)
+    add('low', 'capability', 'bundles a shrinkwrap')
+
+  return findings
+}
+
+const worstSeverity = (findings: AuditFinding[]): AuditSeverity => {
+  let worst: AuditSeverity = 'low'
+  for (const f of findings) {
+    if (severityRank[f.severity] < severityRank[worst]) {
+      worst = f.severity
+    }
+  }
+  return worst
+}
+
+/**
+ * Build the audit report from the security-annotated query result nodes.
+ */
+const buildResult = (
+  nodes: QueryResponseNode[],
+  queryString: string,
+  showAll: boolean,
+): AuditResult => {
+  const summary = {
+    critical: 0,
+    high: 0,
+    medium: 0,
+    low: 0,
+    total: 0,
+  }
+  let packagesScanned = 0
+  const reports: AuditPackageReport[] = []
+
+  for (const node of nodes) {
+    if (node.insights.scanned) packagesScanned++
+    const findings = insightsToFindings(node.insights).filter(
+      f => showAll || f.severity !== 'low',
+    )
+    if (!findings.length) continue
+
+    for (const f of findings) {
+      summary[f.severity]++
+      summary.total++
+    }
+
+    reports.push({
+      id: String(node.id),
+      /* c8 ignore next -- installed nodes always resolve a name */
+      name: node.name ?? '(unknown)',
+      version: node.version,
+      location: node.location,
+      worst: worstSeverity(findings),
+      findings,
+    })
+  }
+
+  // most severe packages first, ties broken alphabetically
+  reports.sort(
+    (a, b) =>
+      severityRank[a.worst] - severityRank[b.worst] ||
+      a.name.localeCompare(b.name),
+  )
+
+  return {
+    reports,
+    summary,
+    packagesAffected: reports.length,
+    packagesScanned,
+    queryString,
+    showAll,
+  }
+}
+
+const style = (
+  colors: boolean | undefined,
+  format: Parameters<typeof utilStyleText>[0],
+  s: string,
+): string =>
+  colors ? utilStyleText(format, s, { validateStream: false }) : s
+
+const severityColor: Record<
+  AuditSeverity,
+  Parameters<typeof utilStyleText>[0]
+> = {
+  critical: ['red', 'bold'],
+  high: 'red',
+  medium: 'yellow',
+  low: 'dim',
+}
+
+/**
+ * Render a fixed-width column, padding the raw text before colorizing so
+ * that ANSI escape codes never throw the alignment off.
+ */
+const cell = (text: string, width: number): string =>
+  text + ' '.repeat(Math.max(0, width - text.length))
+
+const humanView = (
+  result: AuditResult,
+  options: ViewOptions = {},
+): string => {
+  const { colors } = options
+  const title = style(colors, 'bold', 'Security Audit')
+
+  if (!result.reports.length) {
+    const scanned = result.packagesScanned
+    return `${title}\n\n${style(
+      colors,
+      'green',
+      '\u2713 No security issues found',
+    )} across ${scanned} scanned package${scanned === 1 ? '' : 's'}.`
+  }
+
+  type Row = {
+    severity: AuditSeverity
+    pkg: string
+    category: string
+    description: string
+  }
+  const rows: Row[] = []
+  for (const report of result.reports) {
+    const pkg =
+      report.version ?
+        `${report.name}@${report.version}`
+      : report.name
+    for (const f of report.findings) {
+      rows.push({
+        severity: f.severity,
+        pkg,
+        category: f.category,
+        description: f.description,
+      })
+    }
+  }
+
+  const headers = {
+    severity: 'SEVERITY',
+    pkg: 'PACKAGE',
+    category: 'TYPE',
+    description: 'ISSUE',
+  }
+  const widths = {
+    severity: Math.max(
+      headers.severity.length,
+      ...rows.map(r => r.severity.length),
+    ),
+    pkg: Math.max(headers.pkg.length, ...rows.map(r => r.pkg.length)),
+    category: Math.max(
+      headers.category.length,
+      ...rows.map(r => r.category.length),
+    ),
+    description: Math.max(
+      headers.description.length,
+      ...rows.map(r => r.description.length),
+    ),
+  }
+
+  const lines: string[] = [title, '']
+  lines.push(
+    style(
+      colors,
+      'dim',
+      [
+        cell(headers.severity, widths.severity),
+        cell(headers.pkg, widths.pkg),
+        cell(headers.category, widths.category),
+        headers.description,
+      ].join('  '),
+    ),
+  )
+
+  for (const row of rows) {
+    lines.push(
+      [
+        style(
+          colors,
+          severityColor[row.severity],
+          cell(row.severity, widths.severity),
+        ),
+        cell(row.pkg, widths.pkg),
+        style(colors, 'cyan', cell(row.category, widths.category)),
+        row.description,
+      ].join('  '),
+    )
+  }
+
+  const { summary } = result
+  const parts: string[] = []
+  const pushPart = (
+    count: number,
+    severity: AuditSeverity,
+    label: string,
+  ) => {
+    if (count) {
+      parts.push(
+        style(colors, severityColor[severity], `${count} ${label}`),
+      )
+    }
+  }
+  pushPart(summary.critical, 'critical', 'critical')
+  pushPart(summary.high, 'high', 'high')
+  pushPart(summary.medium, 'medium', 'moderate')
+  pushPart(summary.low, 'low', 'low')
+
+  lines.push('')
+  lines.push(
+    `${style(colors, 'bold', 'Summary:')} ${parts.join(', ')} across ${
+      result.packagesAffected
+    } package${result.packagesAffected === 1 ? '' : 's'} (${
+      result.packagesScanned
+    } scanned).`,
+  )
+  if (!result.showAll && !summary.low) {
+    lines.push(
+      style(
+        colors,
+        'dim',
+        'Run with --all to include low-severity capability findings.',
+      ),
+    )
+  }
+
+  return lines.join('\n')
+}
+
+export const views = {
+  human: humanView,
+  json: (result: AuditResult) => ({
+    summary: result.summary,
+    packagesAffected: result.packagesAffected,
+    packagesScanned: result.packagesScanned,
+    reports: result.reports,
+  }),
+} as const satisfies Views<AuditResult>
+
+export const command: CommandFn<AuditResult> = async conf => {
+  const showAll = !!conf.values.all
+  const queryString = conf.positionals[0] || ':scanned'
+
+  const modifiers = GraphModifier.maybeLoad(conf.options)
+  const monorepo = conf.options.monorepo
+  const mainManifest = conf.options.packageJson.maybeRead(
+    conf.options.projectRoot,
+  )
+
+  // nothing to audit if there is no project graph to load
+  if (!mainManifest) {
+    return buildResult([], queryString, showAll)
+  }
+
+  const graph: Graph = actual.load({
+    ...conf.options,
+    mainManifest,
+    modifiers,
+    monorepo,
+    loadManifests: true,
+  })
+  const securityArchive = await SecurityArchive.start({
+    nodes: [...graph.nodes.values()],
+  })
+
+  const nodes = new Set<NodeLike>(graph.nodes.values())
+  const q = new Query({
+    edges: graph.edges,
+    nodes,
+    importers: graph.importers,
+    securityArchive,
+  })
+  const { nodes: resultNodes } = await q.search(queryString, {
+    signal: new AbortController().signal,
+  })
+
+  return buildResult(resultNodes, queryString, showAll)
+}

--- a/src/cli-sdk/src/commands/fund.ts
+++ b/src/cli-sdk/src/commands/fund.ts
@@ -1,0 +1,199 @@
+import { styleText as utilStyleText } from 'node:util'
+import { actual, GraphModifier } from '@vltpkg/graph'
+import { Query } from '@vltpkg/query'
+import { normalizeFunding } from '@vltpkg/types'
+import { commandUsage } from '../config/usage.ts'
+import type { Graph } from '@vltpkg/graph'
+import type { NodeLike, NormalizedFunding } from '@vltpkg/types'
+import type { CommandFn, CommandUsage } from '../index.ts'
+import type { ViewOptions, Views } from '../view.ts'
+
+export const needsRegistry = true
+
+export const usage: CommandUsage = () =>
+  commandUsage({
+    command: 'fund',
+    usage: ['', '[package-names...]', '[<query>]'],
+    description: `Display a list of installed dependencies that declare
+      funding information, along with the URLs where they can be funded.
+
+      Under the hood this uses the vlt Dependency Selector Syntax (the same
+      engine that powers \`vlt query\`) to collect installed dependencies,
+      then reports the ones whose \`package.json\` includes a \`funding\`
+      field.
+
+      Provide package names as positional arguments to limit the report to
+      those packages. Alternatively, pass a DSS query selector to scope the
+      report to an arbitrary subset of the dependency graph.
+
+      Defaults to checking every dependency of the project and its
+      workspaces.`,
+    examples: {
+      '': {
+        description: 'List all dependencies looking for funding',
+      },
+      'foo bar': {
+        description: `Only check the 'foo' and 'bar' packages`,
+      },
+      ':root > *': {
+        description:
+          'Only check direct dependencies of the project root',
+      },
+      '--view=json': {
+        description: 'Output the results as JSON',
+      },
+    },
+    options: {
+      view: {
+        value: '[human | json]',
+        description:
+          'Output format. Defaults to human-readable or json if no tty.',
+      },
+    },
+  })
+
+/**
+ * A single installed dependency that declares funding information.
+ */
+export type FundingReport = {
+  /** The package name. */
+  name: string
+  /** The installed version, when known. */
+  version?: string
+  /** The normalized funding entries declared by the package. */
+  funding: NormalizedFunding
+}
+
+export type FundResult = {
+  reports: FundingReport[]
+}
+
+const renderHuman = (
+  result: FundResult,
+  { colors }: ViewOptions,
+): string => {
+  const paint = (
+    style: Parameters<typeof utilStyleText>[0],
+    s: string,
+  ) =>
+    colors ? utilStyleText(style, s, { validateStream: false }) : s
+
+  const { reports } = result
+  if (reports.length === 0) {
+    return paint(
+      'green',
+      'No funding information found for any installed dependency.',
+    )
+  }
+
+  // Group the packages by their funding URL so users can see, at a
+  // glance, which link funds which set of dependencies.
+  const byUrl = new Map<string, Set<string>>()
+  for (const report of reports) {
+    const label =
+      report.version ?
+        `${report.name}@${report.version}`
+      : /* c8 ignore next */ report.name
+    for (const entry of report.funding) {
+      const packages = byUrl.get(entry.url)
+      if (packages) {
+        packages.add(label)
+      } else {
+        byUrl.set(entry.url, new Set([label]))
+      }
+    }
+  }
+
+  const lines: string[] = []
+  lines.push(
+    paint(
+      'bold',
+      `${reports.length} ${
+        reports.length === 1 ? 'package is' : 'packages are'
+      } looking for funding`,
+    ),
+  )
+  lines.push('')
+
+  const groups = [...byUrl.entries()].sort(([a], [b]) =>
+    a.localeCompare(b, 'en'),
+  )
+  for (const [url, packages] of groups) {
+    lines.push(paint('cyan', url))
+    for (const pkg of [...packages].sort((a, b) =>
+      a.localeCompare(b, 'en'),
+    )) {
+      lines.push(`  ${pkg}`)
+    }
+    lines.push('')
+  }
+
+  return lines.join('\n').trimEnd()
+}
+
+export const views = {
+  human: renderHuman,
+  json: (result: FundResult) => result.reports,
+} as const satisfies Views<FundResult>
+
+export const command: CommandFn<FundResult> = async conf => {
+  const modifiers = GraphModifier.maybeLoad(conf.options)
+  const monorepo = conf.options.monorepo
+  const mainManifest = conf.options.packageJson.maybeRead(
+    conf.options.projectRoot,
+  )
+  let graph: Graph | undefined
+
+  if (mainManifest) {
+    graph = actual.load({
+      ...conf.options,
+      mainManifest,
+      modifiers,
+      monorepo,
+      loadManifests: true,
+    })
+  }
+
+  // Without a graph there's nothing installed to inspect.
+  if (!graph) {
+    return { reports: [] }
+  }
+
+  // Build the query string: an optional set of package names, otherwise
+  // every dependency in the graph.
+  const positionals = conf.positionals
+  const queryString =
+    positionals.length ?
+      positionals.map(k => `#${k.replace(/\//g, '\\/')}`).join(', ')
+    : '*'
+
+  const q = new Query({
+    nodes: new Set<NodeLike>(graph.nodes.values()),
+    edges: graph.edges,
+    importers: graph.importers,
+    securityArchive: undefined,
+  })
+  const { nodes } = await q.search(queryString, {
+    signal: new AbortController().signal,
+  })
+
+  const reports: FundingReport[] = []
+  for (const node of nodes) {
+    // The project root and workspaces aren't the target of a fund report.
+    if (node.importer) continue
+    const funding = normalizeFunding(node.manifest?.funding)?.filter(
+      entry => !!entry.url,
+    )
+    if (!funding?.length) continue
+    reports.push({
+      /* c8 ignore next 2 - installed deps always carry a name/version */
+      name: node.name ?? node.id,
+      version: node.version ?? undefined,
+      funding,
+    })
+  }
+
+  reports.sort((a, b) => a.name.localeCompare(b.name, 'en'))
+
+  return { reports }
+}

--- a/src/cli-sdk/src/commands/outdated.ts
+++ b/src/cli-sdk/src/commands/outdated.ts
@@ -1,0 +1,403 @@
+import { styleText as utilStyleText } from 'node:util'
+import { actual, GraphModifier } from '@vltpkg/graph'
+import { PackageInfoClient } from '@vltpkg/package-info'
+import { Query } from '@vltpkg/query'
+import { compare, satisfies } from '@vltpkg/semver'
+import { hydrate, splitDepID } from '@vltpkg/dep-id'
+import { commandUsage } from '../config/usage.ts'
+import type { Graph, Node } from '@vltpkg/graph'
+import type {
+  QueryResponseEdge,
+  QueryResponseNode,
+} from '@vltpkg/query'
+import type {
+  DependencyTypeShort,
+  EdgeLike,
+  NodeLike,
+  Packument,
+} from '@vltpkg/types'
+import type { CommandFn, CommandUsage } from '../index.ts'
+import type { ViewOptions, Views } from '../view.ts'
+
+export const needsRegistry = true
+
+export const usage: CommandUsage = () =>
+  commandUsage({
+    command: 'outdated',
+    usage: ['', '[package-names...]', '[<query>]'],
+    description: `Display a table of installed dependencies that have newer
+      versions available in the registry.
+
+      Under the hood this uses the vlt Dependency Selector Syntax (the same
+      engine that powers \`vlt query\`) with the \`:outdated\` pseudo-selector.
+      A registry request is made for each candidate package to determine the
+      "wanted" (highest version matching the declared range) and "latest"
+      (the \`latest\` dist-tag) versions.
+
+      Provide package names as positional arguments to limit the report to
+      those packages. Alternatively, pass a DSS query selector to scope the
+      report to an arbitrary subset of the dependency graph.
+
+      Defaults to checking every dependency of the project and its
+      workspaces.`,
+    examples: {
+      '': {
+        description: 'Show all outdated dependencies',
+      },
+      'foo bar': {
+        description: `Only check the 'foo' and 'bar' packages`,
+      },
+      ':root > *': {
+        description:
+          'Only check direct dependencies of the project root',
+      },
+      '--view=json': {
+        description: 'Output the results as JSON',
+      },
+    },
+    options: {
+      view: {
+        value: '[human | json]',
+        description:
+          'Output format. Defaults to human-readable or json if no tty.',
+      },
+    },
+  })
+
+/**
+ * A single outdated dependency relationship.
+ */
+export type OutdatedReport = {
+  /** The package name. */
+  name: string
+  /** The currently installed version. */
+  current?: string
+  /**
+   * The highest version that satisfies the declared dependency range,
+   * i.e. the version an install would upgrade to.
+   */
+  wanted?: string
+  /** The version tagged as `latest` in the registry. */
+  latest?: string
+  /** The kind of dependency (prod, dev, peer, optional). */
+  type: DependencyTypeShort
+  /** The name of the package/workspace that depends on it. */
+  dependedBy: string
+  /** The location of the installed package on disk. */
+  location?: string
+}
+
+export type OutdatedResult = {
+  reports: OutdatedReport[]
+}
+
+/**
+ * Splits a version string into its dot-separated segments, treating the
+ * prerelease/build portion as the trailing segment(s).
+ */
+const versionSegments = (version: string): string[] =>
+  version.split('.')
+
+/**
+ * Highlights the portion of `to` that differs from `from`, choosing a
+ * color based on which segment first changed:
+ * major -> red, minor -> cyan, patch (or lower) -> green.
+ */
+const highlightDiff = (
+  from: string | undefined,
+  to: string,
+  paint: (
+    style: Parameters<typeof utilStyleText>[0],
+    s: string,
+  ) => string,
+): string => {
+  if (!from) return to
+  const f = versionSegments(from)
+  const t = versionSegments(to)
+  let i = 0
+  while (i < t.length && f[i] === t[i]) i++
+  // no difference detected
+  if (i >= t.length) return to
+  const unchanged = t.slice(0, i).join('.')
+  const changed = t.slice(i).join('.')
+  const style: Parameters<typeof utilStyleText>[0] =
+    i === 0 ? 'red'
+    : i === 1 ? 'cyan'
+    : 'green'
+  return `${unchanged}${unchanged ? '.' : ''}${paint(style, changed)}`
+}
+
+/**
+ * Returns the highest version in `versions` that satisfies `range`. When
+ * no range is available or nothing matches, returns `undefined`.
+ */
+export const highestSatisfying = (
+  versions: string[],
+  range: string | undefined,
+): string | undefined => {
+  if (!range) return undefined
+  return versions
+    .filter(v => satisfies(v, range))
+    .sort(compare)
+    .pop()
+}
+
+/**
+ * Returns true when `to` has a greater major version than `from`.
+ */
+const majorBump = (from: string, to: string): boolean => {
+  const f = Number(versionSegments(from)[0])
+  const t = Number(versionSegments(to)[0])
+  return Number.isFinite(f) && Number.isFinite(t) && t > f
+}
+
+const dependencyTypeLabel: Record<DependencyTypeShort, string> = {
+  prod: 'dependencies',
+  dev: 'devDependencies',
+  optional: 'optionalDependencies',
+  peer: 'peerDependencies',
+  peerOptional: 'peerDependencies',
+}
+
+const renderHuman = (
+  result: OutdatedResult,
+  { colors }: ViewOptions,
+): string => {
+  const paint = (
+    style: Parameters<typeof utilStyleText>[0],
+    s: string,
+  ) =>
+    colors ? utilStyleText(style, s, { validateStream: false }) : s
+
+  const { reports } = result
+  if (reports.length === 0) {
+    return paint('green', 'All dependencies are up to date.')
+  }
+
+  const rows = [...reports].sort(
+    (a, b) =>
+      a.name.localeCompare(b.name, 'en') ||
+      a.dependedBy.localeCompare(b.dependedBy, 'en'),
+  )
+
+  type Column = {
+    header: string
+    // raw (uncolored) text used for width calculation
+    raw: (r: OutdatedReport) => string
+    // colored text rendered into the cell
+    render: (r: OutdatedReport) => string
+  }
+
+  const columns: Column[] = [
+    {
+      header: 'Package',
+      raw: r => r.name,
+      render: r =>
+        paint(
+          r.current && r.latest && majorBump(r.current, r.latest) ?
+            'red'
+          : 'yellow',
+          r.name,
+        ),
+    },
+    {
+      header: 'Current',
+      raw: r => r.current ?? 'MISSING',
+      render: r => paint('dim', r.current ?? 'MISSING'),
+    },
+    {
+      header: 'Wanted',
+      raw: r => r.wanted ?? r.current ?? '-',
+      render: r =>
+        r.wanted ?
+          highlightDiff(r.current, r.wanted, paint)
+        : paint('dim', r.current ?? '-'),
+    },
+    {
+      header: 'Latest',
+      raw: r => r.latest ?? '-',
+      render: r =>
+        r.latest ?
+          highlightDiff(r.current, r.latest, paint)
+        : paint('dim', '-'),
+    },
+    {
+      header: 'Type',
+      raw: r => dependencyTypeLabel[r.type],
+      render: r => paint('dim', dependencyTypeLabel[r.type]),
+    },
+    {
+      header: 'Depended By',
+      raw: r => r.dependedBy,
+      render: r => r.dependedBy,
+    },
+  ]
+
+  const widths = columns.map(col =>
+    Math.max(col.header.length, ...rows.map(r => col.raw(r).length)),
+  )
+
+  const pad = (text: string, rawLen: number, width: number): string =>
+    text + ' '.repeat(Math.max(0, width - rawLen))
+
+  const lines: string[] = []
+
+  lines.push(
+    columns
+      .map((col, i) =>
+        pad(
+          paint('bold', paint('underline', col.header)),
+          col.header.length,
+          widths[i] ?? 0,
+        ),
+      )
+      .join('  ')
+      .trimEnd(),
+  )
+
+  for (const r of rows) {
+    lines.push(
+      columns
+        .map((col, i) =>
+          pad(col.render(r), col.raw(r).length, widths[i] ?? 0),
+        )
+        .join('  ')
+        .trimEnd(),
+    )
+  }
+
+  lines.push('')
+  lines.push(
+    paint(
+      'dim',
+      `${rows.length} outdated ${
+        rows.length === 1 ? 'package' : 'packages'
+      } found.`,
+    ),
+  )
+
+  return lines.join('\n')
+}
+
+export const views = {
+  human: renderHuman,
+  json: (result: OutdatedResult) => result.reports,
+} as const satisfies Views<OutdatedResult>
+
+export const command: CommandFn<OutdatedResult> = async conf => {
+  const modifiers = GraphModifier.maybeLoad(conf.options)
+  const monorepo = conf.options.monorepo
+  const mainManifest = conf.options.packageJson.maybeRead(
+    conf.options.projectRoot,
+  )
+  let graph: Graph | undefined
+
+  if (mainManifest) {
+    graph = actual.load({
+      ...conf.options,
+      mainManifest,
+      modifiers,
+      monorepo,
+      loadManifests: true,
+    })
+  }
+
+  // Without a graph there's nothing installed to compare against.
+  if (!graph) {
+    return { reports: [] }
+  }
+
+  // Determine which nodes to treat as top-level importers, mirroring the
+  // behavior of the `query` and `list` commands.
+  const importers = new Set<Node>()
+  if ('workspace' in conf.values && monorepo) {
+    for (const workspace of monorepo.filter(conf.values)) {
+      const w = graph.nodes.get(workspace.id)
+      if (w) importers.add(w)
+    }
+  }
+
+  // Build the query string: an optional user-provided scope combined with
+  // the `:outdated` pseudo-selector.
+  const positionals = conf.positionals
+  const base =
+    positionals.length ?
+      positionals.map(k => `#${k.replace(/\//g, '\\/')}`).join(', ')
+    : '*'
+  const queryString = base
+    .split(',')
+    .map(part => `${part.trim()}:outdated`)
+    .join(', ')
+
+  const q = new Query({
+    nodes: new Set<NodeLike>(graph.nodes.values()),
+    edges: new Set<EdgeLike>(graph.edges),
+    importers:
+      importers.size ?
+        new Set<NodeLike>(importers)
+      : new Set<NodeLike>(graph.importers),
+    securityArchive: undefined,
+  })
+  const { edges, nodes } = await q.search(queryString, {
+    signal: new AbortController().signal,
+  })
+
+  const resultNodes = new Set<QueryResponseNode>(nodes)
+  const pic = new PackageInfoClient(conf.options)
+  const packumentCache = new Map<
+    string,
+    Promise<Packument | undefined>
+  >()
+
+  const fetchPackument = async (
+    node: QueryResponseNode,
+    name: string,
+  ): Promise<Packument | undefined> => {
+    const cached = packumentCache.get(node.id)
+    if (cached) return cached
+    const spec = hydrate(node.id, name, conf.options)
+    const promise = pic
+      .packument(spec)
+      // A missing packument (e.g. 404) shouldn't fail the whole report.
+      .catch(() => undefined)
+    packumentCache.set(node.id, promise)
+    return promise
+  }
+
+  const reports = await Promise.all(
+    edges
+      .filter(
+        (
+          edge,
+        ): edge is QueryResponseEdge & { to: QueryResponseNode } =>
+          !!edge.to &&
+          resultNodes.has(edge.to) &&
+          !edge.to.importer &&
+          splitDepID(edge.to.id)[0] === 'registry',
+      )
+      .map(async (edge): Promise<OutdatedReport> => {
+        const node = edge.to
+        const name = node.name ?? edge.name
+        const packument = await fetchPackument(node, name)
+        const versions =
+          packument ? Object.keys(packument.versions) : []
+        const range = edge.spec.final.range
+        const wanted = highestSatisfying(
+          versions,
+          range ? String(range) : undefined,
+        )
+        const latest = packument?.['dist-tags'].latest
+        return {
+          name,
+          current: node.version ?? undefined,
+          wanted,
+          latest,
+          type: edge.type,
+          dependedBy: edge.from.name ?? edge.from.id,
+          location: node.location,
+        }
+      }),
+  )
+
+  return { reports }
+}

--- a/src/cli-sdk/src/config/definition.ts
+++ b/src/cli-sdk/src/config/definition.ts
@@ -20,6 +20,7 @@ export const defaultEditor = () =>
 
 const canonicalCommands = {
   access: 'access',
+  audit: 'audit',
   bugs: 'bugs',
   build: 'build',
   cache: 'cache',
@@ -31,6 +32,7 @@ const canonicalCommands = {
   docs: 'docs',
   exec: 'exec',
   'exec-local': 'exec-local',
+  fund: 'fund',
   help: 'help',
   init: 'init',
   install: 'install',
@@ -38,6 +40,7 @@ const canonicalCommands = {
   logout: 'logout',
   list: 'list',
   ls: 'ls',
+  outdated: 'outdated',
   pack: 'pack',
   ping: 'ping',
   pkg: 'pkg',
@@ -77,6 +80,7 @@ const aliases = {
   '?': 'help',
   info: 'view',
   ls: 'list',
+  out: 'outdated',
   show: 'view',
   xc: 'exec-cache',
 } as const
@@ -633,6 +637,43 @@ export const definition = j
         'inspect',
         'silent',
       ] as const,
+    },
+  })
+
+  .opt({
+    loglevel: {
+      hint: 'level',
+      default: 'info',
+      description: `Sets the verbosity of diagnostic logging written to
+                    stderr (registry requests, warnings, etc). This is
+                    independent of \`--view\`, which controls a command's
+                    result output on stdout.
+
+                    - silent: No diagnostic logging.
+                    - error: Only errors.
+                    - warn: Errors and warnings.
+                    - info: Default. High-level progress.
+                    - verbose: Adds per-request logging (each registry URL
+                      with its cache/stale/fetch outcome and status code).
+                    - debug: Everything, including low-level detail.
+
+                    \`--verbose\` is shorthand for \`--loglevel=verbose\`.`,
+      validOptions: [
+        'silent',
+        'error',
+        'warn',
+        'info',
+        'verbose',
+        'debug',
+      ] as const,
+    },
+  })
+
+  .flag({
+    verbose: {
+      description: `Shorthand for \`--loglevel=verbose\`. Streams each
+                    registry request to stderr with its cache/fetch outcome
+                    and status code, useful for debugging request behavior.`,
     },
   })
 

--- a/src/cli-sdk/src/config/index.ts
+++ b/src/cli-sdk/src/config/index.ts
@@ -382,6 +382,13 @@ export class Config {
 
     Object.assign(this, p)
 
+    // `--verbose` is shorthand for `--loglevel=verbose`. Only apply it
+    // when loglevel is still at its default so an explicit `--loglevel`
+    // always wins.
+    if (p.values.verbose && p.values.loglevel === 'info') {
+      p.values.loglevel = 'verbose'
+    }
+
     /* c8 ignore start - unpossible */
     if (!isParsed(this)) throw error('failed to parse config')
     /* c8 ignore stop */

--- a/src/cli-sdk/src/output.ts
+++ b/src/cli-sdk/src/output.ts
@@ -23,6 +23,7 @@ import {
   trackCommand,
   trackError,
 } from './telemetry.ts'
+import { startRequestLog } from './verbose-log.ts'
 
 /* c8 ignore start - CI env detection is a best-effort heuristic */
 const isCI = (): boolean =>
@@ -174,6 +175,14 @@ export const outputCommand = async <T>(
   if (stderrColor) styleTextStderr = styleText
   /* c8 ignore stop */
 
+  // Stream per-request diagnostics to stderr when `--loglevel` is verbose
+  // or higher (e.g. via `--verbose`). No-op otherwise.
+  const stopRequestLog = startRequestLog(
+    conf.values.loglevel,
+    line => stderr(line),
+    styleTextStderr,
+  )
+
   const { onDone, onError } = startView(
     conf,
     // assume views will always output to stdout so use color support from there
@@ -195,6 +204,7 @@ export const outputCommand = async <T>(
     }
 
     const output = await onDone(await command(conf))
+    stopRequestLog()
 
     const duration_ms = Date.now() - start
     trackCommand(
@@ -232,6 +242,7 @@ export const outputCommand = async <T>(
     // can still exit promptly.
     await flushTelemetry()
   } catch (err) {
+    stopRequestLog()
     onError?.(err)
     process.exitCode ||= 1
 

--- a/src/cli-sdk/src/print-err.ts
+++ b/src/cli-sdk/src/print-err.ts
@@ -32,6 +32,21 @@ const isNonEmptyString = (v: unknown): v is string =>
 const formatURL = (v: unknown, format: Formatter) =>
   v instanceof URL ? v.toString() : /* c8 ignore next */ format(v)
 
+// True when `v` overrides the default `Object.prototype.toString`, i.e.
+// stringifying it yields something meaningful (like a `Spec` → `next@*`)
+// rather than `[object Object]`.
+const hasCustomToString = (
+  v: unknown,
+): v is { toString: () => string } =>
+  isObject(v) && v.toString !== Object.prototype.toString
+
+// Render a value that has a meaningful custom `toString()` (such as a
+// `Spec`, e.g. `next@*`) as a concise string rather than dumping its
+// entire internal structure via util.inspect. Falls back to `format`
+// for plain values/objects.
+const formatToString = (v: unknown, format: Formatter): string =>
+  hasCustomToString(v) ? v.toString() : format(v)
+
 const formatArray = (v: unknown, format: Formatter, joiner = ', ') =>
   Array.isArray(v) ? v.join(joiner) : /* c8 ignore next */ format(v)
 
@@ -208,7 +223,7 @@ const printCode = (
         stderr(indent(`While fetching: ${formatURL(url, format)}`))
       }
       if (spec) {
-        stderr(indent(`To satisfy: ${format(spec)}`))
+        stderr(indent(`To satisfy: ${formatToString(spec, format)}`))
       }
       if (from) {
         stderr(indent(`From: ${format(from)}`))

--- a/src/cli-sdk/src/verbose-log.ts
+++ b/src/cli-sdk/src/verbose-log.ts
@@ -1,0 +1,100 @@
+import { emitter } from '@vltpkg/output'
+import type { Events } from '@vltpkg/output'
+
+/**
+ * Diagnostic logging levels, ordered from least to most verbose.
+ * Mirrors the `loglevel` option in the config definition.
+ */
+export type LogLevel =
+  'silent' | 'error' | 'warn' | 'info' | 'verbose' | 'debug'
+
+const rank: Record<LogLevel, number> = {
+  silent: 0,
+  error: 1,
+  warn: 2,
+  info: 3,
+  verbose: 4,
+  debug: 5,
+}
+
+/** True when the given level should emit per-request logging. */
+export const isVerbose = (level: LogLevel): boolean =>
+  rank[level] >= rank.verbose
+
+const isDebug = (level: LogLevel): boolean =>
+  rank[level] >= rank.debug
+
+/** The subset of `styleText` color names this module applies. */
+export type StyleColor = 'green' | 'red' | 'gray'
+
+/**
+ * Minimal signature compatible with the `styleText` helpers exported by
+ * `./output.ts` (which accept a wider set of format names). Defaults to an
+ * identity function so this module can be tested without color support.
+ */
+export type StyleFn = (format: StyleColor, s: string) => string
+
+const identityStyle: StyleFn = (_f, s) => s
+
+const tagStyle = (
+  state: Events['request']['state'],
+  statusCode: number | undefined,
+): StyleColor => {
+  switch (state) {
+    case 'cache':
+    case 'stale':
+    case '304':
+      return 'green'
+    case 'start':
+      return 'gray'
+    case 'complete':
+      return statusCode !== undefined && statusCode >= 400 ?
+          'red'
+        : 'green'
+  }
+}
+
+/**
+ * Format a single `request` event into a human-readable log line.
+ * Exported for testing.
+ */
+export const formatRequestEvent = (
+  event: Events['request'],
+  style: StyleFn = identityStyle,
+): string => {
+  const { url, state, method = 'GET', statusCode, durationMs } = event
+  // For completed network requests show the status code rather than the
+  // literal word "complete"; everything else shows the cache/fetch state.
+  const tag = state === 'complete' ? String(statusCode ?? '') : state
+  const duration =
+    durationMs === undefined ? '' : (
+      style('gray', ` (${durationMs}ms)`)
+    )
+  return `${style(tagStyle(state, statusCode), tag.padEnd(8))} ${method} ${String(url)}${duration}`
+}
+
+/**
+ * Subscribe to registry request events and stream them to `write` when
+ * the configured `level` is `verbose` or higher. The `start` event is only
+ * logged at `debug` level to avoid duplicate lines (each network request
+ * also emits a `complete`/`304` line with its status and duration).
+ *
+ * Returns a cleanup function that detaches the subscription. When `level`
+ * is below `verbose`, nothing is subscribed and the cleanup is a no-op.
+ */
+export const startRequestLog = (
+  level: LogLevel,
+  write: (line: string) => void,
+  style: StyleFn = identityStyle,
+): (() => void) => {
+  if (!isVerbose(level)) return () => {}
+  const debug = isDebug(level)
+  const handler = (event: Events['request']) => {
+    // At verbose level, skip the `start` event so each request produces a
+    // single completion line; at debug level, show it too.
+    if (event.state === 'start' && !debug) return
+    write(formatRequestEvent(event, style))
+  }
+  emitter.on('request', handler)
+  return () => emitter.off('request', handler)
+}

--- a/src/cli-sdk/tap-snapshots/test/commands/audit.ts.test.cjs
+++ b/src/cli-sdk/tap-snapshots/test/commands/audit.ts.test.cjs
@@ -1,0 +1,385 @@
+/* IMPORTANT
+ * This snapshot file is auto-generated, but designed for humans.
+ * It should be checked into source control and tracked carefully.
+ * Re-generate by setting TAP_SNAPSHOT=1 and running tests.
+ * Make sure to inspect the output below.  Do not ignore changes!
+ */
+'use strict'
+exports[`test/commands/audit.ts > TAP > command - default audit > human view (colors) 1`] = `
+[1mSecurity Audit[22m
+
+[2mSEVERITY  PACKAGE    TYPE           ISSUE[22m
+[31m[1mcritical[22m[39m  foo@1.0.0  [36mmalware      [39m  known malware
+[31mhigh    [39m  foo@1.0.0  [36mvulnerability[39m  high severity CVE (CVE-2023-1)
+[33mmedium  [39m  bar@1.0.0  [36mmaintenance  [39m  deprecated
+[33mmedium  [39m  baz@1.0.0  [36mlicense      [39m  copyleft license
+
+[1mSummary:[22m [31m[1m1 critical[22m[39m, [31m1 high[39m, [33m2 moderate[39m across 3 packages (4 scanned).
+[2mRun with --all to include low-severity capability findings.[22m
+`
+
+exports[`test/commands/audit.ts > TAP > command - default audit > human view (default opts) 1`] = `
+Security Audit
+
+SEVERITY  PACKAGE    TYPE           ISSUE
+critical  foo@1.0.0  malware        known malware
+high      foo@1.0.0  vulnerability  high severity CVE (CVE-2023-1)
+medium    bar@1.0.0  maintenance    deprecated
+medium    baz@1.0.0  license        copyleft license
+
+Summary: 1 critical, 1 high, 2 moderate across 3 packages (4 scanned).
+Run with --all to include low-severity capability findings.
+`
+
+exports[`test/commands/audit.ts > TAP > command - default audit > human view (no colors) 1`] = `
+Security Audit
+
+SEVERITY  PACKAGE    TYPE           ISSUE
+critical  foo@1.0.0  malware        known malware
+high      foo@1.0.0  vulnerability  high severity CVE (CVE-2023-1)
+medium    bar@1.0.0  maintenance    deprecated
+medium    baz@1.0.0  license        copyleft license
+
+Summary: 1 critical, 1 high, 2 moderate across 3 packages (4 scanned).
+Run with --all to include low-severity capability findings.
+`
+
+exports[`test/commands/audit.ts > TAP > command - default audit > json view 1`] = `
+Object {
+  "packagesAffected": 3,
+  "packagesScanned": 4,
+  "reports": Array [
+    Object {
+      "findings": Array [
+        Object {
+          "category": "malware",
+          "description": "known malware",
+          "severity": "critical",
+        },
+        Object {
+          "category": "vulnerability",
+          "description": "high severity CVE (CVE-2023-1)",
+          "severity": "high",
+        },
+      ],
+      "id": "~npm~foo@1.0.0",
+      "location": "{LOC}",
+      "name": "foo",
+      "version": "1.0.0",
+      "worst": "critical",
+    },
+    Object {
+      "findings": Array [
+        Object {
+          "category": "maintenance",
+          "description": "deprecated",
+          "severity": "medium",
+        },
+      ],
+      "id": "~npm~bar@1.0.0",
+      "location": "{LOC}",
+      "name": "bar",
+      "version": "1.0.0",
+      "worst": "medium",
+    },
+    Object {
+      "findings": Array [
+        Object {
+          "category": "license",
+          "description": "copyleft license",
+          "severity": "medium",
+        },
+      ],
+      "id": "~npm~baz@1.0.0",
+      "location": "{LOC}",
+      "name": "baz",
+      "version": "1.0.0",
+      "worst": "medium",
+    },
+  ],
+  "summary": Object {
+    "critical": 1,
+    "high": 1,
+    "low": 0,
+    "medium": 2,
+    "total": 4,
+  },
+}
+`
+
+exports[`test/commands/audit.ts > TAP > command - include low severity with --all > human view with low severity findings 1`] = `
+Security Audit
+
+SEVERITY  PACKAGE    TYPE           ISSUE
+critical  foo@1.0.0  malware        known malware
+high      foo@1.0.0  vulnerability  high severity CVE (CVE-2023-1)
+medium    bar@1.0.0  maintenance    deprecated
+medium    baz@1.0.0  license        copyleft license
+low       qux@1.0.0  capability     uses eval
+
+Summary: 1 critical, 1 high, 2 moderate, 1 low across 4 packages (4 scanned).
+`
+
+exports[`test/commands/audit.ts > TAP > human view - all severities, no version > renders every severity level without a version 1`] = `
+[1mSecurity Audit[22m
+
+[2mSEVERITY  PACKAGE  TYPE  ISSUE[22m
+[31m[1mcritical[22m[39m  sole     [36mtest[39m  critical issue
+[31mhigh    [39m  sole     [36mtest[39m  high issue
+[33mmedium  [39m  sole     [36mtest[39m  medium issue
+[2mlow     [22m  sole     [36mtest[39m  low issue
+
+[1mSummary:[22m [31m[1m1 critical[22m[39m, [31m1 high[39m, [33m1 moderate[39m, [2m1 low[22m across 1 package (1 scanned).
+`
+
+exports[`test/commands/audit.ts > TAP > human view - no findings > no issues, one package scanned 1`] = `
+Security Audit
+
+✓ No security issues found across 1 scanned package.
+`
+
+exports[`test/commands/audit.ts > TAP > human view - no findings > no issues, zero packages scanned 1`] = `
+[1mSecurity Audit[22m
+
+[32m✓ No security issues found[39m across 0 scanned packages.
+`
+
+exports[`test/commands/audit.ts > TAP > insightsToFindings > covers every finding branch 1`] = `
+Array [
+  Object {
+    "category": "malware",
+    "description": "known malware",
+    "severity": "critical",
+  },
+  Object {
+    "category": "malware",
+    "description": "AI-detected malware",
+    "severity": "high",
+  },
+  Object {
+    "category": "malware",
+    "description": "AI-flagged security issue",
+    "severity": "medium",
+  },
+  Object {
+    "category": "malware",
+    "description": "AI-flagged anomaly",
+    "severity": "low",
+  },
+  Object {
+    "category": "vulnerability",
+    "description": "critical severity CVE (CVE-2020-1)",
+    "severity": "critical",
+  },
+  Object {
+    "category": "typosquat",
+    "description": "likely typosquat",
+    "severity": "high",
+  },
+  Object {
+    "category": "integrity",
+    "description": "manifest confusion",
+    "severity": "high",
+  },
+  Object {
+    "category": "code",
+    "description": "obfuscated code",
+    "severity": "medium",
+  },
+  Object {
+    "category": "trust",
+    "description": "suspicious activity",
+    "severity": "medium",
+  },
+  Object {
+    "category": "trust",
+    "description": "flagged as undesirable",
+    "severity": "medium",
+  },
+  Object {
+    "category": "code",
+    "description": "high-entropy strings",
+    "severity": "low",
+  },
+  Object {
+    "category": "code",
+    "description": "minified, no source",
+    "severity": "low",
+  },
+  Object {
+    "category": "license",
+    "description": "copyleft license",
+    "severity": "medium",
+  },
+  Object {
+    "category": "license",
+    "description": "non-permissive license",
+    "severity": "medium",
+  },
+  Object {
+    "category": "license",
+    "description": "unlicensed",
+    "severity": "medium",
+  },
+  Object {
+    "category": "license",
+    "description": "no license found",
+    "severity": "medium",
+  },
+  Object {
+    "category": "license",
+    "description": "license issues",
+    "severity": "low",
+  },
+  Object {
+    "category": "license",
+    "description": "ambiguous license",
+    "severity": "low",
+  },
+  Object {
+    "category": "license",
+    "description": "unidentified license",
+    "severity": "low",
+  },
+  Object {
+    "category": "maintenance",
+    "description": "deprecated",
+    "severity": "medium",
+  },
+  Object {
+    "category": "maintenance",
+    "description": "abandoned (missing author)",
+    "severity": "medium",
+  },
+  Object {
+    "category": "maintenance",
+    "description": "unmaintained (5+ years)",
+    "severity": "medium",
+  },
+  Object {
+    "category": "maintenance",
+    "description": "unpopular",
+    "severity": "low",
+  },
+  Object {
+    "category": "maintenance",
+    "description": "unstable ownership",
+    "severity": "low",
+  },
+  Object {
+    "category": "maintenance",
+    "description": "new / unknown author",
+    "severity": "low",
+  },
+  Object {
+    "category": "maintenance",
+    "description": "trivial package",
+    "severity": "low",
+  },
+  Object {
+    "category": "capability",
+    "description": "uses eval",
+    "severity": "low",
+  },
+  Object {
+    "category": "capability",
+    "description": "shell access",
+    "severity": "low",
+  },
+  Object {
+    "category": "capability",
+    "description": "network access",
+    "severity": "low",
+  },
+  Object {
+    "category": "capability",
+    "description": "filesystem access",
+    "severity": "low",
+  },
+  Object {
+    "category": "capability",
+    "description": "reads env vars",
+    "severity": "low",
+  },
+  Object {
+    "category": "capability",
+    "description": "dynamic require",
+    "severity": "low",
+  },
+  Object {
+    "category": "capability",
+    "description": "debug access",
+    "severity": "low",
+  },
+  Object {
+    "category": "capability",
+    "description": "native code",
+    "severity": "low",
+  },
+  Object {
+    "category": "capability",
+    "description": "telemetry",
+    "severity": "low",
+  },
+  Object {
+    "category": "capability",
+    "description": "install scripts",
+    "severity": "low",
+  },
+  Object {
+    "category": "capability",
+    "description": "bundles a shrinkwrap",
+    "severity": "low",
+  },
+]
+`
+
+exports[`test/commands/audit.ts > TAP > usage > should have usage 1`] = `
+Usage:
+  vlt audit
+  vlt audit <query> --view=<human | json>
+
+Run a security audit of the installed dependency graph.
+
+Uses the vlt Dependency Selector Syntax (the same engine that powers \`vlt
+query\`) together with the Socket security database to surface packages that may
+need attention: known malware, published vulnerabilities (CVEs), typosquats,
+license problems, unmaintained or deprecated packages, and more.
+
+By default it scans every package that has security metadata and reports any
+finding with a severity of moderate or higher. Provide a DSS query as a
+positional argument to audit a specific subset of the graph (for example
+':workspace > *' to only audit your workspaces' direct dependencies).
+
+  Examples
+
+    Audit all installed dependencies
+
+    ​vlt audit
+
+    Only audit direct dependencies of your workspaces
+
+    ​vlt audit ':workspace > *'
+
+    Emit the audit report as JSON for tooling / CI
+
+    ​vlt audit --view=json
+
+    Include low-severity findings such as behavioral capabilities
+
+    ​vlt audit --all
+
+  Options
+
+    all
+      Include low-severity findings (behavioral capabilities, minor hygiene
+      issues).
+
+      ​--all
+
+    view
+      Output format. Defaults to human-readable, or json if there is no tty.
+
+      ​--view=[human | json]
+
+`

--- a/src/cli-sdk/tap-snapshots/test/commands/fund.ts.test.cjs
+++ b/src/cli-sdk/tap-snapshots/test/commands/fund.ts.test.cjs
@@ -1,0 +1,130 @@
+/* IMPORTANT
+ * This snapshot file is auto-generated, but designed for humans.
+ * It should be checked into source control and tracked carefully.
+ * Re-generate by setting TAP_SNAPSHOT=1 and running tests.
+ * Make sure to inspect the output below.  Do not ignore changes!
+ */
+'use strict'
+exports[`test/commands/fund.ts > TAP > fund > should have usage 1`] = `
+Usage:
+  vlt fund
+  vlt fund [package-names...]
+  vlt fund [<query>]
+
+Display a list of installed dependencies that declare funding information, along
+with the URLs where they can be funded.
+
+Under the hood this uses the vlt Dependency Selector Syntax (the same engine
+that powers \`vlt query\`) to collect installed dependencies, then reports the
+ones whose \`package.json\` includes a \`funding\` field.
+
+Provide package names as positional arguments to limit the report to those
+packages. Alternatively, pass a DSS query selector to scope the report to an
+arbitrary subset of the dependency graph.
+
+Defaults to checking every dependency of the project and its workspaces.
+
+  Examples
+
+    List all dependencies looking for funding
+
+    ​vlt fund
+
+    Only check the 'foo' and 'bar' packages
+
+    ​vlt fund foo bar
+
+    Only check direct dependencies of the project root
+
+    ​vlt fund :root > *
+
+    Output the results as JSON
+
+    ​vlt fund --view=json
+
+  Options
+
+    view
+      Output format. Defaults to human-readable or json if no tty.
+
+      ​--view=[human | json]
+
+`
+
+exports[`test/commands/fund.ts > TAP > fund > should list funded pkgs in human readable format 1`] = `
+3 packages are looking for funding
+
+https://github.com/sponsors/bar
+  bar@2.0.0
+
+https://opencollective.com/foo
+  baz@3.0.0
+  foo@1.0.0
+
+https://patreon.com/baz
+  baz@3.0.0
+`
+
+exports[`test/commands/fund.ts > TAP > fund > should list funded pkgs in json format 1`] = `
+[
+  {
+    "name": "bar",
+    "version": "2.0.0",
+    "funding": [
+      {
+        "url": "https://github.com/sponsors/bar",
+        "type": "github"
+      }
+    ]
+  },
+  {
+    "name": "baz",
+    "version": "3.0.0",
+    "funding": [
+      {
+        "url": "https://opencollective.com/foo",
+        "type": "opencollective"
+      },
+      {
+        "url": "https://patreon.com/baz",
+        "type": "patreon"
+      }
+    ]
+  },
+  {
+    "name": "foo",
+    "version": "1.0.0",
+    "funding": [
+      {
+        "url": "https://opencollective.com/foo",
+        "type": "opencollective"
+      }
+    ]
+  }
+]
+`
+
+exports[`test/commands/fund.ts > TAP > fund > should scope report to named packages 1`] = `
+1 package is looking for funding
+
+https://opencollective.com/foo
+  foo@1.0.0
+`
+
+exports[`test/commands/fund.ts > TAP > fund > should use colors when set in human readable format 1`] = `
+[1m3 packages are looking for funding[22m
+
+[36mhttps://github.com/sponsors/bar[39m
+  bar@2.0.0
+
+[36mhttps://opencollective.com/foo[39m
+  baz@3.0.0
+  foo@1.0.0
+
+[36mhttps://patreon.com/baz[39m
+  baz@3.0.0
+`
+
+exports[`test/commands/fund.ts > TAP > no funded dependencies > should report that no funding was found 1`] = `
+No funding information found for any installed dependency.
+`

--- a/src/cli-sdk/tap-snapshots/test/commands/outdated.ts.test.cjs
+++ b/src/cli-sdk/tap-snapshots/test/commands/outdated.ts.test.cjs
@@ -1,0 +1,102 @@
+/* IMPORTANT
+ * This snapshot file is auto-generated, but designed for humans.
+ * It should be checked into source control and tracked carefully.
+ * Re-generate by setting TAP_SNAPSHOT=1 and running tests.
+ * Make sure to inspect the output below.  Do not ignore changes!
+ */
+'use strict'
+exports[`test/commands/outdated.ts > TAP > command > default report > rendered default report 1`] = `
+Package  Current  Wanted  Latest  Type                  Depended By
+anon     1.0.0    1.0.0   2.0.0   dependencies          file;.
+bar      1.0.0    1.0.0   1.2.0   devDependencies       my-project
+baz      1.0.0    1.0.0   -       peerDependencies      bar
+foo      1.0.0    1.5.0   2.0.0   dependencies          my-project
+nover    MISSING  1.0.0   1.0.0   peerDependencies      my-project
+qux      1.0.0    1.0.1   1.0.1   optionalDependencies  bar
+qux      1.0.0    1.0.1   1.0.1   optionalDependencies  my-project
+
+7 outdated packages found.
+`
+
+exports[`test/commands/outdated.ts > TAP > human view > renders a table with colors 1`] = `
+[1m[4mPackage[24m[22m  [1m[4mCurrent[24m[22m  [1m[4mWanted[24m[22m  [1m[4mLatest[24m[22m  [1m[4mType[24m[22m                  [1m[4mDepended By[24m[22m
+[33mbar[39m      [2m1.0.0[22m    [2m1.0.0[22m   1.[36m2.0[39m   [2mdevDependencies[22m       my-project
+[33mbaz[39m      [2m1.0.0[22m    [2m1.0.0[22m   [2m-[22m       [2mpeerDependencies[22m      bar
+[31mfoo[39m      [2m1.0.0[22m    1.[36m5.0[39m   [31m2.0.0[39m   [2mdependencies[22m          my-project
+[33mnover[39m    [2mMISSING[22m  1.0.0   1.0.0   [2mpeerDependencies[22m      my-project
+[33mqux[39m      [2m1.0.0[22m    1.0.0   1.0.[32m1[39m   [2moptionalDependencies[22m  my-project
+[33munknown[39m  [2mMISSING[22m  [2m-[22m       [2m-[22m       [2mdependencies[22m          my-project
+
+[2m6 outdated packages found.[22m
+`
+
+exports[`test/commands/outdated.ts > TAP > human view > renders a table without colors 1`] = `
+Package  Current  Wanted  Latest  Type                  Depended By
+bar      1.0.0    1.0.0   1.2.0   devDependencies       my-project
+baz      1.0.0    1.0.0   -       peerDependencies      bar
+foo      1.0.0    1.5.0   2.0.0   dependencies          my-project
+nover    MISSING  1.0.0   1.0.0   peerDependencies      my-project
+qux      1.0.0    1.0.0   1.0.1   optionalDependencies  my-project
+unknown  MISSING  -       -       dependencies          my-project
+
+6 outdated packages found.
+`
+
+exports[`test/commands/outdated.ts > TAP > human view > uses singular wording for a single package 1`] = `
+Package  Current  Wanted  Latest  Type          Depended By
+foo      1.0.0    1.5.0   2.0.0   dependencies  my-project
+
+1 outdated package found.
+`
+
+exports[`test/commands/outdated.ts > TAP > usage > should have usage 1`] = `
+Usage:
+  vlt outdated
+  vlt outdated [package-names...]
+  vlt outdated [<query>]
+
+Display a table of installed dependencies that have newer versions available in
+the registry.
+
+Under the hood this uses the vlt Dependency Selector Syntax (the same engine
+that powers \`vlt query\`) with the \`:outdated\` pseudo-selector. A registry
+request is made for each candidate package to determine the "wanted" (highest
+version matching the declared range) and "latest" (the \`latest\` dist-tag)
+versions.
+
+Provide package names as positional arguments to limit the report to those
+packages. Alternatively, pass a DSS query selector to scope the report to an
+arbitrary subset of the dependency graph.
+
+Defaults to checking every dependency of the project and its workspaces.
+
+  Aliases
+
+    ​out
+
+  Examples
+
+    Show all outdated dependencies
+
+    ​vlt outdated
+
+    Only check the 'foo' and 'bar' packages
+
+    ​vlt outdated foo bar
+
+    Only check direct dependencies of the project root
+
+    ​vlt outdated :root > *
+
+    Output the results as JSON
+
+    ​vlt outdated --view=json
+
+  Options
+
+    view
+      Output format. Defaults to human-readable or json if no tty.
+
+      ​--view=[human | json]
+
+`

--- a/src/cli-sdk/tap-snapshots/test/config/definition.ts.test.cjs
+++ b/src/cli-sdk/tap-snapshots/test/config/definition.ts.test.cjs
@@ -10,6 +10,7 @@ Object {
   "?": "help",
   "access": "access",
   "add": "install",
+  "audit": "audit",
   "b": "build",
   "bugs": "bugs",
   "build": "build",
@@ -23,6 +24,7 @@ Object {
   "exec": "exec",
   "exec-cache": "exec-cache",
   "exec-local": "exec-local",
+  "fund": "fund",
   "h": "help",
   "help": "help",
   "i": "install",
@@ -33,6 +35,8 @@ Object {
   "login": "login",
   "logout": "logout",
   "ls": "list",
+  "out": "outdated",
+  "outdated": "outdated",
   "p": "pkg",
   "pack": "pack",
   "ping": "ping",
@@ -196,6 +200,7 @@ Object {
     "type": "string",
     "validOptions": Array [
       "access",
+      "audit",
       "bugs",
       "build",
       "cache",
@@ -207,6 +212,7 @@ Object {
       "docs",
       "exec",
       "exec-local",
+      "fund",
       "help",
       "init",
       "install",
@@ -214,6 +220,7 @@ Object {
       "logout",
       "list",
       "ls",
+      "outdated",
       "pack",
       "ping",
       "pkg",
@@ -346,6 +353,30 @@ Object {
   "lockfile-only": Object {
     "description": "Only update the lockfile (vlt-lock.json) and package.json files, skip all node_modules operations including package extraction and filesystem changes.",
     "type": "boolean",
+  },
+  "loglevel": Object {
+    "description": String(
+      Sets the verbosity of diagnostic logging written to stderr (registry requests, warnings, etc). This is independent of \`--view\`, which controls a command's result output on stdout.
+      
+      - silent: No diagnostic logging.
+      - error: Only errors.
+      - warn: Errors and warnings.
+      - info: Default. High-level progress.
+      - verbose: Adds per-request logging (each registry URL with its cache/stale/fetch outcome and status code).
+      - debug: Everything, including low-level detail.
+      
+      \`--verbose\` is shorthand for \`--loglevel=verbose\`.
+    ),
+    "hint": "level",
+    "type": "string",
+    "validOptions": Array [
+      "silent",
+      "error",
+      "warn",
+      "info",
+      "verbose",
+      "debug",
+    ],
   },
   "no-bail": Object {
     "description": "When running scripts across multiple workspaces, continue on failure, running the script for all workspaces.",
@@ -514,6 +545,10 @@ Object {
     ),
     "type": "boolean",
   },
+  "verbose": Object {
+    "description": "Shorthand for \`--loglevel=verbose\`. Streams each registry request to stderr with its cache/fetch outcome and status code, useful for debugging request behavior.",
+    "type": "boolean",
+  },
   "version": Object {
     "description": "Print the version",
     "short": "v",
@@ -609,6 +644,7 @@ Array [
   "--jsr-registries=<name=url>",
   "--libc=<libc>",
   "--lockfile-only",
+  "--loglevel=<level>",
   "--no-bail",
   "--no-color",
   "--node-version=<version>",
@@ -632,6 +668,7 @@ Array [
   "--tag=<tag>",
   "--target=<query>",
   "--telemetry",
+  "--verbose",
   "--version",
   "--view=<output>",
   "--workspace=<ws>",
@@ -674,6 +711,7 @@ Array [
   "jsr-registries",
   "libc",
   "lockfile-only",
+  "loglevel",
   "no-bail",
   "no-color",
   "node-version",
@@ -697,6 +735,7 @@ Array [
   "tag",
   "target",
   "telemetry",
+  "verbose",
   "version",
   "view",
   "workspace",

--- a/src/cli-sdk/tap-snapshots/test/index.ts.test.cjs
+++ b/src/cli-sdk/tap-snapshots/test/index.ts.test.cjs
@@ -66,6 +66,7 @@ Unknown option '--unknown'. To specify a positional argument starting with a '-'
     --jsr-registries=<name=url>
     --libc=<libc>
     --lockfile-only
+    --loglevel=<level>
     --no-bail
     --no-color
     --node-version=<version>
@@ -89,6 +90,7 @@ Unknown option '--unknown'. To specify a positional argument starting with a '-'
     --tag=<tag>
     --target=<query>
     --telemetry
+    --verbose
     --version
     --view=<output>
     --workspace=<ws>
@@ -134,6 +136,7 @@ Unknown config option: asdf
     jsr-registries
     libc
     lockfile-only
+    loglevel
     no-bail
     no-color
     node-version
@@ -157,6 +160,7 @@ Unknown config option: asdf
     tag
     target
     telemetry
+    verbose
     version
     view
     workspace

--- a/src/cli-sdk/tap-snapshots/test/print-err.ts.test.cjs
+++ b/src/cli-sdk/tap-snapshots/test/print-err.ts.test.cjs
@@ -154,6 +154,51 @@ exports[`test/print-err.ts > TAP > snapshots > ERESOLVE > basic > output no file
 Resolve Error: bloopy doop
 `
 
+exports[`test/print-err.ts > TAP > snapshots > ERESOLVE > spec-object > file 1`] = `
+Error: missing tarball
+    at {STACK_LINE} {
+  [cause]: {
+    code: 'ERESOLVE',
+    spec: {
+      type: 'registry',
+      spec: 'next@*',
+      toString: [Function: toString]
+    }
+  }
+}
+`
+
+exports[`test/print-err.ts > TAP > snapshots > ERESOLVE > spec-object > output 1`] = `
+Resolve Error: missing tarball
+  To satisfy: next@*
+
+Full details written to: {CWD}/.tap/fixtures/test-print-err.ts-snapshots-ERESOLVE-spec-object/vlt/error-logs/error-123.log
+`
+
+exports[`test/print-err.ts > TAP > snapshots > ERESOLVE > spec-object > output no file 1`] = `
+Resolve Error: missing tarball
+  To satisfy: next@*
+`
+
+exports[`test/print-err.ts > TAP > snapshots > ERESOLVE > spec-plain > file 1`] = `
+Error: missing tarball
+    at {STACK_LINE} {
+  [cause]: { code: 'ERESOLVE', spec: { type: 'registry', spec: 'x@1' } }
+}
+`
+
+exports[`test/print-err.ts > TAP > snapshots > ERESOLVE > spec-plain > output 1`] = `
+Resolve Error: missing tarball
+  To satisfy: { type: 'registry', spec: 'x@1' }
+
+Full details written to: {CWD}/.tap/fixtures/test-print-err.ts-snapshots-ERESOLVE-spec-plain/vlt/error-logs/error-123.log
+`
+
+exports[`test/print-err.ts > TAP > snapshots > ERESOLVE > spec-plain > output no file 1`] = `
+Resolve Error: missing tarball
+  To satisfy: { type: 'registry', spec: 'x@1' }
+`
+
 exports[`test/print-err.ts > TAP > snapshots > ERESOLVE > url > file 1`] = `
 Error: bloopy doop
     at {STACK_LINE} {

--- a/src/cli-sdk/test/commands/audit.ts
+++ b/src/cli-sdk/test/commands/audit.ts
@@ -1,0 +1,421 @@
+import t from 'tap'
+import { PathScurry } from 'path-scurry'
+import * as Graph from '@vltpkg/graph'
+import { PackageJson } from '@vltpkg/package-json'
+import { Spec } from '@vltpkg/spec'
+import type { SpecOptions } from '@vltpkg/spec'
+import type { Test } from 'tap'
+import type { LoadedConfig } from '../../src/config/index.ts'
+import type {
+  AuditResult,
+  AuditFinding,
+} from '../../src/commands/audit.ts'
+import type { Insights } from '@vltpkg/query'
+
+t.cleanSnapshot = s =>
+  s.replace(/^(\s+)"location": ".*"/gm, '$1"location": "{LOC}"')
+
+const specOptions = {
+  registry: 'https://registry.npmjs.org/',
+  registries: {
+    npm: 'https://registry.npmjs.org/',
+  },
+} satisfies SpecOptions
+
+const mainManifest = {
+  name: 'my-project',
+  version: '1.0.0',
+  dependencies: {
+    foo: '^1.0.0',
+    bar: '^1.0.0',
+    baz: '^1.0.0',
+    qux: '^1.0.0',
+    clean: '^1.0.0',
+  },
+}
+
+const buildGraph = () => {
+  const graph = new Graph.Graph({
+    projectRoot: t.testdirName,
+    ...specOptions,
+    mainManifest,
+  })
+  for (const name of ['foo', 'bar', 'baz', 'qux', 'clean']) {
+    graph.placePackage(
+      graph.mainImporter,
+      'prod',
+      Spec.parse(name, '^1.0.0', specOptions),
+      { name, version: '1.0.0' },
+    )
+  }
+  return graph
+}
+
+const score = {
+  overall: 0.5,
+  license: 0.5,
+  maintenance: 0.5,
+  quality: 0.5,
+  supplyChain: 0.5,
+  vulnerability: 0.5,
+}
+
+// keyed by package name; matched against the node's DepID string
+const reports: Record<
+  string,
+  { score: typeof score; alerts: any[] }
+> = {
+  foo: {
+    score,
+    alerts: [
+      { type: 'malware', severity: 'critical', category: 'malware' },
+      {
+        type: 'cve',
+        severity: 'high',
+        category: 'vulnerability',
+        props: { cveId: 'CVE-2023-1', cwes: [{ id: 'CWE-79' }] },
+      },
+    ],
+  },
+  bar: {
+    score,
+    alerts: [
+      {
+        type: 'deprecated',
+        severity: 'low',
+        category: 'maintenance',
+      },
+    ],
+  },
+  baz: {
+    score,
+    alerts: [
+      {
+        type: 'copyleftLicense',
+        severity: 'low',
+        category: 'license',
+      },
+    ],
+  },
+  qux: {
+    score,
+    alerts: [
+      { type: 'usesEval', severity: 'low', category: 'capability' },
+    ],
+  },
+}
+
+const reportFor = (id: string) => {
+  for (const [name, report] of Object.entries(reports)) {
+    if (id.includes(`${name}@`)) return report
+  }
+  return undefined
+}
+
+const securityArchive = {
+  ok: true,
+  has: (id: string) => !!reportFor(id),
+  get: (id: string) => reportFor(id),
+}
+
+const mockAudit = async (
+  t: Test,
+  { graph = buildGraph() }: { graph?: Graph.Graph } = {},
+) =>
+  t.mockImport<typeof import('../../src/commands/audit.ts')>(
+    '../../src/commands/audit.ts',
+    {
+      '@vltpkg/graph': t.createMock(Graph, {
+        actual: { load: () => graph },
+      }),
+      '@vltpkg/security-archive': {
+        SecurityArchive: {
+          async start() {
+            return securityArchive
+          },
+        },
+      },
+    },
+  )
+
+const makeConfig = ({
+  positionals = [],
+  values = {},
+  hasManifest = true,
+}: {
+  positionals?: string[]
+  values?: Partial<LoadedConfig['values']>
+  hasManifest?: boolean
+} = {}): LoadedConfig => {
+  const packageJson = new PackageJson()
+  packageJson.maybeRead = () =>
+    hasManifest ? mainManifest : undefined
+  return {
+    positionals,
+    values,
+    get: (key: string) => (values as Record<string, unknown>)[key],
+    options: {
+      ...specOptions,
+      projectRoot: t.testdirName,
+      scurry: new PathScurry(),
+      packageJson,
+    },
+  } as unknown as LoadedConfig
+}
+
+t.test('usage', async t => {
+  const Command = await mockAudit(t)
+  t.matchSnapshot(Command.usage().usage(), 'should have usage')
+})
+
+t.test('insightsToFindings', async t => {
+  const { insightsToFindings } = await mockAudit(t)
+
+  const base: Insights = { scanned: true }
+  t.strictSame(
+    insightsToFindings(base),
+    [],
+    'no insights means no findings',
+  )
+
+  const kitchenSink: Insights = {
+    scanned: true,
+    malware: { low: true, medium: true, high: true, critical: true },
+    severity: {
+      low: false,
+      medium: false,
+      high: false,
+      critical: true,
+    },
+    cve: ['CVE-2020-1'],
+    cwe: ['CWE-79'],
+    squat: { medium: false, critical: true },
+    confused: true,
+    obfuscated: true,
+    suspicious: true,
+    undesirable: true,
+    entropic: true,
+    minified: true,
+    license: {
+      unlicensed: true,
+      misc: true,
+      restricted: true,
+      ambiguous: true,
+      copyleft: true,
+      unknown: true,
+      none: true,
+      exception: false,
+    },
+    deprecated: true,
+    abandoned: true,
+    unmaintained: true,
+    unpopular: true,
+    unstable: true,
+    unknown: true,
+    trivial: true,
+    eval: true,
+    shell: true,
+    network: true,
+    fs: true,
+    env: true,
+    dynamic: true,
+    debug: true,
+    native: true,
+    tracker: true,
+    scripts: true,
+    shrinkwrap: true,
+  }
+  t.matchSnapshot(
+    insightsToFindings(kitchenSink),
+    'covers every finding branch',
+  )
+
+  const highSev: Insights = {
+    scanned: true,
+    severity: {
+      low: false,
+      medium: false,
+      high: true,
+      critical: false,
+    },
+  }
+  t.equal(
+    insightsToFindings(highSev)[0]?.severity,
+    'high',
+    'high severity vulnerability',
+  )
+
+  const medSev: Insights = {
+    scanned: true,
+    severity: {
+      low: false,
+      medium: true,
+      high: false,
+      critical: false,
+    },
+    squat: { medium: true, critical: false },
+  }
+  const medFindings = insightsToFindings(medSev)
+  t.equal(
+    medFindings[0]?.severity,
+    'medium',
+    'potential vulnerability',
+  )
+  t.ok(
+    medFindings.some(f => f.category === 'typosquat'),
+    'possible typosquat',
+  )
+
+  const lowSev: Insights = {
+    scanned: true,
+    severity: {
+      low: true,
+      medium: false,
+      high: false,
+      critical: false,
+    },
+  }
+  t.equal(
+    insightsToFindings(lowSev)[0]?.severity,
+    'low',
+    'low severity vulnerability',
+  )
+
+  const cveOnly: Insights = { scanned: true, cve: ['CVE-2021-9'] }
+  const cveFinding = insightsToFindings(cveOnly)[0]
+  t.equal(cveFinding?.severity, 'high', 'bare cve treated as high')
+  t.match(
+    cveFinding?.description,
+    /CVE-2021-9/,
+    'includes the cve id',
+  )
+})
+
+t.test('command - no project manifest', async t => {
+  const Command = await mockAudit(t)
+  const res = await Command.command(
+    makeConfig({ hasManifest: false }),
+  )
+  t.equal(res.packagesAffected, 0, 'nothing to audit')
+  t.equal(res.packagesScanned, 0, 'nothing scanned')
+})
+
+t.test('command - default audit', async t => {
+  const Command = await mockAudit(t)
+  const res = await Command.command(makeConfig())
+
+  t.equal(res.queryString, ':scanned', 'defaults to :scanned')
+  t.equal(res.packagesScanned, 4, 'foo, bar, baz and qux are scanned')
+  t.strictSame(
+    res.reports.map(r => r.name),
+    ['foo', 'bar', 'baz'],
+    'sorted by severity then name, qux (low only) omitted',
+  )
+  t.equal(res.summary.critical, 1)
+  t.equal(res.summary.high, 1)
+  t.equal(res.summary.medium, 2)
+  t.equal(res.summary.low, 0)
+
+  t.matchSnapshot(Command.views.json(res), 'json view')
+  t.matchSnapshot(
+    Command.views.human(res, { colors: false }),
+    'human view (no colors)',
+  )
+  t.matchSnapshot(
+    Command.views.human(res, { colors: true }),
+    'human view (colors)',
+  )
+  t.matchSnapshot(
+    Command.views.human(res),
+    'human view (default opts)',
+  )
+})
+
+t.test('command - include low severity with --all', async t => {
+  const Command = await mockAudit(t)
+  const res = await Command.command(
+    makeConfig({ values: { all: true } }),
+  )
+  t.equal(res.showAll, true)
+  t.equal(res.summary.low, 1, 'qux eval capability included')
+  t.strictSame(
+    res.reports.map(r => r.name),
+    ['foo', 'bar', 'baz', 'qux'],
+    'qux now included',
+  )
+  t.matchSnapshot(
+    Command.views.human(res, { colors: false }),
+    'human view with low severity findings',
+  )
+})
+
+t.test('command - positional query', async t => {
+  const Command = await mockAudit(t)
+  const res = await Command.command(
+    makeConfig({ positionals: ['#foo'] }),
+  )
+  t.equal(res.queryString, '#foo', 'uses the provided query')
+  t.strictSame(
+    res.reports.map(r => r.name),
+    ['foo'],
+    'only audits the queried package',
+  )
+})
+
+t.test('human view - no findings', async t => {
+  const Command = await mockAudit(t)
+
+  const singular: AuditResult = {
+    reports: [],
+    summary: { critical: 0, high: 0, medium: 0, low: 0, total: 0 },
+    packagesAffected: 0,
+    packagesScanned: 1,
+    queryString: ':scanned',
+    showAll: false,
+  }
+  t.matchSnapshot(
+    Command.views.human(singular, { colors: false }),
+    'no issues, one package scanned',
+  )
+
+  const plural: AuditResult = { ...singular, packagesScanned: 0 }
+  t.matchSnapshot(
+    Command.views.human(plural, { colors: true }),
+    'no issues, zero packages scanned',
+  )
+})
+
+t.test('human view - all severities, no version', async t => {
+  const Command = await mockAudit(t)
+  const finding = (
+    severity: AuditFinding['severity'],
+  ): AuditFinding => ({
+    severity,
+    category: 'test',
+    description: `${severity} issue`,
+  })
+  const res: AuditResult = {
+    reports: [
+      {
+        id: 'sole',
+        name: 'sole',
+        worst: 'critical',
+        findings: [
+          finding('critical'),
+          finding('high'),
+          finding('medium'),
+          finding('low'),
+        ],
+      },
+    ],
+    summary: { critical: 1, high: 1, medium: 1, low: 1, total: 4 },
+    packagesAffected: 1,
+    packagesScanned: 1,
+    queryString: ':scanned',
+    showAll: true,
+  }
+  t.matchSnapshot(
+    Command.views.human(res, { colors: true }),
+    'renders every severity level without a version',
+  )
+})

--- a/src/cli-sdk/test/commands/fund.ts
+++ b/src/cli-sdk/test/commands/fund.ts
@@ -1,0 +1,274 @@
+import t from 'tap'
+import { PathScurry } from 'path-scurry'
+import * as Graph from '@vltpkg/graph'
+import { PackageJson } from '@vltpkg/package-json'
+import { Spec } from '@vltpkg/spec'
+import { Monorepo } from '@vltpkg/workspaces'
+import { unload } from '@vltpkg/vlt-json'
+import type { SpecOptions } from '@vltpkg/spec'
+import type { Test } from 'tap'
+import type { LoadedConfig } from '../../src/config/index.ts'
+
+const specOptions = {
+  registry: 'https://registry.npmjs.org/',
+  registries: {
+    npm: 'https://registry.npmjs.org/',
+  },
+} satisfies SpecOptions
+
+const sharedOptions = {
+  scurry: new PathScurry(),
+  packageJson: new PackageJson(),
+}
+
+const graph = new Graph.Graph({
+  projectRoot: t.testdirName,
+  ...specOptions,
+  mainManifest: {
+    name: 'my-project',
+    version: '1.0.0',
+    dependencies: {
+      foo: '^1.0.0',
+      bar: '^1.0.0',
+      baz: '^1.0.0',
+      'empty-fund': '^1.0.0',
+      'no-funding': '^1.0.0',
+    },
+  },
+})
+graph.placePackage(
+  graph.mainImporter,
+  'prod',
+  Spec.parse('foo', '^1.0.0', specOptions),
+  {
+    name: 'foo',
+    version: '1.0.0',
+    funding: [
+      {
+        url: 'https://opencollective.com/foo',
+        type: 'opencollective',
+      },
+    ],
+  },
+)
+graph.placePackage(
+  graph.mainImporter,
+  'prod',
+  Spec.parse('bar', '^1.0.0', specOptions),
+  {
+    name: 'bar',
+    version: '2.0.0',
+    funding: [
+      { url: 'https://github.com/sponsors/bar', type: 'github' },
+    ],
+  },
+)
+// shares a funding url with foo, plus a second unique url
+graph.placePackage(
+  graph.mainImporter,
+  'prod',
+  Spec.parse('baz', '^1.0.0', specOptions),
+  {
+    name: 'baz',
+    version: '3.0.0',
+    funding: [
+      {
+        url: 'https://opencollective.com/foo',
+        type: 'opencollective',
+      },
+      { url: 'https://patreon.com/baz', type: 'patreon' },
+    ],
+  },
+)
+// funding field present but with no usable url -> filtered out
+graph.placePackage(
+  graph.mainImporter,
+  'prod',
+  Spec.parse('empty-fund', '^1.0.0', specOptions),
+  {
+    name: 'empty-fund',
+    version: '1.0.0',
+    funding: [{ url: '', type: 'individual' }],
+  },
+)
+// no funding at all
+graph.placePackage(
+  graph.mainImporter,
+  'prod',
+  Spec.parse('no-funding', '^1.0.0', specOptions),
+  {
+    name: 'no-funding',
+    version: '1.0.0',
+  },
+)
+
+const mockFund = async (
+  t: Test,
+  { graph: g = graph, ...mocks }: Record<string, any> = {},
+) =>
+  t.mockImport<typeof import('../../src/commands/fund.ts')>(
+    '../../src/commands/fund.ts',
+    {
+      '@vltpkg/graph': t.createMock(Graph, {
+        actual: {
+          load: () => g,
+        },
+      }),
+      ...mocks,
+    },
+  )
+
+const Command = await mockFund(t)
+
+const runCommand = async (
+  {
+    options = {},
+    positionals = [],
+    values,
+  }: {
+    options?: object
+    positionals?: string[]
+    values: Partial<LoadedConfig['values']> & {
+      view: Exclude<LoadedConfig['values']['view'], 'inspect'>
+    }
+  },
+  cmd = Command,
+) => {
+  const config = {
+    options,
+    positionals,
+    values,
+    get: (key: string) => (values as any)[key],
+  } as LoadedConfig
+  const res = await cmd.command(config)
+  const output =
+    values.view === 'human' ?
+      cmd.views.human(res, { colors: values.color })
+    : cmd.views.json(res)
+  return values.view === 'json' ?
+      JSON.stringify(output, null, 2)
+    : output
+}
+
+t.test('fund', async t => {
+  t.matchSnapshot(Command.usage().usage(), 'should have usage')
+
+  sharedOptions.packageJson.read = () => graph.mainImporter.manifest!
+  const options = {
+    ...sharedOptions,
+    projectRoot: t.testdirName,
+  }
+
+  t.matchSnapshot(
+    await runCommand({
+      positionals: [],
+      values: { view: 'human' },
+      options,
+    }),
+    'should list funded pkgs in human readable format',
+  )
+
+  t.matchSnapshot(
+    await runCommand({
+      positionals: [],
+      values: { view: 'human', color: true },
+      options,
+    }),
+    'should use colors when set in human readable format',
+  )
+
+  t.matchSnapshot(
+    await runCommand({
+      positionals: [],
+      values: { view: 'json' },
+      options,
+    }),
+    'should list funded pkgs in json format',
+  )
+
+  t.matchSnapshot(
+    await runCommand({
+      positionals: ['foo'],
+      values: { view: 'human' },
+      options,
+    }),
+    'should scope report to named packages',
+  )
+})
+
+t.test('no funded dependencies', async t => {
+  const emptyGraph = new Graph.Graph({
+    projectRoot: t.testdirName,
+    ...specOptions,
+    mainManifest: {
+      name: 'my-project',
+      version: '1.0.0',
+      dependencies: { plain: '^1.0.0' },
+    },
+  })
+  emptyGraph.placePackage(
+    emptyGraph.mainImporter,
+    'prod',
+    Spec.parse('plain', '^1.0.0', specOptions),
+    { name: 'plain', version: '1.0.0' },
+  )
+
+  sharedOptions.packageJson.read = () =>
+    emptyGraph.mainImporter.manifest!
+  const options = {
+    ...sharedOptions,
+    projectRoot: t.testdirName,
+  }
+
+  const Command = await mockFund(t, { graph: emptyGraph })
+
+  t.matchSnapshot(
+    await runCommand(
+      {
+        positionals: [],
+        values: { view: 'human' },
+        options,
+      },
+      Command,
+    ),
+    'should report that no funding was found',
+  )
+
+  t.equal(
+    await runCommand(
+      {
+        positionals: [],
+        values: { view: 'json' },
+        options,
+      },
+      Command,
+    ),
+    JSON.stringify([], null, 2),
+    'should return an empty json array',
+  )
+})
+
+t.test('no package.json in project root', async t => {
+  const dir = t.testdir()
+  t.chdir(dir)
+  unload()
+
+  const Command = await mockFund(t)
+  const options = {
+    scurry: new PathScurry(dir),
+    packageJson: new PackageJson(),
+    projectRoot: dir,
+    monorepo: Monorepo.maybeLoad(dir),
+  }
+
+  t.strictSame(
+    await Command.command({
+      options,
+      positionals: [],
+      values: { view: 'json' },
+      get: () => undefined,
+    } as unknown as LoadedConfig),
+    { reports: [] },
+    'should return no reports when there is no graph',
+  )
+})

--- a/src/cli-sdk/test/commands/outdated.ts
+++ b/src/cli-sdk/test/commands/outdated.ts
@@ -1,0 +1,406 @@
+import t from 'tap'
+import type { Test } from 'tap'
+import type { LoadedConfig } from '../../src/config/index.ts'
+import type {
+  OutdatedReport,
+  OutdatedResult,
+} from '../../src/commands/outdated.ts'
+
+// Import the real module for view + pure-function tests.
+const real = await import('../../src/commands/outdated.ts')
+
+t.test('usage', async t => {
+  t.matchSnapshot(real.usage().usage(), 'should have usage')
+})
+
+t.test('highestSatisfying', async t => {
+  t.equal(
+    real.highestSatisfying(['1.0.0', '1.5.0', '2.0.0'], '^1.0.0'),
+    '1.5.0',
+    'returns the highest in-range version',
+  )
+  t.equal(
+    real.highestSatisfying(['1.0.0', '2.0.0'], undefined),
+    undefined,
+    'returns undefined when no range provided',
+  )
+  t.equal(
+    real.highestSatisfying([], '^1.0.0'),
+    undefined,
+    'returns undefined when no versions available',
+  )
+})
+
+const reports: OutdatedReport[] = [
+  {
+    // major bump -> name red, latest red
+    name: 'foo',
+    current: '1.0.0',
+    wanted: '1.5.0',
+    latest: '2.0.0',
+    type: 'prod',
+    dependedBy: 'my-project',
+    location: 'node_modules/foo',
+  },
+  {
+    // minor bump -> latest cyan, no range so wanted falls back to current
+    name: 'bar',
+    current: '1.0.0',
+    wanted: undefined,
+    latest: '1.2.0',
+    type: 'dev',
+    dependedBy: 'my-project',
+  },
+  {
+    // patch bump -> latest green, wanted == current (no diff highlight)
+    name: 'qux',
+    current: '1.0.0',
+    wanted: '1.0.0',
+    latest: '1.0.1',
+    type: 'optional',
+    dependedBy: 'my-project',
+  },
+  {
+    // missing packument -> unknown latest
+    name: 'baz',
+    current: '1.0.0',
+    wanted: undefined,
+    latest: undefined,
+    type: 'peer',
+    dependedBy: 'bar',
+  },
+  {
+    // installed version unknown -> highlightDiff receives no `from`
+    name: 'nover',
+    current: undefined,
+    wanted: '1.0.0',
+    latest: '1.0.0',
+    type: 'peerOptional',
+    dependedBy: 'my-project',
+  },
+  {
+    // nothing is known -> every version column falls back to a placeholder
+    name: 'unknown',
+    current: undefined,
+    wanted: undefined,
+    latest: undefined,
+    type: 'prod',
+    dependedBy: 'my-project',
+  },
+]
+
+t.test('human view', async t => {
+  t.matchSnapshot(
+    real.views.human({ reports }, { colors: false }),
+    'renders a table without colors',
+  )
+  t.matchSnapshot(
+    real.views.human({ reports }, { colors: true }),
+    'renders a table with colors',
+  )
+  t.matchSnapshot(
+    real.views.human({ reports: [reports[0]!] }, { colors: false }),
+    'uses singular wording for a single package',
+  )
+  t.equal(
+    real.views.human({ reports: [] }, { colors: false }),
+    'All dependencies are up to date.',
+    'reports when everything is up to date',
+  )
+})
+
+t.test('json view', async t => {
+  t.strictSame(
+    real.views.json({ reports }),
+    reports,
+    'returns the raw reports array',
+  )
+})
+
+// ---------------------------------------------------------------------------
+// Command integration tests (graph + query + registry fully mocked)
+// ---------------------------------------------------------------------------
+
+type FakeNode = {
+  id: string
+  name?: string
+  version?: string
+  importer: boolean
+  location?: string
+}
+
+type FakeEdge = {
+  name: string
+  type: string
+  spec: { final: { range?: string } }
+  from: { name?: string; id: string }
+  to?: FakeNode
+}
+
+const packuments: Record<
+  string,
+  {
+    'dist-tags': Record<string, string>
+    versions: Record<string, unknown>
+  }
+> = {
+  foo: {
+    'dist-tags': { latest: '2.0.0' },
+    versions: { '1.0.0': {}, '1.5.0': {}, '2.0.0': {} },
+  },
+  bar: {
+    'dist-tags': { latest: '1.2.0' },
+    versions: { '1.0.0': {}, '1.2.0': {} },
+  },
+  qux: {
+    'dist-tags': { latest: '1.0.1' },
+    versions: { '1.0.0': {}, '1.0.1': {} },
+  },
+  nover: {
+    'dist-tags': { latest: '1.0.0' },
+    versions: { '1.0.0': {} },
+  },
+  anon: {
+    'dist-tags': { latest: '2.0.0' },
+    versions: { '1.0.0': {}, '2.0.0': {} },
+  },
+}
+
+const nodeFoo: FakeNode = {
+  id: 'registry;;foo@1.0.0',
+  name: 'foo',
+  version: '1.0.0',
+  importer: false,
+  location: 'node_modules/foo',
+}
+const nodeBar: FakeNode = {
+  id: 'registry;;bar@1.0.0',
+  name: 'bar',
+  version: '1.0.0',
+  importer: false,
+}
+const nodeQux: FakeNode = {
+  id: 'registry;;qux@1.0.0',
+  name: 'qux',
+  version: '1.0.0',
+  importer: false,
+}
+const nodeBaz: FakeNode = {
+  id: 'registry;;baz@1.0.0',
+  name: 'baz',
+  version: '1.0.0',
+  importer: false,
+}
+const nodeNover: FakeNode = {
+  id: 'registry;;nover@1.0.0',
+  name: 'nover',
+  version: undefined,
+  importer: false,
+}
+const nodeWorkspace: FakeNode = {
+  id: 'workspace;packages/a',
+  name: 'a',
+  version: '1.0.0',
+  importer: true,
+}
+const nodeFile: FakeNode = {
+  id: 'file;.',
+  name: 'local-thing',
+  version: '1.0.0',
+  importer: false,
+}
+const nodeGhost: FakeNode = {
+  id: 'registry;;ghost@1.0.0',
+  name: 'ghost',
+  version: '1.0.0',
+  importer: false,
+}
+const nodeAnon: FakeNode = {
+  // no name -> the edge name is used instead
+  id: 'registry;;anon@1.0.0',
+  name: undefined,
+  version: '1.0.0',
+  importer: false,
+}
+
+const mkEdge = (
+  to: FakeNode | undefined,
+  name: string,
+  range: string | undefined,
+  type: string,
+  from = 'my-project',
+): FakeEdge => ({
+  name,
+  type,
+  spec: { final: { range } },
+  from: { name: from, id: 'file;.' },
+  to,
+})
+
+const resultNodes = [
+  nodeFoo,
+  nodeBar,
+  nodeQux,
+  nodeBaz,
+  nodeNover,
+  nodeAnon,
+  nodeWorkspace,
+  nodeFile,
+]
+
+const resultEdges: FakeEdge[] = [
+  mkEdge(nodeFoo, 'foo', '^1.0.0', 'prod'),
+  mkEdge(nodeBar, 'bar', undefined, 'dev'),
+  // two dependents on the same node exercises the packument cache
+  mkEdge(nodeQux, 'qux', '^1.0.0', 'optional', 'my-project'),
+  mkEdge(nodeQux, 'qux', '^1.0.0', 'optional', 'bar'),
+  mkEdge(nodeBaz, 'baz', '^1.0.0', 'peer', 'bar'),
+  mkEdge(nodeNover, 'nover', '^1.0.0', 'peerOptional'),
+  // node without a name + dependent without a name
+  {
+    ...mkEdge(nodeAnon, 'anon', '^1.0.0', 'prod'),
+    from: { id: 'file;.' },
+  },
+  // excluded: importer node
+  mkEdge(nodeWorkspace, 'a', '^1.0.0', 'prod'),
+  // excluded: non-registry node
+  mkEdge(nodeFile, 'local-thing', '^1.0.0', 'prod'),
+  // excluded: node not present in the result set
+  mkEdge(nodeGhost, 'ghost', '^1.0.0', 'prod'),
+  // excluded: no destination node
+  mkEdge(undefined, 'gone', '^1.0.0', 'prod'),
+]
+
+let capturedQuery: string | undefined
+
+const mockGraph = {
+  nodes: new Map(resultNodes.map(n => [n.id, n])),
+  edges: new Set(resultEdges),
+  importers: new Set([nodeWorkspace]),
+}
+
+const loadCommand = async (t: Test) =>
+  t.mockImport<typeof import('../../src/commands/outdated.ts')>(
+    '../../src/commands/outdated.ts',
+    {
+      '@vltpkg/graph': {
+        actual: { load: () => mockGraph },
+        GraphModifier: { maybeLoad: () => undefined },
+      },
+      '@vltpkg/query': {
+        Query: class {
+          async search(query: string) {
+            capturedQuery = query
+            return {
+              edges: resultEdges,
+              nodes: resultNodes,
+              importers: [],
+            }
+          }
+        },
+      },
+      '@vltpkg/dep-id': {
+        hydrate: (_id: string, name: string) => ({ name }),
+        splitDepID: (id: string) => id.split(';'),
+      },
+      '@vltpkg/package-info': {
+        PackageInfoClient: class {
+          async packument(spec: { name: string }) {
+            const p = packuments[spec.name]
+            if (!p) throw new Error('404')
+            return p
+          }
+        },
+      },
+    },
+  )
+
+const makeConfig = (
+  positionals: string[],
+  values: Record<string, unknown>,
+  options: Record<string, unknown> = {},
+  mainManifest: unknown = { name: 'my-project', version: '1.0.0' },
+): LoadedConfig =>
+  ({
+    positionals,
+    values,
+    get: (k: string) => values[k],
+    options: {
+      projectRoot: '/test/project',
+      packageJson: { maybeRead: () => mainManifest },
+      ...options,
+    },
+  }) as unknown as LoadedConfig
+
+t.test('command', async t => {
+  t.beforeEach(() => {
+    capturedQuery = undefined
+  })
+
+  await t.test('default report', async t => {
+    const Command = await loadCommand(t)
+    const res: OutdatedResult = await Command.command(
+      makeConfig([], { view: 'human' }),
+    )
+    t.equal(capturedQuery, '*:outdated', 'builds the default query')
+    const names = res.reports.map(r => r.name).sort()
+    t.strictSame(
+      names,
+      ['anon', 'bar', 'baz', 'foo', 'nover', 'qux', 'qux'],
+      'includes only registry, non-importer deps with a destination',
+    )
+    const anon = res.reports.find(r => r.name === 'anon')
+    t.equal(
+      anon?.dependedBy,
+      'file;.',
+      'falls back to the dependent id',
+    )
+    t.matchSnapshot(
+      real.views.human(res, { colors: false }),
+      'rendered default report',
+    )
+  })
+
+  await t.test('positional package names', async t => {
+    const Command = await loadCommand(t)
+    await Command.command(
+      makeConfig(['foo', '@scope/pkg'], { view: 'human' }),
+    )
+    t.equal(
+      capturedQuery,
+      '#foo:outdated, #@scope\\/pkg:outdated',
+      'scopes the query to the requested package names',
+    )
+  })
+
+  await t.test('workspace filter', async t => {
+    const Command = await loadCommand(t)
+    const monorepo = {
+      filter: () => [{ id: nodeWorkspace.id }],
+    }
+    await Command.command(
+      makeConfig(
+        [],
+        { view: 'human', workspace: ['a'] },
+        { monorepo },
+      ),
+    )
+    t.equal(
+      capturedQuery,
+      '*:outdated',
+      'still runs the outdated query',
+    )
+  })
+
+  await t.test('no project graph', async t => {
+    const Command = await loadCommand(t)
+    const res: OutdatedResult = await Command.command(
+      makeConfig([], { view: 'json' }, {}, null),
+    )
+    t.strictSame(
+      res.reports,
+      [],
+      'returns no reports without a graph',
+    )
+  })
+})

--- a/src/cli-sdk/test/config/index.ts
+++ b/src/cli-sdk/test/config/index.ts
@@ -1049,6 +1049,45 @@ t.test('read catalogs from config file', async t => {
   )
 })
 
+t.test('--verbose is shorthand for --loglevel=verbose', async t => {
+  const dir = t.testdir({ 'vlt.json': '{}', '.git': {} })
+  t.chdir(dir)
+
+  const { Config } = await t.mockImport<
+    typeof import('../../src/config/index.ts')
+  >('../../src/config/index.ts')
+
+  clearEnv()
+  const def = await Config.load(dir, ['install'], true)
+  t.equal(def.get('loglevel'), 'info', 'defaults to info')
+  t.equal(def.get('verbose'), undefined, 'verbose unset by default')
+
+  clearEnv()
+  const verbose = await Config.load(
+    dir,
+    ['install', '--verbose'],
+    true,
+  )
+  t.equal(verbose.get('verbose'), true)
+  t.equal(
+    verbose.get('loglevel'),
+    'verbose',
+    '--verbose bumps loglevel to verbose',
+  )
+
+  clearEnv()
+  const explicit = await Config.load(
+    dir,
+    ['install', '--verbose', '--loglevel', 'debug'],
+    true,
+  )
+  t.equal(
+    explicit.get('loglevel'),
+    'debug',
+    'explicit --loglevel wins over --verbose',
+  )
+})
+
 t.test('reloadFromDisk method', async t => {
   const projectDir = t.testdir({
     'vlt.json': JSON.stringify({

--- a/src/cli-sdk/test/print-err.ts
+++ b/src/cli-sdk/test/print-err.ts
@@ -152,6 +152,29 @@ t.test('snapshots', async t => {
         response: { statusCode: 200 },
       }),
     )
+    // a spec-like object with a custom toString (like a Spec) prints
+    // concisely (e.g. `next@*`) rather than dumping its internals.
+    await testErr(
+      t,
+      'spec-object',
+      error('missing tarball', {
+        code: 'ERESOLVE',
+        spec: {
+          type: 'registry',
+          spec: 'next@*',
+          toString: () => 'next@*',
+        },
+      }),
+    )
+    // a plain spec object (no custom toString) falls back to `format`.
+    await testErr(
+      t,
+      'spec-plain',
+      error('missing tarball', {
+        code: 'ERESOLVE',
+        spec: { type: 'registry', spec: 'x@1' },
+      }),
+    )
   })
 
   t.test('ECONFIG', async t => {

--- a/src/cli-sdk/test/verbose-log.ts
+++ b/src/cli-sdk/test/verbose-log.ts
@@ -1,0 +1,129 @@
+import { emitter } from '@vltpkg/output'
+import type { Events } from '@vltpkg/output'
+import t from 'tap'
+import {
+  formatRequestEvent,
+  isVerbose,
+  startRequestLog,
+} from '../src/verbose-log.ts'
+
+// A visible style wrapper so we can assert coloring was applied.
+const style = (f: string, s: string) => `<${f}>${s}`
+
+t.test('isVerbose', async t => {
+  t.equal(isVerbose('silent'), false)
+  t.equal(isVerbose('error'), false)
+  t.equal(isVerbose('warn'), false)
+  t.equal(isVerbose('info'), false)
+  t.equal(isVerbose('verbose'), true)
+  t.equal(isVerbose('debug'), true)
+})
+
+t.test('formatRequestEvent', async t => {
+  const cases: [Events['request'], RegExp][] = [
+    [
+      { url: 'https://x/', state: 'cache' },
+      /^cache\s+GET https:\/\/x\/$/,
+    ],
+    [{ url: 'https://x/', state: 'stale' }, /^stale\s+GET/],
+    [{ url: 'https://x/', state: '304' }, /^304\s+GET/],
+    [{ url: 'https://x/', state: 'start' }, /^start\s+GET/],
+    [
+      {
+        url: 'https://x/',
+        state: 'complete',
+        method: 'HEAD',
+        statusCode: 200,
+        durationMs: 12,
+      },
+      /^200\s+HEAD https:\/\/x\/ \(12ms\)$/,
+    ],
+    [
+      { url: 'https://x/', state: 'complete', statusCode: 404 },
+      /^404\s+GET/,
+    ],
+    [{ url: 'https://x/', state: 'complete' }, /GET https:\/\/x\/$/],
+  ]
+  for (const [event, re] of cases) {
+    t.match(formatRequestEvent(event), re, event.state)
+  }
+
+  // with a style function, error statuses use red, others green/gray
+  t.match(
+    formatRequestEvent(
+      { url: 'https://x/', state: 'complete', statusCode: 500 },
+      style,
+    ),
+    /<red>/,
+    '5xx status colored red',
+  )
+  t.match(
+    formatRequestEvent(
+      { url: 'https://x/', state: 'complete', statusCode: 200 },
+      style,
+    ),
+    /<green>/,
+    '2xx status colored green',
+  )
+  t.match(
+    formatRequestEvent({ url: 'https://x/', state: 'start' }, style),
+    /<gray>/,
+    'start colored gray',
+  )
+  t.match(
+    formatRequestEvent(
+      {
+        url: 'https://x/',
+        state: 'complete',
+        statusCode: 200,
+        durationMs: 5,
+      },
+      style,
+    ),
+    /<gray> \(5ms\)/,
+    'duration colored gray',
+  )
+})
+
+t.test('startRequestLog below verbose is a no-op', async t => {
+  const lines: string[] = []
+  const stop = startRequestLog('info', l => lines.push(l))
+  emitter.emit('request', { url: 'https://x/', state: 'cache' })
+  stop()
+  t.strictSame(lines, [], 'nothing logged when loglevel < verbose')
+})
+
+t.test('startRequestLog at verbose skips start events', async t => {
+  const lines: string[] = []
+  const stop = startRequestLog('verbose', l => lines.push(l))
+  emitter.emit('request', { url: 'https://x/', state: 'start' })
+  emitter.emit('request', { url: 'https://x/', state: 'cache' })
+  emitter.emit('request', {
+    url: 'https://x/',
+    state: 'complete',
+    statusCode: 200,
+    durationMs: 3,
+  })
+  stop()
+  // start is skipped at verbose level
+  t.equal(lines.length, 2)
+  t.match(lines[0], /^cache/)
+  t.match(lines[1], /^200/)
+
+  // after stop(), no more logging
+  emitter.emit('request', { url: 'https://x/', state: 'cache' })
+  t.equal(lines.length, 2, 'cleanup detaches the subscription')
+})
+
+t.test('startRequestLog at debug includes start events', async t => {
+  const lines: string[] = []
+  const stop = startRequestLog('debug', l => lines.push(l), style)
+  emitter.emit('request', {
+    url: 'https://x/',
+    state: 'start',
+    method: 'GET',
+  })
+  stop()
+  t.equal(lines.length, 1, 'start is logged at debug level')
+  t.match(lines[0], /start/)
+})

--- a/src/output/src/index.ts
+++ b/src/output/src/index.ts
@@ -4,12 +4,21 @@ export type Events = {
   request: {
     url: URL | string
     state: 'start' | 'complete' | '304' | 'cache' | 'stale'
+    /** HTTP method for the request, when known. */
+    method?: string
+    /** HTTP status code, set on `complete`/`304` completion events. */
+    statusCode?: number
+    /** Wall-clock duration of the request in ms, set on completion. */
+    durationMs?: number
   }
   graphStep: {
     step: 'build' | 'actual' | 'reify'
     state: 'start' | 'stop'
   }
 }
+
+/** Optional diagnostic details attached to a `request` event. */
+export type RequestDetails = Omit<Events['request'], 'url' | 'state'>
 
 export class OutputEmitter {
   private emitter = new EventEmitter()
@@ -40,8 +49,9 @@ export const emitter = new OutputEmitter()
 export const logRequest = (
   url: URL | string,
   state: Events['request']['state'],
+  details: RequestDetails = {},
 ) => {
-  emitter.emit('request', { url, state })
+  emitter.emit('request', { url, state, ...details })
 }
 
 export const graphStep = (step: Events['graphStep']['step']) => {

--- a/src/output/tap-snapshots/test/index.ts.test.cjs
+++ b/src/output/tap-snapshots/test/index.ts.test.cjs
@@ -11,6 +11,18 @@ Array [
     "state": "start",
     "url": "https://example.com",
   },
+  Object {
+    "method": "GET",
+    "state": "cache",
+    "url": "https://example.com",
+  },
+  Object {
+    "durationMs": 12,
+    "method": "GET",
+    "state": "complete",
+    "statusCode": 200,
+    "url": "https://example.com",
+  },
 ]
 `
 

--- a/src/output/test/index.ts
+++ b/src/output/test/index.ts
@@ -14,6 +14,12 @@ t.test('output', async t => {
   emitter.on('graphStep', stepHandler)
 
   logRequest('https://example.com', 'start')
+  logRequest('https://example.com', 'cache', { method: 'GET' })
+  logRequest('https://example.com', 'complete', {
+    method: 'GET',
+    statusCode: 200,
+    durationMs: 12,
+  })
   graphStep('build')()
 
   emitter.off('request', reqHandler)

--- a/src/package-info/src/index.ts
+++ b/src/package-info/src/index.ts
@@ -232,7 +232,10 @@ export class PackageInfoClient {
             throw this.#resolveError(
               spec,
               options,
-              'failed to fetch tarball',
+              `Registry returned HTTP ${response.statusCode} when ` +
+                `fetching the tarball for ${spec}. The resolved version ` +
+                `may have been unpublished, or the registry may be ` +
+                `misconfigured or unreachable.`,
               {
                 url: r.resolved,
                 response,
@@ -486,7 +489,9 @@ export class PackageInfoClient {
           throw this.#resolveError(
             spec,
             options,
-            'no dist object found in manifest',
+            `The registry manifest for ${spec} has no "dist" section, ` +
+              `so no tarball can be resolved. The package version may be ` +
+              `malformed or unpublished.`,
           )
 
         const { tarball, integrity } = dist
@@ -494,7 +499,9 @@ export class PackageInfoClient {
           throw this.#resolveError(
             spec,
             options,
-            'no tarball found in manifest.dist',
+            `The registry manifest for ${spec} is missing a tarball URL ` +
+              `(dist.tarball). The package version may be malformed or ` +
+              `unpublished in this registry.`,
           )
         }
 
@@ -515,7 +522,10 @@ export class PackageInfoClient {
             throw this.#resolveError(
               spec,
               options,
-              'failed to fetch tarball',
+              `Registry returned HTTP ${response.statusCode} when ` +
+                `fetching the tarball for ${spec} at ${tarball}. The ` +
+                `version may have been unpublished, or the registry may ` +
+                `be misconfigured or unreachable.`,
               { response, url: tarball },
             )
           }

--- a/src/registry-client/src/index.ts
+++ b/src/registry-client/src/index.ts
@@ -444,18 +444,19 @@ export class RegistryClient {
 
     const entry = buffer ? CacheEntry.decode(buffer) : undefined
     if (entry?.valid) {
-      logRequest(url, 'cache')
+      logRequest(url, 'cache', { method })
       return entry
     }
 
     if (staleWhileRevalidate && entry?.staleWhileRevalidate && m) {
       // revalidate while returning the stale entry
       register(dirname(this.cache.path()), m, url)
-      logRequest(url, 'stale')
+      logRequest(url, 'stale', { method })
       return entry
     }
 
-    logRequest(url, 'start')
+    logRequest(url, 'start', { method })
+    const requestStart = Date.now()
 
     // either no cache entry, or need to revalidate before use.
     setCacheHeaders(options, entry)
@@ -522,6 +523,16 @@ export class RegistryClient {
       options,
       response,
       entry,
+    )
+
+    logRequest(
+      url,
+      response.statusCode === 304 ? '304' : 'complete',
+      {
+        method,
+        statusCode: response.statusCode,
+        durationMs: Date.now() - requestStart,
+      },
     )
 
     if (result.getHeader('integrity')) {

--- a/www/docs/src/content/docs/cli/commands.mdx
+++ b/www/docs/src/content/docs/cli/commands.mdx
@@ -4,6 +4,7 @@ sidebar:
   hidden: true
 ---
 
+- [audit](/cli/commands/audit)
 - [cache](/cli/commands/cache)
 - [config](/cli/commands/config)
 - [exec](/cli/commands/exec)
@@ -15,6 +16,7 @@ sidebar:
 - [list](/cli/commands/list)
 - [login](/cli/commands/login)
 - [logout](/cli/commands/logout)
+- [outdated](/cli/commands/outdated)
 - [pkg](/cli/commands/pkg)
 - [query](/cli/commands/query)
 - [run-exec](/cli/commands/run-exec)

--- a/www/docs/src/content/docs/cli/commands/audit.mdx
+++ b/www/docs/src/content/docs/cli/commands/audit.mdx
@@ -1,0 +1,171 @@
+---
+title: vlt audit
+sidebar:
+  label: audit
+---
+
+import { Code } from '@astrojs/starlight/components'
+
+Usage:
+
+<Code
+  code="$ vlt audit
+$ vlt audit <query> --view=[human | json]
+"
+  title="Terminal"
+  lang="bash"
+/>
+
+Run a security audit of the installed dependency graph.
+
+Uses the [Dependency Selector Syntax](/cli/selectors) (the same engine
+that powers [`vlt query`](/cli/commands/query)) together with the
+[Socket](https://socket.dev/) security database to surface packages
+that may need attention: known malware, published vulnerabilities
+(CVEs), typosquats, license problems, unmaintained or deprecated
+packages, and more.
+
+By default it scans every package that has security metadata and
+reports any finding with a severity of **moderate or higher**. Provide
+a DSS query as a positional argument to narrow the scope of the audit.
+
+## Output
+
+The human-readable view renders a color-coded table sorted by
+severity:
+
+<Code
+  code={`Security Audit
+
+SEVERITY  PACKAGE           TYPE           ISSUE
+critical  evil-pkg@1.0.0    malware        known malware
+high      risky-lib@2.3.1   vulnerability  high severity CVE (CVE-2024-1234)
+medium    old-util@0.9.0    maintenance    deprecated
+medium    gpl-lib@3.0.0     license        copyleft license
+
+Summary: 1 critical, 1 high, 2 moderate across 4 packages (128 scanned).
+Run with --all to include low-severity capability findings.`}
+  title="Terminal"
+  lang="ansi"
+/>
+
+## Examples
+
+Audit all installed dependencies
+
+<Code code="$ vlt audit" title="Terminal" lang="bash" />
+
+Only audit direct dependencies of your workspaces
+
+<Code
+  code="$ vlt audit ':workspace > *'"
+  title="Terminal"
+  lang="bash"
+/>
+
+Audit only production dependencies
+
+<Code code="$ vlt audit ':prod'" title="Terminal" lang="bash" />
+
+Include low-severity findings (behavioral capabilities, minor hygiene
+issues)
+
+<Code code="$ vlt audit --all" title="Terminal" lang="bash" />
+
+Emit the audit report as JSON for tooling or CI
+
+<Code code="$ vlt audit --view=json" title="Terminal" lang="bash" />
+
+## What Gets Flagged
+
+The audit maps each package's security insights into severity-ranked
+findings. The categories below are ordered from most to least severe.
+
+### Critical & High
+
+- **Malware** — known malware, AI-detected malware
+- **Vulnerabilities** — critical/high severity CVEs (with CVE IDs)
+- **Typosquats** — likely typosquat (`:squat(critical)`)
+- **Integrity** — manifest confusion (`:confused`)
+
+### Medium (Moderate)
+
+- **Malware** — AI-flagged security issues
+- **Vulnerabilities** — potential vulnerabilities
+- **Code** — obfuscated code
+- **Trust** — suspicious activity, flagged as undesirable
+- **License** — copyleft, non-permissive, unlicensed, no license found
+- **Maintenance** — deprecated, abandoned, unmaintained (5+ years)
+
+### Low (shown with `--all`)
+
+- **Code** — high-entropy strings, minified without source
+- **License** — misc issues, ambiguous, unidentified
+- **Maintenance** — unpopular, unstable ownership, new/unknown author,
+  trivial package
+- **Capabilities** — uses eval, shell access, network access,
+  filesystem access, reads env vars, dynamic require, debug access,
+  native code, telemetry, install scripts, bundled shrinkwrap
+
+## Options
+
+### view
+
+Output format. Defaults to human-readable, or json if there is no tty.
+
+```
+--view=[human | json]
+```
+
+The JSON output includes a structured `reports` array with per-package
+findings, a `summary` object with severity counts, and metadata like
+`packagesScanned` and `packagesAffected`.
+
+### all
+
+Include low-severity findings. Without this flag, behavioral
+capability alerts and minor hygiene issues are omitted to keep the
+output focused on actionable security concerns.
+
+```
+--all
+```
+
+## CI / CD Integration
+
+Use `vlt audit` in pipelines to surface security issues. Pair it with
+`--view=json` and your preferred JSON tool, or use
+[`vlt query`](/cli/commands/query) with `--expect-results=0` to fail a
+build when specific selectors match:
+
+<Code
+  code={`# Human-readable audit summary in CI logs
+$ vlt audit
+
+# Machine-readable for post-processing
+
+$ vlt audit --view=json | jq '.summary'
+
+# Fail the build if any malware is found (via query)
+
+$ vlt query ':malware' --expect-results=0
+
+# Fail on copyleft licenses
+
+$ vlt query ':license(copyleft)' --expect-results=0`}
+  title="Terminal"
+  lang="bash"
+/>
+
+## Relationship to `vlt query`
+
+`vlt audit` is a convenience command built on top of `vlt query`. It
+runs a query (`:scanned` by default), then transforms the structured
+[security insights](/cli/selectors/security-insights) attached to each
+matching node into a categorized, severity-ranked report. If you need
+more control — custom selectors, graph views, `--expect-results` gates,
+or image output — use `vlt query` directly.
+
+For a full reference of security-related selectors, see the
+[Security Insights](/cli/selectors/security-insights) selector docs and
+the [Security & Malware Detection](/cli/security) guide.

--- a/www/docs/src/content/docs/cli/commands/fund.mdx
+++ b/www/docs/src/content/docs/cli/commands/fund.mdx
@@ -1,0 +1,58 @@
+---
+title: vlt fund
+sidebar:
+  label: fund
+---
+
+import { Code } from '@astrojs/starlight/components'
+
+Usage:
+
+<Code
+  code="$ vlt fund
+$ vlt fund [package-names...]
+$ vlt fund <query>"
+  title="Terminal"
+  lang="bash"
+/>
+
+Display a list of installed dependencies that declare funding
+information, along with the URLs where they can be funded.
+
+Under the hood this uses the vlt Dependency Selector Syntax (the same
+engine that powers `vlt query`) to collect installed dependencies, then
+reports the ones whose `package.json` includes a `funding` field.
+Defaults to checking every dependency of the project and its
+workspaces.
+
+## Examples
+
+List all dependencies looking for funding
+
+<Code code="$ vlt fund" title="Terminal" lang="bash" />
+
+Only check the 'foo' and 'bar' packages
+
+<Code code="$ vlt fund foo bar" title="Terminal" lang="bash" />
+
+Only check direct dependencies of the project root
+
+<Code
+  code={`$ vlt fund ':root > *'`}
+  title="Terminal"
+  lang="bash"
+/>
+
+Output the results as JSON
+
+<Code code="$ vlt fund --view=json" title="Terminal" lang="bash" />
+
+## Options
+
+### view
+
+Output format. Defaults to human-readable or json if no tty.
+
+```
+--view=[human | json]
+```

--- a/www/docs/src/content/docs/cli/commands/outdated.mdx
+++ b/www/docs/src/content/docs/cli/commands/outdated.mdx
@@ -1,0 +1,64 @@
+---
+title: vlt outdated
+sidebar:
+  label: outdated
+---
+
+import { Code } from '@astrojs/starlight/components'
+
+Usage:
+
+<Code
+  code="$ vlt outdated
+$ vlt outdated [package-names...]
+$ vlt outdated [<query>] --view=[human | json]"
+  title="Terminal"
+  lang="bash"
+/>
+
+Display a table of installed dependencies that have newer versions
+available in the registry.
+
+Under the hood this uses the vlt Dependency Selector Syntax (the same
+engine that powers [`vlt query`](/cli/commands/query)) with the
+[`:outdated`](/cli/selectors/pseudo-classes/outdated) pseudo-selector. A
+registry request is made for each candidate package to determine the
+"wanted" (the highest version matching the declared range) and "latest"
+(the `latest` dist-tag) versions.
+
+The report highlights how far behind each dependency is: package names
+turn red when a new major version is available, and the changed portion
+of the target version is colored by the kind of update — red for a major
+bump, cyan for a minor bump, and green for a patch.
+
+## Examples
+
+Show all outdated dependencies
+
+<Code code="$ vlt outdated" title="Terminal" lang="bash" />
+
+Only check the `foo` and `bar` packages
+
+<Code code="$ vlt outdated foo bar" title="Terminal" lang="bash" />
+
+Only check direct dependencies of the project root
+
+<Code
+  code={`$ vlt outdated ':root > *'`}
+  title="Terminal"
+  lang="bash"
+/>
+
+Output the results as JSON
+
+<Code code="$ vlt outdated --view=json" title="Terminal" lang="bash" />
+
+## Options
+
+### view
+
+Output format. Defaults to human-readable or json if no tty.
+
+```
+--view=[human | json]
+```

--- a/www/docs/src/content/docs/cli/security.mdx
+++ b/www/docs/src/content/docs/cli/security.mdx
@@ -198,6 +198,31 @@ $ vlt query ':license(copyleft)'`} title="Terminal" lang="bash" />
 
 ## Comprehensive Security Audit
 
+The fastest way to get a complete picture is with
+[`vlt audit`](/cli/commands/audit), which scans every dependency and
+renders a severity-ranked table:
+
+<Code
+  code={`# Full audit — moderate+ findings by default
+$ vlt audit
+
+# Include low-severity capability findings
+
+$ vlt audit --all
+
+# Only audit direct workspace dependencies
+
+$ vlt audit ':workspace > *'
+
+# JSON output for CI tooling
+
+$ vlt audit --view=json`}
+  title="Terminal"
+  lang="bash"
+/>
+
+You can also compose multi-criteria queries manually with `vlt query`:
+
 <Code
   code={
     "# Multi-criteria security check - combine multiple selectors\n$ vlt query ':malware, :eval, :shell, :obfuscated'\n\n# Production dependencies security audit\n$ vlt query ':prod (:malware, :cve(*), :deprecated, :abandoned)'\n\n# Workspace security overview\n$ vlt query ':workspace (:malware, :score(\"<0.5\"), :unmaintained)'"
@@ -222,10 +247,12 @@ $ vlt query ':license(copyleft)'`} title="Terminal" lang="bash" />
 
 ### Regular Security Audits
 
-1. **Daily Quick Check**: `vlt query ':malware'`
+1. **Daily Quick Check**: `vlt audit` or `vlt query ':malware'`
 2. **Weekly Comprehensive Scan**:
+   `vlt audit --all` or
    `vlt query ':host(local) :is(:malware, :not(:scanned))'`
 3. **Before Releasing Projects**:
+   `vlt audit ':workspace > :prod'` or
    `vlt query ':root :is(:malware, :score("<0.6"))'`
 
 ### Automated Security Monitoring

--- a/www/docs/vercel.json
+++ b/www/docs/vercel.json
@@ -1,5 +1,4 @@
 {
-  "git": {
-    "ignoredCommand": "! git diff --quiet $VERCEL_GIT_PREVIOUS_SHA $VERCEL_GIT_COMMIT_SHA -- www/docs/"
-  }
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "ignoreCommand": "git diff --quiet $VERCEL_GIT_PREVIOUS_SHA $VERCEL_GIT_COMMIT_SHA -- www/docs/"
 }


### PR DESCRIPTION
This pull request introduces a new `fund` command to the CLI, adds improved logging options for diagnostic output, and enhances error formatting for better readability. The most important changes are grouped below:

---

### New Features

* Added a `fund` command (`fund.ts`) that reports installed dependencies with funding information, supporting package name and query filters, and multiple output formats (human, JSON).
* Registered the `fund` command and other related commands/aliases in the CLI command definitions for discoverability and usage. [[1]](diffhunk://#diff-b9c23f9393f280d575d0d18b9a34ec5c580a49739046ac4c28a2598f14c9fcecR23) [[2]](diffhunk://#diff-b9c23f9393f280d575d0d18b9a34ec5c580a49739046ac4c28a2598f14c9fcecR35-R43) [[3]](diffhunk://#diff-b9c23f9393f280d575d0d18b9a34ec5c580a49739046ac4c28a2598f14c9fcecR83)

### Diagnostic Logging Improvements

* Introduced a `loglevel` option (with levels: silent, error, warn, info, verbose, debug) and a `--verbose` flag (shorthand for `--loglevel=verbose`) to control diagnostic logging output. [[1]](diffhunk://#diff-b9c23f9393f280d575d0d18b9a34ec5c580a49739046ac4c28a2598f14c9fcecR643-R679) [[2]](diffhunk://#diff-341eb97153ab34fc6ced1ce6451711b620efcc0457e46939f03681ecd641d020R385-R391)
* Implemented per-request logging: when `loglevel` is `verbose` or higher, registry request events are streamed to stderr, showing cache/fetch outcomes and status codes. [[1]](diffhunk://#diff-19a31ce218a8bf7d5b8344923b61ac0b74e8cda593880eaad74e3d1754aec457R1-R100) [[2]](diffhunk://#diff-fb8a6a1031e4d671462a7f65457b72411171049fd769a216f1ecee88e3ec8322R26) [[3]](diffhunk://#diff-fb8a6a1031e4d671462a7f65457b72411171049fd769a216f1ecee88e3ec8322R178-R185) [[4]](diffhunk://#diff-fb8a6a1031e4d671462a7f65457b72411171049fd769a216f1ecee88e3ec8322R207) [[5]](diffhunk://#diff-fb8a6a1031e4d671462a7f65457b72411171049fd769a216f1ecee88e3ec8322R245)

### Error and Output Formatting

* Improved error output for dependencies by rendering objects with a custom `toString()` (such as `Spec` instances) as concise strings, making error messages more readable. [[1]](diffhunk://#diff-90246b82cea11e2a0c3a51753f7ce244fb8086f3674c04f90b46fc6bdf9faa14R35-R49) [[2]](diffhunk://#diff-90246b82cea11e2a0c3a51753f7ce244fb8086f3674c04f90b46fc6bdf9faa14L211-R226)