### PR TITLE
chore: restore vlt-lock consistency check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,8 +136,8 @@ jobs:
         continue-on-error: true
         run: |
           vlr fix:pkg
-          if [ -n "$(git status --porcelain -- . ':!vlt-lock.json')" ]; then
-            git diff -- . ':!vlt-lock.json'
+          if [ -n "$(git status --porcelain)" ]; then
+            git diff
             exit 1
           fi
 

--- a/vlt-lock.json
+++ b/vlt-lock.json
@@ -29,6 +29,10 @@
       "typescript-eslint": "^8.49.0",
       "typescript": "5.7.3",
       "walk-up-path": "^4.0.0"
+    },
+    "registry": "https://registry.npmjs.org/",
+    "registries": {
+      "npm": "https://registry.npmjs.org/"
     }
   },
   "nodes": {


### PR DESCRIPTION
## Summary

- restore the full working-tree diff check after `vlr fix:pkg`
- record normalized npm registry settings in `vlt-lock.json` so source-built vlt no longer rewrites it
- preserve the existing dependency resolutions instead of accepting unrelated lockfile churn

## Testing

- `vlr format`
- `vlr lint`
- full test suite
- verified a clean source install leaves `vlt-lock.json` byte-for-byte unchanged
- coverage was attempted but hit the existing `src/registry-client` fixture cleanup race (`ENOTEMPTY`); types were not run after that failure per the repository validation order