### PR TITLE
fix: decompress gzip OTP challenges

### DIFF
--- a/src/registry-client/src/otplease.ts
+++ b/src/registry-client/src/otplease.ts
@@ -7,6 +7,7 @@ import type {
 import { getWebAuthChallenge } from './web-auth-challenge.ts'
 import { urlOpen } from '@vltpkg/url-open'
 import { createInterface } from 'node:readline/promises'
+import { gunzipSync } from 'node:zlib'
 
 // eslint-disable-next-line no-console
 const log = (msg: string) => console.error(msg)
@@ -23,6 +24,18 @@ const question = async (text: string): Promise<string> => {
 
 const otpChallengeNotice =
   /^Open ([^ ]+) to use your security key for authentication or enter OTP from your authenticator app/i
+
+const responseBodyText = async (
+  response: Dispatcher.ResponseData,
+): Promise<string> => {
+  const contentEncoding = String(
+    response.headers['content-encoding'] ?? '',
+  )
+  if (/\bgzip\b/i.test(contentEncoding)) {
+    return gunzipSync(await response.body.arrayBuffer()).toString()
+  }
+  return await response.body.text()
+}
 
 export type OtpResult =
   | { retry: RegistryClientRequestOptions }
@@ -48,7 +61,9 @@ export const otplease = async (
   if (wwwAuth.has('otp')) {
     // do a web auth opener to get otp token
     const challenge = getWebAuthChallenge(
-      await response.body.json().catch(() => null),
+      await responseBodyText(response)
+        .then(text => JSON.parse(text) as unknown)
+        .catch(() => null),
     )
     if (challenge) {
       return {
@@ -94,7 +109,7 @@ export const otplease = async (
   // Consume the body to check if it's prompting for OTP.
   // We must return the consumed text so the caller doesn't try to
   // re-read from the already-drained stream.
-  const text = await response.body.text().catch(() => '')
+  const text = await responseBodyText(response).catch(() => '')
   if (text.toLowerCase().includes('one-time pass')) {
     return {
       retry: {

--- a/src/registry-client/test/otplease.ts
+++ b/src/registry-client/test/otplease.ts
@@ -1,4 +1,5 @@
 import t from 'tap'
+import { gzipSync } from 'node:zlib'
 import type { Dispatcher } from 'undici'
 import type { RegistryClient } from '../src/index.ts'
 import type { WebAuthChallenge } from '../src/web-auth-challenge.ts'
@@ -34,6 +35,11 @@ const mockClient = {
     return { token: 'token' }
   },
 } as unknown as RegistryClient
+
+const body = (text: string, gzip = false) =>
+  gzip ?
+    { arrayBuffer: async () => gzipSync(text) }
+  : { text: async () => text }
 
 const { otplease } = await t.mockImport<
   typeof import('../src/otplease.ts')
@@ -92,9 +98,7 @@ t.test('unknown www-authenticate challenges', async t => {
       headers: {
         'www-authenticate': 'otp',
       },
-      body: {
-        json: async () => ({}),
-      },
+      body: body('{}'),
     } as unknown as Dispatcher.ResponseData),
     {
       message: 'Unrecognized OTP authentication challenge',
@@ -107,15 +111,34 @@ t.test('www-authenticate otp challenge', async t => {
     headers: {
       'www-authenticate': 'otp',
     },
-    body: {
-      json: async () => ({
+    body: body(
+      JSON.stringify({
         loginUrl: 'login url',
         doneUrl: 'done url',
       }),
-    },
+    ),
   } as unknown as Dispatcher.ResponseData)
   t.strictSame(doneUrlsOpened, ['done url'])
   t.strictSame(urlsOpened, ['login url'])
+  t.match(result, { retry: { otp: 'token' } })
+})
+
+t.test('gzip-compressed www-authenticate otp challenge', async t => {
+  const result = await otplease(mockClient, {}, {
+    headers: {
+      'www-authenticate': 'otp',
+      'content-encoding': 'gzip',
+    },
+    body: body(
+      JSON.stringify({
+        authUrl: 'auth url',
+        doneUrl: 'done url',
+      }),
+      true,
+    ),
+  } as unknown as Dispatcher.ResponseData)
+  t.strictSame(doneUrlsOpened, ['done url'])
+  t.strictSame(urlsOpened, ['auth url'])
   t.match(result, { retry: { otp: 'token' } })
 })
 
@@ -126,9 +149,7 @@ t.test('npm-notice prompting for OTP', async t => {
       'npm-notice':
         'Open {login-url} to use your security key for authentication or enter OTP from your authenticator app',
     },
-    body: {
-      json: async () => ({}),
-    },
+    body: body('{}'),
   } as unknown as Dispatcher.ResponseData)
   t.strictSame(doneUrlsOpened, [])
   t.strictSame(urlsOpened, ['{login-url}'])
@@ -146,6 +167,20 @@ t.test('body prompting for OTP', async t => {
     body: {
       text: async () => 'oNe-TiME pAsS',
     },
+  } as unknown as Dispatcher.ResponseData
+  const result = await otplease(mockClient, {}, resp)
+  t.ok(result && 'retry' in result)
+  if (result && 'retry' in result) {
+    t.equal(result.retry.otp, 'oNe-TiME pAsS')
+  }
+})
+
+t.test('gzip-compressed body prompting for OTP', async t => {
+  const resp = {
+    headers: {
+      'content-encoding': 'gzip',
+    },
+    body: body('oNe-TiME pAsS', true),
   } as unknown as Dispatcher.ResponseData
   const result = await otplease(mockClient, {}, resp)
   t.ok(result && 'retry' in result)


### PR DESCRIPTION
## Summary

Registry authentication errors bypass the cache path that normally decompresses response bodies. Decode gzip-compressed OTP challenge bodies before parsing JSON or checking the fallback text prompt.

Fixes #1683