### PR TITLE
release: support exact version override

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,6 +75,20 @@ jobs:
       # once vlt version supports --no-git-tag-version (see: https://github.com/vltpkg/vltpkg/issues/1514)
       - name: Version CLI Packages
         run: |
+          release_version=""
+          if [[ -f .release-version ]]; then
+            release_version="$(< .release-version)"
+            if ! node --eval "
+              const value = process.argv[1];
+              if (require('semver').valid(value) !== value) process.exit(1);
+            " "$release_version"; then
+              echo "Invalid version in .release-version: $release_version" >&2
+              exit 1
+            fi
+            echo "Using exact version from .release-version: $release_version"
+            rm .release-version
+          fi
+
           bump_prerelease() {
             local current="$1"
             node --eval "
@@ -97,7 +111,18 @@ jobs:
           }
           for pkg in ./infra/cli*/package.json; do
             current=$(jq -r .version "$pkg")
-            new_version=$(bump_prerelease "$current")
+            if [[ -n "$release_version" ]]; then
+              if ! node --eval "
+                const semver = require('semver');
+                if (!semver.gt(process.argv[1], process.argv[2])) process.exit(1);
+              " "$release_version" "$current"; then
+                echo ".release-version must be greater than $current: $release_version" >&2
+                exit 1
+              fi
+              new_version="$release_version"
+            else
+              new_version=$(bump_prerelease "$current")
+            fi
             jq --arg v "$new_version" '.version = $v' "$pkg" > "$pkg.tmp" && mv "$pkg.tmp" "$pkg"
           done
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -129,6 +129,19 @@ will contain any release related commits, usually just the bumping of
 When that PR is merged the same workflow will then publish the bumped
 packages.
 
+By default, the workflow increments the current prerelease version. To
+set an exact version for the next release, add a `.release-version`
+file at the repository root containing a valid semver without a
+leading `v`. It must be greater than the current version:
+
+```text
+1.0.0
+```
+
+Merge that file through a normal PR. The workflow will use the exact
+version for all released packages, then delete `.release-version` in
+the generated release PR so the override only applies once.
+
 ### Release Manager
 
 The weekly release manager's role is to merge the release PR. Pretty


### PR DESCRIPTION
## Summary

- allow a one-shot .release-version file to select the exact next release version
- validate that the override is valid SemVer and greater than the current CLI version
- consume the marker in the generated release commit so it only applies once
- document the stable-release process

## Validation

- vlr format
- vlr lint