### PR TITLE
feat(query): return informational messages for empty results in default human view

### DIFF
--- a/src/cli-sdk/src/commands/query.ts
+++ b/src/cli-sdk/src/commands/query.ts
@@ -202,10 +202,12 @@ export const command: CommandFn<QueryResult> = async conf => {
     )
     scopeNodes = resultNodes
     if (scopeNodes.length === 0) {
-      stdout(
-        'No packages found matching scope query:',
-        scopeQueryString,
-      )
+      if (conf.values.view === 'human') {
+        stdout(
+          'No packages found matching scope query:',
+          scopeQueryString,
+        )
+      }
       return {
         importers: new Set(),
         edges: [],
@@ -234,7 +236,9 @@ export const command: CommandFn<QueryResult> = async conf => {
       }
     }
     if (importers.size === 0) {
-      stdout('No matching workspaces found:', conf.values.workspace)
+      if (conf.values.view === 'human') {
+        stdout('No matching workspaces found:', conf.values.workspace)
+      }
       return {
         importers: new Set(),
         edges: [],
@@ -288,7 +292,9 @@ export const command: CommandFn<QueryResult> = async conf => {
     edges.length === 0 &&
     !conf.values['expect-results']
   ) {
-    stdout('No packages found matching query:', query)
+    if (conf.values.view === 'human') {
+      stdout('No packages found matching query:', query)
+    }
     return {
       importers: new Set(),
       edges: [],

--- a/src/cli-sdk/src/commands/query.ts
+++ b/src/cli-sdk/src/commands/query.ts
@@ -6,8 +6,9 @@ import {
   mermaidOutput,
   GraphModifier,
 } from '@vltpkg/graph'
-import { error } from '@vltpkg/error-cause'
 import { Query } from '@vltpkg/query'
+import { stdout } from '../output.ts'
+import { error } from '@vltpkg/error-cause'
 import { createDiffFilesProvider } from '../query-diff-files.ts'
 import { SecurityArchive } from '@vltpkg/security-archive'
 import { commandUsage } from '../config/usage.ts'
@@ -200,6 +201,19 @@ export const command: CommandFn<QueryResult> = async conf => {
       },
     )
     scopeNodes = resultNodes
+    if (scopeNodes.length === 0) {
+      stdout(
+        'No packages found matching scope query:',
+        scopeQueryString,
+      )
+      return {
+        importers: new Set(),
+        edges: [],
+        nodes: [],
+        highlightSelection: false,
+        queryString: scopeQueryString,
+      }
+    }
   }
 
   if (scopeQueryString && scopeNodes) {
@@ -217,6 +231,16 @@ export const command: CommandFn<QueryResult> = async conf => {
           importers.add(w)
           scopeIDs.push(workspace.id)
         }
+      }
+    }
+    if (importers.size === 0) {
+      stdout('No matching workspaces found:', conf.values.workspace)
+      return {
+        importers: new Set(),
+        edges: [],
+        nodes: [],
+        highlightSelection: false,
+        queryString: queryString ?? '',
       }
     }
   }
@@ -258,6 +282,21 @@ export const command: CommandFn<QueryResult> = async conf => {
     })
   }
 
+  if (
+    graph &&
+    nodes.length === 0 &&
+    edges.length === 0 &&
+    !conf.values['expect-results']
+  ) {
+    stdout('No packages found matching query:', query)
+    return {
+      importers: new Set(),
+      edges: [],
+      nodes: [],
+      highlightSelection: false,
+      queryString: query,
+    }
+  }
   return {
     importers:
       importers.size === 0 ?

--- a/src/cli-sdk/test/commands/query.ts
+++ b/src/cli-sdk/test/commands/query.ts
@@ -827,4 +827,191 @@ t.test('query', async t => {
       'should handle complex query string',
     )
   })
