### PR TITLE
fix(package-info): coalesce full packument requests

### DIFF
--- a/src/cli-sdk/src/commands/view.ts
+++ b/src/cli-sdk/src/commands/view.ts
@@ -370,7 +370,7 @@ export const command: CommandFn<ViewResult> = async conf => {
 
   // Fetch the full packument (needs time, maintainers) and resolved manifest
   const [packument, resolvedManifest] = await Promise.all([
-    pic.packument(spec, { fullPackument: true }),
+    pic.packument(spec),
     pic.manifest(spec),
   ])
   const manifest = resolvedManifest as Manifest

--- a/src/package-info/src/index.ts
+++ b/src/package-info/src/index.ts
@@ -66,11 +66,6 @@ export type PackageInfoClientRequestOptions = PickManifestOptions &
   RegistryClientRequestOptions & {
     /** dir to resolve `file://` specifiers against. Defaults to projectRoot. */
     from?: string
-    /**
-     * @deprecated Packuments always include the full registry metadata.
-     * This option is retained for backwards compatibility.
-     */
-    fullPackument?: boolean
   }
 
 export type PackageInfoClientExtractOptions =

--- a/src/package-info/src/index.ts
+++ b/src/package-info/src/index.ts
@@ -67,12 +67,8 @@ export type PackageInfoClientRequestOptions = PickManifestOptions &
     /** dir to resolve `file://` specifiers against. Defaults to projectRoot. */
     from?: string
     /**
-     * When true, requests the full packument document from the registry
-     * instead of the abbreviated "corgi" format. Use this when you need
-     * fields like `time`, `maintainers`, or `_rev` that are stripped
-     * from the abbreviated response.
-     *
-     * Defaults to `false` (abbreviated packument for faster installs).
+     * @deprecated Packuments always include the full registry metadata.
+     * This option is retained for backwards compatibility.
      */
     fullPackument?: boolean
   }
