### PR TITLE
doc: add "Edit page" links to bottom of doc pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -85,3 +85,4 @@ knip.d.ts.map
 
 **/.opencode/**
 opencode.jsonc
+**/.serena/**

--- a/www/docs/src/components/edit-link/edit-link.astro
+++ b/www/docs/src/components/edit-link/edit-link.astro
@@ -1,0 +1,6 @@
+---
+import type { Props } from '@astrojs/starlight/props'
+import { EditLink as EditLinkComponent } from './edit-link.tsx'
+---
+
+<EditLinkComponent {...Astro.props} />

--- a/www/docs/src/components/edit-link/edit-link.tsx
+++ b/www/docs/src/components/edit-link/edit-link.tsx
@@ -1,0 +1,17 @@
+import { PencilIcon } from 'lucide-react'
+import type { Props } from '@astrojs/starlight/props'
+
+export const EditLink = ({ editUrl }: Props) => {
+  if (!editUrl) return null
+
+  return (
+    <a
+      href={editUrl.toString()}
+      className="text-sm text-muted-foreground no-underline transition-all hover:text-foreground">
+      <span className="inline-flex items-center gap-2">
+        <PencilIcon size={16} />
+        Edit this page
+      </span>
+    </a>
+  )
+}

--- a/www/docs/src/components/footer/footer.astro
+++ b/www/docs/src/components/footer/footer.astro
@@ -1,6 +1,10 @@
 ---
 import type { Props } from '@astrojs/starlight/props'
+import EditLink from '@/components/edit-link/edit-link.astro'
 import Pagination from '@/components/pagination/pagination.astro'
 ---
 
-<Pagination {...Astro.props} />
+<div class="flex flex-col gap-8">
+  <EditLink {...Astro.props} class="mt-4" />
+  <Pagination {...Astro.props} />
+</div>

--- a/www/docs/src/components/footer/footer.astro
+++ b/www/docs/src/components/footer/footer.astro
@@ -4,7 +4,7 @@ import EditLink from '@/components/edit-link/edit-link.astro'
 import Pagination from '@/components/pagination/pagination.astro'
 ---
 
-<div class="flex flex-col gap-8 mt-6">
+<div class="mt-6 flex flex-col gap-8">
   <EditLink {...Astro.props} />
   <Pagination {...Astro.props} />
 </div>

--- a/www/docs/src/components/footer/footer.astro
+++ b/www/docs/src/components/footer/footer.astro
@@ -4,7 +4,7 @@ import EditLink from '@/components/edit-link/edit-link.astro'
 import Pagination from '@/components/pagination/pagination.astro'
 ---
 
-<div class="flex flex-col gap-8">
-  <EditLink {...Astro.props} class="mt-4" />
+<div class="flex flex-col gap-8 mt-6">
+  <EditLink {...Astro.props} />
   <Pagination {...Astro.props} />
 </div>


### PR DESCRIPTION
## Changes

The config was added, but the component was missing. 
This PR adds an edit link component that appears above pagination at the bottom of documentation pages, to encourage contribution to docs if people find any mismatch or missing info.

The edit link:
- Uses Starlight's `editUrl` prop from the editLink.baseUrl config
- Displays a pencil icon with 'Edit this page' text
- Links directly to edit the source file on GitHub
- Styled to match the site's link design with transition-all hover effect

<img width="1470" height="563" alt="Screenshot 2026-08-14 at 10 16 13 AM" src="https://github.com/user-attachments/assets/ca985b24-9369-4256-ace8-437640a6f275" />

