### PR TITLE
security-archive: fix results for npm mirrors

### DIFF
--- a/.cursor/rules/security-archive.mdc
+++ b/.cursor/rules/security-archive.mdc
@@ -12,7 +12,11 @@ Fetches, caches, and serves Socket.dev security data for the query system.
 - `src/security-archive/src/index.ts` — `SecurityArchive` class (extends `LRUCache<DepID, PackageReportData>`)
 - Uses Socket API v0 (`https://api.socket.dev/v0/purl?alerts=true`) with public API token
 - Stores in SQLite DB (XDG data dir) with TTL-based expiration
-- Only supports `https://registry.npmjs.org/` packages (via `targetSecurityRegistry`)
+- Eligible packages: origin is `https://registry.npmjs.org/` or the URL
+  configured as `registries.npm` (via `usesNpmRegistry`). Other registries
+  are skipped. `vlt login --registry=<mirror>` writes only the scalar
+  `registry` option, so a non-npmjs.org mirror configured that way is not
+  scanned — use `vlt setup` or `vlt config set registries=npm=<url>`.
 
 ## Data Flow
 

--- a/src/cli-sdk/src/commands/view.ts
+++ b/src/cli-sdk/src/commands/view.ts
@@ -1,10 +1,11 @@
 import * as dotProp from '@vltpkg/dot-prop'
 import { error } from '@vltpkg/error-cause'
+import { getId } from '@vltpkg/dep-id'
 import { PackageInfoClient } from '@vltpkg/package-info'
 import { SecurityArchive } from '@vltpkg/security-archive'
 import { Spec } from '@vltpkg/spec'
-import { joinDepIDTuple } from '@vltpkg/dep-id'
 import { commandUsage } from '../config/usage.ts'
