### PR TITLE
docs: refresh onboarding and CLI package readme

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,36 @@
 # Contributing Guide
 
+## Getting Started
+
+Development requires Git, Node.js 22.22.x, and the latest released
+`vlt` CLI. If you use [`nvm`](https://github.com/nvm-sh/nvm), the
+repository's `.nvmrc` selects the supported Node.js major.
+
+```bash
+# Clone the repository
+git clone https://github.com/vltpkg/vltpkg.git
+cd vltpkg
+
+# Install and select the Node.js version from .nvmrc
+nvm install
+nvm use
+
+# Install the released CLI used to bootstrap the repository
+curl -fsSL https://install.vlt.sh | bash
+
+# Install dependencies and prepare generated workspace files
+vlt install
+vlr --recursive prepare
+
+# Run the CLI directly from source
+./scripts/bins/vlt --version
+```
+
+You do not need to run `vlt setup` to work on this repository. That
+command configures registry aliases and authentication for a vlt.io
+account. The checked-in [`vlt.json`](./vlt.json) already points this
+project at the public registry used to install its dependencies.
+
 ## Workspace Structure
 
 The workspaces are divided among a few top-level directories.
@@ -10,24 +41,24 @@ specific to that component.
 
 ### [`src`](./src/)
 
-These workspaces are all are direct dependencies of the `vlt` CLI.
+These workspaces are direct dependencies of the `vlt` CLI.
 
-The actual CLI is also a workspace in [`src/cli-sdk`](./src/cli-sdk/).
+The CLI framework is also a workspace in
+[`src/cli-sdk`](./src/cli-sdk/).
 
 Most of these are also published separately under the `@vltpkg` scope.
 
 ### [`infra`](./infra/)
 
-These workspaces are internal tools that we use for tasks like
-building, bundling, and benchmarking the other workspaces.
-
-These are internal and highly coupled to our monorepo setup, so they
-are not published to any registry.
+These workspaces contain tools for building, bundling, and
+benchmarking the other workspaces. They also contain the publishable
+CLI distributions in [`infra/cli`](./infra/cli/) and
+[`infra/cli-js`](./infra/cli-js/).
 
 ### [`www`](./www/)
 
 These are websites that get deployed. Currently only
-[docs.vlt.io](https://docs.vlt.io).
+[docs.vlt.sh](https://docs.vlt.sh).
 
 ## Linting / Formatting
 
@@ -36,18 +67,19 @@ code, and to attempt to fix them.
 
 ## Running TypeScript Directly
 
-If you are on the latest version of Node, you can run TypeScript files
-directly using `node ./path/to/file.ts`.
+This repository uses Node.js 22.22.x, where type stripping is enabled
+by default. TypeScript files that use erasable syntax can be run
+directly:
 
-If you are on Node 22, you can use `node --experimental-strip-types`.
+```bash
+node ./path/to/file.ts
+```
 
-For both of those options you will see a warning. If that bothers you
-then you can run with `--no-warnings` as well.
-
-In order to make this work for all places where we might spawn a node
-process, run
-`export NODE_OPTIONS=--experimental-strip-types --no-warnings` to set
-this in the environment, rather than on each command.
+Node's built-in type stripping does not type-check files or support
+TypeScript syntax that requires transformation. The launchers in
+`./scripts/bins` set the repository's required `NODE_OPTIONS`
+automatically, so no global environment configuration is needed for
+normal development.
 
 ## Using `nave`
 
@@ -72,9 +104,9 @@ of this project.
 
 ## Using NVM
 
-If you use [`nvm`](https://github.com/nvm-sh/nvm), a compatible
-version of `node` should be automatically installed & used as defined
-in our project's root `.nvmrc` file. Notably, there are
+If you use [`nvm`](https://github.com/nvm-sh/nvm), run `nvm install`
+and `nvm use` to install and select the version defined in the root
+`.nvmrc` file. Notably, there are
 [known issues](https://nodejs.org/en/blog/vulnerability/december-2025-security-releases#downloads-and-release-details)
 in `node` versions `<22.22` and unknown compatibility for `>=23`. If
 you are using a version outside of the known-good range set you are
@@ -83,9 +115,9 @@ in-range version.
 
 ## Using `setup-node` in CI
 
-Our CI uses the `setup-node` action and is explictely configured to
-use the "latest", known-good version of `node` (`^22.14.0`) available.
-You can find this configuration in `.github/workflows/*.yml`.
+Our CI uses the `setup-node` action and is explicitly configured to
+use the latest known-good version of Node.js (`^22.22.0`). You can
+find this configuration in `.github/workflows/*.yml`.
 
 ## Root Level Scripts
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 **Develop. Run. Distribute.**
 
-This is the source monorepo for the [vlt](https://www.vlt.sh) package
+This is the source monorepo for the [vlt](https://www.vlt.io) package
 manager.
 
 ### Documentation
@@ -18,22 +18,39 @@ manager.
 Full documentation, startup guides & API references can be found at
 [docs.vlt.sh](https://docs.vlt.sh).
 
-#### Development
+## Contributing
+
+Development requires Git, Node.js 22.22.x, and the latest released
+`vlt` CLI. The repository's [`.nvmrc`](./.nvmrc) selects the supported
+Node.js major when using `nvm`.
 
 ```bash
-# Clone the repo
-git clone git@github.com:vltpkg/vltpkg.git
+# Clone the repository
+git clone https://github.com/vltpkg/vltpkg.git
 cd vltpkg
 
-# Install deps (and run prepare scripts)
-vlt install
+# Install and select the Node.js version from .nvmrc
+nvm install
+nvm use
 
-# Run the locally built CLI
-vlr vlt # OR ./node_modules/.bin/vlt
+# Install the released CLI used to bootstrap the repository
+curl -fsSL https://install.vlt.sh | bash
+
+# Install dependencies and prepare generated workspace files
+vlt install
+vlr --recursive prepare
+
+# Run the CLI directly from source
+./scripts/bins/vlt --version
 ```
 
-See the [contributing guide](./CONTRIBUTING.md) for more information
-on how to build and develop the various workspaces.
+`vlt setup` is not required for this repository. That command connects
+the CLI to a vlt.io account; this repository's checked-in
+[`vlt.json`](./vlt.json) already configures the registry used to
+bootstrap its dependencies.
+
+See the [contributing guide](./CONTRIBUTING.md) for development
+commands and workspace-specific guidance.
 
 ### Contributors
 

--- a/infra/cli/README.md
+++ b/infra/cli/README.md
@@ -8,8 +8,6 @@
 ![Discord Server Status](https://img.shields.io/discord/1093366081067954178?logo=discord&label=Discord)
 [![Socket Security Status](https://socket.dev/api/badge/npm/package/vlt)](https://socket.dev/npm/package/vlt)
 
-## Commands you know, With more possibility
-
 vlt delivers the tools and infrastructure developers need to
 streamline package management, scale efficiently, and secure a faster,
 more tailored web experience.

--- a/infra/cli/README.md
+++ b/infra/cli/README.md
@@ -8,99 +8,85 @@
 ![Discord Server Status](https://img.shields.io/discord/1093366081067954178?logo=discord&label=Discord)
 [![Socket Security Status](https://socket.dev/api/badge/npm/package/vlt)](https://socket.dev/npm/package/vlt)
 
-**Develop. Run. Distribute.**
+## Commands you know, With more possibility
 
-This is the source monorepo for the [vlt](https://www.vlt.sh) package
-manager.
+vlt delivers the tools and infrastructure developers need to
+streamline package management, scale efficiently, and secure a faster,
+more tailored web experience.
 
-### Documentation
+## Getting Started
 
-Full documentation, startup guides & API references can be found at
-[docs.vlt.sh](https://docs.vlt.sh).
+### Installation
 
-#### Development
+vlt requires Node.js 22.22 or later. Install the CLI with the official
+install script:
 
 ```bash
-# clone the repo
-git clone git@github.com:vltpkg/vltpkg.git
-cd vltpkg
-
-# install deps
-vlt install
-
-# run the locally built cli
-vlr vlt # OR ./node_modules/.bin/vlt
+curl -fsSL https://install.vlt.sh | bash
 ```
 
-See the [contributing guide](./CONTRIBUTING.md) for more information
-on how to build and develop the various workspaces.
+### Configure a registry
 
-### Contributors
+Sign up or log in at [vlt.io](https://www.vlt.io), then run the
+onboarding wizard:
 
-<a href="https://github.com/vltpkg/vltpkg/graphs/contributors">
-  <img src="https://contrib.rocks/image?repo=vltpkg/vltpkg" />
-</a>
+```bash
+vlt setup
+```
 
-### Licenses
+The wizard authenticates with your account and configures the registry
+aliases used by `vlt install` and `vlx`. You can instead
+[configure another registry directly](https://docs.vlt.sh/cli/registries).
 
-Below you can find a complete table of each workspace available in
-this repository and its corresponding license:
+### Install and run
 
-#### Reusable Client Internals (`src/*`)
+In an existing JavaScript project:
 
-| Workspace Name                                     | License                                               | Downloads                                                                         |
-| -------------------------------------------------- | ----------------------------------------------------- | --------------------------------------------------------------------------------- |
-| [@vltpkg/cache](./src/cache)                       | [BSD-2-Clause-Patent](./src/cache/LICENSE)            | ![NPM Downloads](https://img.shields.io/npm/dm/@vltpkg/cache?logo=npm)            |
-| [@vltpkg/cache-unzip](./src/cache-unzip)           | [BSD-2-Clause-Patent](./src/cache-unzip/LICENSE)      | ![NPM Downloads](https://img.shields.io/npm/dm/@vltpkg/cache-unzip?logo=npm)      |
-| [@vltpkg/cli-sdk](./src/cli-sdk)                   | [BSD-2-Clause-Patent](./src/cli-sdk/LICENSE)          | ![NPM Downloads](https://img.shields.io/npm/dm/@vltpkg/cli-sdk?logo=npm)          |
-| [@vltpkg/cmd-shim](./src/cmd-shim)                 | [BSD-2-Clause-Patent](./src/cmd-shim/LICENSE)         | ![NPM Downloads](https://img.shields.io/npm/dm/@vltpkg/cmd-shim?logo=npm)         |
-| [@vltpkg/config](./src/config)                     | [BSD-2-Clause-Patent](./src/config/LICENSE)           | ![NPM Downloads](https://img.shields.io/npm/dm/@vltpkg/config?logo=npm)           |
-| [@vltpkg/dep-id](./src/dep-id)                     | [BSD-2-Clause-Patent](./src/dep-id/LICENSE)           | ![NPM Downloads](https://img.shields.io/npm/dm/@vltpkg/dep-id?logo=npm)           |
-| [@vltpkg/dot-prop](./src/dot-prop)                 | [MIT](./src/dot-prop/LICENSE)                         | ![NPM Downloads](https://img.shields.io/npm/dm/@vltpkg/dot-prop?logo=npm)         |
-| [@vltpkg/dss-breadcrumb](./src/dss-breadcrumb)     | [BSD-2-Clause-Patent](./src/dss-breadcrumb/LICENSE)   | ![NPM Downloads](https://img.shields.io/npm/dm/@vltpkg/dss-breadcrumb?logo=npm)   |
-| [@vltpkg/dss-parser](./src/dss-parser)             | [BSD-2-Clause-Patent](./src/dss-parser/LICENSE)       | ![NPM Downloads](https://img.shields.io/npm/dm/@vltpkg/dss-parser?logo=npm)       |
-| [@vltpkg/error-cause](./src/error-cause)           | [BSD-2-Clause-Patent](./src/error-cause/LICENSE)      | ![NPM Downloads](https://img.shields.io/npm/dm/@vltpkg/error-cause?logo=npm)      |
-| [@vltpkg/fast-split](./src/fast-split)             | [BSD-2-Clause-Patent](./src/fast-split/LICENSE)       | ![NPM Downloads](https://img.shields.io/npm/dm/@vltpkg/fast-split?logo=npm)       |
-| [@vltpkg/git](./src/git)                           | [ISC](./src/git/LICENSE)                              | ![NPM Downloads](https://img.shields.io/npm/dm/@vltpkg/git?logo=npm)              |
-| [@vltpkg/git-scp-url](./src/git-scp-url)           | [BSD-2-Clause-Patent](./src/git-scp-url/LICENSE)      | ![NPM Downloads](https://img.shields.io/npm/dm/@vltpkg/git-scp-url?logo=npm)      |
-| [@vltpkg/graph](./src/graph)                       | [BSD-2-Clause-Patent](./src/graph/LICENSE)            | ![NPM Downloads](https://img.shields.io/npm/dm/@vltpkg/graph?logo=npm)            |
-| [@vltpkg/graph-run](./src/graph-run)               | [BSD-2-Clause-Patent](./src/graph-run/LICENSE)        | ![NPM Downloads](https://img.shields.io/npm/dm/@vltpkg/graph-run?logo=npm)        |
-| [@vltpkg/init](./src/init)                         | [BSD-2-Clause-Patent](./src/init/LICENSE)             | ![NPM Downloads](https://img.shields.io/npm/dm/@vltpkg/init?logo=npm)             |
-| [@vltpkg/keychain](./src/keychain)                 | [BSD-2-Clause-Patent](./src/keychain/LICENSE)         | ![NPM Downloads](https://img.shields.io/npm/dm/@vltpkg/keychain?logo=npm)         |
-| [@vltpkg/output](./src/output)                     | [BSD-2-Clause-Patent](./src/output/LICENSE)           | ![NPM Downloads](https://img.shields.io/npm/dm/@vltpkg/output?logo=npm)           |
-| [@vltpkg/package-info](./src/package-info)         | [BSD-2-Clause-Patent](./src/package-info/LICENSE)     | ![NPM Downloads](https://img.shields.io/npm/dm/@vltpkg/package-info?logo=npm)     |
-| [@vltpkg/package-json](./src/package-json)         | [BSD-2-Clause-Patent](./src/package-json/LICENSE)     | ![NPM Downloads](https://img.shields.io/npm/dm/@vltpkg/package-json?logo=npm)     |
-| [@vltpkg/pick-manifest](./src/pick-manifest)       | [BSD-2-Clause-Patent](./src/pick-manifest/LICENSE)    | ![NPM Downloads](https://img.shields.io/npm/dm/@vltpkg/pick-manifest?logo=npm)    |
-| [@vltpkg/promise-spawn](./src/promise-spawn)       | [ISC](./src/promise-spawn/LICENSE)                    | ![NPM Downloads](https://img.shields.io/npm/dm/@vltpkg/promise-spawn?logo=npm)    |
-| [@vltpkg/query](./src/query)                       | [BSD-2-Clause-Patent](./src/query/LICENSE)            | ![NPM Downloads](https://img.shields.io/npm/dm/@vltpkg/query?logo=npm)            |
-| [@vltpkg/registry-client](./src/registry-client)   | [BSD-2-Clause-Patent](./src/registry-client/LICENSE)  | ![NPM Downloads](https://img.shields.io/npm/dm/@vltpkg/registry-client?logo=npm)  |
-| [@vltpkg/rollback-remove](./src/rollback-remove)   | [BSD-2-Clause-Patent](./src/rollback-remove/LICENSE)  | ![NPM Downloads](https://img.shields.io/npm/dm/@vltpkg/rollback-remove?logo=npm)  |
-| [@vltpkg/run](./src/run)                           | [BSD-2-Clause-Patent](./src/run/LICENSE)              | ![NPM Downloads](https://img.shields.io/npm/dm/@vltpkg/run?logo=npm)              |
-| [@vltpkg/satisfies](./src/satisfies)               | [BSD-2-Clause-Patent](./src/satisfies/LICENSE)        | ![NPM Downloads](https://img.shields.io/npm/dm/@vltpkg/satisfies?logo=npm)        |
-| [@vltpkg/security-archive](./src/security-archive) | [BSD-2-Clause-Patent](./src/security-archive/LICENSE) | ![NPM Downloads](https://img.shields.io/npm/dm/@vltpkg/security-archive?logo=npm) |
-| [@vltpkg/semver](./src/semver)                     | [BSD-2-Clause-Patent](./src/semver/LICENSE)           | ![NPM Downloads](https://img.shields.io/npm/dm/@vltpkg/semver?logo=npm)           |
-| [@vltpkg/spec](./src/spec)                         | [BSD-2-Clause-Patent](./src/spec/LICENSE)             | ![NPM Downloads](https://img.shields.io/npm/dm/@vltpkg/spec?logo=npm)             |
-| [@vltpkg/tar](./src/tar)                           | [BSD-2-Clause-Patent](./src/tar/LICENSE)              | ![NPM Downloads](https://img.shields.io/npm/dm/@vltpkg/tar?logo=npm)              |
-| [@vltpkg/types](./src/types)                       | [BSD-2-Clause-Patent](./src/types/LICENSE)            | ![NPM Downloads](https://img.shields.io/npm/dm/@vltpkg/types?logo=npm)            |
-| [@vltpkg/url-open](./src/url-open)                 | [BSD-2-Clause-Patent](./src/url-open/LICENSE)         | ![NPM Downloads](https://img.shields.io/npm/dm/@vltpkg/url-open?logo=npm)         |
-| [@vltpkg/vlt-json](./src/vlt-json)                 | [BSD-2-Clause-Patent](./src/vlt-json/LICENSE)         | ![NPM Downloads](https://img.shields.io/npm/dm/@vltpkg/vlt-json?logo=npm)         |
-| [@vltpkg/vlx](./src/vlx)                           | [BSD-2-Clause-Patent](./src/vlx/LICENSE)              | ![NPM Downloads](https://img.shields.io/npm/dm/@vltpkg/vlx?logo=npm)              |
-| [@vltpkg/which](./src/which)                       | [ISC](./src/which/LICENSE)                            | ![NPM Downloads](https://img.shields.io/npm/dm/@vltpkg/which?logo=npm)            |
-| [@vltpkg/workspaces](./src/workspaces)             | [BSD-2-Clause-Patent](./src/workspaces/LICENSE)       | ![NPM Downloads](https://img.shields.io/npm/dm/@vltpkg/workspaces?logo=npm)       |
-| [@vltpkg/xdg](./src/xdg)                           | [BSD-2-Clause-Patent](./src/xdg/LICENSE)              | ![NPM Downloads](https://img.shields.io/npm/dm/@vltpkg/xdg?logo=npm)              |
+```bash
+# Install dependencies from package.json
+vlt install
 
-#### Infrastructure (`infra/*`)
+# Add a dependency
+vlt install lodash
 
-| Workspace Name                           | License                                           | Downloads                                                               |
-| ---------------------------------------- | ------------------------------------------------- | ----------------------------------------------------------------------- |
-| [@vltpkg/benchmark](./infra/benchmark)   | [BSD-2-Clause-Patent](./infra/benchmark/LICENSE)  | N/A                                                                     |
-| [@vltpkg/infra-build](./infra/build)     | [BSD-2-Clause-Patent](./infra/build/LICENSE)      | N/A                                                                     |
-| [vlt](./infra/cli)                       | [BSD-2-Clause-Patent](./infra/cli/LICENSE)        | ![NPM Downloads](https://img.shields.io/npm/dm/vlt?logo=npm)            |
-| [@vltpkg/cli-js](./infra/cli-js)         | [BSD-2-Clause-Patent](./infra/cli-js/LICENSE)     | ![NPM Downloads](https://img.shields.io/npm/dm/@vltpkg/cli-js?logo=npm) |
-| [@vltpkg/smoke-test](./infra/smoke-test) | [BSD-2-Clause-Patent](./infra/smoke-test/LICENSE) | N/A                                                                     |
+# Run a package.json script
+vlt run test
 
-#### Documentation (`www/*`)
+# Execute a package without installing it as a dependency
+vlx cowsay "hello from vlt"
+```
 
-| Workspace Name             | License                                   |
-| -------------------------- | ----------------------------------------- |
-| [@vltpkg/docs](./www/docs) | [BSD-2-Clause-Patent](./www/docs/LICENSE) |
+vlt does not run dependency lifecycle scripts during installation.
+Review packages that require scripts and build the approved ones
+explicitly:
+
+```bash
+vlt query ':scripts'
+vlt build
+```
+
+## Documentation
+
+Visit [docs.vlt.sh](https://docs.vlt.sh/cli) for guides, migration
+instructions, configuration, and the complete command reference.
+
+## Community
+
+Report bugs in
+[GitHub Issues](https://github.com/vltpkg/vltpkg/issues), ask
+questions and share ideas in
+[GitHub Discussions](https://github.com/vltpkg/vltpkg/discussions), or
+chat with the community on
+[Discord](https://discord.com/invite/qdbXTqxZzZ). Please follow the
+[Code of Conduct](https://github.com/vltpkg/vltpkg/blob/main/CODE_OF_CONDUCT.md)
+in all community spaces.
+
+## Contributing
+
+Contributions are welcome. Read the
+[contributing guide](https://github.com/vltpkg/vltpkg/blob/main/CONTRIBUTING.md)
+before opening a pull request.
+
+## License
+
+[BSD-2-Clause-Patent](./LICENSE)

--- a/scripts/consistent-package-json.ts
+++ b/scripts/consistent-package-json.ts
@@ -314,22 +314,6 @@ const fixCliVariants = async (ws: Workspace) => {
   }
 
   ws.pj.description = 'The vlt CLI'
-  const readmeContent = readFileSync(
-    resolve(ws.dir, 'README.md'),
-    'utf8',
-  )
-  const parts = readmeContent.split(/(```[\s\S]*?```)/g)
-  const processedContent = parts
-    .map((part, i) => {
-      if (i % 2 === 0) {
-        return part
-          .replaceAll(/`vlt`( \(.*\))?/g, '`vlt`')
-          .replaceAll(/^# .*$/gm, `# ${ws.pj.name}`)
-      }
-      return part
-    })
-    .join('')
-  await writeFormatted(resolve(ws.dir, 'README.md'), processedContent)
 }
 
 const fixEngines = async (ws: Workspace) => {

--- a/www/docs/src/content/docs/cli/index.mdx
+++ b/www/docs/src/content/docs/cli/index.mdx
@@ -10,17 +10,9 @@ import { Code } from '@astrojs/starlight/components'
 ## Installation
 
 <Code
-  code="$ npm install vlt@latest -g"
+  code="$ curl -fsSL https://install.vlt.sh | bash"
   title="Terminal"
   lang="bash"
 />
 
-<Code code="$ pnpm i -g vlt" title="Terminal" lang="bash" />
-
-<Code
-  code="$ curl https://install.vlt.sh"
-  title="Terminal"
-  lang="bash"
-/>
-
-`vlt` is supported on Node versions `20` or `22` currently.
+`vlt` requires Node.js 22.22 or later.

--- a/www/docs/src/content/docs/cli/security.mdx
+++ b/www/docs/src/content/docs/cli/security.mdx
@@ -7,10 +7,10 @@ sidebar:
 
 import { Code } from '@astrojs/starlight/components'
 
-VLT provides powerful security analysis capabilities through
+vlt provides powerful security analysis capabilities through
 integration with [Socket](https://socket.dev/), enabling you to
 identify and assess security risks in your dependencies. This guide
-covers how to use VLT's security-focused selectors to detect malware,
+covers how to use vlt's security-focused selectors to detect malware,
 vulnerabilities, and other security issues.
 
 ## Quick Security Scan

--- a/www/docs/src/content/docs/get-started/npm-interoperability.mdx
+++ b/www/docs/src/content/docs/get-started/npm-interoperability.mdx
@@ -42,14 +42,10 @@ The full set of options, including per-registry auth, is in
 You don't need it to use the registry, but the vlt CLI adds
 [catalogs](/cli/catalogs),
 [Dependency Selector Syntax](/cli/selectors), & safer installs.
-Install it with the tools you already have:
+Install it with the official install script:
 
 ```bash
-npm install vlt@latest -g
-# or
-pnpm i -g vlt
-# or
-curl https://install.vlt.sh
+curl -fsSL https://install.vlt.sh | bash
 ```
 
-vlt runs on Node 20 & 22.
+vlt requires Node.js 22.22 or later.


### PR DESCRIPTION
## Summary

- update the root README and contributing guide with the current repository bootstrap flow
- clarify that `vlt setup` configures a vlt.io account and is not required for this repository because its checked-in `vlt.json` provides registry configuration
- replace the published `vlt` package README’s monorepo details with installation, setup, common usage, documentation, and community guidance
- reuse the official client page’s hero copy in the published package README, using lowercase `vlt` in prose
- use the canonical `curl -fsSL https://install.vlt.sh | bash` installation flow from the vlt client page throughout
- align the public getting-started pages with the `>=22.22.0` engine requirement
- normalize the remaining uppercase `VLT` references in Markdown prose
- remove obsolete CLI README rewriting from the package consistency script while retaining CLI manifest normalization

## Published README

The package README now follows the concise, user-facing shape used by packages such as `next`: product overview, getting started, documentation, community, contributing, and license. Local repository development instructions remain in the root README and contributing guide.

## Validation

- `vlr format:check`
- `vlr lint:check`
- `vlr --workspace ./www/docs lint:mdx`
- `vlr --workspace ./www/docs posttest`
- `vlr --recursive prepare`
- `./scripts/bins/vlt --version`
- `vlr fix:pkg` with byte-identical CLI READMEs before and after
- dry-packed `infra/cli` and verified the rewritten README is included byte-for-byte