@@ -877,12 +873,6 @@ export class PackageInfoClient {
       case 'registry': {
         const { registry, name } = f
         if (!registry) throw noRegistryError(spec)
-        // Full packument requests bypass coalescing since they
-        // return different data than the abbreviated format.
-        if (options.fullPackument) {
-          const pakuURL = new URL(name, registry)
-          return this.#fetchPackument(spec, options, pakuURL)
-        }
         const packumentKey = `${registry}${name}`
         const inflight = this.#packumentPromises.get(packumentKey)
         if (inflight) return inflight
@@ -906,12 +896,8 @@ export class PackageInfoClient {
     options: PackageInfoClientRequestOptions,
     pakuURL: URL,
   ): Promise<Packument> {
-    const accept =
-      options.fullPackument ?
-        'application/json'
-      : 'application/vnd.npm.install-v1+json; q=1.0, application/json; q=0.8, */*'
     const response = await this.registryClient.request(pakuURL, {
-      headers: { accept },
+      headers: { accept: 'application/json' },
     })
     if (response.statusCode !== 200) {
       throw this.#resolveError(

--- a/src/package-info/test/index.ts
+++ b/src/package-info/test/index.ts
@@ -1911,9 +1911,9 @@ t.test(
     coalescedPackumentRequests = 0
     coalescedPackumentAccept = undefined
 
-    const [paku, fullPaku, exact, range] = await Promise.all([
+    const [paku, pakuAgain, exact, range] = await Promise.all([
       pi.packument('coalesced'),
-      pi.packument('coalesced', { fullPackument: true }),
+      pi.packument('coalesced'),
       pi.manifest('coalesced@2.0.0'),
       pi.manifest('coalesced@2'),
     ])
@@ -1930,7 +1930,7 @@ t.test(
     )
     t.equal(
       paku,
-      fullPaku,
+      pakuAgain,
       'packument requests returned the same object',
     )
     t.equal(

--- a/src/package-info/test/index.ts
+++ b/src/package-info/test/index.ts
@@ -172,6 +172,14 @@ const server = createServer((req, res) => {
       res.setHeader('content-length', j.byteLength)
       return res.end(j)
     }
+    case '/coalesced': {
+      coalescedPackumentRequests++
+      coalescedPackumentAccept = req.headers.accept
+      const json = Buffer.from(JSON.stringify(pakuAbbrev))
+      res.setHeader('content-length', json.byteLength)
+      setTimeout(() => res.end(json), 50)
+      return
+    }
     case '/corrupted/-/corrupted-1.0.0.tgz': {
       // Serve a tarball whose content does NOT match the integrity
       // in the manifest (simulates a supply-chain attack / registry bug)
@@ -318,6 +326,8 @@ const server = createServer((req, res) => {
 
 const notFoundURLs: string[] = []
 let corruptedOnceServed = 0
+let coalescedPackumentRequests = 0
+let coalescedPackumentAccept: string | undefined
 
 const defaultRegistry = `http://localhost:${PORT}/`
 const options = {
@@ -1892,49 +1902,50 @@ t.test('path git selector', async t => {
 })
 
 t.test(
-  'packument request coalescing avoids duplicate requests',
+  'full packument requests coalesce and retain manifest metadata',
   async t => {
-    const pi = new PackageInfoClient(options)
+    const pi = new PackageInfoClient({
+      ...options,
+      cache: t.testdir(),
+    })
+    coalescedPackumentRequests = 0
+    coalescedPackumentAccept = undefined
 
-    // Multiple concurrent packument requests for the same package
-    // should be coalesced into a single fetch.
-    const [p1, p2] = await Promise.all([
-      pi.packument('abbrev'),
-      pi.packument('abbrev'),
+    const [paku, fullPaku, exact, range] = await Promise.all([
+      pi.packument('coalesced'),
+      pi.packument('coalesced', { fullPackument: true }),
+      pi.manifest('coalesced@2.0.0'),
+      pi.manifest('coalesced@2'),
     ])
-    t.strictSame(p1, pakuAbbrev, 'first packument matches')
-    t.strictSame(p2, pakuAbbrev, 'second packument matches')
-    t.equal(p1, p2, 'both return the same object (coalesced)')
 
-    // Concurrent manifest requests for the same package also
-    // coalesce via the shared packument() call.
-    const [m1, m2] = await Promise.all([
-      pi.manifest('abbrev@2.0.0'),
-      pi.manifest('abbrev@2'),
-    ])
-    t.strictSame(
-      m1,
-      pakuAbbrev.versions['2.0.0'],
-      'first manifest matches',
+    t.equal(
+      coalescedPackumentRequests,
+      1,
+      'made one registry request',
     )
-    t.strictSame(
-      m2,
-      pakuAbbrev.versions['2.0.0'],
-      'second manifest matches',
+    t.equal(
+      coalescedPackumentAccept,
+      'application/json',
+      'requested the full packument',
     )
+    t.equal(
+      paku,
+      fullPaku,
+      'packument requests returned the same object',
+    )
+    t.equal(
+      exact,
+      paku.versions['2.0.0'],
+      'exact manifest came from the coalesced packument',
+    )
+    t.equal(
+      range,
+      paku.versions['2.0.0'],
+      'range manifest came from the coalesced packument',
+    )
+    t.equal(exact.license, 'ISC', 'manifest retains license metadata')
   },
 )
-
-t.test('fullPackument bypasses coalescing', async t => {
-  const pi = new PackageInfoClient(options)
-
-  // A fullPackument request should not be coalesced with
-  // abbreviated requests and should return the full document.
-  const paku = await pi.packument('abbrev', {
-    fullPackument: true,
-  })
-  t.strictSame(paku, pakuAbbrev, 'full packument matches')
-})
 
 t.test('no registry configured', async t => {
   // there is no default registry -- both places that build a registry


### PR DESCRIPTION
## Summary

- request full JSON packuments so installed graph manifests retain license and other registry metadata
- keep one in-flight request per registry and package for ordinary packument, exact manifest, and ranged manifest callers
- use a single response representation so the RegistryClient URL-only disk cache cannot mix abbreviated and full metadata
- remove the prerelease-only `fullPackument` option and use the full response unconditionally

## Context

This is a follow-up to #1692. That PR added request coalescing but also routed manifest resolution through abbreviated packuments, which omit license metadata. This PR preserves the coalescing optimization while restoring complete manifest data.

See #1705 for the rc.32/rc.33 isolation and reproduction details.

## Performance

Compared with #1692, request count and in-flight coalescing are unchanged, but full responses transfer and parse more data than abbreviated responses. Compared with the state before #1692, ranged resolution keeps the coalescing improvement, while exact-only resolution fetches the full package document instead of the smaller version endpoint.

The current Vue benchmark fixture exits nonzero on an npm alias on both the base branch and this branch, so those workflow timings are not valid install comparisons.

## Tests

Package info:

- `vlr format`
- `vlr lint`
- `vlr test -- -Rtap --disable-coverage test/index.ts`
- `vlr test -- -Rsilent --coverage-report=text-lcov test/index.ts`
- `vlr posttest`

CLI SDK:

- `vlr format`
- `vlr lint`
- `vlr test -- -Rtap --disable-coverage test/commands/view.ts`
- `vlr test -- -Rsilent --coverage-report=text-lcov test/commands/view.ts`
- `vlr posttest`

The regression test verifies concurrent packument, exact-manifest, and ranged-manifest callers make exactly one `application/json` request and retain license metadata. Coverage remains 100% for lines, branches, and functions.

Closes #1705.