### PR TITLE
docs: adds Image component to astro docs

### DIFF
--- a/www/docs/src/components/image/image.astro
+++ b/www/docs/src/components/image/image.astro
@@ -1,0 +1,42 @@
+---
+export interface Props {
+  src: string
+  alt: string
+  href?: string
+  variant?: 'landscape' | 'portrait' | 'square'
+  caption?: string
+}
+
+const { src, alt, href, variant = 'landscape', caption } = Astro.props
+
+const variantClasses = {
+  portrait: 'max-w-[420px]',
+  landscape: 'max-w-full',
+  square: 'max-w-[420px] md:max-w-[640px]',
+}[variant]
+---
+
+<figure class={`flex flex-col gap-2 ${variantClasses}`}>
+  {
+    href ?
+      <a href={href}>
+        <img
+          src={src}
+          alt={alt}
+          class="h-auto w-full rounded-sm border border-border"
+        />
+      </a>
+    : <img
+        src={src}
+        alt={alt}
+        class="h-auto w-full rounded-sm border border-border"
+      />
+  }
+  {
+    caption && (
+      <figcaption class="text-sm text-muted-foreground">
+        {caption}
+      </figcaption>
+    )
+  }
+</figure>

--- a/www/docs/src/content/docs/registry/dashboard.mdx
+++ b/www/docs/src/content/docs/registry/dashboard.mdx
@@ -6,10 +6,12 @@ sidebar:
 ---
 
 import { Aside, Badge, Code } from '@astrojs/starlight/components'
+import Image from '../../components/image/image.astro'
 
-<img
+<Image
   src="/images/dashboard.png"
   alt="vlt Registry Dashboard showing the account overview, recent publishes, and navigation menu"
+  variant="landscape"
 />
 
 ## Around the dashboard

--- a/www/docs/src/content/docs/registry/dashboard.mdx
+++ b/www/docs/src/content/docs/registry/dashboard.mdx
@@ -10,7 +10,6 @@ import { Aside, Badge, Code } from '@astrojs/starlight/components'
 <img
   src="/images/dashboard.png"
   alt="vlt Registry Dashboard showing the account overview, recent publishes, and navigation menu"
-  style={{ width: '100%', maxWidth: '1200px', height: 'auto' }}
 />
 
 ## Around the dashboard

--- a/www/docs/src/content/docs/registry/index.mdx
+++ b/www/docs/src/content/docs/registry/index.mdx
@@ -19,51 +19,48 @@ To publish packages to the vlt registry, you first have to
 
 <Steps>
 
-1.  **Create your account**
+1. **Create your account**
 
-    You can sign up with Github, Google (Gmail) or with an email and
-    password.
+   You can sign up with Github, Google (Gmail) or with an email and
+   password.
 
-    <img
-      src="/images/signin.png"
-      alt="Sign up form on vlt's sign up view with first name and last name fields, and login buttons connecting to Google and Github"
-      className="border-sm"
-      style={{ maxWidth: '420px', width: '100%', height: 'auto' }}
-    />
+   <img
+     src="/images/signin.png"
+     alt="Sign up form on vlt's sign up view with first name and last name fields, and login buttons connecting to Google and Github"
+     style={{ maxWidth: '420px', width: '100%', height: 'auto' }}
+   />
 
-2.  **Verify your email**
+2. **Verify your email**
 
-    If you signed up with an email and password, check your inbox for
-    a one-time passcode (OTP). Paste it into the verification view to
-    confirm your account.
+   If you signed up with an email and password, check your inbox for a
+   one-time passcode (OTP). Paste it into the verification view to
+   confirm your account.
 
-    <img
-      src="/images/otp-email.png"
-      alt="Screenshot of vlt signup one-time passcode email"
-      className="border-sm"
-      style={{ maxWidth: '420px', width: '100%', height: 'auto' }}
-    />
+   <img
+     src="/images/otp-email.png"
+     alt="Screenshot of vlt signup one-time passcode email"
+     className="sm:max-w-[420px]"
+   />
 
-3.  Set up your account
+3. Set up your account
 