+
+  await t.test('empty result messages', async t => {
+    const logged: unknown[][] = []
+    const stdout = (...a: unknown[]) => logged.push(a)
+    const stderr = (..._a: unknown[]) => {}
+
+    const mockQueryWithStdout = async (t: Test) =>
+      t.mockImport<typeof import('../../src/commands/query.ts')>(
+        '../../src/commands/query.ts',
+        {
+          '@vltpkg/graph': t.createMock(Graph, {
+            actual: {
+              load: () => graph,
+            },
+            install: () => {},
+            uninstall: () => {},
+            reify: {},
+            ideal: {},
+            asDependency: () => {},
+          }),
+          '@vltpkg/security-archive': {
+            SecurityArchive: {
+              async start() {
+                return {
+                  ok: false,
+                  get: () => undefined,
+                }
+              },
+            },
+          },
+          '../../src/output.ts': { stdout, stderr },
+        },
+      )
+
+    await t.test('scope query matches nothing', async t => {
+      logged.length = 0
+      const Command = await mockQueryWithStdout(t)
+
+      const values = {
+        scope: '[name="nonexistent"]',
+        view: 'human',
+      }
+      await Command.command({
+        positionals: [],
+        values,
+        options,
+        get: (key: string) => (values as any)[key],
+      } as unknown as LoadedConfig)
+
+      t.equal(logged.length, 1, 'should log one message')
+      t.match(
+        logged[0],
+        [/No packages found matching scope query/],
+        'should show scope query message',
+      )
+    })
+
+    await t.test('workspace filter matches nothing', async t => {
+      logged.length = 0
+      const mainManifest = {
+        name: 'my-project',
+        version: '1.0.0',
+      }
+      const dir = t.testdir({
+        'package.json': JSON.stringify(mainManifest),
+        'vlt.json': JSON.stringify({
+          workspaces: { packages: ['./packages/*'] },
+        }),
+        packages: {
+          a: {
+            'package.json': JSON.stringify({
+              name: 'a',
+              version: '1.0.0',
+            }),
+          },
+        },
+      })
+      t.chdir(dir)
+      unload()
+
+      const monorepo = Monorepo.load(dir)
+      const graph = new Graph.Graph({
+        ...specOptions,
+        projectRoot: dir,
+        mainManifest,
+        monorepo,
+      })
+
+      const Command = await t.mockImport<
+        typeof import('../../src/commands/query.ts')
+      >('../../src/commands/query.ts', {
+        '@vltpkg/graph': t.createMock(Graph, {
+          actual: {
+            load: () => graph,
+          },
+          install: () => {},
+          uninstall: () => {},
+          reify: {},
+          ideal: {},
+          asDependency: () => {},
+        }),
+        '@vltpkg/security-archive': {
+          SecurityArchive: {
+            async start() {
+              return {
+                ok: false,
+                get: () => undefined,
+              }
+            },
+          },
+        },
+        '../../src/output.ts': { stdout, stderr },
+      })
+
+      const values = {
+        workspace: ['nonexistent'],
+        view: 'human',
+      }
+      await Command.command({
+        positionals: [],
+        values,
+        options: {
+          ...sharedOptions,
+          projectRoot: dir,
+          monorepo,
+        },
+        get: (key: string) => (values as any)[key],
+      } as unknown as LoadedConfig)
+
+      t.equal(logged.length, 1, 'should log one message')
+      t.match(
+        logged[0],
+        [/No matching workspaces found/],
+        'should show workspace filter message',
+      )
+    })
+
+    await t.test(
+      'main query matches nothing (with graph)',
+      async t => {
+        logged.length = 0
+        const Command = await mockQueryWithStdout(t)
+
+        const values = {
+          view: 'human',
+        }
+        await Command.command({
+          positionals: ['[name="nonexistent"]'],
+          values,
+          options,
+          get: (key: string) => (values as any)[key],
+        } as unknown as LoadedConfig)
+
+        t.equal(logged.length, 1, 'should log one message')
+        t.match(
+          logged[0],
+          [/No packages found matching query/],
+          'should show main query message',
+        )
+      },
+    )
+
+    await t.test(
+      'expect-results overrides empty result message',
+      async t => {
+        logged.length = 0
+        const Command = await mockQueryWithStdout(t)
+
+        const values = {
+          'expect-results': '1',
+          view: 'human',
+        }
+        await t.rejects(
+          Command.command({
+            positionals: ['[name="nonexistent"]'],
+            values,
+            options,
+            get: (key: string) => (values as any)[key],
+          } as unknown as LoadedConfig),
+          /Unexpected number of items/,
+          'should throw validation error instead of empty message',
+        )
+
+        t.equal(logged.length, 0, 'should not log empty message')
+      },
+    )
+  })
 })

--- a/src/cli-sdk/test/commands/query.ts
+++ b/src/cli-sdk/test/commands/query.ts
@@ -884,8 +884,32 @@ t.test('query', async t => {
       )
     })
 
