### PR TITLE
tar: fix tar max unpacked size

### DIFF
--- a/src/tar/README.md
+++ b/src/tar/README.md
@@ -83,6 +83,14 @@ by default (with the same windows/umask caveats as files, so maybe
 that's `0o775` or some such.) All ctime/mtime/atime/birthtime values
 will just be left as the current time.
 
+Gzip-compressed tarballs are inflated with a size bound before any tar
+structure checks run. The cap is the smaller of 2 GiB and 1000 times
+the compressed size (the same 1000:1 ratio node-tar and npm use).
+Exceeding it fails with `tarball exceeds maximum unpacked size` rather
+than allocating the decompressed buffer. Raise the ceiling with
+`VLT_TAR_MAX_UNPACKED_BYTES` if a legitimate package is larger than 2
+GiB unpacked.
+
 It does not do any of the binary linking or other stuff that a package
 manager will need to do. It _just_ does the unpack, as ruthlessly fast
 as possible, and that's all.

--- a/src/tar/src/unpack.ts
+++ b/src/tar/src/unpack.ts
@@ -16,13 +16,47 @@ import { Pax } from 'tar/pax'
 import { unzip as unzipCB } from 'node:zlib'
 import { findTarDir } from './find-tar-dir.ts'
 
-const unzip = async (input: Buffer) =>
-  new Promise<Buffer>(
-    (res, rej) =>
-      /* c8 ignore start */
-      unzipCB(input, (er, result) => (er ? rej(er) : res(result))),
-    /* c8 ignore stop */
+// Matches node-tar's MAX_DECOMPRESSION_RATIO, which npm uses via pacote.
+const MAX_DECOMPRESSION_RATIO = 1000
+
+// node-tar streams, so its ratio alone bounds peak memory. We inflate into
+// a single Buffer, so without a ceiling a large tarball still commits
+// ratio * compressed bytes.
+const defaultMaxUnpackedBytes = 2 * 1024 * 1024 * 1024
+
+const parseMaxUnpackedBytes = (raw: string | undefined): number => {
+  const n = Number(raw)
+  return Number.isFinite(n) && n >= 1 ?
+      Math.floor(n)
+    : defaultMaxUnpackedBytes
+}
+const maxUnpackedBytes = parseMaxUnpackedBytes(
+  process.env.VLT_TAR_MAX_UNPACKED_BYTES,
+)
+
+const unzip = async (input: Buffer) => {
+  const max = Math.min(
+    maxUnpackedBytes,
+    input.length * MAX_DECOMPRESSION_RATIO,
   )
+  return new Promise<Buffer>((res, rej) =>
+    unzipCB(input, { maxOutputLength: max }, (er, result) => {
+      if (!er) return res(result)
+      return rej(
+        (
+          (er as NodeJS.ErrnoException).code ===
+            'ERR_BUFFER_TOO_LARGE'
+        ) ?
+          error('tarball exceeds maximum unpacked size', {
+            found: input.length,
+            max,
+            cause: er,
+          })
+        : er,
+      )
+    }),
+  )
+}
 
 const exists = async (path: string): Promise<boolean> => {
   try {

--- a/src/tar/test/unpack.ts
+++ b/src/tar/test/unpack.ts
@@ -505,6 +505,59 @@ t.test('invalid VLT_TAR_WRITE_LANES falls back', async t => {
   }
 })
 
+t.test('gzip decompression ratio cap', async t => {
+  const bomb = gzipSync(Buffer.alloc(2 * 1024 * 1024))
+  await t.rejects(() => unpack(bomb, t.testdir()), {
+    message: 'tarball exceeds maximum unpacked size',
+  })
+})
+
+t.test('gzip absolute unpacked size ceiling', async t => {
+  const prev = process.env.VLT_TAR_MAX_UNPACKED_BYTES
+  process.env.VLT_TAR_MAX_UNPACKED_BYTES = '4096'
+  t.teardown(() => {
+    if (prev === undefined) {
+      delete process.env.VLT_TAR_MAX_UNPACKED_BYTES
+    } else {
+      process.env.VLT_TAR_MAX_UNPACKED_BYTES = prev
+    }
+  })
+  const { unpack } = await t.mockImport<
+    typeof import('../src/unpack.ts')
+  >('../src/unpack.ts')
+  await t.rejects(() => unpack(gzipped, t.testdir()), {
+    message: 'tarball exceeds maximum unpacked size',
+  })
+})
+
+t.test('invalid VLT_TAR_MAX_UNPACKED_BYTES falls back', async t => {
+  const gzippedFiles = gzipSync(makeFilesTar({ z: 'z' }))
+  for (const raw of ['nope', '0', '-1']) {
+    const prev = process.env.VLT_TAR_MAX_UNPACKED_BYTES
+    process.env.VLT_TAR_MAX_UNPACKED_BYTES = raw
+    t.teardown(() => {
+      if (prev === undefined) {
+        delete process.env.VLT_TAR_MAX_UNPACKED_BYTES
+      } else {
+        process.env.VLT_TAR_MAX_UNPACKED_BYTES = prev
+      }
+    })
+    const { unpack } = await t.mockImport<
+      typeof import('../src/unpack.ts')
+    >('../src/unpack.ts')
+    const dir = t.testdirName
+    await unpack(gzippedFiles, dir)
+    t.equal(readFileSync(dir + '/z', 'utf8'), 'z', raw)
+  }
+})
+
+t.test('non-bomb zlib errors pass through', async t => {
+  const garbage = Buffer.from([0x1f, 0x8b, 0xff, 0xff, 0xff, 0xff])
+  await t.rejects(() => unpack(garbage, t.testdir()), {
+    message: 'unknown compression method',
+  })
+})
+
 t.test('checkFs differential vs relative() impl', t => {
   const checkFsOld = (
     h: { path?: string },


### PR DESCRIPTION
Pass maxOutputLength to zlib.unzip so gzip tarballs are rejected before tar validation runs, preventing decompression bombs from committing unbounded memory during install.

The cap is min(2 GiB, compressedSize × 1000), matching node-tar/npm's 1000:1 ratio with an absolute ceiling for buffered inflation. Override with `VLT_TAR_MAX_UNPACKED_BYTES`.