-    <img
-      src="/images/account-setup.png"
-      alt="Screenshot of vlt account setup view with display name and slug fields, and a grid of plans for user selection"
-      className="border-sm"
-      style={{ width: '100%', height: 'auto' }}
-    />
+   <img
+     src="/images/account-setup.png"
+     alt="Screenshot of vlt account setup view with display name and slug fields, and a grid of plans for user selection"
+     className="sm:max-w-[420px]"
+   />
 
-    <Badge text="Caution" variant="caution" /> The slug appears in
-    your registry URLs and in your package scope, so choose carefully.
+   <Badge text="Caution" variant="caution" /> The slug appears in your
+   registry URLs and in your package scope, so choose carefully.
 
-4.  You've signed up! You'll be logged into the Dashboard.
+4. You've signed up! You'll be logged into the Dashboard.
 
-    <img
-      src="/images/dashboard.png"
-      alt="Screenshot of vlt Dashboard view displaying left side side navigation where using can browse through registries and account settings"
-      className="border-sm"
-      style={{ width: '100%', height: 'auto' }}
-    />
+   <img
+     src="/images/dashboard.png"
+     alt="Screenshot of vlt Dashboard view displaying left side side navigation where using can browse through registries and account settings"
+     className="border-sm"
+     style={{ width: '100%', height: 'auto' }}
+   />
 
 </Steps>
 
@@ -71,18 +68,18 @@ To publish packages to the vlt registry, you first have to
 
 <Steps>
 
-1. **Enter your credentials**
+1.  **Enter your credentials**
 
-   Log in with your email address, or continue with Github or Google.
-   You can also use a passkey if you've set one up.
+    Log in with your email address, or continue with Github or Google.
+    You can also use a passkey if you've set one up.
 
-   <img
-     src="/images/login.png"
-     alt="Login view on vlt.io with Email address input, continue button, and Github and Google login buttons. Below are links to Use passkey and a call to action to sign up if the user does not have an account"
-     style={{ maxWidth: '420px', width: '100%', height: 'auto' }}
-   />
+          <img
+         src="/images/login.png"
+         alt="Login view on vlt.io with Email address input, continue button, and Github and Google login buttons. Below are links to Use passkey and a call to action to sign up if the user does not have an account"
+         className="sm:max-w-[420px]"
+         />
 
-</Steps>
+    </Steps>
 
 ## Set up your package manager
 

--- a/www/docs/src/content/docs/registry/index.mdx
+++ b/www/docs/src/content/docs/registry/index.mdx
@@ -58,8 +58,6 @@ To publish packages to the vlt registry, you first have to
    <img
      src="/images/dashboard.png"
      alt="Screenshot of vlt Dashboard view displaying left side side navigation where using can browse through registries and account settings"
-     className="border-sm"
-     style={{ width: '100%', height: 'auto' }}
    />
 
 </Steps>
@@ -68,18 +66,18 @@ To publish packages to the vlt registry, you first have to
 
 <Steps>
 
-1.  **Enter your credentials**
+1. **Enter your credentials**
 
-    Log in with your email address, or continue with Github or Google.
-    You can also use a passkey if you've set one up.
+   Log in with your email address, or continue with Github or Google.
+   You can also use a passkey if you've set one up.
 
-          <img
-         src="/images/login.png"
-         alt="Login view on vlt.io with Email address input, continue button, and Github and Google login buttons. Below are links to Use passkey and a call to action to sign up if the user does not have an account"
-         className="sm:max-w-[420px]"
-         />
+   <img
+     src="/images/login.png"
+     alt="Login view on vlt.io with Email address input, continue button, and Github and Google login buttons. Below are links to Use passkey and a call to action to sign up if the user does not have an account"
+     className="sm:max-w-[420px]"
+   />
 
-    </Steps>
+</Steps>
 
 ## Set up your package manager
 

--- a/www/docs/src/content/docs/registry/index.mdx
+++ b/www/docs/src/content/docs/registry/index.mdx
@@ -11,6 +11,7 @@ import {
   Tabs,
   TabItem,
 } from '@astrojs/starlight/components'
+import Image from '../../../components/image/image.astro'
 
 ## Sign Up
 
