### PR TITLE
docs: redirect /migration/from-pnpm to /cli/migration/from-pnpm

### DIFF
--- a/www/docs/vercel.json
+++ b/www/docs/vercel.json
@@ -1,4 +1,11 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
-  "ignoreCommand": "git diff --quiet $VERCEL_GIT_PREVIOUS_SHA $VERCEL_GIT_COMMIT_SHA -- www/docs/"
+  "ignoreCommand": "git diff --quiet $VERCEL_GIT_PREVIOUS_SHA $VERCEL_GIT_COMMIT_SHA -- www/docs/",
+  "redirects": [
+    {
+      "source": "/migration/from-pnpm",
+      "destination": "/cli/migration/from-pnpm",
+      "permanent": true
+    }
+  ]
 }


### PR DESCRIPTION
Add server-side redirect in vercel.json to route the old migration URL path to the correct location under the CLI section.