### PR TITLE
registry-client: tweak undici options

### DIFF
--- a/.cursor/rules/registries-and-auth.mdc
+++ b/.cursor/rules/registries-and-auth.mdc
@@ -105,3 +105,26 @@ Tokens stored in XDG data dir: `vlt/auth/${identity}/keychain.json`
 
 - `src/registry-client/` — HTTP client for registry API
 - `src/keychain/` — secure token storage (`@vltpkg/keychain`)
+
+## Packument Accept header (do not enable corgi)
+
+`PackageInfoClient.#fetchPackument` always sends
+`accept: application/json` (full packument). Do **not** switch to npm
+abbreviated/"corgi" packuments
+(`application/vnd.npm.install-v1+json`) as a perf shortcut.
+
+Corgi omits `license` (also `time`, `readme`, `maintainers`, `_rev`,
+`scripts`). The version entry becomes `node.manifest` and is persisted
+to the lockfile, so graph queries like `[license=MPL-2.0]` miss. This
+shipped in 1.0.0-rc.33 (#1692), caused false-positive license CI on
+#1704, and was reverted in #1707.
+
+The registry-client disk cache key is method + URL only (no `accept`,
+no `Vary`). Full and abbreviated responses for the same URL would
+collide. `:dist` / `:outdated` may use corgi via raw `fetch` because
+they never touch that cache and only read `dist-tags` / `versions`
+keys.
+
+To revisit: representation must be part of the disk-cache key **and**
+the in-flight coalescing key, and the SWR revalidate child must replay
+the same Accept.

--- a/src/package-info/src/index.ts
+++ b/src/package-info/src/index.ts
@@ -107,6 +107,9 @@ export class PackageInfoClient {
   #trustedIntegrities = new Map<string, Integrity>()
   #manifestCacheMinAge = Date.now() - manifestCacheMaxAge
   #cachePath: string
+  // In-flight coalescing key is `${registry}${name}` — no representation
+  // component. Safe only because every caller requests the same full
+  // packument (see #fetchPackument).
   #packumentPromises = new Map<string, Promise<Packument>>()
 
   get registryClient() {
@@ -864,6 +867,7 @@ export class PackageInfoClient {
       case 'registry': {
         const { registry, name } = f
         if (!registry) throw noRegistryError(spec)
+        // Coalescing key has no representation component (see #fetchPackument).
         const packumentKey = `${registry}${name}`
         const inflight = this.#packumentPromises.get(packumentKey)
         if (inflight) return inflight
@@ -888,6 +892,31 @@ export class PackageInfoClient {
     pakuURL: URL,
     useCache?: false,
   ): Promise<Packument> {
+    // Always request the full packument (`application/json`), never the
+    // abbreviated "corgi" form:
+    //   accept: application/vnd.npm.install-v1+json; q=1.0,
+    //           application/json; q=0.8, */*
+    //
+    // Corgi is smaller (~−41% packument bytes, est. 1–3s on clean installs)
+    // but is disabled for two load-bearing reasons:
+    //
+    // 1. Metadata loss reaches the lockfile. The version entry returned
+    //    here is `node.manifest` and is persisted to vlt-lock.json / the
+    //    hidden lockfile. Corgi drops `license` (also `time`, `readme`,
+    //    `maintainers`, `_rev`, `scripts`), so graph queries like
+    //    `[license=MPL-2.0]` cannot match a field that was never stored.
+    //    Shipped in 1.0.0-rc.33 via #1692 (8ba2b10c); 24 false-positive
+    //    edges in the dependency-check job on #1704
+    //    (`@resvg/resvg-wasm@2.6.2` MPL-2.0 in package.json, blank in the
+    //    stored graph); isolated in #1705; reverted in #1707.
+    //
+    // 2. The RegistryClient disk cache key is method + URL only — no
+    //    accept, no Vary — so a full-packument request can be served a
+    //    cached abbreviated body (and vice versa).
+    //
+    // To revisit: put the requested representation on both the disk-cache
+    // key and the in-flight coalescing key, and have the SWR child
+    // (cache-revalidate / revalidate) re-request the same representation.
     const response = await this.registryClient.request(pakuURL, {
       headers: { accept: 'application/json' },
       ...(useCache === false ? { useCache } : {}),

--- a/src/package-info/test/index.ts
+++ b/src/package-info/test/index.ts
@@ -1983,6 +1983,8 @@ t.test(
       1,
       'made one registry request',
     )
+    // Regression guard: #1692 briefly requested corgi and dropped license
+    // from stored manifests. See PackageInfoClient.#fetchPackument.
     t.equal(
       coalescedPackumentAccept,
       'application/json',

--- a/src/query/src/pseudo/dist.ts
+++ b/src/query/src/pseudo/dist.ts
@@ -30,6 +30,8 @@ export const retrieveDistTags = async (
   const url = new URL(spec.registry)
   url.pathname = `/${node.name}`
 
+  // Corgi is safe here: raw fetch (never the RegistryClient disk cache),
+  // and only dist-tags are read.
   const response = await fetch(String(url), {
     headers: {
       Accept: 'application/vnd.npm.install-v1+json',

--- a/src/query/src/pseudo/outdated.ts
+++ b/src/query/src/pseudo/outdated.ts
@@ -86,6 +86,8 @@ export const retrieveRemoteVersions = async (
   const url = new URL(spec.registry)
   url.pathname = `/${node.name}`
 
+  // Corgi is safe here: raw fetch (never the RegistryClient disk cache),
+  // and only versions keys are read.
   const response = await fetch(String(url), {
     headers: {
       Accept: 'application/vnd.npm.install-v1+json',

--- a/src/registry-client/src/index.ts
+++ b/src/registry-client/src/index.ts
@@ -7,6 +7,7 @@ import type { Integrity } from '@vltpkg/types'
 import { urlOpen } from '@vltpkg/url-open'
 import { XDG } from '@vltpkg/xdg'
 import { randomUUID } from 'node:crypto'
+import { availableParallelism } from 'node:os'
 import { dirname, resolve } from 'node:path'
 import { setTimeout } from 'node:timers/promises'
 import { loadPackageJson } from 'package-json-from-dist'
@@ -204,7 +205,11 @@ export const userAgent = `@vltpkg/registry-client/${version} ${nua}`
 // pipelining:1 is intentional — pipelining:10 had no measured CPU benefit
 // and HOL-blocks packuments behind large tarballs; some CDNs drop pipelined
 // requests.
-// connections:64 bounds cold-start TLS; still above reify's in-flight cap.
+// connections scales with reify's in-flight cap ((cores-1)*8, see
+// src/graph/src/reify/index.ts) so tarball fetches don't queue behind
+// the pool on many-core machines. The floor of 64 bounds cold-start TLS
+// on small machines; the ceiling of 128 avoids connection storms and
+// CDN throttling beyond what reify can consume.
 // HTTP/2 (allowH2) is untested and unjustified while transport CPU is ~1/4
 // of body handling.
 const agentOptions: Agent.Options = {
@@ -219,7 +224,10 @@ const agentOptions: Agent.Options = {
     keepAliveInitialDelay: 30_000,
     sessionTimeout: 600,
   },
-  connections: 64,
+  connections: Math.min(
+    128,
+    Math.max(64, (availableParallelism() - 1) * 8),
+  ),
   pipelining: 1,
 }
 
@@ -508,10 +516,8 @@ export class RegistryClient {
 
     redirections.add(String(url))
 
-    Object.assign(options, {
-      path: u.pathname.replace(/\/+$/, '') + u.search,
-    })
-
+    // eslint-disable-next-line @typescript-eslint/no-deprecated -- deprecated for callers; this is the one place that sets it
+    options.path = u.pathname.replace(/\/+$/, '') + u.search
     options.origin = u.origin
     options.headers = addHeader(
       addHeader(

--- a/src/registry-client/src/index.ts
+++ b/src/registry-client/src/index.ts
@@ -195,6 +195,18 @@ const nua =
 
 export const userAgent = `@vltpkg/registry-client/${version} ${nua}`
 
+// Agent-level knobs only. Do not spread these onto per-request options —
+// connections/pipelining/keepAlive/connect are ignored at dispatch time,
+// and bodyTimeout/headersTimeout would clobber caller overrides.
+//
+// Keep undici (not globalThis.fetch): fetch measured +56% user CPU and
+// +90–140MB RSS on the same 753-body install workload.
+// pipelining:1 is intentional — pipelining:10 had no measured CPU benefit
+// and HOL-blocks packuments behind large tarballs; some CDNs drop pipelined
+// requests.
+// connections:64 bounds cold-start TLS; still above reify's in-flight cap.
+// HTTP/2 (allowH2) is untested and unjustified while transport CPU is ~1/4
+// of body handling.
 const agentOptions: Agent.Options = {
   bodyTimeout: 600_000,
   headersTimeout: 600_000,
@@ -207,8 +219,8 @@ const agentOptions: Agent.Options = {
     keepAliveInitialDelay: 30_000,
     sessionTimeout: 600,
   },
-  connections: 128,
-  pipelining: 10,
+  connections: 64,
+  pipelining: 1,
 }
 
 const xdg = new XDG('vlt')
@@ -466,7 +478,9 @@ export class RegistryClient {
 
     ;(signal as AbortSignal | null)?.throwIfAborted()
 
-    // first, try to get from the cache before making any request.
+    // Method + URL only. Headers (including accept) are not part of the
+    // key and there is no Vary handling — callers must not vary the
+    // response representation for the same URL.
     const key = `${method !== 'GET' ? method + ' ' : ''}${u}`
     const buffer =
       useCache ?
@@ -496,7 +510,6 @@ export class RegistryClient {
 
     Object.assign(options, {
       path: u.pathname.replace(/\/+$/, '') + u.search,
-      ...agentOptions,
     })
 
     options.origin = u.origin

--- a/src/registry-client/test/index.ts
+++ b/src/registry-client/test/index.ts
@@ -6,6 +6,7 @@ import { dirname, resolve } from 'node:path'
 import { gzipSync } from 'node:zlib'
 import type { Test } from 'tap'
 import t from 'tap'
+import type { Dispatcher } from 'undici'
 import { CacheEntry } from '../src/cache-entry.ts'
 import type {
   RegistryClient,
@@ -974,4 +975,48 @@ t.test('VLT_CACHE_MAX_SIZE', async t => {
     t.equal(floored.cache.get('k'), undefined)
     await floored.cache.promise()
   })
+})
+
+t.test('per-request options omit agent knobs', async t => {
+  dropConnection = false
+  const rc = t.context.rc as RegistryClient
+  const seen: Dispatcher.RequestOptions[] = []
+  const orig = rc.agent.request.bind(rc.agent)
+  rc.agent.request = async (opts: Dispatcher.RequestOptions) => {
+    seen.push(opts)
+    return orig(opts)
+  }
+
+  await rc.request(`${registryURL}/abbrev`)
+  const first = seen[0]
+  if (!first) {
+    t.fail('dispatched a request')
+    return
+  }
+  t.hasStrict(
+    first,
+    {
+      connections: undefined,
+      pipelining: undefined,
+      keepAliveMaxTimeout: undefined,
+      keepAliveTimeout: undefined,
+      keepAliveTimeoutThreshold: undefined,
+      connect: undefined,
+    },
+    'agent-level knobs are not copied onto the request',
+  )
+
+  seen.length = 0
+  await rc.request(`${registryURL}/abbrev`, {
+    useCache: false,
+    headersTimeout: 12_345,
+    bodyTimeout: 54_321,
+  })
+  const second = seen[0]
+  if (!second) {
+    t.fail('dispatched a second request')
+    return
+  }
+  t.equal(second.headersTimeout, 12_345)
+  t.equal(second.bodyTimeout, 54_321)
 })

--- a/www/docs/src/content/docs/get-started/concepts/packuments.mdx
+++ b/www/docs/src/content/docs/get-started/concepts/packuments.mdx
@@ -47,7 +47,7 @@ version, then fetches that version's manifest and tarball.
 Registries may return a **minified packument** (npm's abbreviated
 "corgi" format) — containing only install-critical fields — to reduce
 payload size. vlt can parse both full and minified packuments, but
-always *requests* the full document (`application/json`). Abbreviated
+always _requests_ the full document (`application/json`). Abbreviated
 responses omit `license` and other metadata that is persisted onto
 graph manifests and queried later; the registry-client cache also
 cannot yet distinguish representations of the same URL.

--- a/www/docs/src/content/docs/get-started/concepts/packuments.mdx
+++ b/www/docs/src/content/docs/get-started/concepts/packuments.mdx
@@ -44,10 +44,13 @@ version, then fetches that version's manifest and tarball.
 
 ## Minified packuments
 
-Registries may return a **minified packument** for version lookups —
-containing only the requested version's manifest and essential
-metadata — to reduce payload size. vlt handles both full and minified
-packuments transparently.
+Registries may return a **minified packument** (npm's abbreviated
+"corgi" format) — containing only install-critical fields — to reduce
+payload size. vlt can parse both full and minified packuments, but
+always *requests* the full document (`application/json`). Abbreviated
+responses omit `license` and other metadata that is persisted onto
+graph manifests and queried later; the registry-client cache also
+cannot yet distinguish representations of the same URL.
 
 ## Related concepts
 


### PR DESCRIPTION
Set pipelining to 1 and connections to 64, stop spreading agent options onto per-request dispatch, and add comments explaining why full packuments stay required (license/lockfile + cache-key collision).