-    await t.test('workspace filter matches nothing', async t => {
-      logged.length = 0
+    await t.test(
+      'scope query matches nothing (non-human view)',
+      async t => {
+        logged.length = 0
+        const Command = await mockQueryWithStdout(t)
+
+        const values = {
+          scope: '[name="nonexistent"]',
+          view: 'json',
+        }
+        await Command.command({
+          positionals: [],
+          values,
+          options,
+          get: (key: string) => (values as any)[key],
+        } as unknown as LoadedConfig)
+
+        t.equal(
+          logged.length,
+          0,
+          'should not log message for json view',
+        )
+      },
+    )
+
+    const setupWorkspace = async (t: Test) => {
       const mainManifest = {
         name: 'my-project',
         version: '1.0.0',
@@ -941,18 +965,28 @@ t.test('query', async t => {
         '../../src/output.ts': { stdout, stderr },
       })
 
-      const values = {
-        workspace: ['nonexistent'],
-        view: 'human',
-      }
-      await Command.command({
-        positionals: [],
-        values,
+      return {
+        Command,
         options: {
           ...sharedOptions,
           projectRoot: dir,
           monorepo,
         },
+      }
+    }
+
+    await t.test('workspace filter matches nothing', async t => {
+      logged.length = 0
+      const { Command: WorkspaceCmd, options: wsOptions } =
+        await setupWorkspace(t)
+      const values = {
+        workspace: ['nonexistent'],
+        view: 'human',
+      }
+      await WorkspaceCmd.command({
+        positionals: [],
+        values,
+        options: wsOptions,
         get: (key: string) => (values as any)[key],
       } as unknown as LoadedConfig)
 
@@ -963,6 +997,32 @@ t.test('query', async t => {
         'should show workspace filter message',
       )
     })
+
+    await t.test(
+      'workspace filter matches nothing (non-human view)',
+      async t => {
+        logged.length = 0
+
+        const { Command: WorkspaceCmd, options: wsOptions } =
+          await setupWorkspace(t)
+        const values = {
+          workspace: ['nonexistent'],
+          view: 'count',
+        }
+        await WorkspaceCmd.command({
+          positionals: [],
+          values,
+          options: wsOptions,
+          get: (key: string) => (values as any)[key],
+        } as unknown as LoadedConfig)
+
+        t.equal(
+          logged.length,
+          0,
+          'should not log message for count view',
+        )
+      },
+    )
 
     await t.test(
       'main query matches nothing (with graph)',
@@ -985,6 +1045,30 @@ t.test('query', async t => {
           logged[0],
           [/No packages found matching query/],
           'should show main query message',
+        )
+      },
+    )
+
+    await t.test(
+      'main query matches nothing (non-human view)',
+      async t => {
+        logged.length = 0
+        const Command = await mockQueryWithStdout(t)
+
+        const values = {
+          view: 'json',
+        }
+        await Command.command({
+          positionals: ['[name="nonexistent"]'],
+          values,
+          options,
+          get: (key: string) => (values as any)[key],
+        } as unknown as LoadedConfig)
+
+        t.equal(
+          logged.length,
+          0,
+          'should not log message for json view',
         )
       },
     )


### PR DESCRIPTION
Add informational stdout messages when `vlt query` returns no results:

## Changes

- If scope query matches nothing: `No packages found matching scope query: <query>`
- if workspace filter matches nothing: `No matching workspaces found: <workspace>`
- if main query matches nothing: `No packages found matching query: <query>`


Added unit tests in `src/cli-sdk/test/commands/query.ts` for:
1. scope query matches nothing — verifies stdout is called with "No packages found matching scope query:" when scope selector matches no packages
2. workspace filter matches nothing — verifies stdout is called with "No matching workspaces found:" when workspace filter doesn't match any workspace
3. main query matches nothing (with graph) — verifies stdout is called with "No packages found matching query:" when main query matches no packages (graph defined)
4. expect-results overrides empty result message — verifies `--expect-results` takes priority and throws validation error instead of logging empty message


Previously these scenarios silently returned empty output with no user feedback. 
Messages are only shown when a graph is loaded (not when resolving via host contexts without a local `package.json`).

I primarily became concerned about this as I plan on promoting the `vlt query :malware` command and when I run it in a workspace where no query results are found for that command, I get no feedback. 

Before:
<img width="571" height="66" alt="Screenshot 2026-08-03 at 9 31 09 AM" src="https://github.com/user-attachments/assets/0816ab2f-f4f4-41e9-a01e-9ab91c5f9953" />

After:
<img width="524" height="64" alt="Screenshot 2026-08-03 at 9 32 01 AM" src="https://github.com/user-attachments/assets/887f1e28-5224-4a35-b983-6a07548c72f7" />

## Testing this locally

```bash
node src/cli/dist/index.js query ':malware'

# Or run the test suite:
cd ~/vltpkg/src/cli-sdk
vlx tap test/commands/query.ts

To test the specific scenarios manually, create a temp directory with a package.json and run from there:
mkdir /tmp/test-query && cd /tmp/test-query
echo '{"name":"test","version":"1.0.0","dependencies":{"foo":"^1.0.0"}}' > package.json
vlt install
~/vltpkg/src/cli/dist/index.js query ':malware'
~/vltpkg/src/cli/dist/index.js query '#nonexistent'
~/vltpkg/src/cli/dist/index.js query --scope='#nonexistent' '*'
```