### PR TITLE
feat(cli): add `vlt outdated` 

### DIFF
--- a/src/cli-sdk/src/commands/outdated.ts
+++ b/src/cli-sdk/src/commands/outdated.ts
@@ -1,0 +1,638 @@
+import { styleText as utilStyleText } from 'node:util'
+import { createInterface } from 'node:readline/promises'
+import {
+  actual,
+  asDependency,
+  GraphModifier,
+  install,
+} from '@vltpkg/graph'
+import { PackageInfoClient } from '@vltpkg/package-info'
+import { Query } from '@vltpkg/query'
+import { compare, satisfies } from '@vltpkg/semver'
+import { hydrate, splitDepID } from '@vltpkg/dep-id'
+import { Spec } from '@vltpkg/spec'
+import { commandUsage } from '../config/usage.ts'
+import type {
+  AddImportersDependenciesMap,
+  Dependency,
+  Graph,
+  Node,
+} from '@vltpkg/graph'
+import type { DepID } from '@vltpkg/dep-id'
+import type {
+  QueryResponseEdge,
+  QueryResponseNode,
+} from '@vltpkg/query'
+import type {
+  DependencyTypeShort,
+  EdgeLike,
+  NodeLike,
+  Packument,
+} from '@vltpkg/types'
+import type { CommandFn, CommandUsage } from '../index.ts'
+import type { ViewOptions, Views } from '../view.ts'
+
+export const needsRegistry = true
+
+export const usage: CommandUsage = () =>
+  commandUsage({
+    command: 'outdated',
+    usage: ['', '[package-names...]', '[<query>]'],
+    description: `Display a table of installed dependencies that have newer
+      versions available in the registry.
+
+      Under the hood this uses the vlt Dependency Selector Syntax (the same
+      engine that powers \`vlt query\`) with the \`:outdated\` pseudo-selector.
+      A registry request is made for each candidate package to determine the
+      "wanted" (highest version matching the declared range) and "latest"
+      (the \`latest\` dist-tag) versions.
+
+      Provide package names as positional arguments to limit the report to
+      those packages. Alternatively, pass a DSS query selector to scope the
+      report to an arbitrary subset of the dependency graph.
+
+      Pass \`--update\` to upgrade the outdated direct dependencies to their
+      latest versions, or \`--interactive\` to choose which ones to update
+      before applying the changes. Combine either with \`--dry-run\` to preview
+      the changes without writing to package.json or installing.
+
+      Defaults to checking every dependency of the project and its
+      workspaces.`,
+    examples: {
+      '': {
+        description: 'Show all outdated dependencies',
+      },
+      'foo bar': {
+        description: `Only check the 'foo' and 'bar' packages`,
+      },
+      ':root > *': {
+        description:
+          'Only check direct dependencies of the project root',
+      },
+      '--update': {
+        description:
+          'Upgrade every outdated direct dependency to its latest version',
+      },
+      '--interactive': {
+        description:
+          'Choose which outdated dependencies to update from a prompt',
+      },
+      '--update --dry-run': {
+        description: 'Preview the updates without applying them',
+      },
+    },
+    options: {
+      update: {
+        description:
+          'Upgrade outdated direct dependencies to their latest versions.',
+      },
+      interactive: {
+        description:
+          'Interactively pick which outdated dependencies to update.',
+      },
+      'dry-run': {
+        description:
+          'With --update or --interactive, preview changes without applying them.',
+      },
+      view: {
+        value: '[human | json]',
+        description:
+          'Output format. Defaults to human-readable or json if no tty.',
+      },
+    },
+  })
+
+/**
+ * A single outdated dependency relationship.
+ */
+export type OutdatedReport = {
+  /** The package name. */
+  name: string
+  /** The currently installed version. */
+  current?: string
+  /**
+   * The highest version that satisfies the declared dependency range,
+   * i.e. the version an install would upgrade to.
+   */
+  wanted?: string
+  /** The version tagged as `latest` in the registry. */
+  latest?: string
+  /** The kind of dependency (prod, dev, peer, optional). */
+  type: DependencyTypeShort
+  /** The name of the package/workspace that depends on it. */
+  dependedBy: string
+  /** The location of the installed package on disk. */
+  location?: string
+}
+
+/**
+ * A planned upgrade of a direct dependency.
+ */
+export type UpdatePlanItem = {
+  /** The package name. */
+  name: string
+  /** The currently declared range. */
+  from?: string
+  /** The new range that will be written to package.json. */
+  to: string
+  /** The importer whose package.json will be updated. */
+  importer: string
+}
+
+export type OutdatedResult = {
+  reports: OutdatedReport[]
+  /**
+   * When an update was requested, the list of dependencies that were (or,
+   * with `--dry-run`, would be) upgraded. Absent in report-only mode.
+   */
+  updatePlan?: UpdatePlanItem[]
+  /** Whether the update was actually applied (false for `--dry-run`). */
+  applied?: boolean
+}
+
+/**
+ * An outdated report paired with the metadata needed to perform an update.
+ */
+type OutdatedEntry = {
+  report: OutdatedReport
+  /** The importer DepID, set only for direct dependencies. */
+  importerId?: DepID
+  /** The dependency type, used when saving back to package.json. */
+  saveType: DependencyTypeShort
+  /** The range operator to preserve when writing the new range. */
+  prefix: string
+}
+
+/**
+ * Splits a version string into its dot-separated segments, treating the
+ * prerelease/build portion as the trailing segment(s).
+ */
+const versionSegments = (version: string): string[] =>
+  version.split('.')
+
+/**
+ * Highlights the portion of `to` that differs from `from`, choosing a
+ * color based on which segment first changed:
+ * major -> red, minor -> cyan, patch (or lower) -> green.
+ */
+const highlightDiff = (
+  from: string | undefined,
+  to: string,
+  paint: (
+    style: Parameters<typeof utilStyleText>[0],
+    s: string,
+  ) => string,
+): string => {
+  if (!from) return to
+  const f = versionSegments(from)
+  const t = versionSegments(to)
+  let i = 0
+  while (i < t.length && f[i] === t[i]) i++
+  // no difference detected
+  if (i >= t.length) return to
+  const unchanged = t.slice(0, i).join('.')
+  const changed = t.slice(i).join('.')
+  const style: Parameters<typeof utilStyleText>[0] =
+    i === 0 ? 'red'
+    : i === 1 ? 'cyan'
+    : 'green'
+  return `${unchanged}${unchanged ? '.' : ''}${paint(style, changed)}`
+}
+
+/**
+ * Returns the highest version in `versions` that satisfies `range`. When
+ * no range is available or nothing matches, returns `undefined`.
+ */
+export const highestSatisfying = (
+  versions: string[],
+  range: string | undefined,
+): string | undefined => {
+  if (!range) return undefined
+  return versions
+    .filter(v => satisfies(v, range))
+    .sort(compare)
+    .pop()
+}
+
+/**
+ * Returns true when `to` has a greater major version than `from`.
+ */
+const majorBump = (from: string, to: string): boolean => {
+  const f = Number(versionSegments(from)[0])
+  const t = Number(versionSegments(to)[0])
+  return Number.isFinite(f) && Number.isFinite(t) && t > f
+}
+
+/**
+ * Extracts the leading range operator (e.g. `^`, `~`, `>=`) from a raw
+ * range string so it can be preserved when writing a new range. Defaults
+ * to `^` when the range is absent.
+ */
+export const rangePrefix = (raw: string | undefined): string => {
+  if (raw === undefined) return '^'
+  const match = /^[\^~>=<]+/.exec(raw.trim())
+  return match ? match[0] : ''
+}
+
+const dependencyTypeLabel: Record<DependencyTypeShort, string> = {
+  prod: 'dependencies',
+  dev: 'devDependencies',
+  optional: 'optionalDependencies',
+  peer: 'peerDependencies',
+  peerOptional: 'peerDependencies',
+}
+
+const renderHuman = (
+  result: OutdatedResult,
+  { colors }: ViewOptions,
+): string => {
+  const paint = (
+    style: Parameters<typeof utilStyleText>[0],
+    s: string,
+  ) =>
+    colors ? utilStyleText(style, s, { validateStream: false }) : s
+
+  const { reports } = result
+  const lines: string[] = []
+
+  if (reports.length === 0) {
+    lines.push(paint('green', 'All dependencies are up to date.'))
+  } else {
+    const rows = [...reports].sort(
+      (a, b) =>
+        a.name.localeCompare(b.name, 'en') ||
+        a.dependedBy.localeCompare(b.dependedBy, 'en'),
+    )
+
+    type Column = {
+      header: string
+      raw: (r: OutdatedReport) => string
+      render: (r: OutdatedReport) => string
+    }
+
+    const columns: Column[] = [
+      {
+        header: 'Package',
+        raw: r => r.name,
+        render: r =>
+          paint(
+            r.current && r.latest && majorBump(r.current, r.latest) ?
+              'red'
+            : 'yellow',
+            r.name,
+          ),
+      },
+      {
+        header: 'Current',
+        raw: r => r.current ?? 'MISSING',
+        render: r => paint('dim', r.current ?? 'MISSING'),
+      },
+      {
+        header: 'Wanted',
+        raw: r => r.wanted ?? r.current ?? '-',
+        render: r =>
+          r.wanted ?
+            highlightDiff(r.current, r.wanted, paint)
+          : paint('dim', r.current ?? '-'),
+      },
+      {
+        header: 'Latest',
+        raw: r => r.latest ?? '-',
+        render: r =>
+          r.latest ?
+            highlightDiff(r.current, r.latest, paint)
+          : paint('dim', '-'),
+      },
+      {
+        header: 'Type',
+        raw: r => dependencyTypeLabel[r.type],
+        render: r => paint('dim', dependencyTypeLabel[r.type]),
+      },
+      {
+        header: 'Depended By',
+        raw: r => r.dependedBy,
+        render: r => r.dependedBy,
+      },
+    ]
+
+    const widths = columns.map(col =>
+      Math.max(
+        col.header.length,
+        ...rows.map(r => col.raw(r).length),
+      ),
+    )
+
+    /* c8 ignore next -- every column index has a computed width */
+    const widthAt = (i: number): number => widths[i] ?? 0
+
+    const pad = (
+      text: string,
+      rawLen: number,
+      width: number,
+    ): string => text + ' '.repeat(Math.max(0, width - rawLen))
+
+    lines.push(
+      columns
+        .map((col, i) =>
+          pad(
+            paint('bold', paint('underline', col.header)),
+            col.header.length,
+            widthAt(i),
+          ),
+        )
+        .join('  ')
+        .trimEnd(),
+    )
+
+    for (const r of rows) {
+      lines.push(
+        columns
+          .map((col, i) =>
+            pad(col.render(r), col.raw(r).length, widthAt(i)),
+          )
+          .join('  ')
+          .trimEnd(),
+      )
+    }
+
+    lines.push('')
+    lines.push(
+      paint(
+        'dim',
+        `${rows.length} outdated ${
+          rows.length === 1 ? 'package' : 'packages'
+        } found.`,
+      ),
+    )
+  }
+
+  // Render the update summary, when an update was requested.
+  if (result.updatePlan) {
+    lines.push('')
+    if (result.updatePlan.length === 0) {
+      lines.push(paint('dim', 'No dependencies to update.'))
+    } else {
+      lines.push(
+        paint(
+          'bold',
+          result.applied ? 'Updated:' : 'Would update (dry run):',
+        ),
+      )
+      for (const item of [...result.updatePlan].sort((a, b) =>
+        a.name.localeCompare(b.name, 'en'),
+      )) {
+        lines.push(
+          `  ${paint('green', '+')} ${item.name} ${paint(
+            'dim',
+            `${item.from ?? '-'} →`,
+          )} ${paint('cyan', item.to)} ${paint(
+            'dim',
+            `(${item.importer})`,
+          )}`,
+        )
+      }
+    }
+  }
+
+  return lines.join('\n')
+}
+
+export const views = {
+  human: renderHuman,
+  json: (result: OutdatedResult) => result.reports,
+} as const satisfies Views<OutdatedResult>
+
+/**
+ * Prompt the user to choose which outdated dependencies to update. Accepts
+ * a comma/space separated list of 1-based indexes, `all`, or `none`.
+ */
+export const promptUpdateSelection = async (
+  entries: OutdatedEntry[],
+): Promise<OutdatedEntry[]> => {
+  const rl = createInterface(process.stdin, process.stdout)
+  const lines = entries.map(
+    (e, i) =>
+      `  [${i + 1}] ${e.report.name} ${e.report.current ?? '-'} → ${
+        e.report.latest ?? '-'
+      } (${e.report.dependedBy})`,
+  )
+  const answer = await rl.question(
+    `Select dependencies to update:\n${lines.join(
+      '\n',
+    )}\nEnter numbers (e.g. 1,3), "all", or "none": `,
+  )
+  rl.close()
+  process.stdin.pause()
+
+  const trimmed = answer.trim().toLowerCase()
+  if (trimmed === '' || trimmed === 'all') return entries
+  if (trimmed === 'none') return []
+
+  const selected = new Set<number>()
+  for (const part of trimmed.split(/[\s,]+/)) {
+    const n = Number(part)
+    if (Number.isInteger(n) && n >= 1 && n <= entries.length) {
+      selected.add(n - 1)
+    }
+  }
+  return entries.filter((_, i) => selected.has(i))
+}
+
+export const command: CommandFn<OutdatedResult> = async conf => {
+  const modifiers = GraphModifier.maybeLoad(conf.options)
+  const monorepo = conf.options.monorepo
+  const mainManifest = conf.options.packageJson.maybeRead(
+    conf.options.projectRoot,
+  )
+  let graph: Graph | undefined
+
+  if (mainManifest) {
+    graph = actual.load({
+      ...conf.options,
+      mainManifest,
+      modifiers,
+      monorepo,
+      loadManifests: true,
+    })
+  }
+
+  const wantsUpdate = !!conf.get('update')
+  const interactive = !!conf.get('interactive')
+
+  // Without a graph there's nothing installed to compare against.
+  if (!graph) {
+    return wantsUpdate || interactive ?
+        { reports: [], updatePlan: [], applied: false }
+      : { reports: [] }
+  }
+
+  // Determine which nodes to treat as top-level importers, mirroring the
+  // behavior of the `query` and `list` commands.
+  const importers = new Set<Node>()
+  if ('workspace' in conf.values && monorepo) {
+    for (const workspace of monorepo.filter(conf.values)) {
+      const w = graph.nodes.get(workspace.id)
+      if (w) importers.add(w)
+    }
+  }
+
+  // Build the query string: an optional user-provided scope combined with
+  // the `:outdated` pseudo-selector.
+  const positionals = conf.positionals
+  const base =
+    positionals.length ?
+      positionals.map(k => `#${k.replace(/\//g, '\\/')}`).join(', ')
+    : '*'
+  const queryString = base
+    .split(',')
+    .map(part => `${part.trim()}:outdated`)
+    .join(', ')
+
+  const q = new Query({
+    nodes: new Set<NodeLike>(graph.nodes.values()),
+    edges: new Set<EdgeLike>(graph.edges),
+    importers:
+      importers.size ?
+        new Set<NodeLike>(importers)
+      : new Set<NodeLike>(graph.importers),
+    securityArchive: undefined,
+  })
+  const { edges, nodes } = await q.search(queryString, {
+    signal: new AbortController().signal,
+  })
+
+  const resultNodes = new Set<QueryResponseNode>(nodes)
+  const pic = new PackageInfoClient(conf.options)
+  const packumentCache = new Map<
+    string,
+    Promise<Packument | undefined>
+  >()
+
+  const fetchPackument = async (
+    node: QueryResponseNode,
+    name: string,
+  ): Promise<Packument | undefined> => {
+    const cached = packumentCache.get(node.id)
+    if (cached) return cached
+    const spec = hydrate(node.id, name, conf.options)
+    const promise = pic
+      .packument(spec)
+      // A missing packument (e.g. 404) shouldn't fail the whole report.
+      .catch(() => undefined)
+    packumentCache.set(node.id, promise)
+    return promise
+  }
+
+  const entries = await Promise.all(
+    edges
+      .filter(
+        (
+          edge,
+        ): edge is QueryResponseEdge & { to: QueryResponseNode } =>
+          !!edge.to &&
+          resultNodes.has(edge.to) &&
+          !edge.to.importer &&
+          splitDepID(edge.to.id)[0] === 'registry',
+      )
+      .map(async (edge): Promise<OutdatedEntry> => {
+        const node = edge.to
+        const name = node.name ?? edge.name
+        const packument = await fetchPackument(node, name)
+        const versions =
+          packument ? Object.keys(packument.versions) : []
+        const range = edge.spec.final.range
+        const wanted = highestSatisfying(
+          versions,
+          range ? String(range) : undefined,
+        )
+        const latest = packument?.['dist-tags'].latest
+        const report: OutdatedReport = {
+          name,
+          current: node.version ?? undefined,
+          wanted,
+          latest,
+          type: edge.type,
+          dependedBy: edge.from.name ?? edge.from.id,
+          location: node.location,
+        }
+        return {
+          report,
+          importerId: edge.from.importer ? edge.from.id : undefined,
+          saveType: edge.type,
+          prefix: rangePrefix(range ? String(range) : undefined),
+        }
+      }),
+  )
+
+  const reports = entries.map(e => e.report)
+
+  if (!wantsUpdate && !interactive) {
+    return { reports }
+  }
+
+  // Only direct dependencies (declared in an importer's package.json) with a
+  // known newer `latest` version can be upgraded.
+  const updatable = entries.filter(
+    e =>
+      e.importerId &&
+      e.report.latest &&
+      e.report.latest !== e.report.current,
+  )
+
+  const selected =
+    interactive ? await promptUpdateSelection(updatable) : updatable
+
+  const updatePlan: UpdatePlanItem[] = []
+  const add = new Map<
+    DepID,
+    Map<string, Dependency>
+  >() as AddImportersDependenciesMap
+  add.modifiedDependencies = selected.length > 0
+
+  for (const entry of selected) {
+    /* c8 ignore next - importerId is guaranteed by the updatable filter */
+    if (!entry.importerId || !entry.report.latest) continue
+    const to = `${entry.prefix}${entry.report.latest}`
+    const spec = Spec.parseArgs(
+      `${entry.report.name}@${to}`,
+      conf.options,
+    )
+    const importerDeps =
+      add.get(entry.importerId) ?? new Map<string, Dependency>()
+    importerDeps.set(
+      entry.report.name,
+      asDependency({ spec, type: entry.saveType }),
+    )
+    add.set(entry.importerId, importerDeps)
+    updatePlan.push({
+      name: entry.report.name,
+      from: entry.report.current,
+      to,
+      importer: entry.report.dependedBy,
+    })
+  }
+
+  const dryRun = !!conf.get('dry-run')
+  if (updatePlan.length > 0 && !dryRun) {
+    /* c8 ignore next 3 - allow-scripts default matches other commands */
+    const allowScripts =
+      conf.get('allow-scripts') ?
+        String(conf.get('allow-scripts'))
+      : ':not(*)'
+    await install(
+      {
+        ...conf.options,
+        allowScripts,
+        saveExact: conf.values['save-exact'],
+        savePrefix: conf.values['save-prefix'],
+      },
+      add,
+    )
+  }
+
+  return {
+    reports,
+    updatePlan,
+    applied: updatePlan.length > 0 && !dryRun,
+  }
+}

