### PR TITLE
chore: skip vlt-lock.json when git diffing during lint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,8 +136,8 @@ jobs:
         continue-on-error: true
         run: |
           vlr fix:pkg
-          if [ -n "$(git status --porcelain)" ]; then
-            git diff
+          if [ -n "$(git status --porcelain -- . ':!vlt-lock.json')" ]; then
+            git diff -- . ':!vlt-lock.json'
             exit 1
           fi
 


### PR DESCRIPTION
Since we run vlt i with the current latest and then the built version
from source, it is possible that bug fixes will cause lockfile churn.
So for now we skip diffing the lockfile to builds will pass.
