### PR TITLE
graph: fix warm cache hits

### DIFF
--- a/src/graph/src/lockfile/load-nodes.ts
+++ b/src/graph/src/lockfile/load-nodes.ts
@@ -123,6 +123,7 @@ export const loadNodes = (
       type === 'remote' ? filepath : (
         (resolved ?? referenceNode?.resolved)
       )
+    node.resolvedFromLockfile = !!(node.integrity && node.resolved)
     node.projectRoot = graph.projectRoot
     if (!node.resolved) node.setResolved()
     if (location) {

--- a/src/graph/src/node.ts
+++ b/src/graph/src/node.ts
@@ -140,6 +140,12 @@ export class Node implements NodeLike {
   integrity?: Integrity
 
   /**
+   * True when `integrity` and `resolved` came from a lockfile, i.e. they were
+   * verified by the install that wrote them.
+   */
+  resolvedFromLockfile = false
+
+  /**
    * The manifest this node represents in the graph.
    */
   manifest?: NormalizedManifest

--- a/src/graph/src/reify/extract-node.ts
+++ b/src/graph/src/reify/extract-node.ts
@@ -84,16 +84,23 @@ export const extractNode = async (
     }
   }
 
+  const extractOptions = {
+    from,
+    integrity,
+    resolved,
+    fromLockfile: node.resolvedFromLockfile,
+  }
+
   try {
     await remover.rm(target)
 
     if (removeOptionalFailedNode) {
       try {
-        const result = await packageInfo.extract(spec, target, {
-          from,
-          integrity,
-          resolved,
-        })
+        const result = await packageInfo.extract(
+          spec,
+          target,
+          extractOptions,
+        )
         // Store computed integrity for git/remote deps
         if (result.integrity && !node.integrity) {
           node.integrity = result.integrity
@@ -104,11 +111,11 @@ export const extractNode = async (
         return { success: false, node, error }
       }
     } else {
-      const result = await packageInfo.extract(spec, target, {
-        from,
-        integrity,
-        resolved,
-      })
+      const result = await packageInfo.extract(
+        spec,
+        target,
+        extractOptions,
+      )
       // Store computed integrity for git/remote deps
       if (result.integrity && !node.integrity) {
         node.integrity = result.integrity

--- a/src/graph/tap-snapshots/test/graph.ts.test.cjs
+++ b/src/graph/tap-snapshots/test/graph.ts.test.cjs
@@ -172,6 +172,7 @@ Set {
     "projectRoot": #
     "registry": undefined,
     "resolved": undefined,
+    "resolvedFromLockfile": false,
     "version": "1.0.0",
     "workspaces": Map {
       "b" => Edge {
@@ -294,6 +295,7 @@ Set {
           "projectRoot": #
           "registry": undefined,
           "resolved": undefined,
+          "resolvedFromLockfile": false,
           "version": "1.0.0",
           "workspaces": undefined,
         },
@@ -419,6 +421,7 @@ Set {
           "projectRoot": #
           "registry": undefined,
           "resolved": undefined,
+          "resolvedFromLockfile": false,
           "version": "1.0.0",
           "workspaces": undefined,
         },
@@ -452,6 +455,7 @@ Set {
     "projectRoot": #
     "registry": undefined,
     "resolved": undefined,
+    "resolvedFromLockfile": false,
     "version": "1.0.0",
     "workspaces": undefined,
   },
@@ -481,6 +485,7 @@ Set {
     "projectRoot": #
     "registry": undefined,
     "resolved": undefined,
+    "resolvedFromLockfile": false,
     "version": "1.0.0",
     "workspaces": undefined,
   },

--- a/src/graph/tap-snapshots/test/node.ts.test.cjs
+++ b/src/graph/tap-snapshots/test/node.ts.test.cjs
@@ -17,6 +17,7 @@ Node [@vltpkg/graph.Node] {
   mainImporter: true,
   graph: {},
   integrity: undefined,
+  resolvedFromLockfile: false,
   manifest: [Object],
   projectRoot: #
   registry: undefined,

--- a/src/graph/test/lockfile/load-nodes.ts
+++ b/src/graph/test/lockfile/load-nodes.ts
@@ -52,6 +52,18 @@ t.test('load nodes', async t => {
     ],
   } as LockfileData['nodes']
   loadNodes(graph, nodes, {})
+  t.equal(
+    graph.nodes.get(joinDepIDTuple(['registry', '', 'bar@1.0.0']))
+      ?.resolvedFromLockfile,
+    true,
+    'integrity+resolved from lockfile',
+  )
+  t.equal(
+    graph.nodes.get(joinDepIDTuple(['registry', '', 'foo@1.0.0']))
+      ?.resolvedFromLockfile,
+    false,
+    'integrity without resolved is not lockfile-verified',
+  )
   t.matchSnapshot(
     [...graph.nodes.values()].map(n => n.toJSON()),
     'should load nodes into graph',

--- a/src/graph/test/lockfile/load.ts
+++ b/src/graph/test/lockfile/load.ts
@@ -108,6 +108,18 @@ t.test('load', async t => {
     projectRoot,
     mainManifest,
   })
+  t.equal(
+    graph.nodes.get(joinDepIDTuple(['registry', '', 'bar@1.0.0']))
+      ?.resolvedFromLockfile,
+    true,
+    'integrity+resolved from lockfile',
+  )
+  t.equal(
+    graph.nodes.get(joinDepIDTuple(['registry', '', 'foo@1.0.0']))
+      ?.resolvedFromLockfile,
+    false,
+    'integrity without resolved is not lockfile-verified',
+  )
   t.matchSnapshot(objectLikeOutput(graph))
 })
 
@@ -219,6 +231,18 @@ t.test('loadHidden', async t => {
     projectRoot,
     mainManifest,
   })
+  t.equal(
+    graph.nodes.get(joinDepIDTuple(['registry', '', 'bar@1.0.0']))
+      ?.resolvedFromLockfile,
+    true,
+    'integrity+resolved from hidden lockfile',
+  )
+  t.equal(
+    graph.nodes.get(joinDepIDTuple(['registry', '', 'foo@1.0.0']))
+      ?.resolvedFromLockfile,
+    false,
+    'integrity without resolved is not lockfile-verified',
+  )
   t.matchSnapshot(objectLikeOutput(graph))
 })
 

--- a/src/graph/test/reify/extract-node.ts
+++ b/src/graph/test/reify/extract-node.ts
@@ -50,6 +50,7 @@ t.beforeEach(() => {
 
 const mockNode = (props: Record<string, any>) =>
   ({
+    resolvedFromLockfile: false,
     ...props,
     resolvedLocation: (scurry: PathScurry) =>
       scurry.cwd.resolve(props.location).fullpath(),
@@ -78,6 +79,7 @@ t.test('successfully extract a node', async t => {
     manifest: { name: 'foo', version: '1.2.3' },
     integrity: 'sha512-abc123',
     resolved: 'https://registry.npmjs.org/foo/-/foo-1.2.3.tgz',
+    resolvedFromLockfile: true,
   })
 
   const scurry = new PathScurry(t.testdirName)
@@ -119,6 +121,7 @@ t.test('successfully extract a node', async t => {
     'https://registry.npmjs.org/foo/-/foo-1.2.3.tgz',
     'resolved passed',
   )
+  t.equal(options.fromLockfile, true, 'fromLockfile passed')
 })
 
 t.test('handle extraction failure for optional node', async t => {
@@ -346,6 +349,11 @@ t.test('extract node without diff object', async t => {
       'extraction successful without diff',
     )
     t.equal(extracted.length, 1, 'package extracted')
+    t.equal(
+      extracted[0]?.[2].fromLockfile,
+      false,
+      'fromLockfile false when not from lockfile',
+    )
   })
 
   t.test(

--- a/src/package-info/src/index.ts
+++ b/src/package-info/src/index.ts
@@ -247,20 +247,17 @@ export class PackageInfoClient {
 
           const buf = response.buffer()
 
-          // Verify tarball integrity against the manifest's
-          // dist.integrity. This is a supply-chain security measure:
-          // the registry may not validate integrity, so we do it
-          // client-side on every fresh download. Skip when integrity
-          // came from lockfile/cache (it was already verified on
-          // first install).
-          /* c8 ignore start - defense-in-depth: registry client's
-           * checkIntegrity() usually catches mismatches first since
-           * it checks the same gzip bytes. This fires only when the
-           * registry client check is skipped (trustIntegrity=true). */
-          if (r.integrity && !fromLockfile) {
+          // Verify network-delivered tarball bytes against dist.integrity.
+          // Skip cache-served bodies: they were verified on the fetch that
+          // populated the cache, and cache-unzip rewrites them un-gzipped
+          // so the gzip-hash can never match. Skip lockfile-sourced
+          // integrity: it was verified on first install.
+          if (r.integrity && !fromLockfile && !response.fromCache) {
             const hash = createHash('sha512')
             hash.update(buf)
             const computed: Integrity = `sha512-${hash.digest('base64')}`
+            /* c8 ignore start - defense-in-depth: registry client's
+             * checkIntegrity() usually catches mismatches first. */
             if (computed !== r.integrity) {
               throw error('Tarball integrity check failed', {
                 code: 'EINTEGRITY',
@@ -270,8 +267,8 @@ export class PackageInfoClient {
                 found: computed,
               })
             }
+            /* c8 ignore stop */
           }
-          /* c8 ignore stop */
 
           return buf
         }
@@ -532,13 +529,12 @@ export class PackageInfoClient {
 
           const buf = response.buffer()
 
-          // Verify tarball integrity against the manifest's
-          // dist.integrity.
-          /* c8 ignore start - defense-in-depth (see extract) */
-          if (integrity) {
+          // Same as extract(): only hash network-delivered bodies.
+          if (integrity && !response.fromCache) {
             const hash = createHash('sha512')
             hash.update(buf)
             const computed: Integrity = `sha512-${hash.digest('base64')}`
+            /* c8 ignore start - defense-in-depth (see extract) */
             if (computed !== integrity) {
               throw error('Tarball integrity check failed', {
                 code: 'EINTEGRITY',
@@ -548,8 +544,8 @@ export class PackageInfoClient {
                 found: computed,
               })
             }
+            /* c8 ignore stop */
           }
-          /* c8 ignore stop */
 
           return buf
         }

--- a/src/package-info/test/index.ts
+++ b/src/package-info/test/index.ts
@@ -21,6 +21,7 @@ import type {
   PackageInfoClientOptions,
   PackageInfoClientRequestOptions,
 } from '../src/index.ts'
+import { CacheEntry } from '@vltpkg/registry-client/cache-entry'
 import { PackageInfoClient } from '../src/index.ts'
 
 t.saveFixture = true
@@ -102,6 +103,7 @@ const server = createServer((req, res) => {
   res.setHeader('connection', 'close')
   switch (req.url) {
     case '/abbrev/-/abbrev-2.0.0.tgz': {
+      abbrevTgzRequests++
       res.setHeader('content-type', 'application/octet-stream')
       res.setHeader('content-length', tgzAbbrev.byteLength)
       res.setHeader(
@@ -328,6 +330,7 @@ const notFoundURLs: string[] = []
 let corruptedOnceServed = 0
 let coalescedPackumentRequests = 0
 let coalescedPackumentAccept: string | undefined
+let abbrevTgzRequests = 0
 
 const defaultRegistry = `http://localhost:${PORT}/`
 const options = {
@@ -1103,6 +1106,63 @@ t.test('registry tarball integrity verification', async t => {
         'should verify tarball integrity even with integrity+resolved provided',
       )
       await pi.registryClient.cache.promise()
+    },
+  )
+
+  await t.test(
+    'extract from unzipped cache does not re-fetch tarball',
+    async t => {
+      const dir = t.testdir({ 'vlt.json': '{}' })
+      t.chdir(dir)
+      unload()
+      const cacheDir = dir + '/cache'
+      const tarballUrl = `${defaultRegistry}abbrev/-/abbrev-2.0.0.tgz`
+      const pi = new PackageInfoClient({
+        ...options,
+        cache: cacheDir,
+      })
+      await pi.extract('abbrev@2', dir + '/first')
+      await pi.registryClient.cache.promise()
+
+      const cache = pi.registryClient.cache
+      const buf = await cache.fetch(tarballUrl)
+      t.ok(buf, 'tarball is in cache')
+      if (!buf) return
+      const e = CacheEntry.decode(buf)
+      e.unzip()
+      cache.set(tarballUrl, e.encode(), {
+        integrity: e.integrity,
+      })
+      await cache.promise()
+
+      const before = abbrevTgzRequests
+      const pi2 = new PackageInfoClient({
+        ...options,
+        cache: cacheDir,
+      })
+      await pi2.extract('abbrev@2', dir + '/second')
+      t.equal(
+        abbrevTgzRequests,
+        before,
+        'no tarball requests on warm cache',
+      )
+      const json = readFileSync(`${dir}/second/package.json`, 'utf8')
+      const pkg = JSON.parse(json) as Manifest
+      t.match(pkg, { name: 'abbrev', version: '2.0.0' })
+
+      const pi3 = new PackageInfoClient({
+        ...options,
+        cache: cacheDir,
+      })
+      const tb = await pi3.tarball('abbrev@2')
+      t.equal(
+        abbrevTgzRequests,
+        before,
+        'tarball() also issues no tarball requests on warm cache',
+      )
+      t.ok(tb.length > 0, 'returned cached tarball bytes')
+      await pi2.registryClient.cache.promise()
+      await pi3.registryClient.cache.promise()
     },
   )
 
@@ -1944,6 +2004,7 @@ t.test(
       'range manifest came from the coalesced packument',
     )
     t.equal(exact.license, 'ISC', 'manifest retains license metadata')
+    await pi.registryClient.cache.promise()
   },
 )
 

--- a/src/registry-client/src/cache-entry.ts
+++ b/src/registry-client/src/cache-entry.ts
@@ -128,6 +128,7 @@ export class CacheEntry {
   #json?: JSONObj
   #trustIntegrity
   #staleWhileRevalidateFactor
+  #fromCache = false
 
   constructor(
     statusCode: number,
@@ -316,6 +317,11 @@ export class CacheEntry {
       this.#body.set(b, this.#bodyLength)
       this.#bodyLength += b.byteLength
     }
+  }
+
+  /** True when this entry was decoded from the on-disk cache. */
+  get fromCache(): boolean {
+    return this.#fromCache
   }
 
   get statusCode() {
@@ -563,6 +569,7 @@ export class CacheEntry {
         contentLength: body.byteLength,
       },
     )
+    c.#fromCache = true
 
     if (c.isJSON) {
       try {

--- a/src/registry-client/test/cache-entry.ts
+++ b/src/registry-client/test/cache-entry.ts
@@ -306,6 +306,25 @@ t.equal(
   false,
 )
 
+t.test('fromCache', t => {
+  const entry = new CacheEntry(
+    200,
+    toRawHeaders({ 'content-type': 'application/octet-stream' }),
+  )
+  entry.addBody(Buffer.from('hello'))
+  t.equal(
+    entry.fromCache,
+    false,
+    'constructed entries are not from cache',
+  )
+  t.equal(
+    CacheEntry.decode(entry.encode()).fromCache,
+    true,
+    'decoded entries are from cache',
+  )
+  t.end()
+})
+
 t.test('isGzip', t => {
   const c = new CacheEntry(
     200,

--- a/src/types/src/index.ts
+++ b/src/types/src/index.ts
@@ -1585,6 +1585,7 @@ export type NodeLike = {
   version?: string | null
   integrity?: string | null
   resolved?: string | null
+  resolvedFromLockfile?: boolean
   importer: boolean
   graph: GraphLike
   mainImporter: boolean


### PR DESCRIPTION
Make sure to track nodes that were loaded from a lockfile to avoid hitting the registry for nodes we already cached.