### PR TITLE
registry-client: perf improvements

### DIFF
--- a/src/cache/test/index.ts
+++ b/src/cache/test/index.ts
@@ -304,3 +304,21 @@ t.test('integrity', async t => {
     )
   })
 })
+
+t.test(
+  'maxSize excludes large entries from memory but not disk',
+  async t => {
+    const c = new Cache({
+      path: t.testdir(),
+      maxSize: 10,
+    })
+    const big = Buffer.alloc(100, 1)
+    c.set('big', big)
+    await c.promise()
+    t.equal(c.get('big'), undefined, 'not retained in memory')
+    t.equal(c.size, 0)
+    t.same(await c.fetch('big'), big)
+    t.equal(c.get('big'), undefined)
+    t.same(await readFile(c.path('big')), big)
+  },
+)

--- a/src/package-info/src/index.ts
+++ b/src/package-info/src/index.ts
@@ -886,9 +886,11 @@ export class PackageInfoClient {
     spec: Spec,
     options: PackageInfoClientRequestOptions,
     pakuURL: URL,
+    useCache?: false,
   ): Promise<Packument> {
     const response = await this.registryClient.request(pakuURL, {
       headers: { accept: 'application/json' },
+      ...(useCache === false ? { useCache } : {}),
     })
     if (response.statusCode !== 200) {
       throw this.#resolveError(
@@ -901,7 +903,14 @@ export class PackageInfoClient {
         },
       )
     }
-    return response.json() as Packument
+    try {
+      return response.json() as Packument
+    } catch (er) {
+      if (useCache !== false) {
+        return this.#fetchPackument(spec, options, pakuURL, false)
+      }
+      throw er
+    }
   }
 
   async resolve(

--- a/src/package-info/test/index.ts
+++ b/src/package-info/test/index.ts
@@ -2008,6 +2008,63 @@ t.test(
   },
 )
 
