### PR TITLE
fix: guard ignoreCommand against orphaned VERCEL_GIT_PREVIOUS_SHA

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
-  "ignoreCommand": "git diff --quiet $VERCEL_GIT_PREVIOUS_SHA $VERCEL_GIT_COMMIT_SHA -- www/docs/",
+  "ignoreCommand": "git cat-file -e \"$VERCEL_GIT_PREVIOUS_SHA\" 2>/dev/null && git diff --quiet \"$VERCEL_GIT_PREVIOUS_SHA\" \"$VERCEL_GIT_COMMIT_SHA\" -- www/docs/ || exit 1",
   "outputDirectory": "www/docs/dist",
   "redirects": [
     {

--- a/www/docs/src/content/docs/registry/dashboard.mdx
+++ b/www/docs/src/content/docs/registry/dashboard.mdx
@@ -6,7 +6,7 @@ sidebar:
 ---
 
 import { Aside, Badge, Code } from '@astrojs/starlight/components'
-import Image from '../../components/image/image.astro'
+import Image from '../../../components/image/image.astro'
 
 <Image
   src="/images/dashboard.png"


### PR DESCRIPTION
## Summary

- The `ignoreCommand` in `vercel.json` was originally added to skip Vercel builds when a commit doesn't touch `www/docs/`, preventing excessive builds on every merge to `main`.
- On feature branches, interactive rebases (or force-pushes) can leave `$VERCEL_GIT_PREVIOUS_SHA` pointing at a commit that no longer exists in history. `git diff` against a missing SHA fails fatally (`fatal: bad object`), which broke the build instead of just skipping it.

<img width="1613" height="1158" alt="Screenshot 2026-08-21 at 5 34 10 PM" src="https://github.com/user-attachments/assets/46af860c-3de6-4e8c-bd70-b593023d0f4d" />

As a workaround that _SOMETIMES_ worked everytime I updated a branch, I kept having to uncheck "ignore build" checkbox

- The command now checks that `$VERCEL_GIT_PREVIOUS_SHA` exists with `git cat-file -e` first, and falls back to always building when it doesn't — preserving the original intent (skip unnecessary docs builds) without crashing on rebased/force-pushed branches.

## Test plan

- [x] Confirm `vercel.json` is valid JSON
- [ ] Verify a normal merge to `main` still skips the build when `www/docs/` is untouched
- [x] Verify a feature branch with a rebased/orphaned previous SHA no longer fails the build (was tested on #1734's branch)