### PR TITLE
chore: fix malware dependency check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -188,8 +188,8 @@ jobs:
 
       - name: Check for malware
         run: |
-          vlt query ':malware(critical)'
-          vlt query ':malware(critical)' --expect-results=0
+          vlt query ':malware'
+          vlt query ':malware' --expect-results=0
 
       - name: Check for copyleft licenses
         run: |


### PR DESCRIPTION
## Summary

- update the Dependency Checks workflow for the breaking selector semantics from #1698
- replace the invalid :malware(critical) queries with parameterless :malware
- preserve the existing zero-results malware gate

## Validation

- source CLI 1.0.0-rc.34: both :malware workflow commands pass
- vlr format
- vlr lint
- recursive test run stopped on the known src/registry-client ENOTEMPTY teardown race documented in #1717