+t.test('late parse failure refetches packument', async t => {
+  const pi = new PackageInfoClient({
+    ...options,
+    cache: t.testdir(),
+  })
+  const paku = {
+    name: 'badjson',
+    'dist-tags': { latest: '1.0.0' },
+    versions: {
+      '1.0.0': { name: 'badjson', version: '1.0.0' },
+    },
+  }
+  const jsonHeaders = [
+    Buffer.from('content-type'),
+    Buffer.from('application/json'),
+  ]
+  let calls = 0
+  const rc = pi.registryClient
+  rc.request = async (_url, reqOptions) => {
+    calls++
+    if (reqOptions?.useCache === false) {
+      const good = new CacheEntry(200, jsonHeaders)
+      good.addBody(Buffer.from(JSON.stringify(paku)))
+      return good
+    }
+    const bad = new CacheEntry(200, jsonHeaders)
+    bad.addBody(Buffer.from('{not json}'))
+    return bad
+  }
+
+  const result = await pi.packument('badjson')
+  t.equal(calls, 2)
+  t.equal(result.name, 'badjson')
+})
+
+t.test('packument parse failure retries once', async t => {
+  const pi = new PackageInfoClient({
+    ...options,
+    cache: t.testdir(),
+  })
+  const jsonHeaders = [
+    Buffer.from('content-type'),
+    Buffer.from('application/json'),
+  ]
+  let calls = 0
+  const rc = pi.registryClient
+  rc.request = async () => {
+    calls++
+    const bad = new CacheEntry(200, jsonHeaders)
+    bad.addBody(Buffer.from('{not json}'))
+    return bad
+  }
+
+  await t.rejects(pi.packument('badjson-forever'))
+  t.equal(calls, 2, 'does not retry twice')
+})
+
 t.test('no registry configured', async t => {
   // there is no default registry -- both places that build a registry
   // URL throw ECONFIG rather than a bare `Invalid URL` TypeError

--- a/src/registry-client/src/cache-entry.ts
+++ b/src/registry-client/src/cache-entry.ts
@@ -64,9 +64,11 @@ export type CacheEntryOptions = {
   /**
    * An optional body to use.
    *
-   * This is used when decoding a cache entry from a buffer, and the body
-   * is already in a ArrayBuffer we can use. When this option is
-   * provided the `addBody` method should not be used.
+   * Adopted as-is (no copy). The caller must not mutate or reuse it.
+   * Used when decoding a cache entry from a buffer. Do not call
+   * `addBody` after providing this. Worker-thread transfers must
+   * copy or structuredClone first so the cache ArrayBuffer is not
+   * detached.
    */
   body?: Uint8Array
 
@@ -154,12 +156,9 @@ export class CacheEntry {
       this.#contentLength = contentLength
     }
 
-    // if a body is provided then use that, in this case the `addBody`
-    // method should no longer be used.
+    // if a body is provided then adopt it; `addBody` must not be used.
     if (body) {
-      const buffer = new ArrayBuffer(body.byteLength)
-      this.#body = new Uint8Array(buffer, 0, body.byteLength)
-      this.#body.set(body, 0)
+      this.#body = body
       this.#bodyLength = body.byteLength
       /* c8 ignore start */
     } else if (this.#contentLength) {
@@ -448,11 +447,13 @@ export class CacheEntry {
     const ct = this.getHeaderString('content-type')
     // if it says it's json, assume json
     if (ct) return (this.#isJSON = /\bjson\b/.test(ct))
-    const text = this.text()
     // don't cache, because we might just not have it yet.
-    if (!text) return false
+    if (!this._body.length) return false
+    this.unzip()
+    const buf = this._body
+    if (!buf.length) return false
     // all registry json starts with {, and no tarball ever can.
-    this.#isJSON = text.startsWith('{')
+    this.#isJSON = buf[0] === 0x7b
     if (this.#isJSON) this.setHeader('content-type', 'text/json')
     return this.#isJSON
   }
@@ -571,12 +572,13 @@ export class CacheEntry {
     )
     c.#fromCache = true
 
-    if (c.isJSON) {
-      try {
-        c.json()
-      } catch {
-        return emptyCacheEntry
+    try {
+      if (c.isJSON) {
+        c.unzip()
+        if (!looksLikeJson(c._body)) return emptyCacheEntry
       }
+    } catch {
+      return emptyCacheEntry
     }
     return c
   }
@@ -641,6 +643,37 @@ export class CacheEntry {
     out.set(this._body, off)
     return out
   }
+}
+
+const isJsonWs = (c: number) =>
+  c === 0x20 || c === 0x09 || c === 0x0a || c === 0x0d
+
+const looksLikeJson = (buf: Uint8Array): boolean => {
+  let first: number | undefined
+  let start = 0
+  for (const c of buf) {
+    if (!isJsonWs(c)) {
+      first = c
+      break
+    }
+    start++
+  }
+  if (first === undefined) return false
+  let last = first
+  for (let j = buf.byteLength - 1; j > start; j--) {
+    const c = buf[j]
+    /* c8 ignore start */
+    if (c === undefined) break
+    /* c8 ignore stop */
+    if (!isJsonWs(c)) {
+      last = c
+      break
+    }
+  }
+  return (
+    (first === 0x7b && last === 0x7d) ||
+    (first === 0x5b && last === 0x5d)
+  )
 }
 
 const emptyCacheEntry = new CacheEntry(0, [], { contentLength: 0 })

--- a/src/registry-client/src/cache-entry.ts
+++ b/src/registry-client/src/cache-entry.ts
@@ -254,18 +254,19 @@ export class CacheEntry {
     return this.#cacheControl
   }
 
-  #staleWhileRevalidate?: boolean
+  #staleUntil?: number
   get staleWhileRevalidate(): boolean {
-    if (this.#staleWhileRevalidate !== undefined)
-      return this.#staleWhileRevalidate
+    // memoize the deadline, not the answer, so an entry held for a
+    // long time (decoded-entry memo, long-lived process) still expires
+    if (this.#staleUntil !== undefined)
+      return Date.now() < this.#staleUntil
     if (this.valid || !this.date) return true
     const swv =
       this.cacheControl['stale-while-revalidate'] ??
       this.maxAge * this.#staleWhileRevalidateFactor
 
-    this.#staleWhileRevalidate =
-      this.date.getTime() + swv * 1000 > Date.now()
-    return this.#staleWhileRevalidate
+    this.#staleUntil = this.date.getTime() + swv * 1000
+    return Date.now() < this.#staleUntil
   }
 
   #contentType?: string
@@ -280,8 +281,14 @@ export class CacheEntry {
    * valid to use.
    */
   #valid?: boolean
+  #validUntil?: number
   get valid(): boolean {
     if (this.#valid !== undefined) return this.#valid
+    // time-based validity memoizes the deadline, not the answer, so
+    // an entry held for a long time (decoded-entry memo, long-lived
+    // process) still expires and gets revalidated
+    if (this.#validUntil !== undefined)
+      return Date.now() < this.#validUntil
 
     // immutable = never changes
     if (this.cacheControl.immutable) return (this.#valid = true)
@@ -296,9 +303,8 @@ export class CacheEntry {
     // default to 5m if maxage is not set, as some registries
     // do not set a cache control header at all.
     if (!this.date) return (this.#valid = false)
-    this.#valid =
-      this.date.getTime() + this.maxAge * 1000 > Date.now()
-    return this.#valid
+    this.#validUntil = this.date.getTime() + this.maxAge * 1000
+    return Date.now() < this.#validUntil
   }
 
   /**
@@ -649,9 +655,18 @@ const isJsonWs = (c: number) =>
   c === 0x20 || c === 0x09 || c === 0x0a || c === 0x0d
 
 const looksLikeJson = (buf: Uint8Array): boolean => {
+  // skip a UTF-8 BOM; TextDecoder strips it when the body is parsed
+  const bom =
+    buf[0] === 0xef && buf[1] === 0xbb && buf[2] === 0xbf ? 3 : 0
+  // an empty body is parsed as '{}' by json()
+  if (buf.byteLength === bom) return true
   let first: number | undefined
-  let start = 0
-  for (const c of buf) {
+  let start = bom
+  for (let i = bom; i < buf.byteLength; i++) {
+    const c = buf[i]
+    /* c8 ignore start */
+    if (c === undefined) break
+    /* c8 ignore stop */
     if (!isJsonWs(c)) {
       first = c
       break

--- a/src/registry-client/src/index.ts
+++ b/src/registry-client/src/index.ts
@@ -213,12 +213,22 @@ const agentOptions: Agent.Options = {
 
 const xdg = new XDG('vlt')
 
+const defaultCacheMaxSize = 256 * 1024 * 1024
+
+const parseCacheMaxSize = (raw: string | undefined): number => {
+  const n = Number(raw)
+  return Number.isFinite(n) && n >= 1 ?
+      Math.floor(n)
+    : defaultCacheMaxSize
+}
+
 export class RegistryClient {
   agent: RetryAgent
   cache: Cache
   identity: string
   staleWhileRevalidateFactor: number
   #session = randomUUID()
+  #decoded = new WeakMap<Uint8Array, CacheEntry>()
 
   constructor(options: RegistryClientOptions) {
     const {
@@ -236,6 +246,7 @@ export class RegistryClient {
     const path = resolve(cache, 'registry-client')
     this.cache = new Cache({
       path,
+      maxSize: parseCacheMaxSize(process.env.VLT_CACHE_MAX_SIZE),
       onDiskWrite(_path, key, data) {
         if (CacheEntry.isGzipEntry(data)) {
           cacheUnzipRegister(path, key)
@@ -389,6 +400,16 @@ export class RegistryClient {
     return result
   }
 
+  #decodeCached(buffer: Uint8Array): CacheEntry {
+    const hit = this.#decoded.get(buffer)
+    if (hit) return hit
+    const entry = CacheEntry.decode(buffer)
+    if (entry.statusCode && entry.isJSON) {
+      this.#decoded.set(buffer, entry)
+    }
+    return entry
+  }
+
   async #checkLogin(
     url: URL | string,
     options: RegistryClientRequestOptions = {},
@@ -442,7 +463,9 @@ export class RegistryClient {
         await this.cache.fetch(key, { context: { integrity } })
       : undefined
 
-    const entry = buffer ? CacheEntry.decode(buffer) : undefined
+    const decoded = buffer ? this.#decodeCached(buffer) : undefined
+    // statusCode 0 == undecodable; treat as a miss so we refetch
+    const entry = decoded?.statusCode ? decoded : undefined
     if (entry?.valid) {
       logRequest(url, 'cache', { method })
       return entry

--- a/src/registry-client/src/index.ts
+++ b/src/registry-client/src/index.ts
@@ -400,11 +400,21 @@ export class RegistryClient {
     return result
   }
 
-  #decodeCached(buffer: Uint8Array): CacheEntry {
+  #decodeCached(buffer: Uint8Array): CacheEntry | undefined {
     const hit = this.#decoded.get(buffer)
     if (hit) return hit
     const entry = CacheEntry.decode(buffer)
-    if (entry.statusCode && entry.isJSON) {
+    // statusCode 0 == undecodable, and a cached JSON body that fails
+    // to parse is corrupt. Treat both as a total miss: the caller
+    // refetches without conditional headers, so a fresh response
+    // overwrites the bad entry rather than a 304 re-blessing it.
+    if (!entry.statusCode) return undefined
+    if (entry.isJSON) {
+      try {
+        entry.json()
+      } catch {
+        return undefined
+      }
       this.#decoded.set(buffer, entry)
     }
     return entry
@@ -463,9 +473,7 @@ export class RegistryClient {
         await this.cache.fetch(key, { context: { integrity } })
       : undefined
 
-    const decoded = buffer ? this.#decodeCached(buffer) : undefined
-    // statusCode 0 == undecodable; treat as a miss so we refetch
-    const entry = decoded?.statusCode ? decoded : undefined
+    const entry = buffer ? this.#decodeCached(buffer) : undefined
     if (entry?.valid) {
       logRequest(url, 'cache', { method })
       return entry

--- a/src/registry-client/test/cache-entry.ts
+++ b/src/registry-client/test/cache-entry.ts
@@ -531,7 +531,9 @@ t.test('json shape-check vs parse', t => {
   }
   const parseOk = (body: Uint8Array) => {
     try {
-      JSON.parse(new TextDecoder().decode(body))
+      // mirror json(): TextDecoder strips a BOM, empty parses as {}
+      const text = new TextDecoder().decode(body)
+      JSON.parse(text || '{}')
       return true
     } catch {
       return false
@@ -550,6 +552,9 @@ t.test('json shape-check vs parse', t => {
     ['leading slash', Buffer.from('/{"a":1}')],
     ['whitespace only', Buffer.from('   \n')],
     ['whitespace array', Buffer.from('  [1]  ')],
+    ['bom object', Buffer.from('\uFEFF{"a":1}')],
+    ['bom only', Buffer.from('\uFEFF')],
+    ['bom truncated', Buffer.from('\uFEFF{"a":')],
   ]
 
   for (const [name, body] of corpus) {
@@ -659,4 +664,64 @@ t.test('decode/encode round-trip parity', t => {
 
   roundTrip('existing gzip json fixture', ce, true)
   t.end()
+})
+
+t.test('decode accepts BOM and empty json bodies', t => {
+  const bom = CacheEntry.decode(
+    toRawEntry(
+      200,
+      { 'content-type': 'application/json' },
+      Buffer.from('\uFEFF{"a":1}'),
+    ),
+  )
+  t.equal(bom.statusCode, 200, 'BOM json is not a miss')
+  t.strictSame(bom.json(), { a: 1 }, 'TextDecoder strips the BOM')
+
+  const empty = CacheEntry.decode(
+    toRawEntry(
+      200,
+      { 'content-type': 'application/json' },
+      Buffer.from(''),
+    ),
+  )
+  t.equal(empty.statusCode, 200, 'empty json body is not a miss')
+  t.strictSame(empty.json(), {}, 'json() parses empty as {}')
+  t.end()
+})
+
+t.test('validity deadlines are re-evaluated over time', async t => {
+  const fresh = new CacheEntry(
+    200,
+    toRawHeaders({
+      'content-type': 'application/json',
+      date: new Date().toUTCString(),
+      'cache-control': 'max-age=2',
+    }),
+  )
+  fresh.addBody(Buffer.from('{"a":1}'))
+  t.equal(fresh.valid, true)
+  t.equal(fresh.valid, true, 'deadline memoized, still valid')
+
+  const stale = new CacheEntry(
+    200,
+    toRawHeaders({
+      'content-type': 'application/json',
+      date: new Date(Date.now() - 10_000).toUTCString(),
+      'cache-control': 'max-age=1, stale-while-revalidate=12',
+    }),
+  )
+  stale.addBody(Buffer.from('{"a":1}'))
+  t.equal(stale.valid, false)
+  t.equal(stale.staleWhileRevalidate, true)
+  t.equal(stale.staleWhileRevalidate, true, 'deadline memoized')
+
+  // entries held in memory (e.g. by the decoded-entry memo in a
+  // long-lived process) must still expire once their deadline passes
+  await new Promise(res => setTimeout(res, 2600))
+  t.equal(fresh.valid, false, 'expires after max-age passes')
+  t.equal(
+    stale.staleWhileRevalidate,
+    false,
+    'swr window closes after its deadline passes',
+  )
 })

--- a/src/registry-client/test/cache-entry.ts
+++ b/src/registry-client/test/cache-entry.ts
@@ -44,7 +44,7 @@ const toRawEntry = (
   const chunks: Uint8Array[] = [
     toLenBuf(concatUint8Arrays(headerChunks)),
   ]
-  chunks.push(toLenBuf(body))
+  chunks.push(body)
   return concatUint8Arrays(chunks)
 }
 
@@ -454,4 +454,209 @@ t.test('maxAge', async t => {
   const nma = new CacheEntry(200, toRawHeaders({}))
   t.equal(nma.maxAge, 300)
   t.equal(nma.maxAge, 300, 'memoized')
+})
+
+t.test('decode adopts body without copying', t => {
+  const src = new CacheEntry(
+    200,
+    toRawHeaders({ 'content-type': 'application/octet-stream' }),
+  )
+  src.addBody(Buffer.from('hello'))
+  const enc = src.encode()
+  const dec = CacheEntry.decode(enc)
+  const headSize = enc.readUInt32BE(0)
+  enc[headSize] = 0x41
+  t.equal(dec.buffer()[0], 0x41)
+  t.end()
+})
+
+t.test('decode does not eagerly parse json', t => {
+  const orig = JSON.parse
+  let calls = 0
+  JSON.parse = ((...args: Parameters<typeof JSON.parse>) => {
+    calls++
+    return orig(...args)
+  }) as typeof JSON.parse
+  t.teardown(() => {
+    JSON.parse = orig
+  })
+  const enc = toRawEntry(
+    200,
+    { 'content-type': 'application/json' },
+    Buffer.from('{"a":1}'),
+  )
+  const dec = CacheEntry.decode(enc)
+  t.equal(calls, 0)
+  t.strictSame(dec.json(), { a: 1 })
+  t.equal(calls, 1)
+  t.strictSame(dec.json(), { a: 1 })
+  t.equal(calls, 1, 'json() memoizes')
+  t.end()
+})
+
+t.test('isJSON without content-type uses first byte', t => {
+  const json = new CacheEntry(200, [])
+  json.addBody(Buffer.from('{"x":1}'))
+  t.equal(json.isJSON, true)
+
+  const notJson = new CacheEntry(200, [])
+  notJson.addBody(Buffer.from('hello'))
+  t.equal(notJson.isJSON, false)
+
+  const spaced = new CacheEntry(200, [])
+  spaced.addBody(Buffer.from(' {"x":1}'))
+  t.equal(spaced.isJSON, false, 'matches text().startsWith("{")')
+
+  const gzJson = new CacheEntry(200, [])
+  gzJson.addBody(gzipSync(Buffer.from('{"x":1}')))
+  t.equal(gzJson.isJSON, true)
+
+  const gzNot = new CacheEntry(200, [])
+  gzNot.addBody(gzipSync(Buffer.from('hello')))
+  t.equal(gzNot.isJSON, false)
+
+  const emptyGz = new CacheEntry(200, [])
+  emptyGz.addBody(gzipSync(Buffer.alloc(0)))
+  t.equal(emptyGz.isJSON, false)
+  t.end()
+})
+
+t.test('json shape-check vs parse', t => {
+  const isEmpty = (
+    body: Uint8Array,
+    headers = { 'content-type': 'application/json' },
+  ) => {
+    const dec = CacheEntry.decode(toRawEntry(200, headers, body))
+    return dec.statusCode === 0
+  }
+  const parseOk = (body: Uint8Array) => {
+    try {
+      JSON.parse(new TextDecoder().decode(body))
+      return true
+    } catch {
+      return false
+    }
+  }
+
+  const corpus: [string, Uint8Array][] = [
+    ['object', Buffer.from('{"a":1}')],
+    ['array', Buffer.from('[1,2]')],
+    ['whitespace object', Buffer.from('  {"a":1}\n')],
+    ['truncated', Buffer.from('{"a":')],
+    ['bracket mismatch', Buffer.from('{"a":1]')],
+    ['trailing garbage', Buffer.from('{"a":1}nope')],
+    ['deep corrupt', Buffer.from('{not json}')],
+    ['empty', Buffer.from('')],
+    ['leading slash', Buffer.from('/{"a":1}')],
+    ['whitespace only', Buffer.from('   \n')],
+    ['whitespace array', Buffer.from('  [1]  ')],
+  ]
+
+  for (const [name, body] of corpus) {
+    const empty = isEmpty(body)
+    const ok = parseOk(body)
+    if (ok) t.equal(empty, false, `${name}: parse ok => decoded`)
+    else if (empty) t.ok(true, `${name}: rejected by shape check`)
+    else
+      t.throws(
+        () =>
+          CacheEntry.decode(
+            toRawEntry(
+              200,
+              { 'content-type': 'application/json' },
+              body,
+            ),
+          ).json(),
+        `${name}: deferred to json()`,
+      )
+  }
+
+  t.equal(
+    isEmpty(gzipSync(Buffer.from('{"a":1}'))),
+    false,
+    'gzipped json object',
+  )
+  t.equal(
+    isEmpty(Buffer.from([0x1f, 0x8b, 0x00, 0x00])),
+    true,
+    'invalid gzip json is a miss',
+  )
+  t.equal(
+    isEmpty(Buffer.from('true')),
+    true,
+    'top-level true is a miss',
+  )
+  t.end()
+})
+
+t.test('decode/encode round-trip parity', t => {
+  // decode() injects content-length; encode() of JSON also unzips.
+  // The hard gate is that decode∘encode is a projection: applying it
+  // twice is identity, matching what the previous eager-json decode
+  // produced. Identity JSON already goes through json() on encode(),
+  // so the first encode is already canonical.
+  const roundTrip = (
+    name: string,
+    entry: CacheEntry,
+    canonical = false,
+  ) => {
+    const enc = entry.encode()
+    const once = CacheEntry.decode(enc).encode()
+    if (canonical) {
+      t.strictSame(once, enc, `${name}: first encode is canonical`)
+    }
+    t.strictSame(
+      CacheEntry.decode(once).encode(),
+      once,
+      `${name}: decode(buf).encode() is idempotent`,
+    )
+    t.strictSame(
+      CacheEntry.decode(enc).buffer(),
+      entry.buffer(),
+      `${name}: body bytes preserved`,
+    )
+  }
+
+  const json = new CacheEntry(
+    200,
+    toRawHeaders({ 'content-type': 'application/json' }),
+  )
+  json.addBody(Buffer.from('{"a":1}'))
+  roundTrip('identity json', json, true)
+
+  const arr = new CacheEntry(
+    200,
+    toRawHeaders({ 'content-type': 'application/json' }),
+  )
+  arr.addBody(Buffer.from('  [1,2,3]\n'))
+  roundTrip('identity json array', arr, true)
+
+  const tar = new CacheEntry(
+    200,
+    toRawHeaders({ 'content-type': 'application/octet-stream' }),
+  )
+  tar.addBody(Buffer.from('this is a tarball lets pretend'))
+  roundTrip('identity tarball', tar)
+
+  const gzTar = new CacheEntry(
+    200,
+    toRawHeaders({
+      'content-type': 'application/octet-stream',
+      'content-encoding': 'gzip',
+    }),
+  )
+  gzTar.addBody(
+    gzipSync(Buffer.from('this is a tarball lets pretend')),
+  )
+  roundTrip('gzip tarball', gzTar)
+
+  const gzJson = new CacheEntry(
+    200,
+    toRawHeaders({ 'content-type': 'application/json' }),
+  )
+  gzJson.addBody(gzipSync(Buffer.from('{"hello":"world"}')))
+  roundTrip('gzip json (unzipped by encode)', gzJson, true)
+
+  roundTrip('existing gzip json fixture', ce, true)
+  t.end()
 })

--- a/src/registry-client/test/index.ts
+++ b/src/registry-client/test/index.ts
@@ -870,6 +870,44 @@ t.test('undecodable cache entry is a miss', async t => {
   await rc.cache.promise()
 })
 
+t.test('corrupt shape-valid json entry heals the cache', async t => {
+  dropConnection = false
+  const rc = t.context.rc as RegistryClient
+  const key = `${registryURL}/abbrev`
+  // build a fresh, valid-by-max-age cached entry, then corrupt the
+  // body so it still looks like json (starts {, ends }) but does not
+  // parse. It carries the server's etag: if the refetch were sent
+  // with conditional headers, the server would 304 and re-bless the
+  // corrupt body.
+  const good = new CacheEntry(
+    200,
+    toRawHeaders({
+      'content-type': 'application/json',
+      etag,
+      date: new Date().toUTCString(),
+    }),
+  )
+  good.addBody(Buffer.from(JSON.stringify({ hello: 'world' })))
+  const corrupt = Buffer.from(good.encode())
+  const colon = corrupt.indexOf(0x3a, corrupt.readUInt32BE(0))
+  corrupt[colon] = 0x3b // {"hello";"world"}
+  rc.cache.set(key, corrupt)
+  await rc.cache.promise()
+
+  const result = await rc.request(key)
+  t.equal(result.statusCode, 200)
+  t.strictSame(result.json(), { hello: 'world' })
+  await rc.cache.promise()
+
+  const healed = await rc.cache.fetch(key)
+  t.ok(healed, 'cache still has the key')
+  t.strictSame(
+    CacheEntry.decode(healed!).json(),
+    { hello: 'world' },
+    'poisoned entry was overwritten by the fresh response',
+  )
+})
+
 t.test('decoded json entries are memoized', async t => {
   dropConnection = false
   const rc = t.context.rc as RegistryClient

--- a/src/registry-client/test/index.ts
+++ b/src/registry-client/test/index.ts
@@ -559,6 +559,7 @@ t.test('user-agent', t => {
 })
 
 t.test('npm-session header', async t => {
+  dropConnection = false
   t.test('is a valid UUID, consistent across requests', async t => {
     const rc = t.context.rc as RegistryClient
     const res1 = await rc.request(`${registryURL}/abbrev`)
@@ -568,6 +569,7 @@ t.test('npm-session header', async t => {
     // that the same client produces a consistent session id.
     const res2 = await rc.request(`${registryURL}/abbrev`)
     t.equal(res2.statusCode, 200)
+    await rc.cache.promise()
   })
 
   t.test('different clients have different sessions', async t => {
@@ -582,6 +584,7 @@ t.test('npm-session header', async t => {
     ])
     t.equal(r1.statusCode, 200)
     t.equal(r2.statusCode, 200)
+    await Promise.all([rc1.cache.promise(), rc2.cache.promise()])
   })
 })
 
@@ -853,4 +856,84 @@ t.test('staleWhileRevalidate', async t => {
     'revalidated, got fresh response',
   )
   await cache.promise()
+})
+
+t.test('undecodable cache entry is a miss', async t => {
+  dropConnection = false
+  const rc = t.context.rc as RegistryClient
+  const key = `${registryURL}/abbrev`
+  rc.cache.set(key, Buffer.alloc(0))
+  await rc.cache.promise()
+  const result = await rc.request(key)
+  t.equal(result.statusCode, 200)
+  t.strictSame(result.json(), { hello: 'world' })
+  await rc.cache.promise()
+})
+
+t.test('decoded json entries are memoized', async t => {
+  dropConnection = false
+  const rc = t.context.rc as RegistryClient
+  await rc.request(`${registryURL}/abbrev`)
+  await rc.cache.promise()
+  const a = await rc.request(`${registryURL}/abbrev`)
+  const b = await rc.request(`${registryURL}/abbrev`)
+  t.equal(a, b, 'same CacheEntry instance')
+
+  rc.cache.set(`${registryURL}/abbrev`, a.encode())
+  await rc.cache.promise()
+  const c = await rc.request(`${registryURL}/abbrev`)
+  t.not(a, c, 'cache.set busts the memo')
+})
+
+t.test('tarball entries are not memoized', async t => {
+  dropConnection = false
+  const rc = t.context.rc as RegistryClient
+  await rc.request(`${registryURL}/some/tarball`)
+  await rc.cache.promise()
+  const a = await rc.request(`${registryURL}/some/tarball`)
+  const b = await rc.request(`${registryURL}/some/tarball`)
+  t.not(a, b)
+})
+
+t.test('VLT_CACHE_MAX_SIZE', async t => {
+  t.test('oversized entries skip memory', async t => {
+    t.intercept(process, 'env', {
+      value: { ...process.env, VLT_CACHE_MAX_SIZE: '50' },
+    })
+    const small = new RC({ cache: t.testdir() })
+    const big = Buffer.alloc(100, 7)
+    small.cache.set('k', big)
+    t.equal(
+      small.cache.get('k'),
+      undefined,
+      'oversized not in memory',
+    )
+    await small.cache.promise()
+    t.same(await small.cache.fetch('k'), big)
+    t.equal(small.cache.get('k'), undefined)
+  })
+
+  for (const raw of ['nope', '0', '-1']) {
+    t.test(`${raw} falls back to default`, async t => {
+      t.intercept(process, 'env', {
+        value: { ...process.env, VLT_CACHE_MAX_SIZE: raw },
+      })
+      const fallback = new RC({ cache: t.testdir() })
+      const tiny = Buffer.from('ok')
+      fallback.cache.set('k', tiny)
+      t.same(fallback.cache.get('k'), tiny)
+      await fallback.cache.promise()
+    })
+  }
+
+  t.test('floors fractional sizes', async t => {
+    t.intercept(process, 'env', {
+      value: { ...process.env, VLT_CACHE_MAX_SIZE: '50.9' },
+    })
+    const floored = new RC({ cache: t.testdir() })
+    const over = Buffer.alloc(51, 1)
+    floored.cache.set('k', over)
+    t.equal(floored.cache.get('k'), undefined)
+    await floored.cache.promise()
+  })
 })


### PR DESCRIPTION
Implements
- zero-copy decode
- lazy JSON parse
- decoded-entry memo
- 256MB LRU cap
- refetch on corrupt cache hits.

Skip tarball integrity checks for cache-served bodies; retry packument fetch once on late JSON parse failure.