### PR TITLE
cache: fix in-flight lru-cache misses

### DIFF
--- a/src/cache/src/index.ts
+++ b/src/cache/src/index.ts
@@ -112,7 +112,9 @@ export class Cache extends LRUCache<
         return this.#diskRead(k, v, opts.context?.integrity)
       },
       allowStaleOnFetchRejection: true,
-      allowStaleOnFetchAbort: true,
+      // Eviction aborts in-flight fetch() placeholders. Resolving those
+      // as undefined is treated as a cache miss and re-downloads tarballs.
+      ignoreFetchAbort: true,
       allowStale: true,
       noDeleteOnStaleGet: true,
     })

--- a/src/cache/test/index.ts
+++ b/src/cache/test/index.ts
@@ -322,3 +322,27 @@ t.test(
     t.same(await readFile(c.path('big')), big)
   },
 )
+
+t.test(
+  'eviction of an in-flight fetch does not fake a cache miss',
+  async t => {
+    const dir = t.testdir()
+    const writer = new Cache({ path: dir })
+    writer.set('k', Buffer.from('hello, world'))
+    await writer.promise()
+
+    const c = new Cache({ path: dir, maxSize: 100 })
+    const p = c.fetch('k')
+    c.set('a', Buffer.alloc(40))
+    c.set('b', Buffer.alloc(40))
+    c.set('d', Buffer.alloc(40))
+
+    t.same(
+      await p,
+      Buffer.from('hello, world'),
+      'resolves real bytes',
+    )
+    t.equal(c.get('k'), undefined, 'evicted entry not re-inserted')
+    await c.promise()
+  },
+)


### PR DESCRIPTION
When maxSize eviction aborts a fetch() placeholder, allowStaleOnFetchAbort resolved it undefined — registry-client treated that as a miss and re-downloaded already-cached tarballs on warm installs at high concurrency.

Use ignoreFetchAbort so the disk read completes and returns real bytes without re-inserting past the byte cap. Add regression test.

Refs: https://github.com/vltpkg/vltpkg/issues/1779