### PR TITLE
registry-client: fix swr validation

### DIFF
--- a/infra/build/src/bundle.ts
+++ b/infra/build/src/bundle.ts
@@ -105,13 +105,16 @@ const addBinHashbangs: esbuild.Plugin = {
 
 const codeSplitPlugin = (): {
   paths: () => { source: string; out: string }[]
-  plugin: esbuild.Plugin
+  plugin: (skipSource?: string) => esbuild.Plugin
 } => {
   const codeSplitIdentifier =
     'export const __CODE_SPLIT_SCRIPT_NAME ='
   const found = new Set<{ source: string; out: string }>()
 
-  const fn = async (o: esbuild.OnLoadArgs) => {
+  const fn = async (o: esbuild.OnLoadArgs, skipSource?: string) => {
+    if (skipSource && o.path === skipSource) {
+      return
+    }
     const source = await readFile(o.path, 'utf8')
     if (source.includes(codeSplitIdentifier)) {
       const out = withoutExtension(
@@ -139,10 +142,11 @@ const codeSplitPlugin = (): {
 
   // All files that will be code split into external scripts
   // export __CODE_SPLIT_SCRIPT_NAME which we change to a path
-  // to that external script instead
+  // to that external script instead. skipSource keeps an entry
+  // from stubbing itself when it is the bundle's own entry.
   return {
     paths: () => [...found],
-    plugin: {
+    plugin: (skipSource?: string) => ({
       name: 'code-split-plugin',
       setup({ onLoad }) {
         onLoad(
@@ -155,10 +159,10 @@ const codeSplitPlugin = (): {
             ),
             namespace: 'file',
           },
-          fn,
+          o => fn(o, skipSource),
         )
       },
-    },
+    }),
   }
 }
 
@@ -172,7 +176,7 @@ type CreateBundleOptions = {
 
 type BundleOptions = {
   entryPoints: Exclude<esbuild.BuildOptions['entryPoints'], undefined>
-  plugins?: esbuild.BuildOptions['plugins']
+  plugins: esbuild.Plugin[]
 }
 
 const bundleEntryPoints = async (
@@ -185,7 +189,7 @@ const bundleEntryPoints = async (
     `${importName} as ${u(importName)}`
   const { errors, warnings } = await esbuild.build({
     entryPoints: o.entryPoints,
-    plugins: [nodeImports, resvgWasmExternal, ...(o.plugins ?? [])],
+    plugins: [nodeImports, resvgWasmExternal, ...o.plugins],
     sourcemap: o.sourcemap,
     minify: o.minify,
     outdir: o.outdir,
@@ -291,21 +295,31 @@ export const bundle = async ({
       out: basenameWithoutExtension(file),
     })),
     plugins: [
-      codeSplit.plugin,
+      codeSplit.plugin(),
       hashbang ? addBinHashbangs : null,
     ].filter(v => v !== null),
   })
 
   // bundle manually code split files determined from the
-  // transform souce plugin. these are scripts that are exec'd
-  // at runtime by the CLI
-  const codeSplitPaths = codeSplit.paths()
-  assert(codeSplitPaths.length, 'no code split paths found')
-  for (const { source, out } of codeSplit.paths()) {
-    await esbuildBundle({
-      entryPoints: [{ in: source, out }],
-    })
+  // transform source plugin. these are scripts that are exec'd
+  // at runtime by the CLI. drain as a queue because bundling a
+  // code-split entry with the plugin can discover more entries
+  // (e.g. revalidate importing unzip).
+  const done = new Set<string>()
+  for (;;) {
+    const pending = codeSplit
+      .paths()
+      .filter(({ source }) => !done.has(source))
+    if (!pending.length) break
+    for (const { source, out } of pending) {
+      done.add(source)
+      await esbuildBundle({
+        entryPoints: [{ in: source, out }],
+        plugins: [codeSplit.plugin(source)],
+      })
+    }
   }
+  assert(done.size, 'no code split paths found')
 
   // copy package jsons that get read at runtime
   cpSync(

--- a/infra/build/test/bundle.ts
+++ b/infra/build/test/bundle.ts
@@ -1,7 +1,16 @@
 import { bundle } from '../src/bundle.ts'
 import t from 'tap'
-import { readdirSync, readFileSync } from 'node:fs'
+import {
+  readdirSync,
+  readFileSync,
+  mkdirSync,
+  writeFileSync,
+} from 'node:fs'
 import { join } from 'node:path'
+import { createHash } from 'node:crypto'
+import { spawn } from 'node:child_process'
+import { createServer } from 'node:http'
+import type { AddressInfo } from 'node:net'
 
 t.test('default', async t => {
   const dir = t.testdir()
@@ -37,6 +46,84 @@ t.test('default', async t => {
     ),
     'code split callers reference code split files',
   )
+
+  for (const [f, v] of js) {
+    const mains = v.match(/var __CODE_SPLIT_SCRIPT_NAME = import/g)
+    t.ok(
+      !mains || mains.length <= 1,
+      `${f} has at most one isMain script name`,
+    )
+  }
+
+  const revalidate = js.find(
+    ([f]) => f === 'registry-client-src-revalidate.js',
+  )
+  t.ok(revalidate, 'revalidate chunk emitted')
+  t.notOk(
+    revalidate?.[1].includes('vlt-cache-unzip'),
+    'revalidate chunk does not inline unzip isMain',
+  )
+  t.ok(
+    revalidate?.[1].includes('cache-unzip-src-unzip.js'),
+    'revalidate chunk stubs unzip as a sibling',
+  )
+
+  await t.test('bundled revalidate child runs', async t => {
+    const server = createServer((_req, res) => {
+      res.statusCode = 304
+      res.setHeader('date', new Date().toUTCString())
+      res.end()
+    })
+    await new Promise<void>(res =>
+      server.listen(0, '127.0.0.1', () => res()),
+    )
+    t.teardown(() => server.close())
+    const { port } = server.address() as AddressInfo
+    const target = `http://127.0.0.1:${port}/pkg`
+    const cacheRoot = t.testdir()
+    const rcDir = join(cacheRoot, 'registry-client')
+    mkdirSync(rcDir, { recursive: true })
+
+    const statusBytes = Buffer.from('200')
+    const headerItems: Buffer[] = []
+    for (const [k, v] of Object.entries({
+      date: new Date('2020-01-01').toUTCString(),
+      etag: '"abc"',
+      'content-type': 'application/json',
+    })) {
+      for (const b of [Buffer.from(k), Buffer.from(v)]) {
+        const lb = Buffer.alloc(4)
+        lb.writeUInt32BE(4 + b.byteLength)
+        headerItems.push(lb, b)
+      }
+    }
+    let headLength = 4 + statusBytes.byteLength
+    for (const h of headerItems) headLength += h.byteLength
+    const headLenBytes = Buffer.alloc(4)
+    headLenBytes.writeUInt32BE(headLength)
+    const encoded = Buffer.concat([
+      headLenBytes,
+      statusBytes,
+      ...headerItems,
+      Buffer.from('{"ok":true}'),
+    ])
+    const hash = createHash('sha512').update(target).digest('hex')
+    writeFileSync(join(rcDir, hash), encoded)
+    writeFileSync(join(rcDir, `${hash}.key`), target)
+
+    const script = join(dir, 'registry-client-src-revalidate.js')
+    const result = await new Promise<{
+      status: number | null
+      signal: NodeJS.Signals | null
+    }>(res => {
+      const cp = spawn(process.execPath, [script, cacheRoot], {
+        stdio: ['pipe', 'inherit', 'inherit'],
+      })
+      cp.stdin.write(`GET ${target}\0`, () => cp.stdin.end())
+      cp.on('close', (status, signal) => res({ status, signal }))
+    })
+    t.matchOnlyStrict(result, { status: 0, signal: null })
+  })
 })
 
 t.test('bins', async t => {

--- a/src/registry-client/src/cache-entry.ts
+++ b/src/registry-client/src/cache-entry.ts
@@ -145,6 +145,7 @@ export class CacheEntry {
   #trustIntegrity
   #staleWhileRevalidateFactor
   #fromCache = false
+  #headSize?: number
 
   constructor(
     statusCode: number,
@@ -341,6 +342,14 @@ export class CacheEntry {
   /** True when this entry was decoded from the on-disk cache. */
   get fromCache(): boolean {
     return this.#fromCache
+  }
+
+  /**
+   * Byte length of the encoded head (4-byte length prefix + status +
+   * headers). Set when decoded from cache or after `encodeHead()`.
+   */
+  get headSize(): number | undefined {
+    return this.#headSize
   }
 
   get statusCode() {
@@ -559,29 +568,25 @@ export class CacheEntry {
     return obj
   }
 
-  /**
-   * Pass the contents of a @vltpkg/cache.Cache object as a buffer,
-   * and this static method will decode it into a CacheEntry representing
-   * the cached response.
-   */
-  static decode(buffer: Uint8Array): CacheEntry {
-    if (buffer.length < 4) {
-      return emptyCacheEntry
-    }
+  static #parseHead(buffer: Uint8Array):
+    | {
+        statusCode: number
+        headers: Uint8Array[]
+        integrity?: Integrity
+        headSize: number
+      }
+    | undefined {
+    if (buffer.length < 4) return undefined
     const headSize = readSize(buffer, 0)
-    if (buffer.length < headSize) {
-      return emptyCacheEntry
-    }
+    if (buffer.length < headSize) return undefined
     const statusCode = Number(getDecodedValue(buffer.subarray(4, 7)))
     const headersBuffer = buffer.subarray(7, headSize)
-    // walk through the headers array, building up the rawHeaders
     const headers: Uint8Array[] = []
     let i = 0
     let integrity: Integrity | undefined = undefined
     while (i < headersBuffer.length - 4) {
       const size = readSize(headersBuffer, i)
       const val = headersBuffer.subarray(i + 4, i + size)
-      // if the last one was the key integrity, then this one is the value
       if (headers.length % 2 === 1) {
         const k = getDecodedValue(
           headers[headers.length - 1],
@@ -592,23 +597,53 @@ export class CacheEntry {
       headers.push(val)
       i += size
     }
-    const body = buffer.subarray(headSize)
+    return { statusCode, headers, integrity, headSize }
+  }
+
+  /**
+   * Decode only the status/headers from an encoded cache buffer.
+   * The body is not read; `headSize` records how many bytes the head
+   * occupies so a later `encodeHead()` can be patched in place.
+   */
+  static decodeHead(buffer: Uint8Array): CacheEntry {
+    const parsed = CacheEntry.#parseHead(buffer)
+    if (!parsed) return emptyCacheEntry
+    const c = new CacheEntry(parsed.statusCode, parsed.headers, {
+      body: new Uint8Array(0),
+      integrity: parsed.integrity,
+      trustIntegrity: true,
+    })
+    c.#fromCache = true
+    c.#headSize = parsed.headSize
+    return c
+  }
+
+  /**
+   * Pass the contents of a @vltpkg/cache.Cache object as a buffer,
+   * and this static method will decode it into a CacheEntry representing
+   * the cached response.
+   */
+  static decode(buffer: Uint8Array): CacheEntry {
+    const parsed = CacheEntry.#parseHead(buffer)
+    if (!parsed) return emptyCacheEntry
+    const body = buffer.subarray(parsed.headSize)
 
     const c = new CacheEntry(
-      statusCode,
+      parsed.statusCode,
       setRawHeader(
-        headers,
+        parsed.headers,
         'content-length',
         String(body.byteLength),
       ),
       {
         body,
-        integrity,
+        integrity: parsed.integrity,
         trustIntegrity: true,
         contentLength: body.byteLength,
       },
     )
     c.#fromCache = true
+    c.#headSize = parsed.headSize
 
     try {
       if (c.isJSON) {
@@ -629,56 +664,52 @@ export class CacheEntry {
   }
 
   /**
+   * Encode status + headers (no body) as they appear at the start of
+   * an on-disk cache file.
+   */
+  encodeHead(): Buffer {
+    const statusStr = String(this.#statusCode)
+    const statusBytes = getEncondedValue(statusStr)
+
+    let headLength = 4 + statusBytes.byteLength
+    for (const h of this.#headers) headLength += 4 + h.byteLength
+
+    const out = Buffer.from(
+      new ArrayBuffer(headLength),
+      0,
+      headLength,
+    )
+    let off = 0
+    out[off++] = (headLength >> 24) & 0xff
+    out[off++] = (headLength >> 16) & 0xff
+    out[off++] = (headLength >> 8) & 0xff
+    out[off++] = headLength & 0xff
+    out.set(statusBytes, off)
+    off += statusBytes.byteLength
+    for (const h of this.#headers) {
+      const l = 4 + h.byteLength
+      out[off++] = (l >> 24) & 0xff
+      out[off++] = (l >> 16) & 0xff
+      out[off++] = (l >> 8) & 0xff
+      out[off++] = l & 0xff
+      out.set(h, off)
+      off += h.byteLength
+    }
+    this.#headSize = headLength
+    return out
+  }
+
+  /**
    * Encode the entry as a single Buffer for writing to the cache
    */
   encode(): Buffer {
     if (this.isJSON) this.json()
-    const statusStr = String(this.#statusCode)
-    const statusBytes = getEncondedValue(statusStr)
-
-    // compute headLength = 4 (length field itself) + statusBytes + Σ(4 + headerLen) for each header item
-    let headLength = 4 + statusBytes.byteLength
-    for (const h of this.#headers) headLength += 4 + h.byteLength
-
-    // allocate and fill head length prefix (big-endian)
-    const headLenBytes = new Uint8Array(4)
-    headLenBytes[0] = (headLength >> 24) & 0xff
-    headLenBytes[1] = (headLength >> 16) & 0xff
-    headLenBytes[2] = (headLength >> 8) & 0xff
-    headLenBytes[3] = headLength & 0xff
-
-    // header chunks: [len, bytes] for each header item
-    const headerChunks: Uint8Array[] = []
-    for (const h of this.#headers) {
-      const l = headLenBytes.byteLength + h.byteLength
-      const lb = new Uint8Array(4)
-      lb[0] = (l >> 24) & 0xff
-      lb[1] = (l >> 16) & 0xff
-      lb[2] = (l >> 8) & 0xff
-      lb[3] = l & 0xff
-      headerChunks.push(lb, h)
-    }
-
-    // total size
-    const total =
-      headLenBytes.byteLength +
-      statusBytes.byteLength +
-      headerChunks.reduce((n, b) => n + b.byteLength, 0) +
-      this._body.byteLength
-
-    // returns the concatenate buffer with all the pieces
-    const outBuffer = new ArrayBuffer(total)
-    const out = Buffer.from(outBuffer, 0, total)
-    let off = 0
-    out.set(headLenBytes, off)
-    off += headLenBytes.byteLength
-    out.set(statusBytes, off)
-    off += statusBytes.byteLength
-    for (const chunk of headerChunks) {
-      out.set(chunk, off)
-      off += chunk.byteLength
-    }
-    out.set(this._body, off)
+    const head = this.encodeHead()
+    const body = this._body
+    const total = head.byteLength + body.byteLength
+    const out = Buffer.from(new ArrayBuffer(total), 0, total)
+    out.set(head, 0)
+    out.set(body, head.byteLength)
     return out
   }
 }

--- a/src/registry-client/src/index.ts
+++ b/src/registry-client/src/index.ts
@@ -42,7 +42,7 @@ import type { TokenResponse } from './token-response.ts'
 import { getTokenResponse } from './token-response.ts'
 import type { WebAuthChallenge } from './web-auth-challenge.ts'
 import { getWebAuthChallenge } from './web-auth-challenge.ts'
-import { getEncondedValue } from './string-encoding.ts'
+import { collectHeaders, readBody } from './response.ts'
 import { oidc } from './oidc.ts'
 import type { OidcOptions } from './oidc.ts'
 export {
@@ -70,6 +70,9 @@ export {
 export type CacheableMethod = 'GET' | 'HEAD'
 export const isCacheableMethod = (m: unknown): m is CacheableMethod =>
   m === 'GET' || m === 'HEAD'
+
+export const cacheKey = (method: string, url: URL | string): string =>
+  `${method !== 'GET' ? method + ' ' : ''}${url}`
 
 export type RegistryClientOptions = {
   /**
@@ -489,7 +492,7 @@ export class RegistryClient {
     // Method + URL only. Headers (including accept) are not part of the
     // key and there is no Vary handling — callers must not vary the
     // response representation for the same URL.
-    const key = `${method !== 'GET' ? method + ' ' : ''}${u}`
+    const key = cacheKey(method, u)
     const buffer =
       useCache ?
         await this.cache.fetch(key, { context: { integrity } })
@@ -629,19 +632,7 @@ export class RegistryClient {
       }
     }
 
-    const h: Uint8Array[] = []
-    for (const [key, value] of Object.entries(response.headers)) {
-      /* c8 ignore start - theoretical */
-      if (Array.isArray(value)) {
-        h.push(
-          getEncondedValue(key),
-          getEncondedValue(value.join(', ')),
-        )
-        /* c8 ignore stop */
-      } else if (typeof value === 'string') {
-        h.push(getEncondedValue(key), getEncondedValue(value))
-      }
-    }
+    const h = collectHeaders(response)
 
     const { integrity, trustIntegrity } = options
 
@@ -686,12 +677,6 @@ export class RegistryClient {
       return result
     }
 
-    response.body.on('data', (chunk: Uint8Array) =>
-      result.addBody(chunk),
-    )
-    return await new Promise<CacheEntry>((res, rej) => {
-      response.body.on('error', rej)
-      response.body.on('end', () => res(result))
-    })
+    return await readBody(response, result)
   }
 }

--- a/src/registry-client/src/response.ts
+++ b/src/registry-client/src/response.ts
@@ -1,0 +1,33 @@
+import type { Dispatcher } from 'undici'
+import type { CacheEntry } from './cache-entry.ts'
+import { getEncondedValue } from './string-encoding.ts'
+
+export const collectHeaders = (
+  response: Dispatcher.ResponseData,
+): Uint8Array[] => {
+  const h: Uint8Array[] = []
+  for (const [key, value] of Object.entries(response.headers)) {
+    if (Array.isArray(value)) {
+      h.push(
+        getEncondedValue(key),
+        getEncondedValue(value.join(', ')),
+      )
+    } else if (typeof value === 'string') {
+      h.push(getEncondedValue(key), getEncondedValue(value))
+    }
+  }
+  return h
+}
+
+export const readBody = async (
+  response: Dispatcher.ResponseData,
+  entry: CacheEntry,
+): Promise<CacheEntry> => {
+  response.body.on('data', (chunk: Uint8Array) =>
+    entry.addBody(chunk),
+  )
+  return await new Promise<CacheEntry>((res, rej) => {
+    response.body.on('error', rej)
+    response.body.on('end', () => res(entry))
+  })
+}

--- a/src/registry-client/src/revalidate-entry.ts
+++ b/src/registry-client/src/revalidate-entry.ts
@@ -133,6 +133,24 @@ export const revalidateEntry = async (
         return
       }
 
+      // Lean path uses bare undici (no redirect following). Hand
+      // 3xx back to RegistryClient so per-origin auth, cycle limits,
+      // and the final cache write stay in the tested request() path.
+      const status = response.statusCode
+      if (
+        status === 301 ||
+        status === 302 ||
+        status === 303 ||
+        status === 307 ||
+        status === 308
+      ) {
+        response.body.resume()
+        await fh.close()
+        fh = undefined
+        await rc.request(u, { method, staleWhileRevalidate: false })
+        return
+      }
+
       response.body.resume()
     } finally {
       await fh?.close()

--- a/src/registry-client/src/revalidate-entry.ts
+++ b/src/registry-client/src/revalidate-entry.ts
@@ -1,0 +1,141 @@
+import { randomUUID } from 'node:crypto'
+import { open, readFile } from 'node:fs/promises'
+import type { FileHandle } from 'node:fs/promises'
+import type { Dispatcher } from 'undici'
+import { addHeader } from './add-header.ts'
+import { getTokenByURL } from './auth.ts'
+import { CacheEntry } from './cache-entry.ts'
+import { handleCacheHitResponse } from './handle-304-response.ts'
+import type {
+  RegistryClient,
+  RegistryClientRequestOptions,
+} from './index.ts'
+import { cacheKey, userAgent } from './index.ts'
+import { collectHeaders, readBody } from './response.ts'
+import { setCacheHeaders } from './set-cache-headers.ts'
+
+const patchDateFallback = async (
+  rc: RegistryClient,
+  file: string,
+  key: string,
+  head: CacheEntry,
+) => {
+  const date = head.getHeaderString('date')
+  /* c8 ignore next */
+  if (!date) return
+  const full = await readFile(file)
+  const fullEntry = CacheEntry.decode(full)
+  if (!fullEntry.statusCode) return
+  fullEntry.setHeader('date', date)
+  const buf = fullEntry.encode()
+  rc.cache.set(
+    key,
+    Buffer.from(buf.buffer, buf.byteOffset, buf.byteLength),
+    { integrity: fullEntry.integrity },
+  )
+}
+
+const readHead = async (
+  fh: FileHandle,
+): Promise<CacheEntry | undefined> => {
+  const sizeBuf = Buffer.alloc(4)
+  const { bytesRead } = await fh.read(sizeBuf, 0, 4, 0)
+  if (bytesRead < 4) return
+  const headSize = sizeBuf.readUInt32BE(0)
+  if (headSize < 7) return
+  const headBuf = Buffer.alloc(headSize)
+  sizeBuf.copy(headBuf, 0, 0, 4)
+  const { bytesRead: n } = await fh.read(headBuf, 4, headSize - 4, 4)
+  if (n < headSize - 4) return
+  const entry = CacheEntry.decodeHead(headBuf)
+  return entry.statusCode ? entry : undefined
+}
+
+export const revalidateEntry = async (
+  rc: RegistryClient,
+  method: 'GET' | 'HEAD',
+  url: URL | string,
+): Promise<void> => {
+  try {
+    const u = typeof url === 'string' ? new URL(url) : url
+    const key = cacheKey(method, u)
+    const file = rc.cache.path(key)
+    let fh: FileHandle | undefined
+    try {
+      fh = await open(file, 'r+')
+      const entry = await readHead(fh)
+      if (!entry) return
+      const origHeadSize = entry.headSize
+
+      const options: RegistryClientRequestOptions = {
+        method,
+        origin: u.origin,
+      }
+      // eslint-disable-next-line @typescript-eslint/no-deprecated -- dispatcher requires path
+      options.path = u.pathname.replace(/\/+$/, '') + u.search
+      options.headers = addHeader(
+        addHeader(
+          addHeader(
+            options.headers,
+            'accept-encoding',
+            'gzip;q=1.0, identity;q=0.5',
+          ),
+          'user-agent',
+          userAgent,
+        ),
+        'npm-session',
+        randomUUID(),
+      )
+      setCacheHeaders(options, entry)
+      options.headers = addHeader(
+        options.headers,
+        'authorization',
+        await getTokenByURL(String(u), rc.identity),
+      )
+
+      const response = await rc.agent.request(
+        options as Dispatcher.RequestOptions,
+      )
+
+      if (handleCacheHitResponse(response, entry)) {
+        const newHead = entry.encodeHead()
+        if (newHead.byteLength === origHeadSize) {
+          await fh.write(newHead, 0, newHead.byteLength, 0)
+          return
+        }
+        await fh.close()
+        fh = undefined
+        await patchDateFallback(rc, file, key, entry)
+        return
+      }
+
+      if (response.statusCode === 200 && method === 'GET') {
+        const result = new CacheEntry(
+          response.statusCode,
+          collectHeaders(response),
+          {
+            'stale-while-revalidate-factor':
+              rc.staleWhileRevalidateFactor,
+            contentLength:
+              response.headers['content-length'] ?
+                Number(response.headers['content-length'])
+              : undefined,
+          },
+        )
+        await readBody(response, result)
+        result.unzip()
+        const buf = result.encode()
+        rc.cache.set(
+          key,
+          Buffer.from(buf.buffer, buf.byteOffset, buf.byteLength),
+          { integrity: result.integrity },
+        )
+        return
+      }
+
+      response.body.resume()
+    } finally {
+      await fh?.close()
+    }
+  } catch {}
+}

--- a/src/registry-client/src/revalidate.ts
+++ b/src/registry-client/src/revalidate.ts
@@ -1,8 +1,8 @@
-// This needs to live in the same workspace as the RegistryClient, because
-// otherwise we have a cyclical dependency cycle of dependencies in a cycle,
-// which is even more cyclical than this description describing it.
+import type EventEmitter from 'node:events'
+import { setPriority } from 'node:os'
 import { pathToFileURL } from 'node:url'
 import { RegistryClient } from './index.ts'
+import { revalidateEntry } from './revalidate-entry.ts'
 
 export const __CODE_SPLIT_SCRIPT_NAME = import.meta.filename
 
@@ -10,14 +10,47 @@ const isMain = (path?: string) =>
   path === __CODE_SPLIT_SCRIPT_NAME ||
   path === pathToFileURL(__CODE_SPLIT_SCRIPT_NAME).toString()
 
-export const main = async (cache?: string, input = process.stdin) => {
+const defaultConcurrency = 6
+
+const revalidateConcurrency = (raw: string | undefined): number => {
+  const n = Number(raw)
+  return Number.isFinite(n) && n >= 1 ?
+      Math.min(32, Math.floor(n))
+    : defaultConcurrency
+}
+
+const runPool = async (
+  reqs: ['GET' | 'HEAD', URL][],
+  concurrency: number,
+  fn: (method: 'GET' | 'HEAD', url: URL) => Promise<void>,
+) => {
+  let next = 0
+  const n = Math.min(concurrency, reqs.length)
+  await Promise.all(
+    Array.from({ length: n }, async () => {
+      for (;;) {
+        const i = next++
+        if (i >= reqs.length) return
+        const req = reqs[i]
+        /* c8 ignore next */
+        if (req === undefined) return
+        await fn(req[0], req[1])
+      }
+    }),
+  )
+}
+
+export const main = async (
+  cache?: string,
+  input: EventEmitter = process.stdin,
+) => {
   if (!cache) {
     return false
   }
   const reqs = await new Promise<['GET' | 'HEAD', URL][]>(res => {
     const chunks: Buffer[] = []
     let chunkLen = 0
-    input.on('data', chunk => {
+    input.on('data', (chunk: Buffer) => {
       chunks.push(chunk)
       chunkLen += chunk.length
     })
@@ -46,13 +79,10 @@ export const main = async (cache?: string, input = process.stdin) => {
   }
 
   const rc = new RegistryClient({ cache })
-  await Promise.all(
-    reqs.map(async ([method, url]) => {
-      await rc.request(url, {
-        method,
-        staleWhileRevalidate: false,
-      })
-    }),
+  await runPool(
+    reqs,
+    revalidateConcurrency(process.env.VLT_REVALIDATE_CONCURRENCY),
+    (method, url) => revalidateEntry(rc, method, url),
   )
 
   return true
@@ -60,6 +90,10 @@ export const main = async (cache?: string, input = process.stdin) => {
 
 if (isMain(process.argv[1])) {
   process.title = 'vlt-cache-revalidate'
+  try {
+    setPriority(19)
+    /* c8 ignore next */
+  } catch {}
   const cacheFolder =
     process.argv.length === 2 ? undefined : process.argv.at(-1)
   const res = await main(cacheFolder, process.stdin)

--- a/src/registry-client/test/cache-entry.ts
+++ b/src/registry-client/test/cache-entry.ts
@@ -765,3 +765,47 @@ t.test('VLT_TAR_MAX_UNPACKED_BYTES caps unzip', async t => {
     message: 'cache entry exceeds maximum unpacked size',
   })
 })
+
+t.test('decodeHead / encodeHead', t => {
+  t.equal(
+    CacheEntry.decodeHead(Buffer.alloc(0)).statusCode,
+    0,
+    'empty buffer',
+  )
+  t.equal(
+    CacheEntry.decodeHead(Buffer.from([100, 100, 100, 100, 1]))
+      .statusCode,
+    0,
+    'head shorter than declared size',
+  )
+
+  const tar = new CacheEntry(
+    200,
+    toRawHeaders({
+      'content-type': 'application/octet-stream',
+      etag: '"abc"',
+      date: new Date('2020-01-20').toUTCString(),
+    }),
+  )
+  tar.addBody(Buffer.from('tarball-bytes'))
+  const enc = tar.encode()
+  const headLen = enc.readUInt32BE(0)
+  const head = CacheEntry.decodeHead(enc)
+  t.equal(head.statusCode, 200)
+  t.equal(head.headSize, headLen)
+  t.equal(head.fromCache, true)
+  t.equal(head.buffer().byteLength, 0, 'body not loaded')
+  t.equal(head.getHeaderString('etag'), '"abc"')
+  t.strictSame(head.encodeHead(), enc.subarray(0, headLen))
+  t.strictSame(
+    Buffer.concat([tar.encodeHead(), tar.buffer()]),
+    enc,
+    'encode() is encodeHead + body',
+  )
+
+  const constructed = new CacheEntry(200, toRawHeaders({ a: 'b' }))
+  t.equal(constructed.headSize, undefined, 'not set until encoded')
+  constructed.encodeHead()
+  t.type(constructed.headSize, 'number')
+  t.end()
+})

--- a/src/registry-client/test/response.ts
+++ b/src/registry-client/test/response.ts
@@ -1,0 +1,37 @@
+import { EventEmitter } from 'node:events'
+import t from 'tap'
+import { CacheEntry } from '../src/cache-entry.ts'
+import { collectHeaders, readBody } from '../src/response.ts'
+
+t.test('collectHeaders', t => {
+  const h = collectHeaders({
+    headers: {
+      a: '1',
+      b: ['2', '3'],
+      c: undefined,
+    },
+  } as never)
+  t.strictSame(
+    h.map(v => Buffer.from(v).toString()),
+    ['a', '1', 'b', '2, 3'],
+  )
+  t.end()
+})
+
+t.test('readBody', async t => {
+  const body = new EventEmitter()
+  const entry = new CacheEntry(200, [])
+  const p = readBody({ body } as never, entry)
+  body.emit('data', Buffer.from('ab'))
+  body.emit('data', Buffer.from('c'))
+  body.emit('end')
+  t.equal((await p).text(), 'abc')
+
+  const errBody = new EventEmitter()
+  const errP = readBody(
+    { body: errBody } as never,
+    new CacheEntry(200, []),
+  )
+  errBody.emit('error', new Error('boom'))
+  await t.rejects(errP, { message: 'boom' })
+})

--- a/src/registry-client/test/revalidate-entry.ts
+++ b/src/registry-client/test/revalidate-entry.ts
@@ -300,6 +300,41 @@ t.test('non-2xx/304 leaves the entry untouched', async t => {
   t.strictSame(await readFile(file), before)
 })
 
+t.test('3xx delegates to RegistryClient.request', async t => {
+  const hits: string[] = []
+  const { url } = await listen(t, (req, res) => {
+    hits.push(String(req.url))
+    if (req.url === '/pkg') {
+      res.statusCode = 302
+      res.setHeader('location', `${url}/dest`)
+      res.end()
+      return
+    }
+    res.statusCode = 200
+    res.setHeader('content-type', 'application/json')
+    res.setHeader('date', new Date().toUTCString())
+    res.end('{"redirected":true}')
+  })
+  const rc = new RegistryClient({ cache: t.testdir() })
+  const target = `${url}/pkg`
+  await seed(
+    rc,
+    'GET',
+    target,
+    jsonEntry({
+      date: new Date('2020-01-01').toUTCString(),
+      etag: '"old"',
+    }),
+  )
+  await revalidateEntry(rc, 'GET', target)
+  await rc.cache.promise()
+  t.ok(hits.includes('/pkg'), 'conditional GET hit original URL')
+  t.ok(hits.includes('/dest'), 'full client followed the redirect')
+  const buf = await rc.cache.fetch(cacheKey('GET', `${url}/dest`))
+  t.ok(buf, 'final redirect target was cached')
+  t.strictSame(CacheEntry.decode(buf!).json(), { redirected: true })
+})
+
 t.test('412 patches like 304', async t => {
   const newDate = new Date('2025-06-01T00:00:00.000Z').toUTCString()
   const { url } = await listen(t, (_req, res) => {

--- a/src/registry-client/test/revalidate-entry.ts
+++ b/src/registry-client/test/revalidate-entry.ts
@@ -1,0 +1,403 @@
+import { createServer } from 'node:http'
+import type { IncomingMessage, ServerResponse } from 'node:http'
+import { readFile, stat, utimes } from 'node:fs/promises'
+import type { AddressInfo } from 'node:net'
+import { gzipSync } from 'node:zlib'
+import type { Test } from 'tap'
+import t from 'tap'
+import { CacheEntry } from '../src/cache-entry.ts'
+import { cacheKey, RegistryClient } from '../src/index.ts'
+import { revalidateEntry } from '../src/revalidate-entry.ts'
+import { toRawHeaders } from './fixtures/to-raw-headers.ts'
+
+t.equal(cacheKey('GET', 'http://x.com/a'), 'http://x.com/a')
+t.equal(cacheKey('HEAD', 'http://x.com/a'), 'HEAD http://x.com/a')
+
+const jsonEntry = (
+  headers: Record<string, string>,
+  body = '{"ok":true}',
+) => {
+  const e = new CacheEntry(
+    200,
+    toRawHeaders({
+      'content-type': 'application/json',
+      ...headers,
+    }),
+  )
+  e.addBody(Buffer.from(body))
+  return e
+}
+
+const listen = async (
+  t: Test,
+  handler: (req: IncomingMessage, res: ServerResponse) => void,
+) => {
+  const server = createServer(handler)
+  await new Promise<void>(res => server.listen(0, '127.0.0.1', res))
+  t.teardown(() => server.close())
+  const { port } = server.address() as AddressInfo
+  return { server, url: `http://127.0.0.1:${port}` }
+}
+
+const seed = async (
+  rc: RegistryClient,
+  method: 'GET' | 'HEAD',
+  url: string,
+  entry: CacheEntry,
+) => {
+  rc.cache.set(cacheKey(method, url), entry.encode())
+  await rc.cache.promise()
+}
+
+t.test('missing cache file is a no-op', async t => {
+  let hits = 0
+  const { url } = await listen(t, (_req, res) => {
+    hits++
+    res.end('nope')
+  })
+  const rc = new RegistryClient({ cache: t.testdir() })
+  await revalidateEntry(rc, 'GET', `${url}/pkg`)
+  t.equal(hits, 0)
+})
+
+t.test('truncated cache file is a no-op', async t => {
+  let hits = 0
+  const { url } = await listen(t, (_req, res) => {
+    hits++
+    res.end('nope')
+  })
+  const rc = new RegistryClient({ cache: t.testdir() })
+  const target = `${url}/pkg`
+  const key = cacheKey('GET', target)
+  rc.cache.set(key, Buffer.from('xx'))
+  await rc.cache.promise()
+  await revalidateEntry(rc, 'GET', target)
+  t.equal(hits, 0)
+})
+
+t.test('declared head shorter than 7 is a no-op', async t => {
+  let hits = 0
+  const { url } = await listen(t, (_req, res) => {
+    hits++
+    res.end('nope')
+  })
+  const rc = new RegistryClient({ cache: t.testdir() })
+  const target = `${url}/pkg`
+  const key = cacheKey('GET', target)
+  const buf = Buffer.alloc(8)
+  buf.writeUInt32BE(3, 0)
+  rc.cache.set(key, buf)
+  await rc.cache.promise()
+  await revalidateEntry(rc, 'GET', target)
+  t.equal(hits, 0)
+})
+
+t.test('incomplete head read is a no-op', async t => {
+  let hits = 0
+  const { url } = await listen(t, (_req, res) => {
+    hits++
+    res.end('nope')
+  })
+  const rc = new RegistryClient({ cache: t.testdir() })
+  const target = `${url}/pkg`
+  const key = cacheKey('GET', target)
+  const buf = Buffer.alloc(10)
+  buf.writeUInt32BE(100, 0)
+  rc.cache.set(key, buf)
+  await rc.cache.promise()
+  await revalidateEntry(rc, 'GET', target)
+  t.equal(hits, 0)
+})
+
+t.test('status 0 head is a no-op', async t => {
+  let hits = 0
+  const { url } = await listen(t, (_req, res) => {
+    hits++
+    res.end('nope')
+  })
+  const rc = new RegistryClient({ cache: t.testdir() })
+  const target = `${url}/pkg`
+  const key = cacheKey('GET', target)
+  const buf = Buffer.alloc(7)
+  buf.writeUInt32BE(7, 0)
+  buf[4] = 0x30
+  buf[5] = 0x30
+  buf[6] = 0x30
+  rc.cache.set(key, buf)
+  await rc.cache.promise()
+  await revalidateEntry(rc, 'GET', target)
+  t.equal(hits, 0)
+})
+
+t.test('304 patches the head in place', async t => {
+  const newDate = new Date('2024-06-01T00:00:00.000Z').toUTCString()
+  const { url } = await listen(t, (req, res) => {
+    t.equal(req.headers['if-none-match'], '"abc"')
+    res.statusCode = 304
+    res.setHeader('date', newDate)
+    res.end()
+  })
+  const rc = new RegistryClient({ cache: t.testdir() })
+  const target = `${url}/pkg`
+  const oldDate = new Date('2020-01-01T00:00:00.000Z').toUTCString()
+  const entry = jsonEntry({
+    date: oldDate,
+    etag: '"abc"',
+    'cache-control': 'max-age=0',
+  })
+  await seed(rc, 'GET', target, entry)
+  const file = rc.cache.path(cacheKey('GET', target))
+  const keyFile = file + '.key'
+  const before = await readFile(file)
+  const oldMtime = new Date('2021-01-01T00:00:00.000Z')
+  await utimes(keyFile, oldMtime, oldMtime)
+
+  await revalidateEntry(rc, 'GET', new URL(target))
+
+  const after = await readFile(file)
+  t.equal(after.length, before.length, 'file size unchanged')
+  t.strictSame(
+    after.subarray(before.readUInt32BE(0)),
+    before.subarray(before.readUInt32BE(0)),
+    'body bytes unchanged',
+  )
+  const dec = CacheEntry.decode(after)
+  t.equal(dec.getHeaderString('date'), newDate)
+  t.strictSame(dec.json(), { ok: true })
+  const st = await stat(keyFile)
+  t.equal(st.mtimeMs, oldMtime.getTime(), '.key not rewritten')
+})
+
+t.test(
+  '304 with changed head length falls back to full rewrite',
+  async t => {
+    const newDate = new Date('2024-06-01T00:00:00.000Z').toUTCString()
+    const { url } = await listen(t, (_req, res) => {
+      res.statusCode = 304
+      res.setHeader('date', newDate)
+      res.end()
+    })
+    const rc = new RegistryClient({ cache: t.testdir() })
+    const target = `${url}/pkg`
+    const entry = jsonEntry({
+      etag: '"abc"',
+      'cache-control': 'max-age=0',
+    })
+    await seed(rc, 'GET', target, entry)
+    const file = rc.cache.path(cacheKey('GET', target))
+    const keyFile = file + '.key'
+    const oldMtime = new Date('2021-01-01T00:00:00.000Z')
+    await utimes(keyFile, oldMtime, oldMtime)
+
+    await revalidateEntry(rc, 'GET', target)
+    await rc.cache.promise()
+
+    const dec = CacheEntry.decode(await readFile(file))
+    t.equal(dec.getHeaderString('date'), newDate)
+    t.strictSame(dec.json(), { ok: true })
+    const st = await stat(keyFile)
+    t.ok(st.mtimeMs > oldMtime.getTime(), '.key rewritten')
+  },
+)
+
+t.test('304 fallback no-ops if full decode fails', async t => {
+  const { url } = await listen(t, (_req, res) => {
+    res.statusCode = 304
+    res.setHeader('date', new Date().toUTCString())
+    res.end()
+  })
+  const rc = new RegistryClient({ cache: t.testdir() })
+  const target = `${url}/pkg`
+  const entry = new CacheEntry(
+    200,
+    toRawHeaders({
+      'content-type': 'application/json',
+      etag: '"abc"',
+      'cache-control': 'max-age=0',
+    }),
+  )
+  entry.addBody(Buffer.from('{"a":'))
+  rc.cache.set(
+    cacheKey('GET', target),
+    Buffer.concat([entry.encodeHead(), entry.buffer()]),
+  )
+  await rc.cache.promise()
+  const file = rc.cache.path(cacheKey('GET', target))
+  const before = await readFile(file)
+  await revalidateEntry(rc, 'GET', target)
+  await rc.cache.promise()
+  t.strictSame(await readFile(file), before)
+})
+
+t.test('200 stores the new unzipped body', async t => {
+  const body = Buffer.from('{"hello":"revalidated"}')
+  const gz = gzipSync(body)
+  const { url } = await listen(t, (_req, res) => {
+    res.statusCode = 200
+    res.setHeader('content-type', 'application/json')
+    res.setHeader('content-encoding', 'gzip')
+    res.setHeader('content-length', String(gz.length))
+    res.setHeader('date', new Date().toUTCString())
+    res.end(gz)
+  })
+  const rc = new RegistryClient({ cache: t.testdir() })
+  const target = `${url}/pkg`
+  await seed(
+    rc,
+    'GET',
+    target,
+    jsonEntry({
+      date: new Date('2020-01-01').toUTCString(),
+      etag: '"old"',
+    }),
+  )
+  await revalidateEntry(rc, 'GET', target)
+  await rc.cache.promise()
+  const buf = await rc.cache.fetch(cacheKey('GET', target))
+  t.ok(buf)
+  t.equal(CacheEntry.isGzipEntry(buf!), false)
+  const dec = CacheEntry.decode(buf!)
+  t.strictSame(dec.json(), { hello: 'revalidated' })
+})
+
+t.test('HEAD 200 leaves the entry untouched', async t => {
+  const { url } = await listen(t, (_req, res) => {
+    res.statusCode = 200
+    res.end('ignored')
+  })
+  const rc = new RegistryClient({ cache: t.testdir() })
+  const target = `${url}/pkg`
+  const entry = jsonEntry({
+    date: new Date('2020-01-01').toUTCString(),
+    etag: '"abc"',
+  })
+  await seed(rc, 'HEAD', target, entry)
+  const file = rc.cache.path(cacheKey('HEAD', target))
+  const before = await readFile(file)
+  await revalidateEntry(rc, 'HEAD', target)
+  t.strictSame(await readFile(file), before)
+})
+
+t.test('non-2xx/304 leaves the entry untouched', async t => {
+  const { url } = await listen(t, (_req, res) => {
+    res.statusCode = 500
+    res.end('err')
+  })
+  const rc = new RegistryClient({ cache: t.testdir() })
+  const target = `${url}/pkg`
+  await seed(
+    rc,
+    'GET',
+    target,
+    jsonEntry({
+      date: new Date('2020-01-01').toUTCString(),
+      etag: '"abc"',
+    }),
+  )
+  const file = rc.cache.path(cacheKey('GET', target))
+  const before = await readFile(file)
+  await revalidateEntry(rc, 'GET', target)
+  t.strictSame(await readFile(file), before)
+})
+
+t.test('412 patches like 304', async t => {
+  const newDate = new Date('2025-06-01T00:00:00.000Z').toUTCString()
+  const { url } = await listen(t, (_req, res) => {
+    res.statusCode = 412
+    res.setHeader('date', newDate)
+    res.end()
+  })
+  const rc = new RegistryClient({ cache: t.testdir() })
+  const target = `${url}/pkg`
+  const oldDate = new Date('2020-01-01T00:00:00.000Z').toUTCString()
+  await seed(
+    rc,
+    'GET',
+    target,
+    jsonEntry({ date: oldDate, etag: '"abc"' }),
+  )
+  await revalidateEntry(rc, 'GET', target)
+  const dec = CacheEntry.decode(
+    await readFile(rc.cache.path(cacheKey('GET', target))),
+  )
+  t.equal(dec.getHeaderString('date'), newDate)
+})
+
+t.test('200 identity body without content-length', async t => {
+  const { url } = await listen(t, (_req, res) => {
+    res.statusCode = 200
+    res.setHeader('content-type', 'application/json')
+    res.write('{"n":1}')
+    res.end()
+  })
+  const rc = new RegistryClient({ cache: t.testdir() })
+  const target = `${url}/pkg`
+  await seed(
+    rc,
+    'GET',
+    target,
+    jsonEntry({
+      date: new Date('2020-01-01').toUTCString(),
+      etag: '"old"',
+    }),
+  )
+  await revalidateEntry(rc, 'GET', target)
+  await rc.cache.promise()
+  const buf = await rc.cache.fetch(cacheKey('GET', target))
+  t.strictSame(CacheEntry.decode(buf!).json(), { n: 1 })
+})
+
+t.test('200 unzip failure leaves the entry', async t => {
+  const { url } = await listen(t, (_req, res) => {
+    res.statusCode = 200
+    res.setHeader('content-type', 'application/json')
+    res.setHeader('content-encoding', 'gzip')
+    res.end(Buffer.from([0x1f, 0x8b, 0xff, 0xff]))
+  })
+  const rc = new RegistryClient({ cache: t.testdir() })
+  const target = `${url}/pkg`
+  await seed(
+    rc,
+    'GET',
+    target,
+    jsonEntry({
+      date: new Date('2020-01-01').toUTCString(),
+      etag: '"old"',
+    }),
+  )
+  const file = rc.cache.path(cacheKey('GET', target))
+  const before = await readFile(file)
+  await revalidateEntry(rc, 'GET', target)
+  t.strictSame(await readFile(file), before)
+})
+
+t.test('network errors are swallowed', async t => {
+  const rc = new RegistryClient({ cache: t.testdir() })
+  const target = 'http://127.0.0.1:1/pkg'
+  await seed(rc, 'GET', target, jsonEntry({ etag: '"abc"' }))
+  await revalidateEntry(rc, 'GET', target)
+  t.pass('did not throw')
+})
+
+t.test('304 without date header uses now', async t => {
+  const { url } = await listen(t, (_req, res) => {
+    res.statusCode = 304
+    res.end()
+  })
+  const rc = new RegistryClient({ cache: t.testdir() })
+  const target = `${url}/pkg`
+  const oldDate = new Date('2020-01-01T00:00:00.000Z').toUTCString()
+  await seed(
+    rc,
+    'GET',
+    target,
+    jsonEntry({ date: oldDate, etag: '"abc"' }),
+  )
+  const before = Date.now()
+  await revalidateEntry(rc, 'GET', target)
+  const dec = CacheEntry.decode(
+    await readFile(rc.cache.path(cacheKey('GET', target))),
+  )
+  const d = new Date(dec.getHeaderString('date') ?? 0).getTime()
+  t.ok(d >= before - 1000, 'date bumped to now')
+})

--- a/src/registry-client/test/revalidate.ts
+++ b/src/registry-client/test/revalidate.ts
@@ -1,10 +1,34 @@
 import { spawn, spawnSync } from 'node:child_process'
 import { createServer } from 'node:http'
+import type { AddressInfo } from 'node:net'
+import { PassThrough } from 'node:stream'
 import t from 'tap'
-import { __CODE_SPLIT_SCRIPT_NAME } from '../src/revalidate.ts'
+import { CacheEntry } from '../src/cache-entry.ts'
+import { cacheKey, RegistryClient } from '../src/index.ts'
+import { __CODE_SPLIT_SCRIPT_NAME, main } from '../src/revalidate.ts'
+import { toRawHeaders } from './fixtures/to-raw-headers.ts'
 
 const ENV = {
   NODE_OPTIONS: '--no-warnings --experimental-strip-types',
+}
+
+const seedEntry = async (
+  cache: string,
+  method: 'GET' | 'HEAD',
+  url: string,
+) => {
+  const rc = new RegistryClient({ cache })
+  const e = new CacheEntry(
+    200,
+    toRawHeaders({
+      'content-type': 'application/json',
+      etag: '"x"',
+      date: new Date('2020-01-01').toUTCString(),
+    }),
+  )
+  e.addBody(Buffer.from('{"ok":true}'))
+  rc.cache.set(cacheKey(method, url), e.encode())
+  await rc.cache.promise()
 }
 
 t.test('validate args', async t => {
@@ -50,9 +74,18 @@ t.test('revalidate a url', async t => {
     res.setHeader('connection', 'close')
     res.end('ok')
   })
-  const PORT = 8080 + Number(process.env.TAP_CHILD_ID ?? '0')
-  const reg = `http://localhost:${PORT}`
-  await new Promise<void>(res => server.listen(PORT, () => res()))
+  await new Promise<void>(res =>
+    server.listen(0, '127.0.0.1', () => res()),
+  )
+  t.teardown(() => {
+    server.closeAllConnections()
+    server.close()
+  })
+  const { port } = server.address() as AddressInfo
+  const reg = `http://127.0.0.1:${port}`
+  const dir = t.testdir({})
+  await seedEntry(dir, 'GET', `${reg}/GET`)
+  await seedEntry(dir, 'HEAD', `${reg}/HEAD`)
 
   const res = await new Promise<{
     status: number | null
@@ -60,7 +93,7 @@ t.test('revalidate a url', async t => {
   }>(res => {
     const cp = spawn(
       process.execPath,
-      [__CODE_SPLIT_SCRIPT_NAME, t.testdir({})],
+      [__CODE_SPLIT_SCRIPT_NAME, dir],
       {
         stdio: ['pipe', 'inherit', 'inherit'],
         env: ENV,
@@ -80,6 +113,83 @@ t.test('revalidate a url', async t => {
   })
 
   t.equal(requests, 2)
-  server.closeAllConnections()
-  server.close()
+})
+
+t.test('pool caps in-flight requests', async t => {
+  t.intercept(process, 'env', {
+    value: { ...process.env, VLT_REVALIDATE_CONCURRENCY: '2' },
+  })
+  let inFlight = 0
+  let max = 0
+  const server = createServer((_req, res) => {
+    inFlight++
+    max = Math.max(max, inFlight)
+    setTimeout(() => {
+      inFlight--
+      res.statusCode = 304
+      res.setHeader('date', new Date().toUTCString())
+      res.end()
+    }, 100)
+  })
+  await new Promise<void>(res =>
+    server.listen(0, '127.0.0.1', () => res()),
+  )
+  t.teardown(() => server.close())
+  const { port } = server.address() as AddressInfo
+  const origin = `http://127.0.0.1:${port}`
+  const dir = t.testdir()
+  const urls = [1, 2, 3, 4].map(i => `${origin}/${i}`)
+  for (const u of urls) {
+    await seedEntry(dir, 'GET', u)
+  }
+  const stdin = new PassThrough()
+  const p = main(dir, stdin)
+  stdin.end(urls.map(u => `GET ${u}`).join('\0') + '\0')
+  t.equal(await p, true)
+  t.equal(max, 2, 'never more than 2 in flight')
+})
+
+t.test('invalid concurrency env falls back to default', async t => {
+  t.intercept(process, 'env', {
+    value: { ...process.env, VLT_REVALIDATE_CONCURRENCY: 'nope' },
+  })
+  const server = createServer((_req, res) => {
+    res.statusCode = 304
+    res.setHeader('date', new Date().toUTCString())
+    res.end()
+  })
+  await new Promise<void>(res =>
+    server.listen(0, '127.0.0.1', () => res()),
+  )
+  t.teardown(() => server.close())
+  const { port } = server.address() as AddressInfo
+  const url = `http://127.0.0.1:${port}/x`
+  const dir = t.testdir()
+  await seedEntry(dir, 'GET', url)
+  const stdin = new PassThrough()
+  const p = main(dir, stdin)
+  stdin.end(`GET ${url}\0`)
+  t.equal(await p, true)
+})
+
+t.test('high concurrency env is capped', async t => {
+  t.intercept(process, 'env', {
+    value: { ...process.env, VLT_REVALIDATE_CONCURRENCY: '100' },
+  })
+  const server = createServer((_req, res) => {
+    res.statusCode = 304
+    res.end()
+  })
+  await new Promise<void>(res =>
+    server.listen(0, '127.0.0.1', () => res()),
+  )
+  t.teardown(() => server.close())
+  const { port } = server.address() as AddressInfo
+  const url = `http://127.0.0.1:${port}/x`
+  const dir = t.testdir()
+  await seedEntry(dir, 'GET', url)
+  const stdin = new PassThrough()
+  const p = main(dir, stdin)
+  stdin.end(`GET ${url}\0`)
+  t.equal(await p, true)
 })


### PR DESCRIPTION
Restore the code-split revalidate child by stubbing transitive splits in the bundler instead of inlining unzip.ts’ isMain guard. Add a lean revalidator that reads only cache heads, patches 304s in place, and rewrites on 200 with a bounded worker pool.

Includes `CacheEntry.decodeHead/encodeHead`, shared response helpers, and bundle/revalidate tests.

Refs: https://github.com/vltpkg/vltpkg/issues/1779