### PR TITLE
tar: perf improvements

### DIFF
--- a/src/tar/src/index.ts
+++ b/src/tar/src/index.ts
@@ -1,3 +1,3 @@
-export * from './unpack.ts'
+export { unpack } from './unpack.ts'
 export * from './pool.ts'
 export * from './unpack-request.ts'

--- a/src/tar/src/unpack.ts
+++ b/src/tar/src/unpack.ts
@@ -37,26 +37,119 @@ let id = 1
 const tmp = randomBytes(6).toString('hex') + '.'
 const tmpSuffix = () => tmp + String(id++)
 
-const checkFs = (
-  h: Header,
+type FileEntry = {
+  path: string
+  body: Buffer
+  executable: boolean
+  dir: false
+}
+type DirEntry = {
+  path: string
+  dir: true
+}
+type Entry = FileEntry | DirEntry
+
+/* c8 ignore start - case-folding is platform-specific */
+const foldKeys =
+  process.platform === 'darwin' || process.platform === 'win32'
+const entryKey = (p: string) => (foldKeys ? p.toLowerCase() : p)
+/* c8 ignore stop */
+
+// Shared across concurrent unpacks. Reify runs many extractions at
+// once; a per-tarball pool would multiply in-flight writeFile fds.
+const parseWriteLanes = (raw: string | undefined): number => {
+  const n = Number(raw)
+  return Number.isFinite(n) && n >= 1 ? Math.floor(n) : 64
+}
+const writeLaneLimit = parseWriteLanes(
+  process.env.VLT_TAR_WRITE_LANES,
+)
+let writeLanesUsed = 0
+const writeLaneWaiters: (() => void)[] = []
+
+const acquireWriteLane = async () => {
+  if (writeLanesUsed < writeLaneLimit) {
+    writeLanesUsed++
+    return
+  }
+  await new Promise<void>(res => writeLaneWaiters.push(res))
+}
+
+const releaseWriteLane = () => {
+  const next = writeLaneWaiters.shift()
+  if (next) next()
+  else writeLanesUsed--
+}
+
+const withWriteLane = async <T>(fn: () => Promise<T>): Promise<T> => {
+  await acquireWriteLane()
+  try {
+    return await fn()
+  } finally {
+    releaseWriteLane()
+  }
+}
+
+const rethrowFirst = (
+  results: PromiseSettledResult<unknown>[],
+): void => {
+  for (const result of results) {
+    if (result.status === 'rejected') throw result.reason
+  }
+}
+
+// Fast path: accept only paths that cannot escape. Anything else
+// falls through to relative()/resolve() so drive-relative and
+// `./`-segment cases keep today's exact (platform/cwd-dependent)
+// behavior.
+const isClearlySafeRelPath = (sub: string): boolean => {
+  const len = sub.length
+  if (len === 0) return true
+  // leading /
+  if (sub.charCodeAt(0) === 47) return false
+  // <letter>: prefix (drive-relative)
+  if (len >= 2 && sub.charCodeAt(1) === 58) {
+    const c = sub.charCodeAt(0)
+    if ((c >= 65 && c <= 90) || (c >= 97 && c <= 122)) {
+      return false
+    }
+  }
+  let i = 0
+  while (i < len) {
+    let j = i
+    while (j < len && sub.charCodeAt(j) !== 47) j++
+    const slen = j - i
+    if (slen === 1 && sub.charCodeAt(i) === 46) return false
+    if (
+      slen === 2 &&
+      sub.charCodeAt(i) === 46 &&
+      sub.charCodeAt(i + 1) === 46
+    ) {
+      return false
+    }
+    i = j + 1
+  }
+  return true
+}
+
+export const checkFs = (
+  h: { path?: string },
   tarDir: string | undefined,
   target: string,
-): h is Header & { path: string } => {
-  /* c8 ignore start - impossible */
+): h is { path: string } => {
   if (!h.path) return false
   if (!tarDir) return false
-  /* c8 ignore stop */
   h.path = h.path.replace(/[\\/]+/g, '/')
 
   // packages should always be in a 'package' tarDir in the archive
   if (!h.path.startsWith(tarDir)) return false
 
+  const sub = h.path.slice(tarDir.length)
+  if (isClearlySafeRelPath(sub)) return true
+
   // entries must stay within the package root. separator-aware, so that
   // a sibling dir whose name extends the target's is not a prefix match.
-  const rel = relative(
-    target,
-    resolve(target, h.path.slice(tarDir.length)),
-  )
+  const rel = relative(target, resolve(target, sub))
   if (rel === '..' || rel.startsWith(`..${sep}`) || isAbsolute(rel)) {
     return false
   }
@@ -68,28 +161,12 @@ const write = async (
   body: Buffer,
   executable = false,
 ) => {
-  await mkdirp(dirname(path))
   // if the mode is world-executable, then make it executable
   // this is needed for some packages that have a file that is
   // not a declared bin, but still used as a cli executable.
   await writeFile(path, body, {
     mode: executable ? 0o777 : 0o666,
   })
-}
-
-const made = new Set<string>()
-const making = new Map<string, Promise<boolean>>()
-const mkdirp = async (d: string) => {
-  if (!made.has(d)) {
-    const m =
-      making.get(d) ??
-      mkdir(d, { recursive: true, mode: 0o777 }).then(() =>
-        making.delete(d),
-      )
-    making.set(d, m)
-    await m
-    made.add(d)
-  }
 }
 
 export const unpack = async (
@@ -142,10 +219,10 @@ const unpackUnzipped = async (
   const tmp =
     dirname(target) + sep + '.' + basename(target) + '.' + tmpSuffix()
   const og = tmp + '.ORIGINAL'
-  await Promise.all([rimraf(tmp), rimraf(og)])
 
   let succeeded = false
   try {
+    const entries = new Map<string, Entry>()
     let tarDir: string | undefined = undefined
     let offset = 0
     let h: Header
@@ -172,13 +249,15 @@ const unpackUnzipped = async (
           /* c8 ignore next */
           if (!tarDir) continue
           if (!checkFs(h, tarDir, tmp)) continue
-          await write(
-            resolve(tmp, h.path.substring(tarDir.length)),
-            body,
-            // if it's world-executable, it's an executable
-            // otherwise, make it read-only.
-            1 === ((h.mode ?? 0x666) & 1),
-          )
+          {
+            const dest = resolve(tmp, h.path.substring(tarDir.length))
+            entries.set(entryKey(dest), {
+              path: dest,
+              body,
+              executable: 1 === ((h.mode ?? 0x666) & 1),
+              dir: false,
+            })
+          }
           break
 
         case 'Directory':
@@ -186,7 +265,13 @@ const unpackUnzipped = async (
           if (!tarDir) tarDir = findTarDir(h.path, tarDir)
           if (!tarDir) continue
           if (!checkFs(h, tarDir, tmp)) continue
-          await mkdirp(resolve(tmp, h.path.substring(tarDir.length)))
+          {
+            const dest = resolve(tmp, h.path.substring(tarDir.length))
+            entries.set(entryKey(dest), {
+              path: dest,
+              dir: true,
+            })
+          }
           break
 
         case 'GlobalExtendedHeader':
@@ -205,6 +290,34 @@ const unpackUnzipped = async (
           break
       }
     }
+
+    // Per-unpack memo: paths are tmp-scoped and never reused across
+    // unpacks. The unique dir set is the memo; making/made globals
+    // previously leaked ~18k strings per install.
+    const dirs = new Set<string>()
+    const files: FileEntry[] = []
+    for (const e of entries.values()) {
+      if (e.dir) dirs.add(e.path)
+      else {
+        dirs.add(dirname(e.path))
+        files.push(e)
+      }
+    }
+
+    rethrowFirst(
+      await Promise.allSettled(
+        [...dirs].map(d =>
+          mkdir(d, { recursive: true, mode: 0o777 }),
+        ),
+      ),
+    )
+    rethrowFirst(
+      await Promise.allSettled(
+        files.map(f =>
+          withWriteLane(() => write(f.path, f.body, f.executable)),
+        ),
+      ),
+    )
 
     const targetExists = await exists(target)
     if (targetExists) await rename(target, og)

--- a/src/tar/src/unpack.ts
+++ b/src/tar/src/unpack.ts
@@ -65,7 +65,8 @@ const writeLaneLimit = parseWriteLanes(
   process.env.VLT_TAR_WRITE_LANES,
 )
 let writeLanesUsed = 0
-const writeLaneWaiters: (() => void)[] = []
+const writeLaneWaiters: ((() => void) | undefined)[] = []
+let writeLaneHead = 0
 
 const acquireWriteLane = async () => {
   if (writeLanesUsed < writeLaneLimit) {
@@ -76,9 +77,20 @@ const acquireWriteLane = async () => {
 }
 
 const releaseWriteLane = () => {
-  const next = writeLaneWaiters.shift()
-  if (next) next()
-  else writeLanesUsed--
+  // consume from a head index instead of shift(): shift is O(n) per
+  // release, quadratic when many writes queue behind the lane limit.
+  const next = writeLaneWaiters[writeLaneHead]
+  if (next) {
+    writeLaneWaiters[writeLaneHead] = undefined
+    writeLaneHead++
+    if (writeLaneHead === writeLaneWaiters.length) {
+      writeLaneWaiters.length = 0
+      writeLaneHead = 0
+    }
+    next()
+  } else {
+    writeLanesUsed--
+  }
 }
 
 const withWriteLane = async <T>(fn: () => Promise<T>): Promise<T> => {

--- a/src/tar/src/unpack.ts
+++ b/src/tar/src/unpack.ts
@@ -251,7 +251,15 @@ const unpackUnzipped = async (
           if (!checkFs(h, tarDir, tmp)) continue
           {
             const dest = resolve(tmp, h.path.substring(tarDir.length))
-            entries.set(entryKey(dest), {
+            const key = entryKey(dest)
+            // a repeated path is fine (last wins), but flipping between
+            // file and directory would silently discard data.
+            if (entries.get(key)?.dir === true) {
+              throw error('file/directory collision in tarball', {
+                path: dest,
+              })
+            }
+            entries.set(key, {
               path: dest,
               body,
               executable: 1 === ((h.mode ?? 0x666) & 1),
@@ -267,7 +275,13 @@ const unpackUnzipped = async (
           if (!checkFs(h, tarDir, tmp)) continue
           {
             const dest = resolve(tmp, h.path.substring(tarDir.length))
-            entries.set(entryKey(dest), {
+            const key = entryKey(dest)
+            if (entries.get(key)?.dir === false) {
+              throw error('file/directory collision in tarball', {
+                path: dest,
+              })
+            }
+            entries.set(key, {
               path: dest,
               dir: true,
             })

--- a/src/tar/test/index.ts
+++ b/src/tar/test/index.ts
@@ -7,7 +7,7 @@ import * as index from '../src/index.ts'
 t.strictSame(
   index,
   Object.assign(Object.create(null), {
-    ...unpack,
+    unpack: unpack.unpack,
     ...pool,
     ...unpackRequest,
   }),

--- a/src/tar/test/unpack.ts
+++ b/src/tar/test/unpack.ts
@@ -339,6 +339,30 @@ t.test('last-wins collapsed . and .. segments', async t => {
   t.equal(readFileSync(dir + '/bar', 'utf8'), '4')
 })
 
+t.test('file/dir collision at same path rejects', async t => {
+  const dir = t.testdir()
+  const fileThenDir = makeTar([
+    { path: 'package/a', size: 1 },
+    'x',
+    { path: 'package/a/', type: 'Directory' },
+  ])
+  await t.rejects(
+    unpack(fileThenDir, resolve(dir, 'out')),
+    { message: 'file/directory collision in tarball' },
+    'file then directory',
+  )
+  const dirThenFile = makeTar([
+    { path: 'package/a/', type: 'Directory' },
+    { path: 'package/a', size: 1 },
+    'x',
+  ])
+  await t.rejects(
+    unpack(dirThenFile, resolve(dir, 'out2')),
+    { message: 'file/directory collision in tarball' },
+    'directory then file',
+  )
+})
+
 t.test(
   'A/a last-wins on case-insensitive fs',
   {

--- a/src/tar/test/unpack.ts
+++ b/src/tar/test/unpack.ts
@@ -1,10 +1,11 @@
-import { lstatSync, readFileSync } from 'node:fs'
-import { resolve } from 'node:path'
+import { lstatSync, readFileSync, readdirSync } from 'node:fs'
+import { isAbsolute, relative, resolve, sep } from 'node:path'
 import t from 'tap'
 import type { Test } from 'tap'
 import { Pax } from 'tar'
 import { gzipSync } from 'node:zlib'
-import { unpack } from '../src/unpack.ts'
+import { checkFs, unpack } from '../src/unpack.ts'
+import { findTarDir } from '../src/find-tar-dir.ts'
 import { makeTar } from './fixtures/make-tar.ts'
 
 const pj = JSON.stringify({
@@ -293,5 +294,327 @@ t.test('validate unpack path sanitization', async t => {
     )
   })
 
+  t.end()
+})
+
+const makeFilesTar = (files: Record<string, string>) => {
+  const chunks: (string | { path: string; size: number })[] = []
+  for (const [name, body] of Object.entries(files)) {
+    chunks.push(
+      { path: `package/${name}`, size: Buffer.byteLength(body) },
+      body,
+    )
+  }
+  return makeTar(chunks)
+}
+
+t.test('last-wins under parallelism', async t => {
+  const tar = makeTar([
+    { path: 'package/x', size: 1 },
+    'a',
+    { path: 'package/x', size: 1 },
+    'b',
+    { path: 'package/x', size: 1 },
+    'c',
+  ])
+  const dir = t.testdirName
+  await unpack(tar, dir)
+  t.equal(readFileSync(dir + '/x', 'utf8'), 'c')
+})
+
+t.test('last-wins collapsed . and .. segments', async t => {
+  const tar = makeTar([
+    { path: 'package/a/b', size: 1 },
+    '1',
+    { path: 'package/a/./b', size: 1 },
+    '2',
+    { path: 'package/bar', size: 1 },
+    '3',
+    { path: 'package/foo/../bar', size: 1 },
+    '4',
+  ])
+  const dir = t.testdirName
+  await unpack(tar, dir)
+  t.equal(readFileSync(dir + '/a/b', 'utf8'), '2')
+  t.equal(readFileSync(dir + '/bar', 'utf8'), '4')
+})
+
+t.test(
+  'A/a last-wins on case-insensitive fs',
+  {
+    skip:
+      process.platform !== 'darwin' &&
+      process.platform !== 'win32' &&
+      'case-sensitive file system',
+  },
+  async t => {
+    const tar = makeTar([
+      { path: 'package/A', size: 1 },
+      '1',
+      { path: 'package/a', size: 1 },
+      '2',
+    ])
+    const dir = t.testdirName
+    await unpack(tar, dir)
+    t.equal(readdirSync(dir).length, 1)
+    t.equal(readFileSync(dir + '/A', 'utf8'), '2')
+    t.equal(readFileSync(dir + '/a', 'utf8'), '2')
+  },
+)
+
+t.test('empty-after-filter still rejects', async t => {
+  const tar = makeTar([
+    {
+      path: 'package/slinky',
+      linkpath: 'package/target',
+      type: 'SymbolicLink',
+    },
+    { path: '../outside/x', size: 1 },
+    'x',
+  ])
+  await t.rejects(
+    unpack(tar, t.testdir()),
+    'throws an error when no file is extracted',
+  )
+})
+
+t.test('no preclean on successful unpack', async t => {
+  const FSP = await import('node:fs/promises')
+  const lstatCalls: string[] = []
+  const rimrafCalls: string[] = []
+  const { unpack } = await t.mockImport<
+    typeof import('../src/unpack.ts')
+  >('../src/unpack.ts', {
+    'node:fs/promises': t.createMock(FSP, {
+      lstat: async (path: Parameters<typeof FSP.lstat>[0]) => {
+        lstatCalls.push(String(path))
+        return FSP.lstat(path)
+      },
+    }),
+    rimraf: {
+      rimraf: async (path: string) => {
+        rimrafCalls.push(path)
+      },
+    },
+  })
+  const dir = resolve(t.testdir(), 'out')
+  await unpack(makeFilesTar({ 'hello.txt': 'hello' }), dir)
+  t.equal(readFileSync(dir + '/hello.txt', 'utf8'), 'hello')
+  t.strictSame(lstatCalls, [dir])
+  t.strictSame(rimrafCalls, [])
+})
+
+t.test('concurrent write failure', async t => {
+  const dir = t.testdir({ still: 'here' })
+  const FSP = await import('node:fs/promises')
+  const poop = new Error('poop')
+  let n = 0
+  const unhandled: unknown[] = []
+  const onUnhandled = (er: unknown) => unhandled.push(er)
+  process.on('unhandledRejection', onUnhandled)
+  t.teardown(() =>
+    process.removeListener('unhandledRejection', onUnhandled),
+  )
+  const { unpack } = await t.mockImport<
+    typeof import('../src/unpack.ts')
+  >('../src/unpack.ts', {
+    'node:fs/promises': t.createMock(FSP, {
+      writeFile: async (
+        path: Parameters<typeof FSP.writeFile>[0],
+        data: Parameters<typeof FSP.writeFile>[1],
+        options?: Parameters<typeof FSP.writeFile>[2],
+      ) => {
+        n++
+        if (n === 3) throw poop
+        return FSP.writeFile(path, data, options)
+      },
+    }),
+  })
+  const files: Record<string, string> = {}
+  for (let i = 0; i < 8; i++) files[`f${i}.txt`] = String(i)
+  await t.rejects(() => unpack(makeFilesTar(files), dir), poop)
+  await new Promise<void>(res => setImmediate(res))
+  t.equal(unhandled.length, 0, 'no unhandledRejection')
+  t.equal(readFileSync(dir + '/still', 'utf8'), 'here')
+  t.throws(() => lstatSync(dir + '/f0.txt'))
+})
+
+t.test('lane pool saturation', async t => {
+  const prev = process.env.VLT_TAR_WRITE_LANES
+  process.env.VLT_TAR_WRITE_LANES = '2'
+  t.teardown(() => {
+    if (prev === undefined) {
+      delete process.env.VLT_TAR_WRITE_LANES
+    } else {
+      process.env.VLT_TAR_WRITE_LANES = prev
+    }
+  })
+  const { unpack } = await t.mockImport<
+    typeof import('../src/unpack.ts')
+  >('../src/unpack.ts')
+  const files: Record<string, string> = {}
+  for (let i = 0; i < 5; i++) files[`f${i}.txt`] = `body-${i}`
+  const dir = t.testdirName
+  await unpack(makeFilesTar(files), dir)
+  for (let i = 0; i < 5; i++) {
+    t.equal(readFileSync(dir + `/f${i}.txt`, 'utf8'), `body-${i}`)
+  }
+})
+
+t.test('invalid VLT_TAR_WRITE_LANES falls back', async t => {
+  for (const raw of ['nope', '0', '-1']) {
+    const prev = process.env.VLT_TAR_WRITE_LANES
+    process.env.VLT_TAR_WRITE_LANES = raw
+    t.teardown(() => {
+      if (prev === undefined) {
+        delete process.env.VLT_TAR_WRITE_LANES
+      } else {
+        process.env.VLT_TAR_WRITE_LANES = prev
+      }
+    })
+    const { unpack } = await t.mockImport<
+      typeof import('../src/unpack.ts')
+    >('../src/unpack.ts')
+    const dir = t.testdirName
+    await unpack(makeFilesTar({ z: 'z' }), dir)
+    t.equal(readFileSync(dir + '/z', 'utf8'), 'z', raw)
+  }
+})
+
+t.test('checkFs differential vs relative() impl', t => {
+  const checkFsOld = (
+    h: { path?: string },
+    tarDir: string | undefined,
+    target: string,
+  ): boolean => {
+    if (!h.path) return false
+    if (!tarDir) return false
+    h.path = h.path.replace(/[\\/]+/g, '/')
+    if (!h.path.startsWith(tarDir)) return false
+    const rel = relative(
+      target,
+      resolve(target, h.path.slice(tarDir.length)),
+    )
+    if (
+      rel === '..' ||
+      rel.startsWith(`..${sep}`) ||
+      isAbsolute(rel)
+    ) {
+      return false
+    }
+    return true
+  }
+
+  const fixturePaths = [
+    'package/package.json',
+    resolve('ignore/absolute/paths'),
+    'package/some/empty/dir',
+    'package/some/e',
+    'outside/directory',
+    'package/dir/some-file',
+    'package/asdfasdfasdfasdf',
+    'package/a',
+    'package/slinky',
+    '../dots',
+    'outside/ignoreme',
+    '////package/safe.txt',
+    '../etc/passwd',
+    'package/../../../etc/passwd',
+    'package/foo/../../../../../../tmp/evil',
+    '..\\windows\\system32\\config',
+    'package/../foobar/forbidden',
+    'package/../foo.bar',
+    'c:../../../windows/system32/evil.dll',
+    'd:..\\..\\important\\file.txt',
+    'c:foo/../../../escape.txt',
+    'c:\\c:\\d:\\package/safe.txt',
+    '../../../tmp/evil-dir',
+    'package/../../escape-dir',
+  ]
+
+  const permutations = [
+    '',
+    '.',
+    '..',
+    './.',
+    'package',
+    'package/',
+    'package/.',
+    'package/..',
+    'package/./foo',
+    'package/foo/.',
+    'package/foo/..',
+    'package/foo/../bar',
+    'package/foo/../../bar',
+    'package/a/./b',
+    'package/a/b/c/../../d',
+    'package/.hidden',
+    'package/foo.',
+    'package/...',
+    'package/foo/bar/baz',
+    'package//foo',
+    'package\\\\foo',
+    'package/c:foo',
+    'package/C:foo',
+    'package/1:foo',
+    'package/:foo',
+    '/package/foo',
+    'package/../package/foo',
+    'package/foo/../../../etc/passwd',
+    'foo/bar',
+    'package/foo\\bar',
+    'package/foo/bar/',
+    'package/././foo',
+    'package/foo/././bar',
+    'package/foo/bar/..',
+    'package/foo/bar/../..',
+    'package/foo/bar/../../..',
+    'package/n:foo',
+    'package/foo/bar/baz/qux',
+    'PACKAGE/foo',
+    'package/foo/./../bar',
+    'package/.',
+    'package/..',
+    'package/../',
+    'package/foo//bar',
+    'package/./',
+    'package/c:/windows/x',
+  ]
+
+  const targets = ['/tmp/extract-target', 'C:\\Users\\extract-target']
+
+  const tarDirs = (path: string) => {
+    const found = findTarDir(path)
+    const dirs: (string | undefined)[] = [
+      'package/',
+      'package',
+      undefined,
+    ]
+    if (found !== undefined && !dirs.includes(found)) {
+      dirs.push(found)
+    }
+    return dirs
+  }
+
+  t.equal(
+    checkFs({}, 'package/', targets[0] ?? ''),
+    false,
+    'missing path',
+  )
+  t.equal(
+    checkFs({ path: 'package/foo' }, undefined, targets[0] ?? ''),
+    false,
+    'missing tarDir',
+  )
+
+  for (const path of [...fixturePaths, ...permutations]) {
+    for (const target of targets) {
+      for (const tarDir of tarDirs(path)) {
+        const next = checkFs({ path }, tarDir, target)
+        const old = checkFsOld({ path }, tarDir, target)
+        t.equal(next, old, JSON.stringify({ path, tarDir, target }))
+      }
+    }
+  }
   t.end()
 })


### PR DESCRIPTION
Drop rimraf preclean and parallelize entry writes within a tarball. Also speeds up `checkFs` helper method for faster checks.