@@ -24,10 +25,10 @@ To publish packages to the vlt registry, you first have to
    You can sign up with Github, Google (Gmail) or with an email and
    password.
 
-   <img
+   <Image
      src="/images/signin.png"
      alt="Sign up form on vlt's sign up view with first name and last name fields, and login buttons connecting to Google and Github"
-     style={{ maxWidth: '420px', width: '100%', height: 'auto' }}
+     variant="square"
    />
 
 2. **Verify your email**
@@ -36,18 +37,18 @@ To publish packages to the vlt registry, you first have to
    one-time passcode (OTP). Paste it into the verification view to
    confirm your account.
 
-   <img
+   <Image
      src="/images/otp-email.png"
      alt="Screenshot of vlt signup one-time passcode email"
-     className="sm:max-w-[420px]"
+     variant="square"
    />
 
 3. Set up your account
 
-   <img
+   <Image
      src="/images/account-setup.png"
      alt="Screenshot of vlt account setup view with display name and slug fields, and a grid of plans for user selection"
-     className="sm:max-w-[420px]"
+     variant="landscape"
    />
 
    <Badge text="Caution" variant="caution" /> The slug appears in your
@@ -55,9 +56,10 @@ To publish packages to the vlt registry, you first have to
 
 4. You've signed up! You'll be logged into the Dashboard.
 
-   <img
+   <Image
      src="/images/dashboard.png"
      alt="Screenshot of vlt Dashboard view displaying left side side navigation where using can browse through registries and account settings"
+     variant="landscape"
    />
 
 </Steps>
@@ -71,10 +73,10 @@ To publish packages to the vlt registry, you first have to
    Log in with your email address, or continue with Github or Google.
    You can also use a passkey if you've set one up.
 
-   <img
+   <Image
      src="/images/login.png"
      alt="Login view on vlt.io with Email address input, continue button, and Github and Google login buttons. Below are links to Use passkey and a call to action to sign up if the user does not have an account"
-     className="sm:max-w-[420px]"
+     variant="square"
    />
 
 </Steps>

--- a/www/docs/src/styles/globals.css
+++ b/www/docs/src/styles/globals.css
@@ -214,11 +214,17 @@ html {
   @apply text-foreground transition-all duration-200;
 }
 
-.sl-markdown-content code {
-  @apply overflow-x-auto whitespace-nowrap rounded-sm border-[1px] border-border bg-background px-1 font-medium text-foreground;
-}
+.sl-markdown-content code,
 .sl-markdown-content img {
-  @apply rounded-sm;
+  @apply rounded-sm border border-border;
+}
+
+.sl-markdown-content code {
+  @apply overflow-x-auto whitespace-nowrap bg-background px-1 font-medium text-foreground;
+}
+
+.sl-markdown-content img {
+  @apply h-auto max-w-full;
 }
 /* ***************************************************** */
 /*                    EXPRESSIVE CODE                    */

--- a/www/docs/src/styles/globals.css
+++ b/www/docs/src/styles/globals.css
@@ -223,9 +223,6 @@ html {
   @apply overflow-x-auto whitespace-nowrap bg-background px-1 font-medium text-foreground;
 }
 
-.sl-markdown-content img {
-  @apply h-auto max-w-full;
-}
 /* ***************************************************** */
 /*                    EXPRESSIVE CODE                    */
 /* ***************************************************** */


### PR DESCRIPTION
## Summary

- Make markdown images responsive via global CSS (`max-w-full h-auto`) instead of per-element inline styles -- only applies to landscape images 
- Add shared `border border-border` treatment for `code` and `img` selectors in `globals.css`
- Remove redundant inline `style` props and `border-sm` className from registry MDX images
- Fix `</Steps>` closing tag indentation that caused an MDX parse error


<img width="1470" height="790" alt="Screenshot 2026-08-18 at 12 28 38 PM" src="https://github.com/user-attachments/assets/19b060f1-9539-4802-854d-0443e0a51e0c" />
<img width="1468" height="720" alt="Screenshot 2026-08-18 at 12 28 25 PM" src="https://github.com/user-attachments/assets/ea004674-0975-402a-b831-5b10bc2f8bea" />