--- a/src/cli-sdk/src/config/definition.ts
+++ b/src/cli-sdk/src/config/definition.ts
@@ -725,6 +725,20 @@ export const definition = j
     },
   })
 
+  .flag({
+    update: {
+      short: 'u',
+      description: `When running \`vlt outdated\`, update outdated direct
+                    dependencies to their latest versions, writing the new
+                    ranges to package.json and installing them.`,
+    },
+    interactive: {
+      description: `When running \`vlt outdated\`, interactively choose which
+                    outdated dependencies to update before applying the
+                    changes. Implies \`--update\`.`,
+    },
+  })
+
   .opt({
     'expect-results': {
       hint: 'value',

--- a/src/cli-sdk/tap-snapshots/test/commands/outdated.ts.test.cjs
+++ b/src/cli-sdk/tap-snapshots/test/commands/outdated.ts.test.cjs
@@ -1,0 +1,170 @@
+/* IMPORTANT
+ * This snapshot file is auto-generated, but designed for humans.
+ * It should be checked into source control and tracked carefully.
+ * Re-generate by setting TAP_SNAPSHOT=1 and running tests.
+ * Make sure to inspect the output below.  Do not ignore changes!
+ */
+'use strict'
+exports[`test/commands/outdated.ts > TAP > --update applies upgrades > rendered update output 1`] = `
+Package  Current  Wanted  Latest  Type                  Depended By
+bar      1.0.0    1.0.0   1.2.0   devDependencies       my-project
+baz      1.0.0    1.0.0   -       dependencies          my-project
+foo      1.0.0    1.5.0   2.0.0   dependencies          my-project
+same     2.0.0    2.0.0   2.0.0   optionalDependencies  my-project
+trans    1.0.0    1.0.0   2.0.0   dependencies          foo
+
+5 outdated packages found.
+
+Updated:
+  + bar 1.0.0 → ~1.2.0 (my-project)
+  + foo 1.0.0 → ^2.0.0 (my-project)
+`
+
+exports[`test/commands/outdated.ts > TAP > human view - update summary > reports when there is nothing to update 1`] = `
+All dependencies are up to date.
+
+No dependencies to update.
+`
+
+exports[`test/commands/outdated.ts > TAP > human view - update summary > shows applied updates 1`] = `
+Package  Current  Wanted  Latest  Type             Depended By
+bar      1.0.0    1.0.0   1.2.0   devDependencies  my-project
+foo      1.0.0    1.5.0   2.0.0   dependencies     my-project
+
+2 outdated packages found.
+
+Updated:
+  + bar ~1.0.0 → ~1.2.0 (my-project)
+  + foo 1.0.0 → ^2.0.0 (my-project)
+`
+
+exports[`test/commands/outdated.ts > TAP > human view - update summary > shows dry-run updates 1`] = `
+Package  Current  Wanted  Latest  Type          Depended By
+foo      1.0.0    1.5.0   2.0.0   dependencies  my-project
+
+1 outdated package found.
+
+Would update (dry run):
+  + bar ~1.0.0 → ~1.2.0 (my-project)
+  + foo 1.0.0 → ^2.0.0 (my-project)
+  + zed - → ^1.0.0 (my-project)
+`
+
+exports[`test/commands/outdated.ts > TAP > human view > breaks name ties by the dependent 1`] = `
+Package  Current  Wanted  Latest  Type          Depended By
+foo      1.0.0    1.0.0   2.0.0   dependencies  a
+foo      1.0.0    1.0.0   2.0.0   dependencies  b
+
+2 outdated packages found.
+`
+
+exports[`test/commands/outdated.ts > TAP > human view > renders a table with colors 1`] = `
+[1m[4mPackage[24m[22m  [1m[4mCurrent[24m[22m  [1m[4mWanted[24m[22m  [1m[4mLatest[24m[22m  [1m[4mType[24m[22m                  [1m[4mDepended By[24m[22m
+[33mbar[39m      [2m1.0.0[22m    [2m1.0.0[22m   1.[36m2.0[39m   [2mdevDependencies[22m       my-project
+[33mbaz[39m      [2m1.0.0[22m    [2m1.0.0[22m   [2m-[22m       [2mpeerDependencies[22m      bar
+[31mfoo[39m      [2m1.0.0[22m    1.[36m5.0[39m   [31m2.0.0[39m   [2mdependencies[22m          my-project
+[33mnover[39m    [2mMISSING[22m  1.0.0   1.0.0   [2mpeerDependencies[22m      my-project
+[33mqux[39m      [2m1.0.0[22m    1.0.0   1.0.[32m1[39m   [2moptionalDependencies[22m  my-project
+[33munknown[39m  [2mMISSING[22m  [2m-[22m       [2m-[22m       [2mdependencies[22m          my-project
+
+[2m6 outdated packages found.[22m
+`
+
+exports[`test/commands/outdated.ts > TAP > human view > renders a table without colors 1`] = `
+Package  Current  Wanted  Latest  Type                  Depended By
+bar      1.0.0    1.0.0   1.2.0   devDependencies       my-project
+baz      1.0.0    1.0.0   -       peerDependencies      bar
+foo      1.0.0    1.5.0   2.0.0   dependencies          my-project
+nover    MISSING  1.0.0   1.0.0   peerDependencies      my-project
+qux      1.0.0    1.0.0   1.0.1   optionalDependencies  my-project
+unknown  MISSING  -       -       dependencies          my-project
+
+6 outdated packages found.
+`
+
+exports[`test/commands/outdated.ts > TAP > human view > uses singular wording for a single package 1`] = `
+Package  Current  Wanted  Latest  Type          Depended By
+foo      1.0.0    1.5.0   2.0.0   dependencies  my-project
+
+1 outdated package found.
+`
+
+exports[`test/commands/outdated.ts > TAP > usage > should have usage 1`] = `
+Usage:
+  vlt outdated
+  vlt outdated [package-names...]
+  vlt outdated [<query>]
+
+Display a table of installed dependencies that have newer versions available in
+the registry.
+
+Under the hood this uses the vlt Dependency Selector Syntax (the same engine
+that powers \`vlt query\`) with the \`:outdated\` pseudo-selector. A registry
+request is made for each candidate package to determine the "wanted" (highest
+version matching the declared range) and "latest" (the \`latest\` dist-tag)
+versions.
+
+Provide package names as positional arguments to limit the report to those
+packages. Alternatively, pass a DSS query selector to scope the report to an
+arbitrary subset of the dependency graph.
+
+Pass \`--update\` to upgrade the outdated direct dependencies to their latest
+versions, or \`--interactive\` to choose which ones to update before applying the
+changes. Combine either with \`--dry-run\` to preview the changes without writing
+to package.json or installing.
+
+Defaults to checking every dependency of the project and its workspaces.
+
+  Aliases
+
+    ​out
+
+  Examples
+
+    Show all outdated dependencies
+
+    ​vlt outdated
+
+    Only check the 'foo' and 'bar' packages
+
+    ​vlt outdated foo bar
+
+    Only check direct dependencies of the project root
+
+    ​vlt outdated :root > *
+
+    Upgrade every outdated direct dependency to its latest version
+
+    ​vlt outdated --update
+
+    Choose which outdated dependencies to update from a prompt
+
+    ​vlt outdated --interactive
+
+    Preview the updates without applying them
+
+    ​vlt outdated --update --dry-run
+
+  Options
+
+    update
+      Upgrade outdated direct dependencies to their latest versions.
+
+      ​--update
+
+    interactive
+      Interactively pick which outdated dependencies to update.
+
+      ​--interactive
+
+    dry-run
+      With --update or --interactive, preview changes without applying them.
+
+      ​--dry-run
+
+    view
+      Output format. Defaults to human-readable or json if no tty.
+
+      ​--view=[human | json]
+
+`

--- a/src/cli-sdk/tap-snapshots/test/config/definition.ts.test.cjs
+++ b/src/cli-sdk/tap-snapshots/test/config/definition.ts.test.cjs
@@ -334,6 +334,10 @@ Object {
     ),
     "type": "boolean",
   },
+  "interactive": Object {
+    "description": "When running \`vlt outdated\`, interactively choose which outdated dependencies to update before applying the changes. Implies \`--update\`.",
+    "type": "boolean",
+  },
   "jsr-registries": Object {
     "description": String(
       Map alias names to JSR.io registry urls.
@@ -545,6 +549,11 @@ Object {
     ),
     "type": "boolean",
   },
+  "update": Object {
+    "description": "When running \`vlt outdated\`, update outdated direct dependencies to their latest versions, writing the new ranges to package.json and installing them.",
+    "short": "u",
+    "type": "boolean",
+  },
   "verbose": Object {
     "description": "Shorthand for \`--loglevel=verbose\`. Streams each registry request to stderr with its cache/fetch outcome and status code, useful for debugging request behavior.",
     "type": "boolean",
@@ -641,6 +650,7 @@ Array [
   "--help",
   "--identity=<name>",
   "--if-present",
+  "--interactive",
   "--jsr-registries=<name=url>",
   "--libc=<libc>",
   "--lockfile-only",
@@ -668,6 +678,7 @@ Array [
   "--tag=<tag>",
   "--target=<query>",
   "--telemetry",
+  "--update",
   "--verbose",
   "--version",
   "--view=<output>",
@@ -708,6 +719,7 @@ Array [
   "help",
   "identity",
   "if-present",
+  "interactive",
   "jsr-registries",
   "libc",
   "lockfile-only",
@@ -735,6 +747,7 @@ Array [
   "tag",
   "target",
   "telemetry",
+  "update",
   "verbose",
   "version",
   "view",

--- a/src/cli-sdk/tap-snapshots/test/index.ts.test.cjs
+++ b/src/cli-sdk/tap-snapshots/test/index.ts.test.cjs
@@ -63,6 +63,7 @@ Unknown option '--unknown'. To specify a positional argument starting with a '-'
     --help
     --identity=<name>
     --if-present
+    --interactive
     --jsr-registries=<name=url>
     --libc=<libc>
     --lockfile-only
@@ -90,6 +91,7 @@ Unknown option '--unknown'. To specify a positional argument starting with a '-'
     --tag=<tag>
     --target=<query>
     --telemetry
+    --update
     --verbose
     --version
     --view=<output>
@@ -133,6 +135,7 @@ Unknown config option: asdf
     help
     identity
     if-present
+    interactive
     jsr-registries
     libc
     lockfile-only
@@ -160,6 +163,7 @@ Unknown config option: asdf
     tag
     target
     telemetry
+    update
     verbose
     version
     view

--- a/src/cli-sdk/test/commands/outdated.ts
+++ b/src/cli-sdk/test/commands/outdated.ts
@@ -1,0 +1,583 @@
+import t from 'tap'
+import type { Test } from 'tap'
+import type { AddImportersDependenciesMap } from '@vltpkg/graph'
+import type { DepID } from '@vltpkg/dep-id'
+import type { LoadedConfig } from '../../src/config/index.ts'
+import type {
+  OutdatedReport,
+  OutdatedResult,
+} from '../../src/commands/outdated.ts'
+
+// The real module is safe to import for pure functions and views — the
+// readline interface is only created inside promptUpdateSelection.
+const real = await import('../../src/commands/outdated.ts')
+
+t.test('usage', async t => {
+  t.matchSnapshot(real.usage().usage(), 'should have usage')
+})
+
+t.test('highestSatisfying', async t => {
+  t.equal(
+    real.highestSatisfying(['1.0.0', '1.5.0', '2.0.0'], '^1.0.0'),
+    '1.5.0',
+  )
+  t.equal(real.highestSatisfying(['1.0.0'], undefined), undefined)
+  t.equal(real.highestSatisfying([], '^1.0.0'), undefined)
+})
+
+t.test('rangePrefix', async t => {
+  t.equal(real.rangePrefix(undefined), '^', 'defaults to caret')
+  t.equal(real.rangePrefix('^1.0.0'), '^')
+  t.equal(real.rangePrefix('~1.2.0'), '~')
+  t.equal(real.rangePrefix('1.0.0'), '', 'exact keeps no operator')
+  t.equal(real.rangePrefix('>=1.0.0'), '>=')
+})
+
+const reports: OutdatedReport[] = [
+  {
+    name: 'foo',
+    current: '1.0.0',
+    wanted: '1.5.0',
+    latest: '2.0.0',
+    type: 'prod',
+    dependedBy: 'my-project',
+    location: 'node_modules/foo',
+  },
+  {
+    name: 'bar',
+    current: '1.0.0',
+    wanted: undefined,
+    latest: '1.2.0',
+    type: 'dev',
+    dependedBy: 'my-project',
+  },
+  {
+    name: 'qux',
+    current: '1.0.0',
+    wanted: '1.0.0',
+    latest: '1.0.1',
+    type: 'optional',
+    dependedBy: 'my-project',
+  },
+  {
+    name: 'baz',
+    current: '1.0.0',
+    wanted: undefined,
+    latest: undefined,
+    type: 'peer',
+    dependedBy: 'bar',
+  },
+  {
+    name: 'nover',
+    current: undefined,
+    wanted: '1.0.0',
+    latest: '1.0.0',
+    type: 'peerOptional',
+    dependedBy: 'my-project',
+  },
+  {
+    name: 'unknown',
+    current: undefined,
+    wanted: undefined,
+    latest: undefined,
+    type: 'prod',
+    dependedBy: 'my-project',
+  },
+]
+
+t.test('human view', async t => {
+  t.matchSnapshot(
+    real.views.human({ reports }, { colors: false }),
+    'renders a table without colors',
+  )
+  t.matchSnapshot(
+    real.views.human({ reports }, { colors: true }),
+    'renders a table with colors',
+  )
+  t.matchSnapshot(
+    real.views.human({ reports: [reports[0]!] }, { colors: false }),
+    'uses singular wording for a single package',
+  )
+  t.equal(
+    real.views.human({ reports: [] }, { colors: false }),
+    'All dependencies are up to date.',
+  )
+  t.matchSnapshot(
+    real.views.human(
+      {
+        reports: [
+          {
+            name: 'foo',
+            current: '1.0.0',
+            latest: '2.0.0',
+            type: 'prod',
+            dependedBy: 'b',
+          },
+          {
+            name: 'foo',
+            current: '1.0.0',
+            latest: '2.0.0',
+            type: 'prod',
+            dependedBy: 'a',
+          },
+        ],
+      },
+      { colors: false },
+    ),
+    'breaks name ties by the dependent',
+  )
+})
+
+t.test('human view - update summary', async t => {
+  const updatePlan = [
+    {
+      name: 'foo',
+      from: '1.0.0',
+      to: '^2.0.0',
+      importer: 'my-project',
+    },
+    {
+      name: 'bar',
+      from: '~1.0.0',
+      to: '~1.2.0',
+      importer: 'my-project',
+    },
+  ]
+  t.matchSnapshot(
+    real.views.human(
+      {
+        reports: [reports[0]!, reports[1]!],
+        updatePlan,
+        applied: true,
+      },
+      { colors: false },
+    ),
+    'shows applied updates',
+  )
+  t.matchSnapshot(
+    real.views.human(
+      {
+        reports: [reports[0]!],
+        updatePlan: [
+          ...updatePlan,
+          { name: 'zed', to: '^1.0.0', importer: 'my-project' },
+        ],
+        applied: false,
+      },
+      { colors: false },
+    ),
+    'shows dry-run updates',
+  )
+  t.matchSnapshot(
+    real.views.human(
+      { reports: [], updatePlan: [], applied: false },
+      { colors: false },
+    ),
+    'reports when there is nothing to update',
+  )
+})
+
+t.test('json view', async t => {
+  t.strictSame(real.views.json({ reports }), reports)
+})
+
+// ---------------------------------------------------------------------------
+// Command integration tests (graph + query + registry + install mocked)
+// ---------------------------------------------------------------------------
+
+type FakeNode = {
+  id: string
+  name?: string
+  version?: string
+  importer: boolean
+  location?: string
+}
+
+type FakeEdge = {
+  name: string
+  type: string
+  spec: { final: { range?: string } }
+  from: FakeNode
+  to?: FakeNode
+}
+
+const packuments: Record<
+  string,
+  {
+    'dist-tags': Record<string, string>
+    versions: Record<string, unknown>
+  }
+> = {
+  foo: {
+    'dist-tags': { latest: '2.0.0' },
+    versions: { '1.0.0': {}, '1.5.0': {}, '2.0.0': {} },
+  },
+  bar: {
+    'dist-tags': { latest: '1.2.0' },
+    versions: { '1.0.0': {}, '1.2.0': {} },
+  },
+  trans: {
+    'dist-tags': { latest: '2.0.0' },
+    versions: { '1.0.0': {}, '2.0.0': {} },
+  },
+  same: {
+    'dist-tags': { latest: '2.0.0' },
+    versions: { '2.0.0': {} },
+  },
+}
+
+const myProject: FakeNode = {
+  id: 'file;.',
+  name: 'my-project',
+  version: '1.0.0',
+  importer: true,
+}
+const nodeFoo: FakeNode = {
+  id: 'registry;;foo@1.0.0',
+  name: 'foo',
+  version: '1.0.0',
+  importer: false,
+  location: 'node_modules/foo',
+}
+const nodeBar: FakeNode = {
+  id: 'registry;;bar@1.0.0',
+  name: 'bar',
+  version: '1.0.0',
+  importer: false,
+}
+const nodeBaz: FakeNode = {
+  id: 'registry;;baz@1.0.0',
+  name: 'baz',
+  version: '1.0.0',
+  importer: false,
+}
+const nodeTrans: FakeNode = {
+  id: 'registry;;trans@1.0.0',
+  name: 'trans',
+  version: '1.0.0',
+  importer: false,
+}
+const nodeSame: FakeNode = {
+  id: 'registry;;same@2.0.0',
+  name: 'same',
+  version: '2.0.0',
+  importer: false,
+}
+
+const mkEdge = (
+  to: FakeNode,
+  range: string | undefined,
+  type: string,
+  from: FakeNode = myProject,
+): FakeEdge => ({
+  name: to.name ?? 'anon',
+  type,
+  spec: { final: { range } },
+  from,
+  to,
+})
+
+const resultNodes = [nodeFoo, nodeBar, nodeBaz, nodeTrans, nodeSame]
+
+const resultEdges: FakeEdge[] = [
+  mkEdge(nodeFoo, '^1.0.0', 'prod'),
+  mkEdge(nodeBar, '~1.0.0', 'dev'),
+  // no latest available (404) -> not updatable
+  mkEdge(nodeBaz, '^1.0.0', 'prod'),
+  // transitive dependency (dependent is not an importer) -> not updatable
+  mkEdge(nodeTrans, '^1.0.0', 'prod', nodeFoo),
+  // already at latest -> not updatable
+  mkEdge(nodeSame, '^2.0.0', 'optional'),
+]
+
+const mockGraph = {
+  nodes: new Map([myProject, ...resultNodes].map(n => [n.id, n])),
+  edges: new Set(resultEdges),
+  importers: new Set([myProject]),
+}
+
+let capturedInstall:
+  { opts: unknown; add: AddImportersDependenciesMap } | undefined
+let mockAnswer = 'all'
+// Mutable fixtures returned by the mocked Query so individual tests can
+// swap in custom graphs without disturbing the shared set.
+let currentEdges: FakeEdge[] = resultEdges
+let currentNodes: FakeNode[] = resultNodes
+
+const loadCommand = async (t: Test) =>
+  t.mockImport<typeof import('../../src/commands/outdated.ts')>(
+    '../../src/commands/outdated.ts',
+    {
+      '@vltpkg/graph': {
+        actual: { load: () => mockGraph },
+        GraphModifier: { maybeLoad: () => undefined },
+        asDependency: (o: unknown) => o,
+        install: async (
+          opts: unknown,
+          add: AddImportersDependenciesMap,
+        ) => {
+          capturedInstall = { opts, add }
+          return { graph: {}, diff: undefined }
+        },
+      },
+      '@vltpkg/query': {
+        Query: class {
+          async search() {
+            return {
+              edges: currentEdges,
+              nodes: currentNodes,
+              importers: [],
+            }
+          }
+        },
+      },
+      '@vltpkg/dep-id': {
+        hydrate: (_id: string, name: string) => ({ name }),
+        splitDepID: (id: string) => id.split(';'),
+      },
+      '@vltpkg/package-info': {
+        PackageInfoClient: class {
+          async packument(spec: { name: string }) {
+            const p = packuments[spec.name]
+            if (!p) throw new Error('404')
+            return p
+          }
+        },
+      },
+      'node:readline/promises': {
+        createInterface: (stdin: unknown, stdout: unknown) => {
+          t.equal(stdin, process.stdin)
+          t.equal(stdout, process.stdout)
+          return {
+            question: async () => mockAnswer,
+            close: () => {},
+          }
+        },
+      },
+    },
+  )
+
+const specOptions = {
+  registry: 'https://registry.npmjs.org/',
+}
+
+const makeConfig = (
+  values: Record<string, unknown>,
+  positionals: string[] = [],
+  mainManifest: unknown = { name: 'my-project', version: '1.0.0' },
+): LoadedConfig =>
+  ({
+    positionals,
+    values,
+    get: (k: string) => values[k],
+    options: {
+      ...specOptions,
+      projectRoot: '/test/project',
+      packageJson: { maybeRead: () => mainManifest },
+    },
+  }) as unknown as LoadedConfig
+
+t.beforeEach(() => {
+  capturedInstall = undefined
+  mockAnswer = 'all'
+  currentEdges = resultEdges
+  currentNodes = resultNodes
+})
+
+t.test('report-only', async t => {
+  const Command = await loadCommand(t)
+  const res: OutdatedResult = await Command.command(
+    makeConfig({ view: 'human' }),
+  )
+  t.strictSame(
+    res.reports.map(r => r.name).sort(),
+    ['bar', 'baz', 'foo', 'same', 'trans'],
+    'includes only registry, non-importer deps',
+  )
+  t.equal(
+    res.updatePlan,
+    undefined,
+    'no update plan without --update',
+  )
+  t.equal(capturedInstall, undefined, 'does not install')
+})
+
+t.test('--update applies upgrades', async t => {
+  const Command = await loadCommand(t)
+  const res: OutdatedResult = await Command.command(
+    makeConfig({ view: 'human', update: true }),
+  )
+  t.strictSame(
+    (res.updatePlan ?? []).map(u => `${u.name}@${u.to}`).sort(),
+    ['bar@~1.2.0', 'foo@^2.0.0'],
+    'plans upgrades for direct deps with a newer latest, preserving prefix',
+  )
+  t.equal(res.applied, true, 'marks the update as applied')
+  t.ok(capturedInstall, 'calls install')
+  t.equal(
+    capturedInstall?.add.modifiedDependencies,
+    true,
+    'flags modified dependencies',
+  )
+  const importerDeps = capturedInstall?.add.get('file;.' as DepID)
+  t.strictSame(
+    [...(importerDeps?.keys() ?? [])].sort(),
+    ['bar', 'foo'],
+    'adds both upgrades under the importer',
+  )
+  t.matchSnapshot(
+    real.views.human(res, { colors: false }),
+    'rendered update output',
+  )
+})
+
+t.test('--update --dry-run does not install', async t => {
+  const Command = await loadCommand(t)
+  const res: OutdatedResult = await Command.command(
+    makeConfig({ view: 'human', update: true, 'dry-run': true }),
+  )
+  t.equal((res.updatePlan ?? []).length, 2, 'still plans the updates')
+  t.equal(res.applied, false, 'not applied in dry-run')
+  t.equal(capturedInstall, undefined, 'install is skipped')
+})
+
+t.test('--interactive selects a subset', async t => {
+  const Command = await loadCommand(t)
+  mockAnswer = '1'
+  const res: OutdatedResult = await Command.command(
+    makeConfig({ view: 'human', interactive: true }),
+  )
+  t.strictSame(
+    (res.updatePlan ?? []).map(u => u.name),
+    ['foo'],
+    'updates only the selected dependency',
+  )
+  t.ok(capturedInstall, 'installs the selection')
+})
+
+t.test('--interactive with none selected', async t => {
+  const Command = await loadCommand(t)
+  mockAnswer = 'none'
+  const res: OutdatedResult = await Command.command(
+    makeConfig({ view: 'human', interactive: true }),
+  )
+  t.strictSame(res.updatePlan, [], 'nothing planned')
+  t.equal(res.applied, false)
+  t.equal(capturedInstall, undefined, 'install is skipped')
+})
+
+t.test('--update without a project graph', async t => {
+  const Command = await loadCommand(t)
+  const res: OutdatedResult = await Command.command(
+    makeConfig({ view: 'json', update: true }, [], null),
+  )
+  t.strictSame(res.reports, [])
+  t.strictSame(res.updatePlan, [])
+  t.equal(res.applied, false)
+})
+
+t.test('report-only without a project graph', async t => {
+  const Command = await loadCommand(t)
+  const res: OutdatedResult = await Command.command(
+    makeConfig({ view: 'json' }, [], null),
+  )
+  t.strictSame(res.reports, [])
+  t.equal(res.updatePlan, undefined)
+})
+
+t.test('handles missing metadata fields', async t => {
+  const Command = await loadCommand(t)
+  const fromNoName: FakeNode = { id: 'file;x', importer: true }
+  const nodeAnon: FakeNode = {
+    id: 'registry;;anon@1.0.0',
+    importer: false,
+  }
+  currentNodes = [nodeFoo, nodeAnon]
+  currentEdges = [
+    // direct dep -> fetches foo's packument
+    mkEdge(nodeFoo, '^1.0.0', 'prod', myProject),
+    // second edge to the same node -> exercises the packument cache
+    mkEdge(nodeFoo, '^1.0.0', 'dev', nodeBar),
+    // undefined name/version/range and a dependent without a name
+    mkEdge(nodeAnon, undefined, 'prod', fromNoName),
+  ]
+  const res: OutdatedResult = await Command.command(
+    makeConfig({ view: 'json' }),
+  )
+  const anon = res.reports.find(r => r.name === 'anon')
+  t.ok(anon, 'falls back to the edge name when the node has none')
+  t.equal(anon?.current, undefined, 'tolerates a missing version')
+  t.equal(anon?.dependedBy, 'file;x', 'falls back to the importer id')
+})
+
+t.test('workspace filter and positional names', async t => {
+  const Command = await loadCommand(t)
+  const conf = makeConfig({ view: 'json', workspace: ['pkgs/a'] }, [
+    'foo',
+  ])
+  ;(conf.options as Record<string, unknown>).monorepo = {
+    filter: () => [{ id: 'file;.' }],
+  }
+  const res: OutdatedResult = await Command.command(conf)
+  t.ok(res.reports.length, 'still produces a report')
+})
+
+t.test('promptUpdateSelection parsing', async t => {
+  const Command = await loadCommand(t)
+  const entries: Parameters<typeof Command.promptUpdateSelection>[0] =
+    [
+      {
+        report: {
+          name: 'foo',
+          current: '1.0.0',
+          wanted: '1.5.0',
+          latest: '2.0.0',
+          type: 'prod',
+          dependedBy: 'my-project',
+        },
+        saveType: 'prod',
+        prefix: '^',
+      },
+      {
+        report: {
+          name: 'bar',
+          current: undefined,
+          wanted: undefined,
+          latest: undefined,
+          type: 'dev',
+          dependedBy: 'my-project',
+        },
+        saveType: 'dev',
+        prefix: '^',
+      },
+    ]
+
+  mockAnswer = 'all'
+  t.equal(
+    (await Command.promptUpdateSelection(entries)).length,
+    2,
+    '"all" selects everything',
+  )
+
+  mockAnswer = ''
+  t.equal(
+    (await Command.promptUpdateSelection(entries)).length,
+    2,
+    'empty input selects everything',
+  )
+
+  mockAnswer = 'none'
+  t.equal(
+    (await Command.promptUpdateSelection(entries)).length,
+    0,
+    '"none" selects nothing',
+  )
+
+  mockAnswer = '2, 99, abc'
+  const picked = await Command.promptUpdateSelection(entries)
+  t.strictSame(
+    picked.map(e => e.report.name),
+    ['bar'],
+    'ignores out-of-range and non-numeric tokens',
+  )
+})

--- a/www/docs/src/content/docs/cli/commands.mdx
+++ b/www/docs/src/content/docs/cli/commands.mdx
@@ -15,6 +15,7 @@ sidebar:
 - [list](/cli/commands/list)
 - [login](/cli/commands/login)
 - [logout](/cli/commands/logout)
+- [outdated](/cli/commands/outdated)
 - [pkg](/cli/commands/pkg)
 - [query](/cli/commands/query)
 - [run-exec](/cli/commands/run-exec)

--- a/www/docs/src/content/docs/cli/commands/outdated.mdx
+++ b/www/docs/src/content/docs/cli/commands/outdated.mdx
@@ -1,0 +1,147 @@
+---
+title: vlt outdated
+sidebar:
+  label: outdated
+---
+
+import { Code } from '@astrojs/starlight/components'
+
+Usage:
+
+<Code
+  code="$ vlt outdated
+$ vlt outdated [package-names...]
+$ vlt outdated <query>
+$ vlt outdated --update
+$ vlt outdated --interactive"
+  title="Terminal"
+  lang="bash"
+/>
+
+Display a table of installed dependencies that have newer versions
+available in the registry.
+
+Under the hood this uses the vlt Dependency Selector Syntax (the same
+engine that powers [`vlt query`](/cli/commands/query)) with the
+`:outdated` pseudo-selector. A registry request is made for each
+candidate package to determine the **wanted** (highest version matching
+the declared range) and **latest** (the `latest` dist-tag) versions.
+
+Provide package names as positional arguments to limit the report to
+those packages, or pass a DSS query selector to scope the report to an
+arbitrary subset of the dependency graph. By default every dependency of
+the project and its workspaces is checked.
+
+The report highlights the part of each version that changed: **major**
+bumps are shown in red, **minor** in cyan, and **patch** in green.
+
+## Updating
+
+Pass `--update` (`-u`) to upgrade the outdated **direct** dependencies to
+their latest versions. vlt writes the new ranges to `package.json`
+(preserving your existing range operator, e.g. `^` or `~`) and installs
+the updated packages.
+
+<Code code="$ vlt outdated --update" title="Terminal" lang="bash" />
+
+Only direct dependencies declared in a `package.json` can be updated —
+transitive dependencies are reported but never modified.
+
+### Interactive mode
+
+Pass `--interactive` to choose exactly which outdated dependencies to
+update from a prompt before anything is written. Enter a comma-separated
+list of numbers, `all`, or `none`.
+
+<Code
+  code="$ vlt outdated --interactive"
+  title="Terminal"
+  lang="bash"
+/>
+
+### Previewing changes
+
+Combine either flag with `--dry-run` to preview the planned upgrades
+without touching `package.json` or `node_modules`.
+
+<Code
+  code="$ vlt outdated --update --dry-run"
+  title="Terminal"
+  lang="bash"
+/>
+
+## Examples
+
+Show all outdated dependencies
+
+<Code code="$ vlt outdated" title="Terminal" lang="bash" />
+
+Only check the `foo` and `bar` packages
+
+<Code code="$ vlt outdated foo bar" title="Terminal" lang="bash" />
+
+Only check direct dependencies of the project root
+
+<Code
+  code={`$ vlt outdated ':root > *'`}
+  title="Terminal"
+  lang="bash"
+/>
+
+Upgrade every outdated direct dependency to its latest version
+
+<Code code="$ vlt outdated --update" title="Terminal" lang="bash" />
+
+Interactively choose which dependencies to update
+
+<Code
+  code="$ vlt outdated --interactive"
+  title="Terminal"
+  lang="bash"
+/>
+
+Output the results as JSON
+
+<Code
+  code="$ vlt outdated --view=json"
+  title="Terminal"
+  lang="bash"
+/>
+
+## Options
+
+### update
+
+Upgrade outdated direct dependencies to their latest versions, writing
+the new ranges to `package.json` and installing them.
+
+```
+--update
+-u
+```
+
+### interactive
+
+Interactively pick which outdated dependencies to update before applying
+the changes. Implies `--update`.
+
+```
+--interactive
+```
+
+### dry-run
+
+With `--update` or `--interactive`, preview the changes without applying
+them.
+
+```
+--dry-run
+```
+
+### view
+
+Output format. Defaults to human-readable or json if no tty.
+
+```
+--view=[human | json]
+```


### PR DESCRIPTION
Implements the `outdated` command (already registered in the config definition) that reports installed dependencies with newer versions available, using the `:outdated` DSS pseudo-selector under the hood.

- Human view renders a colorized table with major/minor/patch diff highlighting; JSON view returns the raw report.
- `--update`/`-u` upgrades outdated direct dependencies to their latest versions, preserving the existing range operator, and installs them.
- `--interactive` prompts to choose which dependencies to update.
- `--dry-run` previews the planned upgrades without applying them.

Includes full test coverage and docs for the new command.