### PR TITLE
ci: skip benchmark job on docs-only changes

### DIFF
--- a/.github/workflows/base_benchmarks.yml
+++ b/.github/workflows/base_benchmarks.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - 'www/docs/**'
+      - '**/*.md'
 
 jobs:
   benchmark_base_branch:


### PR DESCRIPTION
## Overview

Skip benchmark jobs when only documentation or markdown files change, since these changes don't affect performance metrics.

## Changes

- Add `paths-ignore` filter to baseline benchmarks workflow
- Excludes: `www/docs/**` and `**/*.md`

## Rationale

Documentation and markdown-only changes don't affect CLI performance, so running benchmarks is unnecessary. This aligns with how the main CI pipeline filters test runs (see `ci.yml` change detection for `src` changes).

Benchmarks will still run on all other changes, ensuring baseline metrics are tracked for performance-relevant code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)