### PR TITLE
graph: memoize peer-spec resolution

### DIFF
--- a/src/graph/src/ideal/peers.ts
+++ b/src/graph/src/ideal/peers.ts
@@ -284,7 +284,7 @@ export const checkPeerEdgesCompatible = (
       )
       if (
         existingTargetSatisfiesPeer &&
-        nodeSatisfiesAll(existingTarget, contextEntry.specs)
+        nodeSatisfiesAll(existingTarget, contextEntry.specs.values())
       ) {
         continue // Truly no conflict
       }
@@ -394,6 +394,21 @@ export const retrievePeerContextHash = (
 }
 
 /**
+ * Generate a dedupe key for a spec stored in a peer context entry's
+ * `specs` map. Two specs with the same key are interchangeable for the
+ * purposes of `incompatibleSpecs()`/`satisfies()` checks, so only one
+ * needs to be retained regardless of how many dependents contribute it.
+ *
+ * Keyed on type + textual spec (name@bareSpec) + registry, since specs
+ * that are textually identical but resolve against different registries
+ * are not interchangeable.
+ */
+export const peerSpecKey = (spec: Spec): string => {
+  const f = spec.final
+  return `${f.type}\0${String(f)}\0${f.registry ?? ''}`
+}
+
+/**
  * Checks if a given spec is compatible with the specs already
  * assigned to a peer context entry.
  *
@@ -413,7 +428,7 @@ export const incompatibleSpecs = (
   entry: PeerContextEntry,
 ): boolean => {
   if (entry.specs.size > 0) {
-    for (const s_ of entry.specs) {
+    for (const s_ of entry.specs.values()) {
       const s = s_.final
       if (
         // Registry types: check semver range intersection
@@ -491,7 +506,7 @@ export const addEntriesToPeerContext = (
     if (!entry) {
       entry = {
         active: true,
-        specs: new Set([spec]),
+        specs: new Map([[peerSpecKey(spec), spec]]),
         target,
         type,
         contextDependents: new Set(),
@@ -507,7 +522,7 @@ export const addEntriesToPeerContext = (
     // update target if compatible with all specs
     if (
       target &&
-      [...entry.specs].every(s =>
+      [...entry.specs.values()].every(s =>
         satisfies(
           target.id,
           s,
@@ -535,7 +550,8 @@ export const addEntriesToPeerContext = (
       entry.target ??= target
     }
 
-    entry.specs.add(spec)
+    const specKey = peerSpecKey(spec)
+    if (!entry.specs.has(specKey)) entry.specs.set(specKey, spec)
     if (dependent) entry.contextDependents.add(dependent)
   }
 
@@ -569,7 +585,7 @@ export const forkPeerContext = (
   for (const [name, entry] of peerContext.entries()) {
     nextPeerContext.set(name, {
       active: false,
-      specs: new Set(entry.specs),
+      specs: new Map(entry.specs),
       target: undefined,
       type: entry.type,
       contextDependents: new Set(entry.contextDependents),
@@ -583,7 +599,7 @@ export const forkPeerContext = (
     const name = target?.name /* c8 ignore next */ ?? spec.final.name
     const newEntry = {
       active: true,
-      specs: new Set([spec]),
+      specs: new Map([[peerSpecKey(spec), spec]]),
       target,
       type,
       contextDependents:
@@ -858,7 +874,10 @@ export const endPeerPlacement = (
         nodeSatisfiesSpec(entry.target, spec, fromNode, graph)
       ) {
         graph.addEdge(type, spec, node, entry.target)
-        entry.specs.add(spec.final)
+        const finalKey = peerSpecKey(spec.final)
+        if (!entry.specs.has(finalKey)) {
+          entry.specs.set(finalKey, spec.final)
+        }
         continue
       }
 

--- a/src/graph/src/ideal/types.ts
+++ b/src/graph/src/ideal/types.ts
@@ -105,8 +105,12 @@ export type PeerContextEntry = {
    * peer context set and should not be considered for resolution.
    */
   active: boolean
-  /** List of full Spec objects that are part of this peer context entry */
-  specs: Set<Spec>
+  /**
+   * Full Spec objects that are part of this peer context entry, keyed by
+   * `peerSpecKey()` so textually identical specs collapse into one entry
+   * instead of piling up per dependent.
+   */
+  specs: Map<string, Spec>
   /** The target Node that satisfies all specs for this peer context entry */
   target: Node | undefined
   /** The type of dependency this entry represents */

--- a/src/graph/test/ideal/append-nodes.ts
+++ b/src/graph/test/ideal/append-nodes.ts
@@ -13,6 +13,7 @@ import { asDependency } from '../../src/dependencies.ts'
 import type { Dependency } from '../../src/dependencies.ts'
 import { Graph } from '../../src/graph.ts'
 import { appendNodes } from '../../src/ideal/append-nodes.ts'
+import { peerSpecKey } from '../../src/ideal/peers.ts'
 import { objectLikeOutput } from '../../src/visualization/object-like-output.ts'
 import type { Node } from '../../src/node.ts'
 import { GraphModifier } from '../../src/modifiers.ts'
@@ -39,6 +40,9 @@ const configData = {
     npm: 'https://registry.npmjs.org/',
   },
 } satisfies SpecOptions
+
+/** Build a single-entry `specs` map for a `PeerContextEntry` test fixture. */
+const oneSpec = (spec: Spec) => new Map([[peerSpecKey(spec), spec]])
 
 t.test('append a new node to a graph from a registry', async t => {
   const fooManifest = {
@@ -2114,7 +2118,7 @@ t.test(
     const peerContext = graph.peerContexts[0]!
     peerContext.set('react', {
       active: true,
-      specs: new Set([Spec.parse('react', '>=18.3.0', configData)]),
+      specs: oneSpec(Spec.parse('react', '>=18.3.0', configData)),
       target: react183,
       type: 'prod',
       contextDependents: new Set(),
@@ -2222,7 +2226,7 @@ t.test(
     const peerContext = graph.peerContexts[0]!
     peerContext.set('react', {
       active: true,
-      specs: new Set([Spec.parse('react', '^18.0.0', configData)]),
+      specs: oneSpec(Spec.parse('react', '^18.0.0', configData)),
       target: react18,
       type: 'prod',
       contextDependents: new Set(),
@@ -2479,7 +2483,7 @@ t.test(
     const peerContext = graph.peerContexts[0]!
     peerContext.set('react', {
       active: true,
-      specs: new Set([Spec.parse('react', '^18.0.0', configData)]),
+      specs: oneSpec(Spec.parse('react', '^18.0.0', configData)),
       target: react183,
       type: 'prod',
       contextDependents: new Set(),
@@ -2629,7 +2633,7 @@ t.test(
     const peerContext = graph.peerContexts[0]!
     peerContext.set('react', {
       active: true,
-      specs: new Set([Spec.parse('react', '^18.0.0', configData)]),
+      specs: oneSpec(Spec.parse('react', '^18.0.0', configData)),
       target: react18,
       type: 'prod',
       contextDependents: new Set(),

--- a/src/graph/test/ideal/peers.ts
+++ b/src/graph/test/ideal/peers.ts
@@ -10,6 +10,7 @@ import {
   endPeerPlacement,
   forkPeerContext,
   getOrderedPeerContextEntries,
+  peerSpecKey,
   postPlacementPeerCheck,
   retrievePeerContextHash,
   startPeerPlacement,
@@ -39,6 +40,9 @@ const configData = {
     npm: 'https://registry.npmjs.org/',
   },
 } satisfies SpecOptions
+
+/** Build a single-entry `specs` map for a `PeerContextEntry` test fixture. */
+const oneSpec = (spec: Spec) => new Map([[peerSpecKey(spec), spec]])
 
 t.test('checkPeerEdgesCompatible', async t => {
   t.test('returns compatible when node has no peer deps', async t => {
@@ -161,7 +165,7 @@ t.test('checkPeerEdgesCompatible', async t => {
       const peerContext: PeerContext = new Map()
       peerContext.set('react', {
         active: true,
-        specs: new Set([Spec.parse('react', '^19.0.0', configData)]),
+        specs: oneSpec(Spec.parse('react', '^19.0.0', configData)),
         target: react19,
         type: 'prod',
         contextDependents: new Set(),
@@ -228,7 +232,7 @@ t.test('checkPeerEdgesCompatible', async t => {
       const peerContext: PeerContext = new Map()
       peerContext.set('react', {
         active: true,
-        specs: new Set([peerSpec]),
+        specs: oneSpec(peerSpec),
         target: react183,
         type: 'prod',
         contextDependents: new Set(),
@@ -582,7 +586,7 @@ t.test('checkPeerEdgesCompatible', async t => {
       const peerContext: PeerContext = new Map()
       peerContext.set('react', {
         active: true,
-        specs: new Set([Spec.parse('react', '^18.0.0', configData)]),
+        specs: oneSpec(Spec.parse('react', '^18.0.0', configData)),
         target: react18,
         type: 'prod',
         contextDependents: new Set(),
@@ -645,7 +649,7 @@ t.test('checkPeerEdgesCompatible', async t => {
       const peerContext: PeerContext = new Map()
       peerContext.set('react', {
         active: true,
-        specs: new Set([Spec.parse('react', '^17.0.0', configData)]),
+        specs: oneSpec(Spec.parse('react', '^17.0.0', configData)),
         target: react17,
         type: 'prod',
         contextDependents: new Set(),
@@ -717,7 +721,7 @@ t.test('checkPeerEdgesCompatible', async t => {
       const peerContext: PeerContext = new Map()
       peerContext.set('react', {
         active: true,
-        specs: new Set([Spec.parse('react', '^18.0.0', configData)]),
+        specs: oneSpec(Spec.parse('react', '^18.0.0', configData)),
         target: react18,
         type: 'prod',
         contextDependents: new Set(),
@@ -1839,6 +1843,123 @@ t.test('endPeerPlacement', async t => {
     t.equal(edge?.to?.id, peerTarget.id, 'should link to peer target')
   })
 
+  t.test(
+    'resolving from context adds a new spec key when the resolved spec is textually distinct',
+    async t => {
+      // PRIORITY 3 (global peer context set) resolves the peer via
+      // `entry.target`, then records `spec.final` in `entry.specs`. When
+      // the resolved spec is textually different from every spec already
+      // tracked on the entry, it must be added as a *new* key rather than
+      // silently deduped away.
+      const peerContext: PeerContext = new Map()
+      const mainManifest = {
+        name: 'my-project',
+        version: '1.0.0',
+      }
+      const graph = new Graph({
+        projectRoot: t.testdirName,
+        ...configData,
+        mainManifest,
+      })
+
+      // place peer-pkg under an unrelated node (not mainImporter) so that
+      // mainImporter has no edge of its own to it - otherwise PRIORITY 1
+      // (fromNode.edgesOut) would resolve the peer before context even
+      // gets a chance to
+      const otherParent = graph.placePackage(
+        graph.mainImporter,
+        'prod',
+        Spec.parse('other-parent', '^1.0.0', configData),
+        { name: 'other-parent', version: '1.0.0' },
+      )!
+      const existingPeerSpec = Spec.parse(
+        'peer-pkg',
+        '>=1.0.0',
+        configData,
+      )
+      const peerTarget = graph.placePackage(
+        otherParent,
+        'prod',
+        existingPeerSpec,
+        { name: 'peer-pkg', version: '1.2.0' },
+      )!
+
+      // context already tracks one spec for peer-pkg, resolved to a
+      // target that also satisfies a stricter, textually distinct spec
+      peerContext.set('peer-pkg', {
+        active: true,
+        specs: oneSpec(existingPeerSpec),
+        target: peerTarget,
+        type: 'prod',
+        contextDependents: new Set(),
+      })
+
+      const nodeSpec = Spec.parse('my-pkg', '^1.0.0', configData)
+      const node = graph.placePackage(
+        graph.mainImporter,
+        'prod',
+        nodeSpec,
+        { name: 'my-pkg', version: '1.0.0' },
+      )!
+
+      // node's own peer dep is satisfied by the same target, but its
+      // bareSpec is distinct from what's already tracked on the entry
+      const distinctPeerSpec = Spec.parse(
+        'peer-pkg',
+        '^1.0.0',
+        configData,
+      )
+      const nextDeps: any[] = []
+      const nextPeerDeps = new Map([
+        [
+          'peer-pkg',
+          { spec: distinctPeerSpec, type: 'peer' as const },
+        ],
+      ])
+      // no sibling/closure providers for peer-pkg, so resolution can
+      // only come from PRIORITY 3 (the peer context entry itself)
+      const queuedEntries: PeerContextEntryInput[] = [
+        { spec: nodeSpec, target: node, type: 'prod' },
+      ]
+
+      const end = endPeerPlacement(
+        peerContext,
+        nextDeps,
+        nextPeerDeps,
+        graph,
+        nodeSpec,
+        graph.mainImporter,
+        node,
+        'prod',
+        queuedEntries,
+      )
+      end.resolvePeerDeps()
+
+      t.equal(
+        nextDeps.length,
+        0,
+        'peer should be resolved, not in nextDeps',
+      )
+      const edge = node.edgesOut.get('peer-pkg')
+      t.equal(
+        edge?.to?.id,
+        peerTarget.id,
+        'should link to the context target',
+      )
+
+      const entry = peerContext.get('peer-pkg')
+      t.equal(
+        entry?.specs.size,
+        2,
+        'the new, textually distinct spec is added alongside the existing one',
+      )
+      t.ok(
+        entry?.specs.has(peerSpecKey(distinctPeerSpec.final)),
+        'entry tracks the newly resolved spec under its own key',
+      )
+    },
+  )
+
   t.test('handles unresolved peerOptional', async t => {
     const peerContext: PeerContext = new Map()
     const mainManifest = {
@@ -2175,7 +2296,7 @@ t.test('endPeerPlacement', async t => {
       const peerContext: PeerContext = new Map()
       peerContext.set('zod', {
         active: true,
-        specs: new Set([Spec.parse('zod', '>=4.0.0', configData)]),
+        specs: oneSpec(Spec.parse('zod', '>=4.0.0', configData)),
         target: otherWorkspaceVersion, // This is what would happen from docs workspace
         type: 'prod',
         contextDependents: new Set(),

--- a/src/semver/src/index.ts
+++ b/src/semver/src/index.ts
@@ -25,6 +25,10 @@ export const parse = (version: Version | string) => {
  * to share across callers. Cleared wholesale once it hits the cap rather
  * than tracking LRU order, since real workloads only see a few hundred to
  * a few thousand distinct range strings per install.
+ *
+ * Sharing instances also means textually identical ranges are identical
+ * objects, which is what makes the identity-keyed `intersectsCache` below
+ * effective.
  */
 const rangeCache = new Map<string, Range | undefined>()
 const MAX_RANGE_CACHE = 4096
@@ -39,7 +43,10 @@ export const parseRange = (
     range = range.raw
   }
   const key = `${+includePrerelease}\0${range}`
-  if (rangeCache.has(key)) return rangeCache.get(key)
+  // single map lookup on the common hit path; the extra has() check only
+  // runs for ranges cached as invalid (undefined) and for misses
+  const cached = rangeCache.get(key)
+  if (cached !== undefined || rangeCache.has(key)) return cached
   let parsed: Range | undefined
   try {
     parsed = new Range(range, includePrerelease)
@@ -448,12 +455,15 @@ export const stable = <T extends Version | string = Version | string>(
   })
 
 /**
- * Bounded cache for {@link intersects}, keyed on the post-parse
- * `(raw, includePrerelease)` pair of both ranges so string and `Range`
- * object inputs share entries. Same clear-on-cap policy as `rangeCache`.
+ * Identity-keyed cache for {@link intersects}. Keying on the `Range`
+ * instances themselves (rather than a string of their raw sources) keeps
+ * the hit path free of string building, and needs no size cap or clear
+ * policy: entries are dropped by GC together with their ranges. It relies
+ * on `rangeCache` deduping instances, so string inputs and `spec.range`
+ * objects for the same source share entries; callers constructing a fresh
+ * `Range` per call simply recompute, as they did before memoization.
  */
-const intersectsCache = new Map<string, boolean>()
-const MAX_INTERSECTS_CACHE = 4096
+const intersectsCache = new WeakMap<Range, WeakMap<Range, boolean>>()
 
 /**
  * Return true if the range r1 intersects any of the ranges r2
@@ -475,18 +485,19 @@ export const intersects = (
   // If either range is 'any', they intersect
   if (range1.isAny || range2.isAny) return true
 
-  const key = `${range1.raw}\0${+range1.includePrerelease}\0${range2.raw}\0${+range2.includePrerelease}`
-  const cached = intersectsCache.get(key)
+  let inner = intersectsCache.get(range1)
+  const cached = inner?.get(range2)
   if (cached !== undefined) return cached
 
   // Check if any set from range1 intersects with any set from range2
   const result = range1.set.some(set1 =>
     range2.set.some(set2 => intersectComparators(set1, set2)),
   )
-  if (intersectsCache.size >= MAX_INTERSECTS_CACHE) {
-    intersectsCache.clear()
+  if (!inner) {
+    inner = new WeakMap()
+    intersectsCache.set(range1, inner)
   }
-  intersectsCache.set(key, result)
+  inner.set(range2, result)
   return result
 }
 

--- a/src/semver/src/index.ts
+++ b/src/semver/src/index.ts
@@ -18,6 +18,17 @@ export const parse = (version: Version | string) => {
   }
 }
 
+/**
+ * Bounded cache for {@link parseRange}, keyed on `(includePrerelease, raw)`.
+ * `Range` is effectively immutable after construction, so parsed results
+ * (including `undefined` for invalid input, tracked via `has()`) are safe
+ * to share across callers. Cleared wholesale once it hits the cap rather
+ * than tracking LRU order, since real workloads only see a few hundred to
+ * a few thousand distinct range strings per install.
+ */
+const rangeCache = new Map<string, Range | undefined>()
+const MAX_RANGE_CACHE = 4096
+
 /** Return the parsed version range, or `undefined` if invalid */
 export const parseRange = (
   range: Range | string,
@@ -27,11 +38,17 @@ export const parseRange = (
     if (range.includePrerelease === includePrerelease) return range
     range = range.raw
   }
+  const key = `${+includePrerelease}\0${range}`
+  if (rangeCache.has(key)) return rangeCache.get(key)
+  let parsed: Range | undefined
   try {
-    return new Range(range, includePrerelease)
+    parsed = new Range(range, includePrerelease)
   } catch {
-    return undefined
+    parsed = undefined
   }
+  if (rangeCache.size >= MAX_RANGE_CACHE) rangeCache.clear()
+  rangeCache.set(key, parsed)
+  return parsed
 }
 
 /**
@@ -431,6 +448,14 @@ export const stable = <T extends Version | string = Version | string>(
   })
 
 /**
+ * Bounded cache for {@link intersects}, keyed on the post-parse
+ * `(raw, includePrerelease)` pair of both ranges so string and `Range`
+ * object inputs share entries. Same clear-on-cap policy as `rangeCache`.
+ */
+const intersectsCache = new Map<string, boolean>()
+const MAX_INTERSECTS_CACHE = 4096
+
+/**
  * Return true if the range r1 intersects any of the ranges r2
  * r1 and r2 are either Range objects or range strings.
  * Returns true if any version would satisfy both ranges.
@@ -450,10 +475,19 @@ export const intersects = (
   // If either range is 'any', they intersect
   if (range1.isAny || range2.isAny) return true
 
+  const key = `${range1.raw}\0${+range1.includePrerelease}\0${range2.raw}\0${+range2.includePrerelease}`
+  const cached = intersectsCache.get(key)
+  if (cached !== undefined) return cached
+
   // Check if any set from range1 intersects with any set from range2
-  return range1.set.some(set1 =>
+  const result = range1.set.some(set1 =>
     range2.set.some(set2 => intersectComparators(set1, set2)),
   )
+  if (intersectsCache.size >= MAX_INTERSECTS_CACHE) {
+    intersectsCache.clear()
+  }
+  intersectsCache.set(key, result)
+  return result
 }
 
 /**

--- a/src/semver/test/index.ts
+++ b/src/semver/test/index.ts
@@ -64,6 +64,54 @@ t.test('parseRange, validRange', t => {
   t.end()
 })
 
+t.test('parseRange caching', t => {
+  const raw = '^7.6.5-unique-parse-range-cache-test'
+
+  const first = parseRange(raw)
+  const second = parseRange(raw)
+  t.equal(
+    first,
+    second,
+    'repeated calls with the same raw+includePrerelease return the cached Range instance',
+  )
+
+  const withPrerelease = parseRange(raw, true)
+  t.not(
+    withPrerelease,
+    first,
+    'includePrerelease flips the cache key to a distinct entry',
+  )
+  t.strictSame(
+    withPrerelease,
+    new Range(raw, true),
+    'cached entry with includePrerelease still parses correctly',
+  )
+
+  const invalid = '>=not-a-valid-range<<'
+  t.equal(
+    parseRange(invalid),
+    undefined,
+    'invalid raw string parses to undefined',
+  )
+  t.equal(
+    parseRange(invalid),
+    undefined,
+    'invalid result is itself cached and still returns undefined',
+  )
+
+  // force the bounded cache past its cap so the clear-on-cap branch runs
+  for (let i = 0; i < 4200; i++) {
+    parseRange(`>=1.0.${i} <2.0.${i}`)
+  }
+  t.strictSame(
+    parseRange(raw),
+    new Range(raw),
+    'still parses correctly for a fresh key after the cache has been cleared',
+  )
+
+  t.end()
+})
+
 t.test('satisfies', t => {
   for (const [range, version] of includes) {
     const v = Version.parse(version)
@@ -797,6 +845,65 @@ t.test('intersects', t => {
       intersects('>=1.0.0-alpha <1.0.0-alpha', '1.0.0-alpha', true),
       false,
       'Impossible prerelease range',
+    )
+
+    t.end()
+  })
+
+  // Test the memoization cache
+  t.test('caching', t => {
+    // string and Range object inputs share the same cache entry
+    const range1 = parseRange('^2.2.2-intersects-cache-test')
+    const range2 = parseRange('^2.2.3-intersects-cache-test')
+    t.ok(range1, 'parsed range1')
+    t.ok(range2, 'parsed range2')
+
+    const fromStrings = intersects(
+      '^2.2.2-intersects-cache-test',
+      '^2.2.3-intersects-cache-test',
+    )
+    if (range1 && range2) {
+      t.equal(
+        intersects(range1, range2),
+        fromStrings,
+        'Range-object call hits the same cache entry as the string call',
+      )
+    }
+
+    // includePrerelease is part of the cache key, so it must not be
+    // conflated with a call for the same ranges without the flag: `^1`'s
+    // lower bound drops from `>=1.0.0` to `>=1.0.0-0` when the flag is
+    // set, which changes whether it intersects an exact prerelease
+    t.equal(
+      intersects('^1', '=1.0.0-beta'),
+      false,
+      'without includePrerelease, ^1 does not intersect =1.0.0-beta',
+    )
+    t.equal(
+      intersects('^1', '=1.0.0-beta', true),
+      true,
+      'with includePrerelease, ^1 does intersect =1.0.0-beta (cached separately)',
+    )
+    // repeat in reverse call order to prove neither entry evicted the other
+    t.equal(
+      intersects('^1', '=1.0.0-beta', true),
+      true,
+      'includePrerelease result is stable on a second call',
+    )
+    t.equal(
+      intersects('^1', '=1.0.0-beta'),
+      false,
+      'no-flag result is unaffected by the cached includePrerelease entry',
+    )
+
+    // force the bounded cache past its cap so the clear-on-cap branch runs
+    for (let i = 0; i < 4200; i++) {
+      intersects(`>=1.0.${i}`, `<2.0.${i}`)
+    }
+    t.equal(
+      intersects('^1.2.3', '^1.2.4'),
+      true,
+      'still computes correctly for a fresh pair after the cache has been cleared',
     )
 
     t.end()

--- a/src/semver/test/index.ts
+++ b/src/semver/test/index.ts
@@ -852,7 +852,8 @@ t.test('intersects', t => {
 
   // Test the memoization cache
   t.test('caching', t => {
-    // string and Range object inputs share the same cache entry
+    // string and Range object inputs share the same cache entry, since
+    // parseRange() dedupes instances and the cache is keyed on identity
     const range1 = parseRange('^2.2.2-intersects-cache-test')
     const range2 = parseRange('^2.2.3-intersects-cache-test')
     t.ok(range1, 'parsed range1')
@@ -867,6 +868,17 @@ t.test('intersects', t => {
         intersects(range1, range2),
         fromStrings,
         'Range-object call hits the same cache entry as the string call',
+      )
+      // same range1 against a new range2 reuses range1's inner map
+      t.equal(
+        intersects(range1, '^3.0.0-intersects-cache-test'),
+        false,
+        'fresh second range against a cached first range computes correctly',
+      )
+      t.equal(
+        intersects(range1, '^3.0.0-intersects-cache-test'),
+        false,
+        'and is itself cached on a repeat call',
       )
     }
 
@@ -896,14 +908,16 @@ t.test('intersects', t => {
       'no-flag result is unaffected by the cached includePrerelease entry',
     )
 
-    // force the bounded cache past its cap so the clear-on-cap branch runs
+    // the identity-keyed cache has no size cap (entries are GC'd with
+    // their ranges), but exercise a large batch of distinct pairs to
+    // confirm results stay correct as the cache grows
     for (let i = 0; i < 4200; i++) {
       intersects(`>=1.0.${i}`, `<2.0.${i}`)
     }
     t.equal(
       intersects('^1.2.3', '^1.2.4'),
       true,
-      'still computes correctly for a fresh pair after the cache has been cleared',
+      'still computes correctly for a fresh pair after many insertions',
     )
 
     t.end()


### PR DESCRIPTION
Dedupe entry.specs by (type, name@bareSpec, registry) instead of Set identity so textually identical peer specs from different dependents no longer pile up, and memoize semver range comparisons so they are O(1) after the first hit: parseRange() on a bounded string-keyed cache, and intersects() on an identity-keyed WeakMap (relying on parseRange deduping Range instances).