### PR TITLE
graph: fix lockfile rewrite

### DIFF
--- a/src/graph/src/diff.ts
+++ b/src/graph/src/diff.ts
@@ -55,7 +55,7 @@ export class Diff {
   }
 
   /**
-   * True if the diff only contains optional nodes (computed during construction)
+   * True if every added node/edge is confined to an optional subtree
    */
   optionalOnly = true
 
@@ -97,7 +97,9 @@ export class Diff {
       if (fromEdge?.to) this.edges.delete.add(fromEdge)
       if (edge.to) {
         this.edges.add.add(edge)
-        if (!edge.optional) {
+        // edge.optional is the edge type only; a non-optional edge whose
+        // source is optional is still confined to an optional subtree
+        if (!edge.optional && !edge.from.optional) {
           this.optionalOnly = false
         }
       }

--- a/src/graph/src/reify/index.ts
+++ b/src/graph/src/reify/index.ts
@@ -133,18 +133,21 @@ export const reify = async (
   const noModifiedDependencies =
     !options.add?.modifiedDependencies &&
     !options.remove?.modifiedDependencies
+  // Skip optional-only diffs only after a prior reify wrote lockfiles.
+  // Otherwise a first install of an optional-only tree would never extract.
+  const hasLockfiles =
+    !!scurry.lstatSync('vlt-lock.json') &&
+    !!scurry.lstatSync('node_modules/.vlt-lock.json')
   const skipOptionalOnly = noModifiedDependencies && diff.optionalOnly
-  const skippable = skipOptionalOnly && !options.update
+  const skippable =
+    skipOptionalOnly && !options.update && hasLockfiles
   const res: ReifyResult = { diff }
   if (!diff.hasChanges() || skippable) {
     // Even when there are no changes to reify, ensure lockfiles
     // exist on disk. This handles the case where a project has no
     // dependencies (or only workspace importers) but still needs
     // lockfiles written on the first install.
-    if (
-      !scurry.lstatSync('vlt-lock.json') ||
-      !scurry.lstatSync('node_modules/.vlt-lock.json')
-    ) {
+    if (!hasLockfiles) {
       saveHidden(options)
       const lfData = lockfileData(options)
       saveData(lfData, scurry.resolve('vlt-lock.json'), false)

--- a/src/graph/test/diff.ts
+++ b/src/graph/test/diff.ts
@@ -965,6 +965,157 @@ t.test('optionalOnly method', async t => {
       t.end()
     },
   )
+
+  // Test 6: prod edge inside an optional subtree should still be optionalOnly
+  t.test(
+    'returns true when a prod edge is inside an optional subtree',
+    t => {
+      const graph1 = loadObject(
+        {
+          projectRoot,
+          mainManifest: {
+            name: 'test',
+            version: '1.0.0',
+          },
+        },
+        {
+          lockfileVersion: 1,
+          options: {
+            registries: {
+              npm: 'https://registry.npmjs.org/',
+            },
+          },
+          nodes: {
+            [joinDepIDTuple(['file', '.'])]: [0, 'my-project'],
+          } as Record<DepID, LockfileNode>,
+          edges: {},
+        },
+      )
+
+      const graph2 = loadObject(
+        {
+          projectRoot,
+          mainManifest: {
+            name: 'test',
+            version: '1.0.0',
+          },
+        },
+        {
+          lockfileVersion: 1,
+          options: {
+            registries: {
+              npm: 'https://registry.npmjs.org/',
+            },
+          },
+          nodes: {
+            [joinDepIDTuple(['file', '.'])]: [0, 'my-project'],
+            [joinDepIDTuple(['registry', '', 'opt-pkg@1.0.0'])]: [
+              1,
+              'opt-pkg',
+              'sha512-optpkg==',
+            ],
+            [joinDepIDTuple(['registry', '', 'opt-child@1.0.0'])]: [
+              1,
+              'opt-child',
+              'sha512-optchild==',
+            ],
+          } as Record<DepID, LockfileNode>,
+          edges: {
+            [edgeKey(['file', '.'], 'opt-pkg')]:
+              'optional ^1.0.0 ' +
+              joinDepIDTuple(['registry', '', 'opt-pkg@1.0.0']),
+            [edgeKey(['registry', '', 'opt-pkg@1.0.0'], 'opt-child')]:
+              'prod ^1.0.0 ' +
+              joinDepIDTuple(['registry', '', 'opt-child@1.0.0']),
+          } as LockfileEdges,
+        },
+      )
+
+      const diff = new Diff(graph1, graph2)
+      t.equal(
+        diff.optionalOnly,
+        true,
+        'prod edge from an optional node should not defeat optionalOnly',
+      )
+      t.equal(diff.edges.add.size, 2, 'should have both edges to add')
+      t.end()
+    },
+  )
+
+  // Test 7: prod edge from a non-optional node should not be optionalOnly
+  t.test(
+    'returns false when a prod edge comes from a non-optional node',
+    t => {
+      const graph1 = loadObject(
+        {
+          projectRoot,
+          mainManifest: {
+            name: 'test',
+            version: '1.0.0',
+          },
+        },
+        {
+          lockfileVersion: 1,
+          options: {
+            registries: {
+              npm: 'https://registry.npmjs.org/',
+            },
+          },
+          nodes: {
+            [joinDepIDTuple(['file', '.'])]: [0, 'my-project'],
+          } as Record<DepID, LockfileNode>,
+          edges: {},
+        },
+      )
+
+      const graph2 = loadObject(
+        {
+          projectRoot,
+          mainManifest: {
+            name: 'test',
+            version: '1.0.0',
+          },
+        },
+        {
+          lockfileVersion: 1,
+          options: {
+            registries: {
+              npm: 'https://registry.npmjs.org/',
+            },
+          },
+          nodes: {
+            [joinDepIDTuple(['file', '.'])]: [0, 'my-project'],
+            [joinDepIDTuple(['registry', '', 'req-pkg@1.0.0'])]: [
+              0,
+              'req-pkg',
+              'sha512-reqpkg==',
+            ],
+            [joinDepIDTuple(['registry', '', 'req-child@1.0.0'])]: [
+              0,
+              'req-child',
+              'sha512-reqchild==',
+            ],
+          } as Record<DepID, LockfileNode>,
+          edges: {
+            [edgeKey(['file', '.'], 'req-pkg')]:
+              'prod ^1.0.0 ' +
+              joinDepIDTuple(['registry', '', 'req-pkg@1.0.0']),
+            [edgeKey(['registry', '', 'req-pkg@1.0.0'], 'req-child')]:
+              'prod ^1.0.0 ' +
+              joinDepIDTuple(['registry', '', 'req-child@1.0.0']),
+          } as LockfileEdges,
+        },
+      )
+
+      const diff = new Diff(graph1, graph2)
+      t.equal(
+        diff.optionalOnly,
+        false,
+        'prod edge from a non-optional node should defeat optionalOnly',
+      )
+      t.end()
+    },
+  )
 })
 
 t.test('toJSON method', async t => {

--- a/src/graph/test/reify/index.ts
+++ b/src/graph/test/reify/index.ts
@@ -482,6 +482,85 @@ t.test('failure of optional node just deletes it', async t => {
   for (const path of expectGone) {
     t.throws(() => lstatSync(resolve(projectRoot, path)))
   }
+
+  // Second install: lockfile still has the failed optional subtree,
+  // hidden lockfile / actual graph do not. Prod edges inside that
+  // subtree must not defeat optionalOnly, or reify never converges.
+  const lockfile = resolve(projectRoot, 'vlt-lock.json')
+  const hiddenLockfile = resolve(
+    projectRoot,
+    'node_modules/.vlt-lock.json',
+  )
+  t.ok(
+    existsSync(lockfile),
+    'lockfile written after optional failure',
+  )
+  t.ok(
+    existsSync(hiddenLockfile),
+    'hidden lockfile written after optional failure',
+  )
+  const lockfileMtime = statSync(lockfile).mtimeMs
+  const hiddenMtime = statSync(hiddenLockfile).mtimeMs
+
+  const actual2 = actual.load({
+    projectRoot,
+    registries,
+    monorepo: Monorepo.maybeLoad(projectRoot),
+    scurry: new PathScurry(projectRoot),
+    packageJson: new PackageJson(),
+  })
+  const graph2 = await ideal.build({
+    projectRoot,
+    packageInfo: mockPackageInfo,
+    registries,
+    monorepo: Monorepo.maybeLoad(projectRoot),
+    scurry: new PathScurry(projectRoot),
+    packageJson: new PackageJson(),
+    remover: new RollbackRemove(),
+  })
+  const glob2 = graph2.mainImporter.edgesOut.get('glob')?.to
+  t.ok(glob2, 'ideal rebuilt glob from lockfile')
+  t.ok(
+    glob2?.edgesOut.get('path-scurry')?.type === 'prod',
+    'glob has a prod edge to path-scurry',
+  )
+
+  let extractCalled = false
+  const res = await reify({
+    projectRoot,
+    registries,
+    monorepo: Monorepo.maybeLoad(projectRoot),
+    scurry: new PathScurry(projectRoot),
+    packageJson: new PackageJson(),
+    packageInfo: createMockPackageInfo({
+      async extract(): Promise<Resolution> {
+        extractCalled = true
+        throw new Error('extract should not be called')
+      },
+    }),
+    graph: graph2,
+    actual: actual2,
+    allowScripts: ':not(*)',
+    remover: new RollbackRemove(),
+  })
+
+  t.ok(res.diff.hasChanges(), 'diff still has optional subtree adds')
+  t.equal(
+    res.diff.optionalOnly,
+    true,
+    'prod edges inside optional subtree keep optionalOnly',
+  )
+  t.equal(extractCalled, false, 'skippable reify must not extract')
+  t.equal(
+    statSync(lockfile).mtimeMs,
+    lockfileMtime,
+    'vlt-lock.json mtime unchanged',
+  )
+  t.equal(
+    statSync(hiddenLockfile).mtimeMs,
+    hiddenMtime,
+    'hidden lockfile mtime unchanged',
+  )
 })
 
 t.test('early termination when no changes are needed', async t => {


### PR DESCRIPTION
Prod edges from optional parents no longer defeat `Diff.optionalOnly`, so repeat installs skip reify instead of rewriting lockfiles forever.

Gate the optional-only reify skip on existing lockfiles so first installs still extract. Add unit + reify regression tests.