### PR TITLE
cli-sdk: startup tweaks

### DIFF
--- a/infra/build/src/bins.ts
+++ b/infra/build/src/bins.ts
@@ -1,5 +1,8 @@
+import module from 'node:module'
 import { resolve } from 'node:path'
 import type { Commands } from '@vltpkg/cli-sdk/definition'
+
+module.enableCompileCache()
 
 export const BINS_DIR = resolve(import.meta.dirname, 'bins')
 

--- a/infra/build/test/bins.ts
+++ b/infra/build/test/bins.ts
@@ -16,6 +16,14 @@ t.test('basic', async t => {
   t.notOk(isBin('vltt'))
 })
 
+t.test('enables compile cache', async t => {
+  const enableCompileCache = t.captureFn(() => {})
+  await mockBins(t, {
+    'node:module': { default: { enableCompileCache } },
+  })
+  t.strictSame(enableCompileCache.args(), [[]])
+})
+
 t.test('changes argv', async t => {
   t.intercept(process, 'argv', { value: ['a', 'b', 'c', 'd'] })
   const runFn = () => true

--- a/src/cache-unzip/src/index.ts
+++ b/src/cache-unzip/src/index.ts
@@ -1,4 +1,5 @@
 import { spawn } from 'node:child_process'
+import module from 'node:module'
 import { __CODE_SPLIT_SCRIPT_NAME } from './unzip.ts'
 
 const isDeno =
@@ -18,10 +19,15 @@ export const register = (path: string, key: string): void => {
 }
 
 const handleBeforeExit = () => {
+  // The compile cache is enabled in-process by the CLI entry, which does
+  // not propagate to child processes, so the worker has to be pointed at
+  // it through the environment to skip re-compiling its bundle.
+  const compileCacheDir = module.getCompileCacheDir()
   for (const [path, r] of registered) {
     /* c8 ignore next */
     if (!r.size) return
     const env = { ...process.env }
+    if (compileCacheDir) env.NODE_COMPILE_CACHE ??= compileCacheDir
     const args = []
     // Deno on Windows does not support detached processes
     // https://github.com/denoland/deno/issues/25867

--- a/src/cache-unzip/test/index.ts
+++ b/src/cache-unzip/test/index.ts
@@ -1,7 +1,10 @@
 import t from 'tap'
 import type { Test } from 'tap'
 
-const mockUnzip = async (t: Test) => {
+const mockUnzip = async (
+  t: Test,
+  mocks: Record<string, any> = {},
+) => {
   let beforeExitHook: (() => void) | null = null
 
   const state = {
@@ -21,6 +24,7 @@ const mockUnzip = async (t: Test) => {
   const { register } = await t.mockImport<
     typeof import('../src/index.ts')
   >('../src/index.ts', {
+    ...mocks,
     child_process: {
       spawn: (
         cmd: string,
@@ -73,6 +77,36 @@ t.test('registering the beforeExit event', async t => {
   t.equal(state.unrefCalled, true)
 
   t.strictSame(state.written, ['key 1\0', 'key 2\0'])
+})
+
+t.test('shares the compile cache dir with the worker', async t => {
+  const { register, beforeExit, state } = await mockUnzip(t, {
+    'node:module': {
+      default: { getCompileCacheDir: () => '/compile/cache' },
+    },
+  })
+
+  register(t.testdirName, 'key 1')
+  beforeExit()
+
+  t.equal(state.opts.env.NODE_COMPILE_CACHE, '/compile/cache')
+})
+
+t.test('does not clobber an explicit NODE_COMPILE_CACHE', async t => {
+  t.intercept(process, 'env', {
+    value: { ...process.env, NODE_COMPILE_CACHE: '/explicit' },
+  })
+
+  const { register, beforeExit, state } = await mockUnzip(t, {
+    'node:module': {
+      default: { getCompileCacheDir: () => '/compile/cache' },
+    },
+  })
+
+  register(t.testdirName, 'key 1')
+  beforeExit()
+
+  t.equal(state.opts.env.NODE_COMPILE_CACHE, '/explicit')
 })
 
 t.test('deno', async t => {

--- a/src/cli-sdk/src/commands/cache.ts
+++ b/src/cli-sdk/src/commands/cache.ts
@@ -201,7 +201,7 @@ const fetchAll = async (
   conf: LoadedConfig,
   test: (entry: CacheEntry, key: string, val: Buffer) => boolean,
 ) => {
-  const rc = conf.options.packageInfo.registryClient
+  const rc = await conf.options.packageInfo.getRegistryClient()
   const { cache } = rc
   const map: CacheMap = {}
   for await (const [key, val] of cache) {
@@ -218,7 +218,7 @@ const fetchKeys = async (
   test: (entry: CacheEntry, key: string, buf: Buffer) => boolean,
   view?: CacheView,
 ) => {
-  const rc = conf.options.packageInfo.registryClient
+  const rc = await conf.options.packageInfo.getRegistryClient()
   const { cache } = rc
   const map: CacheMap = {}
   const results: [string, Buffer | undefined][] = await Promise.all(
@@ -245,7 +245,7 @@ const deleteEntries = async (
   test: (entry: CacheEntry) => boolean,
   view?: CacheView,
 ) => {
-  const rc = conf.options.packageInfo.registryClient
+  const rc = await conf.options.packageInfo.getRegistryClient()
   const { cache } = rc
 
   let count = 0
@@ -329,7 +329,7 @@ const deleteAll = async (
   _: string[],
   view?: CacheView,
 ) => {
-  const { cache } = conf.options.packageInfo.registryClient
+  const { cache } = await conf.options.packageInfo.getRegistryClient()
   await rm(cache.path(), { recursive: true, force: true })
   await mkdir(cache.path(), { recursive: true })
   view?.stdout('Deleted all cache entries.')
@@ -355,7 +355,9 @@ const add = async (
       })
       .then(async r => {
         const { resolved, integrity } = r
-        await packageInfo.registryClient.request(resolved, {
+        await (
+          await packageInfo.getRegistryClient()
+        ).request(resolved, {
           ...conf.options,
           integrity,
           staleWhileRevalidate: false,

--- a/src/cli-sdk/src/commands/ci.ts
+++ b/src/cli-sdk/src/commands/ci.ts
@@ -1,7 +1,7 @@
 import { install } from '@vltpkg/graph'
 import { commandUsage } from '../config/usage.ts'
-import { InstallReporter } from './install/reporter.ts'
 import type { CommandFn, CommandUsage } from '../index.ts'
+import { lazyView } from '../view.ts'
 import type { Views } from '../view.ts'
 import type { InstallResult } from './install.ts'
 
@@ -35,7 +35,10 @@ export const usage: CommandUsage = () =>
 
 export const views = {
   json: i => i.graph.toJSON(),
-  human: InstallReporter,
+  human: lazyView(
+    async () =>
+      (await import('./install/reporter.ts')).InstallReporter,
+  ),
 } as const satisfies Views<CIResult>
 
 export const command: CommandFn<CIResult> = async conf => {

--- a/src/cli-sdk/src/commands/install.ts
+++ b/src/cli-sdk/src/commands/install.ts
@@ -1,11 +1,11 @@
 import { commandUsage } from '../config/usage.ts'
 import { install } from '@vltpkg/graph'
 import { parseAddArgs } from '../parse-add-remove-args.ts'
-import { InstallReporter } from './install/reporter.ts'
 import { trackInstall } from '../telemetry.ts'
 import type { DepID } from '@vltpkg/dep-id'
 import type { Diff, Graph } from '@vltpkg/graph'
 import type { CommandFn, CommandUsage } from '../index.ts'
+import { lazyView } from '../view.ts'
 import type { Views } from '../view.ts'
 
 /**
@@ -156,7 +156,10 @@ export const views = {
       : null),
     }
   },
-  human: InstallReporter,
+  human: lazyView(
+    async () =>
+      (await import('./install/reporter.ts')).InstallReporter,
+  ),
 } as const satisfies Views<InstallResult>
 
 export const command: CommandFn<InstallResult> = async conf => {

--- a/src/cli-sdk/src/commands/uninstall.ts
+++ b/src/cli-sdk/src/commands/uninstall.ts
@@ -3,7 +3,7 @@ import type { Graph } from '@vltpkg/graph'
 import { commandUsage } from '../config/usage.ts'
 import type { CommandFn, CommandUsage } from '../index.ts'
 import { parseRemoveArgs } from '../parse-add-remove-args.ts'
-import { InstallReporter } from './install/reporter.ts'
+import { lazyView } from '../view.ts'
 import type { Views } from '../view.ts'
 
 export type UninstallResult = {
@@ -41,7 +41,10 @@ export const usage: CommandUsage = () =>
 
 export const views = {
   json: i => i.graph.toJSON(),
-  human: InstallReporter,
+  human: lazyView(
+    async () =>
+      (await import('./install/reporter.ts')).InstallReporter,
+  ),
 } as const satisfies Views<UninstallResult>
 
 export const command: CommandFn<UninstallResult> = async conf => {

--- a/src/cli-sdk/src/commands/update.ts
+++ b/src/cli-sdk/src/commands/update.ts
@@ -2,7 +2,7 @@ import { update } from '@vltpkg/graph'
 import { error } from '@vltpkg/error-cause'
 import { commandUsage } from '../config/usage.ts'
 import type { CommandFn, CommandUsage } from '../index.ts'
-import { InstallReporter } from './install/reporter.ts'
+import { lazyView } from '../view.ts'
 import type { Views } from '../view.ts'
 import type { InstallResult } from './install.ts'
 
@@ -33,7 +33,10 @@ export const views = {
     : null),
     graph: i.graph.toJSON(),
   }),
-  human: InstallReporter,
+  human: lazyView(
+    async () =>
+      (await import('./install/reporter.ts')).InstallReporter,
+  ),
 } as const satisfies Views<InstallResult>
 
 export const command: CommandFn<InstallResult> = async conf => {

--- a/src/cli-sdk/src/output.ts
+++ b/src/cli-sdk/src/output.ts
@@ -12,8 +12,8 @@ import {
   hasConfiguredRegistry,
   missingRegistryError,
 } from './require-registry.ts'
-import type { View, ViewOptions, Views } from './view.ts'
-import { isViewClass } from './view.ts'
+import type { LazyView, View, ViewOptions, Views } from './view.ts'
+import { isLazyView, isViewClass, loadLazyView } from './view.ts'
 import {
   generateDefaultHelp,
   generateFullHelp,
@@ -68,18 +68,24 @@ export let styleTextStderr: StyleTextFn = (_, s) => s
 
 const identity = <T>(x: T): T => x
 
-export const getView = <T>(
+const selectView = <T>(
+  viewName: string,
+  views?: Views<T>,
+): View<T> | LazyView<T> | undefined => {
+  if (viewName === 'inspect') return identity
+  if (viewName === 'silent') return () => undefined
+  if (isLazyView<T>(views) || typeof views === 'function') {
+    return views
+  }
+  if (views) return views[viewName]
+  return identity
+}
+
+export const getView = async <T>(
   conf: LoadedConfig,
   views?: Views<T>,
-): View<T> => {
-  const viewName = conf.values.view
-
-  const viewFn =
-    viewName === 'inspect' ? identity
-    : viewName === 'silent' ? () => undefined
-    : typeof views === 'function' ? views
-    : views && typeof views === 'object' ? views[viewName]
-    : identity
+): Promise<View<T>> => {
+  const viewFn = selectView(conf.values.view, views)
 
   // if the user specified a view that doesn't exist, then set it back to the
   // default, and try again. This will fall back to identity if it's also
@@ -97,7 +103,11 @@ export const getView = <T>(
     return getView(conf, views)
   }
 
-  return viewFn ?? identity
+  const resolved = viewFn ?? identity
+  if (isLazyView<T>(resolved)) {
+    return loadLazyView(resolved)
+  }
+  return resolved
 }
 
 export type OnDone<T> = (result: T) => Promise<unknown>
@@ -106,16 +116,16 @@ export type OnDone<T> = (result: T) => Promise<unknown>
  * If the view is a View class, then instantiate and start it.
  * If it's a view function, then just define the onDone method.
  */
-const startView = <T>(
+const startView = async <T>(
   conf: LoadedConfig,
   opts: ViewOptions,
   views?: Views<T>,
   { start }: { start: number } = { start: Date.now() },
-): {
+): Promise<{
   onDone: OnDone<T>
   onError?: (err: unknown) => void
-} => {
-  const View = getView<T>(conf, views)
+}> => {
+  const View = await getView<T>(conf, views)
 
   if (isViewClass(View)) {
     const view = new View(opts, conf)
@@ -183,7 +193,7 @@ export const outputCommand = async <T>(
     styleTextStderr,
   )
 
-  const { onDone, onError } = startView(
+  const { onDone, onError } = await startView(
     conf,
     // assume views will always output to stdout so use color support from there
     { colors: stdoutColor },

--- a/src/cli-sdk/src/view.ts
+++ b/src/cli-sdk/src/view.ts
@@ -47,4 +47,22 @@ export const isViewClass = <T = unknown>(
   'prototype' in view &&
   view.prototype instanceof ViewClass
 
-export type Views<T = unknown> = View<T> | Record<string, View<T>>
+const kLazyView: unique symbol = Symbol.for('vlt.lazyView')
+
+export type LazyView<T = unknown> = {
+  readonly [kLazyView]: () => Promise<View<T>>
+}
+
+export const lazyView = <T>(
+  load: () => Promise<View<T>>,
+): LazyView<T> => ({ [kLazyView]: load })
+
+export const isLazyView = <T = unknown>(
+  v: unknown,
+): v is LazyView<T> => !!v && typeof v === 'object' && kLazyView in v
+
+export const loadLazyView = <T>(v: LazyView<T>): Promise<View<T>> =>
+  v[kLazyView]()
+
+export type Views<T = unknown> =
+  View<T> | LazyView<T> | Record<string, View<T> | LazyView<T>>

--- a/src/cli-sdk/test/commands/cache.ts
+++ b/src/cli-sdk/test/commands/cache.ts
@@ -65,7 +65,7 @@ t.test('add', async t => {
               'sha512-00000000000000000000000000000000000000000000000000000000000000000000000000000000000000==',
           }
         },
-        registryClient: {
+        getRegistryClient: async () => ({
           request: async (
             url: string,
             options: RegistryClientRequestOptions,
@@ -81,7 +81,7 @@ t.test('add', async t => {
               staleWhileRevalidate: false,
             })
           },
-        },
+        }),
       },
     },
   } as unknown as LoadedConfig
@@ -126,7 +126,7 @@ t.test('delete-all', async t => {
     positionals: ['delete-all'],
     options: {
       packageInfo: {
-        registryClient: new MockRegistryClient(),
+        getRegistryClient: async () => new MockRegistryClient(),
       },
     },
   } as unknown as LoadedConfig)

--- a/src/cli-sdk/test/commands/ci.ts
+++ b/src/cli-sdk/test/commands/ci.ts
@@ -1,6 +1,7 @@
 import t from 'tap'
 import type { LoadedConfig } from '../../src/config/index.ts'
 import type { CIResult } from '../../src/commands/ci.ts'
+import { loadLazyView } from '../../src/view.ts'
 
 const options = {}
 let log = ''
@@ -38,7 +39,7 @@ t.test('command execution', async t => {
   )
 })
 
-t.test('views', t => {
+t.test('views', async t => {
   // Test json view
   t.strictSame(
     Command.views.json({
@@ -50,9 +51,9 @@ t.test('views', t => {
     'json view returns graph.toJSON()',
   )
 
-  // Test human view is InstallReporter
+  const human = await loadLazyView(Command.views.human)
   t.equal(
-    Command.views.human.name,
+    human.name,
     'InstallReporter',
     'human view uses InstallReporter',
   )

--- a/src/cli-sdk/test/commands/update.ts
+++ b/src/cli-sdk/test/commands/update.ts
@@ -1,6 +1,7 @@
 import t from 'tap'
 import type { LoadedConfig } from '../../src/config/index.ts'
 import type { InstallResult } from '../../src/commands/install.ts'
+import { isLazyView, loadLazyView } from '../../src/view.ts'
 
 const options = {}
 let log = ''
@@ -79,10 +80,10 @@ t.test('views.json returns graph toJSON', t => {
   t.end()
 })
 
-t.test('views.human uses InstallReporter', t => {
-  // Just check that the human view is the InstallReporter function
-  t.type(Command.views.human, 'function')
-  t.end()
+t.test('views.human uses InstallReporter', async t => {
+  t.ok(isLazyView(Command.views.human))
+  const human = await loadLazyView(Command.views.human)
+  t.equal(human.name, 'InstallReporter')
 })
 
 // Test JSON view with buildQueue

--- a/src/cli-sdk/test/output.ts
+++ b/src/cli-sdk/test/output.ts
@@ -52,8 +52,8 @@ t.test('getView', async t => {
   const confHuman = {
     values: { view: 'human' },
   } as LoadedConfig
-  t.equal(getView(confJson, { json, human }), json)
-  const id = getView(confHuman) as ViewFn
+  t.equal(await getView(confJson, { json, human }), json)
+  const id = (await getView(confHuman)) as ViewFn
   const xx = id(x, options, confHuman)
   t.equal(xx, x, 'identity function returned')
 
@@ -61,7 +61,7 @@ t.test('getView', async t => {
     values: { view: 'unknown' as any },
   } as LoadedConfig
   process.env.VLT_VIEW = 'unknown'
-  const unknown = getView(confUnknown, { json, human })
+  const unknown = await getView(confUnknown, { json, human })
   t.equal(
     unknown,
     json,
@@ -69,7 +69,36 @@ t.test('getView', async t => {
   )
   t.equal(process.env.VLT_VIEW, 'json', 'set view config to default')
   const viewFn = (() => {}) as ViewFn<true>
-  t.equal(getView(confHuman, viewFn), viewFn)
+  t.equal(await getView(confHuman, viewFn), viewFn)
+  t.equal(
+    await getView(
+      confHuman,
+      view.lazyView(async () => viewFn),
+    ),
+    viewFn,
+  )
+
+  let loaded = false
+  const lazyHuman = view.lazyView(async () => {
+    loaded = true
+    return human
+  })
+  t.equal(await getView(confHuman, { json, human: lazyHuman }), human)
+  t.ok(loaded, 'lazy view loader ran for human view')
+
+  loaded = false
+  const confSilent = {
+    values: { view: 'silent' },
+  } as LoadedConfig
+  const silent = await getView(confSilent, {
+    json,
+    human: lazyHuman,
+  })
+  t.equal(
+    (silent as ViewFn)(undefined, options, confSilent),
+    undefined,
+  )
+  t.notOk(loaded, 'lazy view loader skipped for silent view')
   t.end()
 })
 
@@ -347,5 +376,28 @@ t.test('outputCommand', async t => {
     t.ok(startCalled, 'start method was called')
     t.ok(doneCalled, 'done method was called')
     t.notOk(errCalled, 'error method was not called')
+  })
+
+  t.test('lazy view class success', async t => {
+    let startCalled = false
+
+    class MyView extends view.ViewClass<true> {
+      start() {
+        startCalled = true
+      }
+    }
+
+    const cliCommand: Command<true> = {
+      async command() {
+        return true
+      },
+      usage: () => ({ usage: () => 'usage' }) as Jack,
+      views: {
+        human: view.lazyView(async () => MyView),
+      },
+    }
+
+    await outputCommand(cliCommand, confHuman)
+    t.ok(startCalled, 'lazy view class was loaded and started')
   })
 })

--- a/src/cli-sdk/test/view.ts
+++ b/src/cli-sdk/test/view.ts
@@ -1,5 +1,11 @@
 import t from 'tap'
-import { ViewClass, isViewClass } from '../src/view.ts'
+import {
+  ViewClass,
+  isLazyView,
+  isViewClass,
+  lazyView,
+  loadLazyView,
+} from '../src/view.ts'
 import type { ViewOptions } from '../src/view.ts'
 import type { LoadedConfig } from '../src/config/index.ts'
 
@@ -21,3 +27,10 @@ t.equal(vc.error({}), undefined)
 
 class MyView extends ViewClass {}
 t.equal(isViewClass(MyView), true)
+
+const loader = async () => MyView
+const lazy = lazyView(loader)
+t.equal(isLazyView(lazy), true)
+t.equal(isLazyView({}), false)
+t.equal(isLazyView(MyView), false)
+t.equal(await loadLazyView(lazy), MyView)

--- a/src/graph/src/actual/load.ts
+++ b/src/graph/src/actual/load.ts
@@ -21,6 +21,7 @@ import type { DepID } from '@vltpkg/dep-id'
 import type { PackageJson } from '@vltpkg/package-json'
 import type { SpecOptions } from '@vltpkg/spec'
 import type { NormalizedManifest } from '@vltpkg/types'
+import type { LockfileData, SpecCache } from '../lockfile/types.ts'
 import type { Monorepo } from '@vltpkg/workspaces'
 import type { Path, PathScurry } from 'path-scurry'
 import type { Node } from '../node.ts'
@@ -90,6 +91,15 @@ export type LoadOptions = SpecOptions & {
    * operations. Skips package extraction, filesystem operations, and hidden lockfile saves.
    */
   lockfileOnly?: boolean
+  /**
+   * Shared intern cache for parsed lockfile specs.
+   */
+  specCache?: SpecCache
+  /**
+   * Already-parsed main lockfile data. When set, ideal build skips
+   * re-reading `vlt-lock.json`.
+   */
+  lockfileData?: LockfileData
 }
 
 export type ReadEntry = {

--- a/src/graph/src/index.ts
+++ b/src/graph/src/index.ts
@@ -20,13 +20,17 @@ import { load as actualLoad } from './actual/load.ts'
 import type { LoadOptions as ActualLoadOptions } from './actual/load.ts'
 export const actual = { load: actualLoad }
 
-import { load as lockfileLoad } from './lockfile/load.ts'
+import {
+  load as lockfileLoad,
+  loadData as lockfileLoadData,
+} from './lockfile/load.ts'
 import type { LoadOptions as LockfileLoadOptions } from './lockfile/load.ts'
 import { loadEdges } from './lockfile/load-edges.ts'
 import { loadNodes } from './lockfile/load-nodes.ts'
 import { save } from './lockfile/save.ts'
 export const lockfile = {
   load: lockfileLoad,
+  loadData: lockfileLoadData,
   loadEdges,
   loadNodes,
   save,

--- a/src/graph/src/install.ts
+++ b/src/graph/src/install.ts
@@ -17,7 +17,8 @@ import { RollbackRemove } from '@vltpkg/rollback-remove'
 import type { DepID } from '@vltpkg/dep-id'
 import { existsSync, rmSync } from 'node:fs'
 import { resolve } from 'node:path'
-import { load as loadVirtual } from './lockfile/load.ts'
+import { load as loadVirtual, loadData } from './lockfile/load.ts'
+import type { SpecCache } from './lockfile/types.ts'
 import { getImporterSpecs } from './ideal/get-importer-specs.ts'
 import { lockfile } from './index.ts'
 import type { Graph } from './index.ts'
@@ -78,6 +79,10 @@ export const install = async (
     scurry: options.scurry,
   })
 
+  const specCache: SpecCache = new Map()
+  const lockfileData =
+    options.frozenLockfile ? loadData(options.projectRoot) : undefined
+
   if (options.frozenLockfile) {
     // validates no add/remove operations are requested
     if (add?.modifiedDependencies) {
@@ -97,6 +102,8 @@ export const install = async (
       ...options,
       mainManifest,
       monorepo: fullMonorepo,
+      specCache,
+      lockfileData,
     })
 
     const emptyAdd = Object.assign(
@@ -216,6 +223,7 @@ export const install = async (
       loadManifests: true,
       modifiers: undefined, // modifiers should not be used here
       monorepo: fullMonorepo,
+      specCache,
     })
     // if the actual graph has no dependencies, it's simpler to ignore it
     // this allows us to check for its availability later on for properly
@@ -233,6 +241,8 @@ export const install = async (
       remove,
       remover,
       monorepo: fullMonorepo,
+      specCache,
+      lockfileData,
     })
 
     // If lockfileOnly is enabled, skip reify and only save the lockfile

--- a/src/graph/src/lockfile/load-edges.ts
+++ b/src/graph/src/lockfile/load-edges.ts
@@ -14,7 +14,13 @@ import type {
   LockfileData,
   LockfileEdgeKey,
   LockfileEdgeValue,
+  SpecCache,
 } from './types.ts'
+
+export type LoadEdgesCache = {
+  specCache: SpecCache
+  prefix: string
+}
 
 export type ProcessingEdge = {
   fromNode: NodeLike
@@ -52,10 +58,29 @@ const retrieveNodeFromGraph = (
   return foundNode
 }
 
+const parseEdgeSpec = (
+  specName: string,
+  bareSpec: string,
+  options: SpecOptions,
+  cache?: LoadEdgesCache,
+): Spec => {
+  // graph.addEdge mutates name/spec on '(unknown)' instances
+  if (!cache || specName === '(unknown)') {
+    return Spec.parse(specName, bareSpec, options)
+  }
+  const key = `${cache.prefix}\0${specName}\0${bareSpec}`
+  const cached = cache.specCache.get(key)
+  if (cached) return cached
+  const spec = Spec.parse(specName, bareSpec, options)
+  cache.specCache.set(key, spec)
+  return spec
+}
+
 export const loadEdges = (
   graph: GraphLike,
   edges: LockfileData['edges'],
   options: SpecOptions,
+  cache?: LoadEdgesCache,
 ) => {
   const entries = Object.entries(edges) as [
     LockfileEdgeKey,
@@ -138,10 +163,11 @@ export const loadEdges = (
     // loaded), so overriding here would always inject `undefined`
     // and silently revert to the default npm registry.
     // See vltpkg/vltpkg#1580.
-    const spec = Spec.parse(
+    const spec = parseEdgeSpec(
       specName,
       valRest.substring(0, vrSplit),
       options,
+      cache,
     )
 
     if (useOptimizations) {

--- a/src/graph/src/lockfile/load.ts
+++ b/src/graph/src/lockfile/load.ts
@@ -19,7 +19,7 @@ import { LOCKFILE_VERSION } from './types.ts'
 import type { PathScurry } from 'path-scurry'
 import type { NormalizedManifest } from '@vltpkg/types'
 import type { SpecOptions } from '@vltpkg/spec'
-import type { LockfileData } from './types.ts'
+import type { LockfileData, SpecCache } from './types.ts'
 import type { GraphModifier } from '../modifiers.ts'
 
 export type LoadOptions = SpecOptions & {
@@ -55,6 +55,14 @@ export type LoadOptions = SpecOptions & {
    * Whether to throw an error if a manifest is missing when loading nodes.
    */
   throwOnMissingManifest?: boolean
+  /**
+   * Shared intern cache for parsed lockfile specs.
+   */
+  specCache?: SpecCache
+  /**
+   * Already-parsed lockfile data. When set, skips the filesystem read.
+   */
+  lockfileData?: LockfileData
 }
 
 const loadLockfile = (projectRoot: string, lockfilePath: string) =>
@@ -64,11 +72,17 @@ const loadLockfile = (projectRoot: string, lockfilePath: string) =>
     }),
   ) as LockfileData
 
+export const loadData = (
+  projectRoot: string,
+  lockfilePath = 'vlt-lock.json',
+) => loadLockfile(projectRoot, lockfilePath)
+
 export const load = (options: LoadOptions): Graph => {
   const { projectRoot } = options
   return loadObject(
     options,
-    loadLockfile(projectRoot, 'vlt-lock.json'),
+    options.lockfileData ??
+      loadLockfile(projectRoot, 'vlt-lock.json'),
   )
 }
 
@@ -289,7 +303,15 @@ export const loadObject = (
     options.actual,
     options.throwOnMissingManifest,
   )
-  loadEdges(graph, lockfileData.edges, mergedOptions)
+  // Skip interning when modifiers are active — they mutate Spec.overridden
+  const specCache =
+    options.modifiers || !options.specCache ?
+      undefined
+    : {
+        specCache: options.specCache,
+        prefix: JSON.stringify(lockfileOptions),
+      }
+  loadEdges(graph, lockfileData.edges, mergedOptions, specCache)
 
   // hydrate missing node-level registry data
   for (const node of graph.nodes.values()) {

--- a/src/graph/src/lockfile/types.ts
+++ b/src/graph/src/lockfile/types.ts
@@ -34,6 +34,13 @@ export type LockfileData = {
 }
 
 /**
+ * Per-install intern cache for parsed lockfile specs. Shared across
+ * hidden + main lockfile loads so identical (name, bareSpec) pairs
+ * reuse one Spec instance.
+ */
+export type SpecCache = Map<string, Spec>
+
+/**
  * Current lockfile format version.
  * Only lockfiles with matching version are considered valid.
  * Bump when making breaking format changes.

--- a/src/graph/test/install.ts
+++ b/src/graph/test/install.ts
@@ -416,6 +416,12 @@ t.test(
           nodes: new Map(),
           importers: [],
         }),
+        loadData: () => ({
+          lockfileVersion: 1,
+          options: {},
+          nodes: {},
+          edges: {},
+        }),
       },
     })
 
@@ -520,6 +526,12 @@ t.test(
           nodes: new Map(),
           importers: [],
         }),
+        loadData: () => ({
+          lockfileVersion: 1,
+          options: {},
+          nodes: {},
+          edges: {},
+        }),
       },
       '@vltpkg/workspaces': {
         Monorepo: {
@@ -594,6 +606,12 @@ t.test(
         loadHidden: () => ({
           nodes: new Map(),
           importers: [],
+        }),
+        loadData: () => ({
+          lockfileVersion: 1,
+          options: {},
+          nodes: {},
+          edges: {},
         }),
       },
       '@vltpkg/workspaces': {
@@ -698,6 +716,12 @@ t.test('install with frozenLockfile and spec changes', async t => {
       loadHidden: () => ({
         nodes: new Map(),
         importers: [],
+      }),
+      loadData: () => ({
+        lockfileVersion: 1,
+        options: {},
+        nodes: {},
+        edges: {},
       }),
     },
     '@vltpkg/workspaces': {
@@ -822,6 +846,12 @@ t.test(
           nodes: new Map(),
           importers: [],
         }),
+        loadData: () => ({
+          lockfileVersion: 1,
+          options: {},
+          nodes: {},
+          edges: {},
+        }),
       },
       '@vltpkg/workspaces': {
         Monorepo: {
@@ -908,6 +938,12 @@ t.test(
           nodes: new Map(),
           importers: [],
         }),
+        loadData: () => ({
+          lockfileVersion: 1,
+          options: {},
+          nodes: {},
+          edges: {},
+        }),
       },
       '@vltpkg/workspaces': {
         Monorepo: {
@@ -988,6 +1024,12 @@ t.test(
         loadHidden: () => ({
           nodes: new Map(),
           importers: [],
+        }),
+        loadData: () => ({
+          lockfileVersion: 1,
+          options: {},
+          nodes: {},
+          edges: {},
         }),
       },
     })
@@ -1124,6 +1166,12 @@ t.test(
         loadHidden: () => ({
           nodes: new Map(),
           importers: [],
+        }),
+        loadData: () => ({
+          lockfileVersion: 1,
+          options: {},
+          nodes: {},
+          edges: {},
         }),
       },
       '@vltpkg/workspaces': {
@@ -1884,6 +1932,12 @@ t.test('install with frozenLockfile and changed options', async t => {
       loadHidden: () => ({
         nodes: new Map(),
         importers: [],
+      }),
+      loadData: () => ({
+        lockfileVersion: 1,
+        options: {},
+        nodes: {},
+        edges: {},
       }),
     },
   })

--- a/src/graph/test/lockfile/load.ts
+++ b/src/graph/test/lockfile/load.ts
@@ -8,6 +8,7 @@ import type { LockfileNode } from '../../src/index.ts'
 import { Graph } from '../../src/graph.ts'
 import {
   load,
+  loadData,
   loadHidden,
   loadObject,
 } from '../../src/lockfile/load.ts'
@@ -1636,4 +1637,99 @@ t.test('optionsChanged detection', async t => {
       'options changed due to registries change',
     )
   })
+})
+
+t.test('specCache interns specs across loads', async t => {
+  const specCache = new Map()
+  const fooId = joinDepIDTuple(['registry', '', 'foo@1.0.0'])
+  const lockfileData: LockfileData = {
+    lockfileVersion: 1,
+    options: configData,
+    nodes: {
+      [joinDepIDTuple(['file', '.'])]: [0, 'my-project'],
+      [fooId]: [0, 'foo'],
+    } as Record<DepID, LockfileNode>,
+    edges: {
+      [edgeKey(['file', '.'], 'foo')]: `prod ^1.0.0 ${fooId}`,
+    } as LockfileEdges,
+  }
+  const projectRoot = t.testdir({
+    'vlt-lock.json': JSON.stringify(lockfileData),
+    'vlt.json': '{}',
+  })
+  t.chdir(projectRoot)
+  unload('project')
+
+  const opts = { ...configData, projectRoot, mainManifest, specCache }
+  const a = loadObject(opts, lockfileData)
+  const b = loadObject(opts, lockfileData)
+  const specA = [...a.edges][0]?.spec
+  const specB = [...b.edges][0]?.spec
+  t.equal(specA, specB, 'shared cache reuses Spec instances')
+  t.equal(specCache.size, 1)
+
+  const otherData: LockfileData = {
+    ...lockfileData,
+    options: { registry: 'https://other.example.com/' },
+  }
+  const c = loadObject(opts, otherData)
+  t.not([...c.edges][0]?.spec, specA, 'different options prefix')
+  t.equal(specCache.size, 2)
+
+  const { GraphModifier } = await import('../../src/modifiers.ts')
+  const modifiers = new GraphModifier(configData)
+  const skipped = new Map()
+  const d = loadObject(
+    {
+      ...configData,
+      projectRoot,
+      mainManifest,
+      specCache: skipped,
+      modifiers,
+    },
+    lockfileData,
+  )
+  const e = loadObject(
+    {
+      ...configData,
+      projectRoot,
+      mainManifest,
+      specCache: skipped,
+      modifiers,
+    },
+    lockfileData,
+  )
+  t.not([...d.edges][0]?.spec, [...e.edges][0]?.spec)
+  t.equal(skipped.size, 0, 'modifiers disable interning')
+
+  const parsed = loadData(projectRoot)
+  t.equal(parsed.lockfileVersion, 1)
+  const fromData = load({
+    ...configData,
+    projectRoot,
+    mainManifest,
+    lockfileData: parsed,
+  })
+  t.equal(fromData.edges.size, a.edges.size)
+})
+
+t.test('specCache skips (unknown) names', async t => {
+  const specCache = new Map()
+  const projectRoot = t.testdir()
+  const graph = new Graph({
+    mainManifest,
+    projectRoot,
+  })
+  const fromId = joinDepIDTuple(['file', '.'])
+  const toId = joinDepIDTuple(['file', 'x'])
+  graph.addNode(toId, { name: 'x', version: '1.0.0' })
+  loadEdges(
+    graph,
+    {
+      [`${fromId} (unknown)`]: `prod file:./x ${toId}`,
+    } as LockfileEdges,
+    configData,
+    { specCache, prefix: 'p' },
+  )
+  t.equal(specCache.size, 0)
 })

--- a/src/package-info/scripts/benchmark.ts
+++ b/src/package-info/scripts/benchmark.ts
@@ -94,8 +94,8 @@ const CACHE = {
       }
     }
   },
-  resetMemory: () => {
-    p.registryClient.cache.clear()
+  resetMemory: async () => {
+    ;(await p.getRegistryClient()).cache.clear()
     // npm has no in-memory cache by default
   },
   seedMemory: async ({ packages, vlt, npm }: PackageInfoOptions) => {
@@ -143,12 +143,12 @@ const test = async (
 
   switch (id) {
     case 'network':
-      CACHE.resetMemory()
+      await CACHE.resetMemory()
       CACHE.resetFs()
       break
     case 'fs':
       await CACHE.seedFs({ packages, vlt, npm })
-      CACHE.resetMemory()
+      await CACHE.resetMemory()
       break
     case 'memory': {
       const seeded = await CACHE.seedMemory({ packages, vlt, npm })

--- a/src/package-info/src/index.ts
+++ b/src/package-info/src/index.ts
@@ -5,13 +5,13 @@ import { PackageJson } from '@vltpkg/package-json'
 import type { PickManifestOptions } from '@vltpkg/pick-manifest'
 import { pickManifest } from '@vltpkg/pick-manifest'
 import type {
+  RegistryClient,
   RegistryClientOptions,
   RegistryClientRequestOptions,
 } from '@vltpkg/registry-client'
-import { RegistryClient } from '@vltpkg/registry-client'
 import type { SpecOptions } from '@vltpkg/spec'
 import { Spec } from '@vltpkg/spec'
-import { Pool } from '@vltpkg/tar'
+import type { Pool } from '@vltpkg/tar'
 import type { Integrity, Manifest, Packument } from '@vltpkg/types'
 import { asPackument } from '@vltpkg/types'
 import ssri from 'ssri'
@@ -112,16 +112,28 @@ export class PackageInfoClient {
   // packument (see #fetchPackument).
   #packumentPromises = new Map<string, Promise<Packument>>()
 
-  get registryClient() {
-    if (!this.#registryClient) {
-      this.#registryClient = new RegistryClient(this.options)
-    }
-    return this.#registryClient
+  #registryClientPromise?: Promise<RegistryClient>
+  #tarPoolPromise?: Promise<Pool>
+
+  async getRegistryClient() {
+    if (this.#registryClient) return this.#registryClient
+    this.#registryClientPromise ??=
+      import('@vltpkg/registry-client').then(({ RegistryClient }) => {
+        this.#registryClient = new RegistryClient(this.options)
+        return this.#registryClient
+      })
+    return this.#registryClientPromise
   }
 
-  get tarPool() {
-    if (!this.#tarPool) this.#tarPool = new Pool()
-    return this.#tarPool
+  async getTarPool() {
+    if (this.#tarPool) return this.#tarPool
+    this.#tarPoolPromise ??= import('@vltpkg/tar').then(
+      ({ Pool }) => {
+        this.#tarPool = new Pool()
+        return this.#tarPool
+      },
+    )
+    return this.#tarPoolPromise
   }
 
   constructor(options: PackageInfoClientOptions = {}) {
@@ -213,14 +225,13 @@ export class PackageInfoClient {
           const trustIntegrity =
             this.#trustedIntegrities.get(r.resolved) === r.integrity
 
-          const response = await this.registryClient.request(
-            r.resolved,
-            {
-              integrity: r.integrity,
-              trustIntegrity,
-              ...(useCache === false ? { useCache } : {}),
-            },
-          )
+          const response = await (
+            await this.getRegistryClient()
+          ).request(r.resolved, {
+            integrity: r.integrity,
+            trustIntegrity,
+            ...(useCache === false ? { useCache } : {}),
+          })
 
           if (response.statusCode !== 200) {
             throw this.#resolveError(
@@ -297,7 +308,7 @@ export class PackageInfoClient {
         }
 
         try {
-          await this.tarPool.unpack(buf, target)
+          await (await this.getTarPool()).unpack(buf, target)
         } catch (er) {
           throw this.#resolveError(
             spec,
@@ -310,7 +321,9 @@ export class PackageInfoClient {
       }
 
       case 'remote': {
-        const response = await this.registryClient.request(r.resolved)
+        const response = await (
+          await this.getRegistryClient()
+        ).request(r.resolved)
         if (response.statusCode !== 200) {
           throw this.#resolveError(
             spec,
@@ -341,7 +354,7 @@ export class PackageInfoClient {
         r.integrity = computed as Integrity
 
         try {
-          await this.tarPool.unpack(buf, target)
+          await (await this.getTarPool()).unpack(buf, target)
         } catch (er) {
           throw this.#resolveError(
             spec,
@@ -363,10 +376,9 @@ export class PackageInfoClient {
         const st = await stat(path)
         if (st.isFile()) {
           try {
-            await this.tarPool.unpack(
-              await this.tarball(spec, options),
-              target,
-            )
+            await (
+              await this.getTarPool()
+            ).unpack(await this.tarball(spec, options), target)
           } catch (er) {
             throw this.#resolveError(
               spec,
@@ -500,15 +512,14 @@ export class PackageInfoClient {
           const trustIntegrity =
             this.#trustedIntegrities.get(tarball) === integrity
 
-          const response = await this.registryClient.request(
-            tarball,
-            {
-              ...options,
-              integrity,
-              trustIntegrity,
-              ...(useCache === false ? { useCache } : {}),
-            },
-          )
+          const response = await (
+            await this.getRegistryClient()
+          ).request(tarball, {
+            ...options,
+            integrity,
+            trustIntegrity,
+            ...(useCache === false ? { useCache } : {}),
+          })
           if (response.statusCode !== 200) {
             throw this.#resolveError(
               spec,
@@ -612,7 +623,9 @@ export class PackageInfoClient {
         if (!remoteURL) {
           throw this.#resolveError(spec, options)
         }
-        const response = await this.registryClient.request(remoteURL)
+        const response = await (
+          await this.getRegistryClient()
+        ).request(remoteURL)
         if (response.statusCode !== 200) {
           throw this.#resolveError(
             spec,
@@ -757,8 +770,9 @@ export class PackageInfoClient {
         }
         const s = spec
         return await this.#tmpdir(async dir => {
-          const response =
-            await this.registryClient.request(remoteURL)
+          const response = await (
+            await this.getRegistryClient()
+          ).request(remoteURL)
           if (response.statusCode !== 200) {
             throw this.#resolveError(
               s,
@@ -775,7 +789,7 @@ export class PackageInfoClient {
             .toString()
 
           try {
-            await this.tarPool.unpack(buf, dir)
+            await (await this.getTarPool()).unpack(buf, dir)
           } catch (er) {
             throw this.#resolveError(
               s,
@@ -804,7 +818,9 @@ export class PackageInfoClient {
         const s = spec
         return await this.#tmpdir(async dir => {
           try {
-            await this.tarPool.unpack(await readFile(path), dir)
+            await (
+              await this.getTarPool()
+            ).unpack(await readFile(path), dir)
           } catch (er) {
             throw this.#resolveError(
               s,
@@ -917,7 +933,9 @@ export class PackageInfoClient {
     // To revisit: put the requested representation on both the disk-cache
     // key and the in-flight coalescing key, and have the SWR child
     // (cache-revalidate / revalidate) re-request the same representation.
-    const response = await this.registryClient.request(pakuURL, {
+    const response = await (
+      await this.getRegistryClient()
+    ).request(pakuURL, {
       headers: { accept: 'application/json' },
       ...(useCache === false ? { useCache } : {}),
     })

--- a/src/package-info/test/index.ts
+++ b/src/package-info/test/index.ts
@@ -408,6 +408,16 @@ t.test('create git repo', { bail: true }, async () => {
   await git('tag', '-am', 'head version', '69.42.0')
 })
 
+t.test('lazy registry and tar accessors reuse instances', async t => {
+  const pi = new PackageInfoClient({ cache: t.testdirName })
+  const rc1 = await pi.getRegistryClient()
+  const rc2 = await pi.getRegistryClient()
+  t.equal(rc1, rc2)
+  const tar1 = await pi.getTarPool()
+  const tar2 = await pi.getTarPool()
+  t.equal(tar1, tar2)
+})
+
 t.test('packument', async t => {
   t.strictSame(await packument('abbrev', options), pakuAbbrev)
 
@@ -943,7 +953,7 @@ t.test('registry tarball integrity verification', async t => {
       )
       // flush pending cache writes so file handles are released
       // before t.testdir() cleanup (avoids ENOTEMPTY on macOS)
-      await pi.registryClient.cache.promise()
+      await (await pi.getRegistryClient()).cache.promise()
     },
   )
 
@@ -964,7 +974,7 @@ t.test('registry tarball integrity verification', async t => {
       })
       // flush pending cache writes so file handles are released
       // before t.testdir() cleanup (avoids ENOTEMPTY on macOS)
-      await tb.registryClient.cache.promise()
+      await (await tb.getRegistryClient()).cache.promise()
     },
   )
 
@@ -990,7 +1000,7 @@ t.test('registry tarball integrity verification', async t => {
         { cause: { code: 'EINTEGRITY' } },
         'should throw EINTEGRITY via sha512 check',
       )
-      await pi.registryClient.cache.promise()
+      await (await pi.getRegistryClient()).cache.promise()
     },
   )
 
@@ -1005,7 +1015,7 @@ t.test('registry tarball integrity verification', async t => {
       await t.rejects(tb.tarball('corrupted-no-header@1.0.0'), {
         cause: { code: 'EINTEGRITY' },
       })
-      await tb.registryClient.cache.promise()
+      await (await tb.getRegistryClient()).cache.promise()
     },
   )
 
@@ -1105,7 +1115,7 @@ t.test('registry tarball integrity verification', async t => {
         { cause: { code: 'EINTEGRITY' } },
         'should verify tarball integrity even with integrity+resolved provided',
       )
-      await pi.registryClient.cache.promise()
+      await (await pi.getRegistryClient()).cache.promise()
     },
   )
 
@@ -1122,9 +1132,9 @@ t.test('registry tarball integrity verification', async t => {
         cache: cacheDir,
       })
       await pi.extract('abbrev@2', dir + '/first')
-      await pi.registryClient.cache.promise()
+      await (await pi.getRegistryClient()).cache.promise()
 
-      const cache = pi.registryClient.cache
+      const cache = (await pi.getRegistryClient()).cache
       const buf = await cache.fetch(tarballUrl)
       t.ok(buf, 'tarball is in cache')
       if (!buf) return
@@ -1161,8 +1171,8 @@ t.test('registry tarball integrity verification', async t => {
         'tarball() also issues no tarball requests on warm cache',
       )
       t.ok(tb.length > 0, 'returned cached tarball bytes')
-      await pi2.registryClient.cache.promise()
-      await pi3.registryClient.cache.promise()
+      await (await pi2.getRegistryClient()).cache.promise()
+      await (await pi3.getRegistryClient()).cache.promise()
     },
   )
 
@@ -1193,7 +1203,7 @@ t.test('registry tarball integrity verification', async t => {
         2,
         'should have fetched twice (first corrupted, then fresh)',
       )
-      await pi.registryClient.cache.promise()
+      await (await pi.getRegistryClient()).cache.promise()
     },
   )
 })
@@ -2006,7 +2016,7 @@ t.test(
       'range manifest came from the coalesced packument',
     )
     t.equal(exact.license, 'ISC', 'manifest retains license metadata')
-    await pi.registryClient.cache.promise()
+    await (await pi.getRegistryClient()).cache.promise()
   },
 )
 
@@ -2027,7 +2037,7 @@ t.test('late parse failure refetches packument', async t => {
     Buffer.from('application/json'),
   ]
   let calls = 0
-  const rc = pi.registryClient
+  const rc = await pi.getRegistryClient()
   rc.request = async (_url, reqOptions) => {
     calls++
     if (reqOptions?.useCache === false) {
@@ -2055,7 +2065,7 @@ t.test('packument parse failure retries once', async t => {
     Buffer.from('application/json'),
   ]
   let calls = 0
-  const rc = pi.registryClient
+  const rc = await pi.getRegistryClient()
   rc.request = async () => {
     calls++
     const bad = new CacheEntry(200, jsonHeaders)

--- a/src/registry-client/src/cache-revalidate.ts
+++ b/src/registry-client/src/cache-revalidate.ts
@@ -1,4 +1,5 @@
 import { spawn } from 'node:child_process'
+import module from 'node:module'
 import { __CODE_SPLIT_SCRIPT_NAME } from './revalidate.ts'
 
 const isDeno =
@@ -23,10 +24,15 @@ export const register = (
 }
 
 const handleBeforeExit = () => {
+  // The compile cache is enabled in-process by the CLI entry, which does
+  // not propagate to child processes, so the worker has to be pointed at
+  // it through the environment to skip re-compiling its bundle.
+  const compileCacheDir = module.getCompileCacheDir()
   for (const [path, r] of registered) {
     /* c8 ignore next */
     if (!r.size) return
     const env = { ...process.env }
+    if (compileCacheDir) env.NODE_COMPILE_CACHE ??= compileCacheDir
     const args = []
     /* c8 ignore start */
     // If we are running deno from source we need to add the

--- a/src/registry-client/test/cache-revalidate.ts
+++ b/src/registry-client/test/cache-revalidate.ts
@@ -1,4 +1,5 @@
 import t from 'tap'
+import type { Test } from 'tap'
 
 t.test('registering the beforeExit event', async t => {
   const beHooks: (() => void)[] = []
@@ -55,4 +56,68 @@ t.test('registering the beforeExit event', async t => {
   t.type(beHooks[0], 'function')
   beHooks[0]?.()
   t.equal(unrefCalled, true)
+})
+
+const mockRevalidate = async (
+  t: Test,
+  mocks: Record<string, any>,
+) => {
+  const beHooks: (() => void)[] = []
+  t.capture(process, 'on', (_ev: string, fn: () => void) => {
+    beHooks.push(fn)
+  })
+  const state = { opts: {} as Record<string, any> }
+  const { register } = await t.mockImport<
+    typeof import('../src/cache-revalidate.ts')
+  >('../src/cache-revalidate.ts', {
+    ...mocks,
+    child_process: {
+      spawn: (
+        _cmd: string,
+        _args: string[],
+        opts: Record<string, any>,
+      ) => {
+        state.opts = opts
+        return {
+          stdin: { write: () => {}, end: () => {} },
+          unref: () => {},
+        }
+      },
+    },
+  })
+  return {
+    register,
+    beforeExit: () => beHooks[0]?.(),
+    state,
+  }
+}
+
+t.test('shares the compile cache dir with the worker', async t => {
+  const { register, beforeExit, state } = await mockRevalidate(t, {
+    'node:module': {
+      default: { getCompileCacheDir: () => '/compile/cache' },
+    },
+  })
+
+  register(t.testdirName, 'GET', 'https://example.com/')
+  beforeExit()
+
+  t.equal(state.opts.env.NODE_COMPILE_CACHE, '/compile/cache')
+})
+
+t.test('does not clobber an explicit NODE_COMPILE_CACHE', async t => {
+  t.intercept(process, 'env', {
+    value: { ...process.env, NODE_COMPILE_CACHE: '/explicit' },
+  })
+
+  const { register, beforeExit, state } = await mockRevalidate(t, {
+    'node:module': {
+      default: { getCompileCacheDir: () => '/compile/cache' },
+    },
+  })
+
+  register(t.testdirName, 'GET', 'https://example.com/')
+  beforeExit()
+
+  t.equal(state.opts.env.NODE_COMPILE_CACHE, '/explicit')
 })


### PR DESCRIPTION
Enable V8 compile cache at the bin entry, lazy-load the ink reporter and registry-client/tar chunks, and share Spec instances (plus parsed lockfile data on frozen-lockfile/ci) across the dual lockfile loads.