### PR TITLE
fix(rollback-remove): don't register a path as backed up until rename succeeds

### DIFF
--- a/src/rollback-remove/src/index.ts
+++ b/src/rollback-remove/src/index.ts
@@ -14,8 +14,10 @@ export class RollbackRemove {
   async rm(path: string) {
     if (this.#paths.has(path)) return
     const target = `${dirname(path)}/.VLT.DELETE.${this.#key}.${basename(path)}`
-    this.#paths.set(path, target)
-    await rename(path, target).catch((e: unknown) => {
+    // rollback() trusts this map, so only record entries after rename succeeds.
+    try {
+      await rename(path, target)
+    } catch (e: unknown) {
       if (
         e instanceof Error &&
         'code' in e &&
@@ -23,12 +25,11 @@ export class RollbackRemove {
         (e.code === 'ENOENT' || e.code === 'EPERM')
         /* c8 ignore stop */
       ) {
-        this.#paths.delete(path)
         return
       }
-      /* c8 ignore next */
       throw e
-    })
+    }
+    this.#paths.set(path, target)
   }
 
   confirm() {

--- a/src/rollback-remove/test/index.ts
+++ b/src/rollback-remove/test/index.ts
@@ -1,6 +1,7 @@
 import assert from 'node:assert'
 import type { SpawnOptions } from 'node:child_process'
-import { readdirSync } from 'node:fs'
+import { readdirSync, readFileSync } from 'node:fs'
+import * as fsPromisesOrig from 'node:fs/promises'
 import t from 'tap'
 import type { Test } from 'tap'
 
@@ -226,3 +227,44 @@ t.test('deno + windows', async t => {
     reffed: true,
   })
 })
+
+t.test(
+  'rm() does not register a path when rename fails with an unexpected error',
+  async t => {
+    let shouldFail = false
+    const { RollbackRemove } = await t.mockImport<
+      typeof import('../src/index.ts')
+    >('../src/index.ts', {
+      'node:fs/promises': {
+        ...fsPromisesOrig,
+        rename: async (src: string, dest: string) => {
+          if (shouldFail) {
+            const err = new Error(
+              'EBUSY: resource busy or locked',
+            ) as NodeJS.ErrnoException
+            err.code = 'EBUSY'
+            throw err
+          }
+          return fsPromisesOrig.rename(src, dest)
+        },
+      },
+    })
+
+    t.chdir(
+      t.testdir({
+        a: { b: 'important data' },
+      }),
+    )
+
+    const remover = new RollbackRemove()
+    shouldFail = true
+    await t.rejects(remover.rm('a/b'), { code: 'EBUSY' })
+
+    // The failed rename must leave both the file and rollback state untouched.
+    t.strictSame(readdirSync('a'), ['b'])
+
+    await remover.rollback()
+    t.strictSame(readdirSync('a'), ['b'])
+    t.strictSame(readFileSync('a/b', 'utf8'), 'important data')
+  },
+)


### PR DESCRIPTION
Fixes #1776 

Closes the data-loss bug in #1776 : `RollbackRemove.rm()` registered a `path → target` mapping *before* confirming the `rename()` that's supposed to back the file up actually succeeded. Only `ENOENT`/`EPERM` failures un-registered that entry.. any other rename failure (realistically `EBUSY`, common on Windows when antivirus or another process holds a handle on something under `node_modules`) left a stale entry claiming a backup existed when the original file was never moved.

That map is what `rollback()` trusts during a failed install. With a stale entry, `rollback()` would `rimraf(original)` believing it had a backup to restore from, permanently destroying data that was never actually backed up.. then fail to restore it (since the "backup" never existed), with that failure silently swallowed by `.catch(() => {})` at two call sites.

### The fix

Only register the mapping after `rename()` succeeds, instead of before:

```ts
try {
  await rename(path, target)
} catch (e: unknown) {
  if (e instanceof Error && 'code' in e && (e.code === 'ENOENT' || e.code === 'EPERM')) {
    return
  }
  throw e
}
this.#paths.set(path, target)
```

This closes the whole bug class in one change rather than trying to enumerate every OS error code that can legitimately fail a same-directory rename.

### Test plan

- [x] New regression test in `src/rollback-remove/test/index.ts`.. mocks `node:fs/promises` (spreading the real module and overriding only `rename`, since replacing the whole namespace broke other consumers needing e.g. `readlink`) to fail with `EBUSY`, then asserts the original file survives `rollback()` untouched
- [x] `npx tap test/index.ts` in `src/rollback-remove`.. 16/16 pass
- [x] Full package suite (`npx tap`).. 19/19 pass, no regressions
- [x] Verified on Windows (Node v22.23.2)