+import type { SpecOptions } from '@vltpkg/spec'
 import type { Manifest, Packument, NodeLike } from '@vltpkg/types'
 import type {
   PackageReportData,
@@ -289,9 +290,14 @@ export const views = {
  * Create a minimal NodeLike for SecurityArchive lookup.
  * Only the fields used by SecurityArchive.start() are needed.
  */
-const createFakeNode = (name: string, version: string): NodeLike =>
+const createFakeNode = (
+  spec: Spec,
+  name: string,
+  version: string,
+  options: SpecOptions,
+): NodeLike =>
   ({
-    id: joinDepIDTuple(['registry', '', `${name}@${version}`]),
+    id: getId(spec, { name, version }),
     name,
     version,
     confused: false,
@@ -304,7 +310,7 @@ const createFakeNode = (name: string, version: string): NodeLike =>
     dev: false,
     optional: false,
     graph: {} as NodeLike['graph'],
-    options: {},
+    options,
     /* c8 ignore next 5 - stub methods for NodeLike interface */
     toJSON: () => ({}),
     toString: () => `${name}@${version}`,
@@ -382,7 +388,7 @@ export const command: CommandFn<ViewResult> = async conf => {
 
   if (name && version) {
     try {
-      const node = createFakeNode(name, version)
+      const node = createFakeNode(spec, name, version, conf.options)
       const archive = await SecurityArchive.start({
         nodes: [node],
       })

--- a/src/cli-sdk/test/commands/view.ts
+++ b/src/cli-sdk/test/commands/view.ts
@@ -1,6 +1,8 @@
 import t from 'tap'
+import { getId } from '@vltpkg/dep-id'
+import { Spec } from '@vltpkg/spec'
 import type { LoadedConfig } from '../../src/config/index.ts'
-import type { Manifest, Packument } from '@vltpkg/types'
+import type { Manifest, Packument, NodeLike } from '@vltpkg/types'
 import type { PackageReportData } from '@vltpkg/security-archive'
 
 const mockPackument: Packument = {
@@ -66,6 +68,7 @@ const mockSecurity: PackageReportData = {
 let mockPackumentResult: Packument | undefined
 let mockManifestResult: Manifest | undefined
 let securityStartCalled = false
+let lastSecurityNodes: unknown[] = []
 let mockSecurityResult: PackageReportData | undefined
 let mockSecurityShouldThrow = false
 
@@ -90,8 +93,9 @@ const Command = await t.mockImport<
   },
   '@vltpkg/security-archive': {
     SecurityArchive: {
-      start: async (_opts: { nodes: unknown[] }) => {
+      start: async (opts: { nodes: unknown[] }) => {
         securityStartCalled = true
+        lastSecurityNodes = opts.nodes
         if (mockSecurityShouldThrow) {
           throw new Error('Security service unavailable')
         }
@@ -107,6 +111,7 @@ t.beforeEach(() => {
   mockPackumentResult = undefined
   mockManifestResult = undefined
   securityStartCalled = false
+  lastSecurityNodes = []
   mockSecurityResult = undefined
   mockSecurityShouldThrow = false
 })
@@ -295,6 +300,36 @@ t.test('command', async t => {
     t.equal(result.fieldPath, undefined)
     t.ok(securityStartCalled, 'security archive was started')
   })
+
+  t.test(
+    'passes spec-derived id and registries options to archive',
+    async t => {
+      mockPackumentResult = mockPackument
+      mockManifestResult = mockManifest
+      mockSecurityResult = mockSecurity
+
+      const registries = {
+        npm: 'https://registry.vlt.io/acct/npm/',
+      }
+      const config = makeConfig(['test-pkg'])
+      config.options.registries = registries
+      await Command.command(config)
+
+      t.equal(lastSecurityNodes.length, 1)
+      const node = lastSecurityNodes[0] as NodeLike
+      const spec = Spec.parseArgs('test-pkg', config.options)
+      t.equal(
+        node.id,
+        getId(spec, { name: 'test-pkg', version: '2.0.0' }),
+        'should derive the DepID from the parsed spec',
+      )
+      t.strictSame(
+        node.options.registries,
+        registries,
+        'should pass config registries through to the fake node',
+      )
+    },
+  )
 
   t.test('field access - returns field value', async t => {
     mockPackumentResult = mockPackument

--- a/src/security-archive/src/index.ts
+++ b/src/security-archive/src/index.ts
@@ -7,6 +7,7 @@ import pRetry, { AbortError } from 'p-retry'
 import { loadPackageJson } from 'package-json-from-dist'
 import { asDepID, splitDepID, baseDepID } from '@vltpkg/dep-id'
 import { error } from '@vltpkg/error-cause'
+import { defaultRegistryName } from '@vltpkg/spec'
 import { XDG } from '@vltpkg/xdg'
 import { asPackageReportData } from './types.ts'
 import { __CODE_SPLIT_SCRIPT_NAME } from './update-expired.ts'
@@ -25,7 +26,7 @@ const SOCKET_API_V0_URL = 'https://api.socket.dev/v0/purl?alerts=true'
 const SOCKET_PUBLIC_API_TOKEN =
   'sktsec_t_--RAN5U4ivauy4w37-6aoKyYPDt5ZbaT5JBVMqiwKo_api'
 
-export const targetSecurityRegisty = 'https://registry.npmjs.org/'
+export const npmRegistryURL = 'https://registry.npmjs.org/'
 
 export type JSONItemResponse = {
   namespace?: `@{string}`
@@ -70,22 +71,28 @@ export type SecurityArchiveOptions = LRUCache.OptionsBase<
   retries?: number
 }
 
+const normalizeRegistryURL = (url: string): string =>
+  url.endsWith('/') ? url : `${url}/`
+
+const nodeRegistryURL = (node: NodeLike): string | undefined => {
+  const [type, reg] = splitDepID(node.id)
+  if (type !== 'registry') return
+  const url =
+    /^https?:\/\//.test(reg) ? reg : node.options.registries?.[reg]
+  return url ? normalizeRegistryURL(url) : undefined
+}
+
 /**
- * Only the public npm registry has information available in the
- * socket.dev API. This function checks if a given depID is pointing
- * to the public npm registry and returns `true` if it does.
+ * Socket.dev only has reports for the public npm ecosystem. Eligible
+ * when the node's origin is `https://registry.npmjs.org/` or the URL
+ * configured as `registries.npm`.
  */
-const usesTargetRegistry = (node: NodeLike): boolean => {
-  const depID = node.id
-  const specOptions = node.options
-  const [nodeType, nodeRegistry] = splitDepID(depID)
-
-  if (nodeType !== 'registry') {
-    return false
-  }
-
-  const reg = specOptions.registries?.[nodeRegistry]
-  return reg === targetSecurityRegisty
+export const usesNpmRegistry = (node: NodeLike): boolean => {
+  const origin = nodeRegistryURL(node)
+  if (!origin) return false
+  if (origin === npmRegistryURL) return true
+  const npmAlias = node.options.registries?.[defaultRegistryName]
+  return !!npmAlias && normalizeRegistryURL(npmAlias) === origin
 }
 
 // Loads the version number to be used in the User-Agent header
@@ -312,11 +319,10 @@ export class SecurityArchive
     const queue = new Set<Record<'purl', string>>()
     for (const node of this.#nodesByID.values()) {
       const normalizedId = baseDepID(node.id)
-      // only queue up valid public registry
-      // references that are missing from the archive
+      // only queue npm-ecosystem registry refs missing from the archive
       // also skips any pkg marked as expired
       if (
-        usesTargetRegistry(node) &&
+        usesNpmRegistry(node) &&
         !this.has(normalizedId) &&
         !this.#expired.has(normalizedId)
       ) {
@@ -440,12 +446,12 @@ export class SecurityArchive
   }
 
   /**
-   * Validates that all public-registry packages in the nodes
+   * Validates that all npm-ecosystem packages in the nodes
    * have a valid report data in the current in-memory cache.
    */
   #validateReportData() {
     for (const node of this.#nodesByID.values()) {
-      if (usesTargetRegistry(node)) {
+      if (usesNpmRegistry(node)) {
         if (!this.has(baseDepID(node.id))) {
           this.ok = false
           return

--- a/src/security-archive/tap-snapshots/test/index.ts.test.cjs
+++ b/src/security-archive/tap-snapshots/test/index.ts.test.cjs
@@ -206,3 +206,78 @@ Object {
   },
 }
 `
+
+exports[`test/index.ts > TAP > SecurityArchive.refresh with npm mirror > should persist security data for packages from registries.npm 1`] = `
+Object {
+  "~npm~@ruyadorno+foo@1.0.0": Object {
+    "alerts": Array [],
+    "author": Array [
+      "ruyadorno",
+    ],
+    "batchIndex": 1,
+    "id": "99923218962",
+    "license": "MIT",
+    "licenseDetails": Array [],
+    "name": "foo",
+    "namespace": "@ruyadorno",
+    "score": Object {
+      "license": 1,
+      "maintenance": 0.84,
+      "overall": 0.93,
+      "quality": 0.83,
+      "supplyChain": 0.99,
+      "vulnerability": 1,
+    },
+    "size": 13003,
+    "type": "npm",
+    "version": "1.0.0",
+  },
+  "~npm~english-days@1.0.0": Object {
+    "alerts": Array [
+      Object {
+        "category": "maintenance",
+        "key": "QG35N0uHm_B_BG4Bc_OlJW3rR2XiTPlFZMNZjm-G1Ufg",
+        "props": Object {
+          "lastPublish": "2016-02-17T02:52:33.918Z",
+        },
+        "severity": "low",
+        "type": "unmaintained",
+      },
+      Object {
+        "category": "supplyChainRisk",
+        "key": "Q2JOM20TNSY962_q6c1goNPMN46sXiFfk0X_8YrIplsU",
+        "props": Object {
+          "linesOfCode": 9,
+        },
+        "severity": "middle",
+        "type": "trivialPackage",
+      },
+      Object {
+        "category": "quality",
+        "key": "Q1hdrp66HKyFF0sBwU7tGypHUBcwpNViZKOQHEKyvIMo",
+        "severity": "middle",
+        "type": "unpopularPackage",
+      },
+    ],
+    "author": Array [
+      "wesleytodd",
+    ],
+    "batchIndex": 0,
+    "id": "15713076833",
+    "license": "ISC",
+    "licenseDetails": Array [],
+    "name": "english-days",
+    "score": Object {
+      "license": 1,
+      "maintenance": 0.75,
+      "overall": 0.78,
+      "quality": 0.55,
+      "supplyChain": 0.6,
+      "vulnerability": 1,
+    },
+    "size": 1632,
+    "type": "npm",
+    "version": "1.0.0",
+  },
+}
+`

--- a/src/security-archive/test/fixtures/graph.ts
+++ b/src/security-archive/test/fixtures/graph.ts
@@ -17,6 +17,13 @@ export const specOptions = getOptions({
   },
 })
 
+export const mirrorSpecOptions = getOptions({
+  registries: {
+    npm: 'https://registry.vlt.io/acct/npm/',
+    custom: 'http://example.com',
+  },
+})
+
 const projectRoot = '.'
 export const newGraph = (rootName: string): GraphLike => {
   const graph = {} as GraphLike
@@ -42,7 +49,7 @@ export const newGraph = (rootName: string): GraphLike => {
   return graph
 }
 export const newNode =
-  (graph: GraphLike) =>
+  (graph: GraphLike, options = specOptions) =>
   (name: string, version = '1.0.0', registry?: string): NodeLike => {
     const node: NodeLike = {
       projectRoot,
@@ -68,7 +75,7 @@ export const newNode =
       optional: false,
       confused: false,
       workspaces: undefined,
-      options: specOptions,
+      options,
       setResolved() {},
       maybeSetConfusedManifest() {},
       setConfusedManifest() {},
@@ -114,9 +121,11 @@ const newEdge = (
   from.graph.edges.add(edge)
 }
 
-export const getSimpleReportGraph = (): GraphLike => {
+export const getSimpleReportGraph = (
+  options = specOptions,
+): GraphLike => {
   const graph = newGraph('my-project')
-  const addNode = newNode(graph)
+  const addNode = newNode(graph, options)
   const foo = addNode('@ruyadorno/foo')
   const englishDays = addNode('english-days')
   const customRegistry = addNode('registry', '1.0.1', 'custom')
@@ -125,19 +134,19 @@ export const getSimpleReportGraph = (): GraphLike => {
   graph.nodes.set(customRegistry.id, customRegistry)
   newEdge(
     graph.mainImporter,
-    Spec.parse('@ruyadorno/foo', '^1.0.0', specOptions),
+    Spec.parse('@ruyadorno/foo', '^1.0.0', options),
     'prod',
     foo,
   )
   newEdge(
     graph.mainImporter,
-    Spec.parse('english-days', '^1.0.0', specOptions),
+    Spec.parse('english-days', '^1.0.0', options),
     'dev',
     englishDays,
   )
   newEdge(
     graph.mainImporter,
-    Spec.parse('registry', 'custom:registry@^1.0.0', specOptions),
+    Spec.parse('registry', 'custom:registry@^1.0.0', options),
     'dev',
     customRegistry,
   )

--- a/src/security-archive/test/index.ts
+++ b/src/security-archive/test/index.ts
@@ -2,9 +2,13 @@ import { resolve } from 'node:path'
 import { DatabaseSync } from 'node:sqlite'
 import t from 'tap'
 import { joinDepIDTuple, baseDepID } from '@vltpkg/dep-id'
-import { SecurityArchive } from '../src/index.ts'
+import type { DepID } from '@vltpkg/dep-id'
+import type { SpecOptions } from '@vltpkg/spec'
+import type { NodeLike } from '@vltpkg/types'
+import { SecurityArchive, usesNpmRegistry } from '../src/index.ts'
 import {
   getSimpleReportGraph,
+  mirrorSpecOptions,
   newGraph,
   newNode,
 } from './fixtures/graph.ts'
@@ -104,6 +108,157 @@ t.test('map-like', async t => {
   t.strictSame(archive.get(id), { name: 'bar' })
   archive.delete(id)
   t.strictSame(archive.get(id), undefined)
+})
+
+const nodeWith = (id: DepID, options: SpecOptions = {}): NodeLike =>
+  ({
+    id,
+    options,
+  }) as NodeLike
+
+t.test('usesNpmRegistry', async t => {
+  t.equal(
+    usesNpmRegistry(
+      nodeWith(joinDepIDTuple(['git', 'github:user/repo', 'main'])),
+    ),
+    false,
+    'git DepID is ineligible',
+  )
+  t.equal(
+    usesNpmRegistry(nodeWith(joinDepIDTuple(['file', '.']))),
+    false,
+    'file DepID is ineligible',
+  )
+  t.equal(
+    usesNpmRegistry(
+      nodeWith(joinDepIDTuple(['workspace', 'packages/a'])),
+    ),
+    false,
+    'workspace DepID is ineligible',
+  )
+  t.equal(
+    usesNpmRegistry(
+      nodeWith(joinDepIDTuple(['registry', 'npm', 'foo@1.0.0']), {
+        registries: { npm: 'https://registry.npmjs.org/' },
+      }),
+    ),
+    true,
+    'npm alias pointing at registry.npmjs.org is eligible',
+  )
+  t.equal(
+    usesNpmRegistry(
+      nodeWith(joinDepIDTuple(['registry', 'unknown', 'foo@1.0.0']), {
+        registries: { npm: 'https://registry.npmjs.org/' },
+      }),
+    ),
+    false,
+    'unknown alias is ineligible',
+  )
+  t.equal(
+    usesNpmRegistry(
+      nodeWith(joinDepIDTuple(['registry', 'npm', 'foo@1.0.0']), {
+        registries: {
+          npm: 'https://registry.vlt.io/acct/npm/',
+        },
+      }),
+    ),
+    true,
+    'npm alias matching a configured mirror is eligible',
+  )
+  t.equal(
+    usesNpmRegistry(
+      nodeWith(joinDepIDTuple(['registry', 'custom', 'foo@1.0.0']), {
+        registries: {
+          npm: 'https://registry.npmjs.org/',
+          custom: 'http://example.com',
+        },
+      }),
+    ),
+    false,
+    'alias pointing at an unrelated URL is ineligible',
+  )
+  t.equal(
+    usesNpmRegistry(
+      nodeWith(
+        joinDepIDTuple([
+          'registry',
+          'https://registry.npmjs.org/',
+          'foo@1.0.0',
+        ]),
+      ),
+    ),
+    true,
+    'URL-form DepID for registry.npmjs.org is eligible',
+  )
+  t.equal(
+    usesNpmRegistry(
+      nodeWith(
+        joinDepIDTuple([
+          'registry',
+          'https://registry.vlt.io/acct/npm/',
+          'foo@1.0.0',
+        ]),
+        {
+          registries: {
+            npm: 'https://registry.vlt.io/acct/npm/',
+          },
+        },
+      ),
+    ),
+    true,
+    'URL-form DepID matching registries.npm is eligible',
+  )
+  t.equal(
+    usesNpmRegistry(
+      nodeWith(joinDepIDTuple(['registry', 'npm', 'foo@1.0.0']), {
+        registries: { npm: 'https://registry.vlt.io/acct/npm' },
+      }),
+    ),
+    true,
+    'registries.npm without a trailing slash still matches',
+  )
+  t.equal(
+    usesNpmRegistry(
+      nodeWith(
+        joinDepIDTuple([
+          'registry',
+          'https://registry.npmjs.org',
+          'foo@1.0.0',
+        ]),
+      ),
+    ),
+    true,
+    'URL-form DepID for registry.npmjs.org without trailing slash is eligible',
+  )
+  t.equal(
+    usesNpmRegistry(
+      nodeWith(
+        joinDepIDTuple([
+          'registry',
+          'https://registry.vlt.io/acct/npm/',
+          'foo@1.0.0',
+        ]),
+      ),
+    ),
+    false,
+    'URL-form mirror DepID with no registries.npm is ineligible',
+  )
+  t.equal(
+    usesNpmRegistry(
+      nodeWith(joinDepIDTuple(['registry', 'npm', 'foo@1.0.0']), {
+        registries: { npm: '' },
+      }),
+    ),
+    false,
+    'empty registries.npm URL is ineligible',
+  )
+  t.equal(
+    usesNpmRegistry(
+      nodeWith(joinDepIDTuple(['registry', 'npm', 'foo@1.0.0']), {}),
+    ),
+    false,
+    'alias-form DepID with no registries config is ineligible',
+  )
 })
 
 t.test('SecurityArchive.refresh', async t => {
@@ -426,6 +581,57 @@ ${JSON.stringify(englishDaysReport)}
       'should calculate average score correctly with 2 decimal places',
     )
   })
+})
+
+t.test('SecurityArchive.refresh with npm mirror', async t => {
+  const dir = t.testdir()
+  const path = resolve(dir, 'mirror.db')
+  const graph = getSimpleReportGraph(mirrorSpecOptions)
+  const nodes = [...graph.nodes.values()]
+
+  let fetchBody: unknown
+  t.intercept(global, 'fetch', {
+    value: async (_url: string, init?: { body?: string }) => {
+      fetchBody = JSON.parse(init?.body ?? '{}')
+      return {
+        ok: true,
+        status: 200,
+        text: async () => `${JSON.stringify(fooReport)}
+${JSON.stringify(englishDaysReport)}
+`,
+      } as unknown as Response
+    },
+  })
+
+  const archive = await SecurityArchive.start({ nodes, path })
+
+  t.ok(archive.ok, 'archive is complete for npm-mirror packages')
+  t.strictSame(
+    fetchBody,
+    {
+      components: [
+        { purl: 'pkg:npm/@ruyadorno/foo@1.0.0' },
+        { purl: 'pkg:npm/english-days@1.0.0' },
+      ],
+    },
+    'should queue only npm-alias packages from the mirror',
+  )
+  t.ok(
+    archive.has(
+      joinDepIDTuple(['registry', 'npm', '@ruyadorno/foo@1.0.0']),
+    ),
+    'should store the mirrored npm package',
+  )
+  t.notOk(
+    archive.has(
+      joinDepIDTuple(['registry', 'custom', 'registry@1.0.1']),
+    ),
+    'should skip the custom-registry package',
+  )
+  t.matchSnapshot(
+    archive.toJSON(),
+    'should persist security data for packages from registries.npm',
+  )
 })
 
 t.test('DepID normalization', async t => {

--- a/www/docs/src/content/docs/cli/security.mdx
+++ b/www/docs/src/content/docs/cli/security.mdx
@@ -285,6 +285,17 @@ requires network access to fetch the latest threat intelligence. The
 first query may take longer as security metadata is downloaded and
 cached locally.
 
+Packages are eligible when their origin is the public npm registry
+(`https://registry.npmjs.org/`) or whatever URL is configured as
+`registries.npm` (for example a vlt.io npm mirror from
+[`vlt setup`](/cli/commands/setup)). Packages from other registries
+have no security data.
+
+`vlt login --registry=<url>` writes only the scalar `registry` option.
+If that URL is not `https://registry.npmjs.org/` and `registries.npm`
+is unset, those packages are not scanned. Use `vlt setup` or
+`vlt config set registries=npm=<url>` instead.
+
 For more detailed information about specific security selectors, see
 the [Dependency Selector Syntax](/cli/selectors/security-insights)
 reference.


### PR DESCRIPTION
After removing the default registry, security-archive still required `registries[alias] === https://registry.npmjs.org/`, so vlt.io mirrors configured via registries.npm were never queued or validated.

Resolve each node's origin URL from its DepID (alias or URL form) and treat packages as npm-ecosystem when the origin matches registry.npmjs.org or the configured registries.npm URL.

Also fix vlt view to pass conf.options and a spec-derived DepID into SecurityArchive.start(), and document that
`vlt login --registry=<mirror>` alone does not enable security scans without registries.npm.