### PR TITLE
cli-sdk: validate npm registry alias

### DIFF
--- a/infra/smoke-test/test/fixtures/run.ts
+++ b/infra/smoke-test/test/fixtures/run.ts
@@ -177,6 +177,8 @@ const spawnCommand = async (
         // there is no default registry, so registry-hitting commands
         // need one configured. individual tests can override this.
         VLT_REGISTRY: 'https://registry.npmjs.org/',
+        // install-related commands also require the npm alias
+        VLT_REGISTRIES: 'npm=https://registry.npmjs.org/',
         ...variant.env,
         ...env,
         // We stop walking to find config at $HOME so set that to the root

--- a/infra/smoke-test/test/install.ts
+++ b/infra/smoke-test/test/install.ts
@@ -45,7 +45,7 @@ t.test('no registry configured', async t => {
   const { status, output } = await runMultiple(t, ['i', 'abbrev'], {
     match: ['status'],
     // unset the registry that run.ts configures by default
-    env: { VLT_REGISTRY: '' },
+    env: { VLT_REGISTRY: '', VLT_REGISTRIES: '' },
   })
   t.not(status, 0, 'exits non-zero')
   t.match(output, 'Missing registry configuration')
@@ -58,9 +58,37 @@ t.test('no registry configured, --help still works', async t => {
     ['install', '--help'],
     {
       match: ['status'],
-      env: { VLT_REGISTRY: '' },
+      env: { VLT_REGISTRY: '', VLT_REGISTRIES: '' },
     },
   )
   t.equal(status, 0, 'exits zero')
   t.match(output, 'vlt install')
 })
+
+t.test('no registries.npm configured', async t => {
+  const { status, output } = await runMultiple(t, ['i', 'abbrev'], {
+    match: ['status'],
+    // scalar --registry still set via the fixture default; only the
+    // npm alias is missing
+    env: { VLT_REGISTRIES: '' },
+  })
+  t.not(status, 0, 'exits non-zero')
+  t.match(output, 'Missing npm registry configuration')
+  t.match(output, 'registries.npm')
+})
+
+t.test(
+  'no registries.npm configured, --help still works',
+  async t => {
+    const { status, output } = await runMultiple(
+      t,
+      ['install', '--help'],
+      {
+        match: ['status'],
+        env: { VLT_REGISTRIES: '' },
+      },
+    )
+    t.equal(status, 0, 'exits zero')
+    t.match(output, 'vlt install')
+  },
+)

--- a/src/cli-sdk/src/commands/ci.ts
+++ b/src/cli-sdk/src/commands/ci.ts
@@ -8,6 +8,7 @@ import type { InstallResult } from './install.ts'
 export type CIResult = Omit<InstallResult, 'buildQueue'>
 
 export const needsRegistry = true
+export const needsNpmRegistry = true
 
 export const usage: CommandUsage = () =>
   commandUsage({

--- a/src/cli-sdk/src/commands/exec.ts
+++ b/src/cli-sdk/src/commands/exec.ts
@@ -12,6 +12,7 @@ import { styleTextStdout } from '../output.ts'
 export { views } from '../exec-command.ts'
 
 export const needsRegistry = true
+export const needsNpmRegistry = true
 
 export const usage: CommandUsage = () =>
   commandUsage({

--- a/src/cli-sdk/src/commands/install.ts
+++ b/src/cli-sdk/src/commands/install.ts
@@ -27,6 +27,7 @@ export type InstallResult = {
 }
 
 export const needsRegistry = true
+export const needsNpmRegistry = true
 
 export const usage: CommandUsage = () =>
   commandUsage({

--- a/src/cli-sdk/src/commands/uninstall.ts
+++ b/src/cli-sdk/src/commands/uninstall.ts
@@ -14,6 +14,7 @@ export type UninstallResult = {
 }
 
 export const needsRegistry = true
+export const needsNpmRegistry = true
 
 export const usage: CommandUsage = () =>
   commandUsage({

--- a/src/cli-sdk/src/commands/update.ts
+++ b/src/cli-sdk/src/commands/update.ts
@@ -7,6 +7,7 @@ import type { Views } from '../view.ts'
 import type { InstallResult } from './install.ts'
 
 export const needsRegistry = true
+export const needsNpmRegistry = true
 
 export const usage: CommandUsage = () =>
   commandUsage({

--- a/src/cli-sdk/src/config/README.md
+++ b/src/cli-sdk/src/config/README.md
@@ -60,10 +60,12 @@ nothing is configured (neither `--registry` nor the
 so usage is readable with nothing set up. Inside a command, use the
 `requireRegistry(conf)` helper rather than a non-null assertion.
 
-Install-related commands (`install`, `update`, `uninstall`, `ci`) also
-export `needsNpmRegistry = true`. That gate lives next to
-`needsRegistry` in `outputCommand()` and throws when `registries.npm`
-is unset -- a scalar `--registry` or some other alias is not enough.
+Commands that install packages (`install`, `update`, `uninstall`,
+`ci`, `exec`/`vlx`) also export `needsNpmRegistry = true`. That gate
+lives next to `needsRegistry` in `outputCommand()` and throws when the
+alias bare specs resolve through is unset -- `registries.npm` by
+default, or the alias named by `default-registry-alias`. A scalar
+`--registry` or some unrelated alias is not enough.
 
 ### The `npm` alias is no longer built in
 

--- a/src/cli-sdk/src/config/README.md
+++ b/src/cli-sdk/src/config/README.md
@@ -60,6 +60,11 @@ nothing is configured (neither `--registry` nor the
 so usage is readable with nothing set up. Inside a command, use the
 `requireRegistry(conf)` helper rather than a non-null assertion.
 
+Install-related commands (`install`, `update`, `uninstall`, `ci`) also
+export `needsNpmRegistry = true`. That gate lives next to
+`needsRegistry` in `outputCommand()` and throws when `registries.npm`
+is unset -- a scalar `--registry` or some other alias is not enough.
+
 ### The `npm` alias is no longer built in
 
 Bare specifiers (`foo`, `foo@latest`) and transitive dependencies

--- a/src/cli-sdk/src/load-command.ts
+++ b/src/cli-sdk/src/load-command.ts
@@ -24,9 +24,11 @@ export type Command<T> = {
    */
   needsRegistry?: boolean
   /**
-   * Set to `true` by install-related commands (`install`, `update`,
-   * `uninstall`, `ci`). `outputCommand()` fails early with an
-   * `ECONFIG` error when `registries.npm` is not configured.
+   * Set to `true` by commands that install packages (`install`,
+   * `update`, `uninstall`, `ci`, `exec`/`vlx`). `outputCommand()`
+   * fails early with an `ECONFIG` error when the alias bare specs
+   * resolve through (`registries.npm`, or the alias named by
+   * `default-registry-alias`) is not configured.
    */
   needsNpmRegistry?: boolean
 }

--- a/src/cli-sdk/src/load-command.ts
+++ b/src/cli-sdk/src/load-command.ts
@@ -23,6 +23,12 @@ export type Command<T> = {
    * early with an `ECONFIG` error when one of these runs unconfigured.
    */
   needsRegistry?: boolean
+  /**
+   * Set to `true` by install-related commands (`install`, `update`,
+   * `uninstall`, `ci`). `outputCommand()` fails early with an
+   * `ECONFIG` error when `registries.npm` is not configured.
+   */
+  needsNpmRegistry?: boolean
 }
 
 export const loadCommand = async <T>(

--- a/src/cli-sdk/src/output.ts
+++ b/src/cli-sdk/src/output.ts
@@ -216,7 +216,9 @@ export const outputCommand = async <T>(
       throw missingRegistryError()
     }
     if (needsNpmRegistry && !hasNpmRegistry(conf)) {
-      throw missingNpmRegistryError()
+      throw missingNpmRegistryError(
+        conf.options['default-registry-alias'],
+      )
     }
 
     const output = await onDone(await command(conf))

--- a/src/cli-sdk/src/output.ts
+++ b/src/cli-sdk/src/output.ts
@@ -10,6 +10,8 @@ import type { Command } from './index.ts'
 import { printErr, formatOptions } from './print-err.ts'
 import {
   hasConfiguredRegistry,
+  hasNpmRegistry,
+  missingNpmRegistryError,
   missingRegistryError,
 } from './require-registry.ts'
 import type { LazyView, View, ViewOptions, Views } from './view.ts'
@@ -160,7 +162,8 @@ export const outputCommand = async <T>(
     start: Date.now(),
   },
 ) => {
-  const { usage, views, command, needsRegistry } = cliCommand
+  const { usage, views, command, needsRegistry, needsNpmRegistry } =
+    cliCommand
 
   const stdoutColor =
     conf.values.color ?? supportsColor(process.stdout)
@@ -211,6 +214,9 @@ export const outputCommand = async <T>(
     // nothing is configured.
     if (needsRegistry && !hasConfiguredRegistry(conf)) {
       throw missingRegistryError()
+    }
+    if (needsNpmRegistry && !hasNpmRegistry(conf)) {
+      throw missingNpmRegistryError()
     }
 
     const output = await onDone(await command(conf))

--- a/src/cli-sdk/src/require-registry.ts
+++ b/src/cli-sdk/src/require-registry.ts
@@ -21,16 +21,19 @@ export const missingRegistryError = (): Error =>
   )
 
 /**
- * Install-related commands need the `npm` alias specifically (not
- * merely some other configured registry) so bare specs and the
- * security archive have an npm origin.
+ * Install-related commands need the alias that bare specs resolve
+ * through (not merely some other configured registry) so packages and
+ * transitive deps get stable, alias-keyed DepIDs. That alias is
+ * `registries.npm` unless `default-registry-alias` points elsewhere.
  */
-export const missingNpmRegistryError = (): Error =>
+export const missingNpmRegistryError = (
+  alias: string = defaultRegistryName,
+): Error =>
   error(
     [
-      'Missing npm registry configuration.',
+      `Missing ${alias} registry configuration.`,
       '',
-      `Install commands require the \`registries.${defaultRegistryName}\` alias.`,
+      `Install commands require the \`registries.${alias}\` alias.`,
       'Run `vlt setup` to get configured.',
       '',
       'See https://docs.vlt.sh/cli for other ways to set a registry.',
@@ -111,13 +114,15 @@ export const hasConfiguredRegistry = (conf: LoadedConfig): boolean =>
   !!conf.options.registry || gatherCandidates(conf).length > 0
 
 /**
- * Whether `registries.npm` is configured. A scalar `--registry` or
- * some other alias is not enough: install-related commands need the
- * npm alias itself. Kept next to {@link hasConfiguredRegistry} so
- * both pre-command gates share the same config surface.
+ * Whether the alias bare specs resolve through is configured:
+ * `registries.npm` by default, or whatever `default-registry-alias`
+ * points at. A scalar `--registry` or some unrelated alias is not
+ * enough: install-related commands need the default alias itself.
+ * Kept next to {@link hasConfiguredRegistry} so both pre-command
+ * gates share the same config surface.
  */
 export const hasNpmRegistry = (conf: LoadedConfig): boolean =>
-  !!conf.options.registries[defaultRegistryName]
+  !!conf.options.registries[conf.options['default-registry-alias']]
 
 /**
  * Synchronous, non-interactive registry resolution used by

--- a/src/cli-sdk/src/require-registry.ts
+++ b/src/cli-sdk/src/require-registry.ts
@@ -1,5 +1,5 @@
 import { error } from '@vltpkg/error-cause'
-import { defaultRegistries } from '@vltpkg/spec'
+import { defaultRegistries, defaultRegistryName } from '@vltpkg/spec'
 import { selectRegistry } from './select-registry.ts'
 import type { RegistryCandidate } from './select-registry.ts'
 import type { LoadedConfig } from './config/index.ts'
@@ -14,6 +14,24 @@ export const missingRegistryError = (): Error =>
       'Missing registry configuration.',
       '',
       'vlt has no default registry. Run `vlt setup` to get configured.',
+      '',
+      'See https://docs.vlt.sh/cli for other ways to set a registry.',
+    ].join('\n'),
+    { code: 'ECONFIG' },
+  )
+
+/**
+ * Install-related commands need the `npm` alias specifically (not
+ * merely some other configured registry) so bare specs and the
+ * security archive have an npm origin.
+ */
+export const missingNpmRegistryError = (): Error =>
+  error(
+    [
+      'Missing npm registry configuration.',
+      '',
+      `Install commands require the \`registries.${defaultRegistryName}\` alias.`,
+      'Run `vlt setup` to get configured.',
       '',
       'See https://docs.vlt.sh/cli for other ways to set a registry.',
     ].join('\n'),
@@ -91,6 +109,15 @@ const gatherCandidates = (
  */
 export const hasConfiguredRegistry = (conf: LoadedConfig): boolean =>
   !!conf.options.registry || gatherCandidates(conf).length > 0
+
+/**
+ * Whether `registries.npm` is configured. A scalar `--registry` or
+ * some other alias is not enough: install-related commands need the
+ * npm alias itself. Kept next to {@link hasConfiguredRegistry} so
+ * both pre-command gates share the same config surface.
+ */
+export const hasNpmRegistry = (conf: LoadedConfig): boolean =>
+  !!conf.options.registries[defaultRegistryName]
 
 /**
  * Synchronous, non-interactive registry resolution used by

--- a/src/cli-sdk/test/commands/deprecate.ts
+++ b/src/cli-sdk/test/commands/deprecate.ts
@@ -1,5 +1,5 @@
 import t from 'tap'
-import { defaultRegistries } from '@vltpkg/spec'
+import { defaultRegistries, defaultRegistryName } from '@vltpkg/spec'
 import type { LoadedConfig } from '../../src/config/index.ts'
 import type { Packument } from '@vltpkg/types'
 
@@ -242,6 +242,7 @@ t.test('error: unknown package name', async t => {
     },
     '@vltpkg/spec': {
       defaultRegistries,
+      defaultRegistryName,
       Spec: {
         parseArgs: () => ({
           name: '(unknown)',

--- a/src/cli-sdk/test/commands/dist-tag.ts
+++ b/src/cli-sdk/test/commands/dist-tag.ts
@@ -1,5 +1,5 @@
 import t from 'tap'
-import { defaultRegistries } from '@vltpkg/spec'
+import { defaultRegistries, defaultRegistryName } from '@vltpkg/spec'
 import type { LoadedConfig } from '../../src/config/index.ts'
 
 let requestLog: {
@@ -39,6 +39,7 @@ const Command = await t.mockImport<
   },
   '@vltpkg/spec': {
     defaultRegistries,
+    defaultRegistryName,
     Spec: {
       parseArgs(spec: string) {
         const at = spec.lastIndexOf('@')

--- a/src/cli-sdk/test/index.ts
+++ b/src/cli-sdk/test/index.ts
@@ -249,8 +249,9 @@ t.test('invalid workspace-group', async t => {
   t.matchSnapshot(logs.join('\n'))
 })
 
-// the `needsRegistry` gate itself lives in outputCommand, which is
-// mocked out here. these cover the config plumbing that feeds it.
+// the `needsRegistry` / `needsNpmRegistry` gates live in
+// outputCommand, which is mocked out here. these cover the config
+// plumbing that feeds them.
 t.test('registry config resolution', async t => {
   t.test('undefined when nothing is configured', async t => {
     const cwd = t.testdir({

--- a/src/cli-sdk/test/output.ts
+++ b/src/cli-sdk/test/output.ts
@@ -364,6 +364,7 @@ t.test('outputCommand', async t => {
         options: {
           registry: 'https://registry.npmjs.org/',
           registries: {},
+          'default-registry-alias': 'npm',
         },
       } as unknown as LoadedConfig)
       t.strictSame(exits(), [[1]])
@@ -385,6 +386,7 @@ t.test('outputCommand', async t => {
           values: { view: 'json' },
           options: {
             registries: { main: 'https://example.com/' },
+            'default-registry-alias': 'npm',
           },
         } as unknown as LoadedConfig)
         t.strictSame(exits(), [[1]])
@@ -392,6 +394,25 @@ t.test('outputCommand', async t => {
         t.match(String(errsPrinted[0]), /Missing npm registry/)
       },
     )
+
+    t.test('error names the default-registry-alias', async t => {
+      errsPrinted.length = 0
+      const { exitCode = 0 } = process
+      const exits = t.capture(process, 'exit').args
+      t.teardown(() => {
+        if (t.passing()) process.exitCode = exitCode
+      })
+      await outputCommand(npmRegistryCommand, {
+        values: { view: 'json' },
+        options: {
+          registries: {},
+          'default-registry-alias': 'custom',
+        },
+      } as unknown as LoadedConfig)
+      t.strictSame(exits(), [[1]])
+      t.match(String(errsPrinted[0]), /Missing custom registry/)
+      t.match(String(errsPrinted[0]), /registries\.custom/)
+    })
 
     t.test('--help is answered before the check', async t => {
       const logs = t.capture(console, 'log').args
@@ -408,10 +429,28 @@ t.test('outputCommand', async t => {
         values: { view: 'json' },
         options: {
           registries: { npm: 'https://registry.npmjs.org/' },
+          'default-registry-alias': 'npm',
         },
       } as unknown as LoadedConfig)
       t.strictSame(logs(), [['true']])
     })
+
+    t.test(
+      'runs when default-registry-alias points at another configured alias',
+      async t => {
+        const logs = t.capture(console, 'log').args
+        // registries.npm is missing, but bare specs resolve through
+        // `main` here, so the gate must not block
+        await outputCommand(npmRegistryCommand, {
+          values: { view: 'json' },
+          options: {
+            registries: { main: 'https://example.com/' },
+            'default-registry-alias': 'main',
+          },
+        } as unknown as LoadedConfig)
+        t.strictSame(logs(), [['true']])
+      },
+    )
   })
 
   t.test('view class success', async t => {

--- a/src/cli-sdk/test/output.ts
+++ b/src/cli-sdk/test/output.ts
@@ -340,6 +340,80 @@ t.test('outputCommand', async t => {
     })
   })
 
+  t.test('needsNpmRegistry', async t => {
+    const npmRegistryCommand: Command<true> = {
+      async command() {
+        return true
+      },
+      usage: () => ({ usage: () => 'usage' }) as Jack,
+      views: { json: x => x },
+      needsNpmRegistry: true,
+    }
+
+    t.test('ECONFIG when registries.npm is missing', async t => {
+      errsPrinted.length = 0
+      const { exitCode = 0 } = process
+      const exits = t.capture(process, 'exit').args
+      t.teardown(() => {
+        if (t.passing()) process.exitCode = exitCode
+      })
+      // a scalar --registry is enough for needsRegistry, but not
+      // for the install-related npm alias gate
+      await outputCommand(npmRegistryCommand, {
+        values: { view: 'json' },
+        options: {
+          registry: 'https://registry.npmjs.org/',
+          registries: {},
+        },
+      } as unknown as LoadedConfig)
+      t.strictSame(exits(), [[1]])
+      t.equal(process.exitCode, 1)
+      t.match(errsPrinted[0], { cause: { code: 'ECONFIG' } })
+      t.match(String(errsPrinted[0]), /registries\.npm/)
+    })
+
+    t.test(
+      'ECONFIG when only a non-npm alias is configured',
+      async t => {
+        errsPrinted.length = 0
+        const { exitCode = 0 } = process
+        const exits = t.capture(process, 'exit').args
+        t.teardown(() => {
+          if (t.passing()) process.exitCode = exitCode
+        })
+        await outputCommand(npmRegistryCommand, {
+          values: { view: 'json' },
+          options: {
+            registries: { main: 'https://example.com/' },
+          },
+        } as unknown as LoadedConfig)
+        t.strictSame(exits(), [[1]])
+        t.equal(process.exitCode, 1)
+        t.match(String(errsPrinted[0]), /Missing npm registry/)
+      },
+    )
+
+    t.test('--help is answered before the check', async t => {
+      const logs = t.capture(console, 'log').args
+      await outputCommand(npmRegistryCommand, {
+        values: { help: true },
+        options: {},
+      } as LoadedConfig)
+      t.strictSame(logs(), [['usage']], 'usage printed, no error')
+    })
+
+    t.test('runs when registries.npm is configured', async t => {
+      const logs = t.capture(console, 'log').args
+      await outputCommand(npmRegistryCommand, {
+        values: { view: 'json' },
+        options: {
+          registries: { npm: 'https://registry.npmjs.org/' },
+        },
+      } as unknown as LoadedConfig)
+      t.strictSame(logs(), [['true']])
+    })
+  })
+
   t.test('view class success', async t => {
     let startCalled = false
     let doneCalled = false

--- a/src/cli-sdk/test/require-registry.ts
+++ b/src/cli-sdk/test/require-registry.ts
@@ -44,6 +44,14 @@ t.test('missingRegistryError / ambiguousRegistryError', async t => {
     cause: { code: 'ECONFIG' },
   })
   t.match(String(mod.missingNpmRegistryError()), /registries\.npm/)
+  t.match(mod.missingNpmRegistryError('custom'), {
+    message: /Missing custom registry configuration/,
+    cause: { code: 'ECONFIG' },
+  })
+  t.match(
+    String(mod.missingNpmRegistryError('custom')),
+    /registries\.custom/,
+  )
   t.match(
     mod.ambiguousRegistryError([
       { alias: 'npm', url: 'https://n/' },
@@ -286,5 +294,23 @@ t.test('hasNpmRegistry', async t => {
   t.ok(
     mod.hasNpmRegistry(mkConf({ registries: { npm: 'https://n/' } })),
     'npm alias -> true',
+  )
+  t.ok(
+    mod.hasNpmRegistry(
+      mkConf({
+        registries: { main: 'https://m/' },
+        'default-registry-alias': 'main',
+      }),
+    ),
+    'default-registry-alias at a configured alias -> true',
+  )
+  t.notOk(
+    mod.hasNpmRegistry(
+      mkConf({
+        registries: { npm: 'https://n/' },
+        'default-registry-alias': 'main',
+      }),
+    ),
+    'default-registry-alias at a missing alias -> false',
   )
 })

--- a/src/cli-sdk/test/require-registry.ts
+++ b/src/cli-sdk/test/require-registry.ts
@@ -39,6 +39,11 @@ t.test('missingRegistryError / ambiguousRegistryError', async t => {
     message: /Missing registry configuration/,
     cause: { code: 'ECONFIG' },
   })
+  t.match(mod.missingNpmRegistryError(), {
+    message: /Missing npm registry configuration/,
+    cause: { code: 'ECONFIG' },
+  })
+  t.match(String(mod.missingNpmRegistryError()), /registries\.npm/)
   t.match(
     mod.ambiguousRegistryError([
       { alias: 'npm', url: 'https://n/' },
@@ -257,5 +262,29 @@ t.test('hasConfiguredRegistry', async t => {
       mkConf({ registries: { gh: 'https://custom/' } }),
     ),
     'overridden built-in alias -> true',
+  )
+})
+
+t.test('hasNpmRegistry', async t => {
+  const mod = await load()
+
+  t.notOk(mod.hasNpmRegistry(mkConf({})), 'no registries -> false')
+  t.notOk(
+    mod.hasNpmRegistry(mkConf({ registry: 'https://scalar/' })),
+    'registry scalar alone -> false',
+  )
+  t.notOk(
+    mod.hasNpmRegistry(
+      mkConf({ registries: { main: 'https://m/' } }),
+    ),
+    'other alias -> false',
+  )
+  t.notOk(
+    mod.hasNpmRegistry(mkConf({ registries: { npm: '' } })),
+    'empty npm url -> false',
+  )
+  t.ok(
+    mod.hasNpmRegistry(mkConf({ registries: { npm: 'https://n/' } })),
+    'npm alias -> true',
   )
 })

--- a/www/docs/src/content/docs/cli/commands/install.mdx
+++ b/www/docs/src/content/docs/cli/commands/install.mdx
@@ -59,8 +59,9 @@ Installing by name (a **bare spec**) requires a registry to be
 configured — the `npm` alias has no built-in URL. Run
 [`vlt setup`](/cli/registries#getting-started-with-vlt-setup) once to
 configure your account's registries. `vlt install` (and `vlt update`,
-`vlt uninstall`, `vlt ci`) require `registries.npm` specifically, and
-fail with a config error when it is missing.
+`vlt uninstall`, `vlt ci`, `vlx`/`vlt exec`) require `registries.npm`
+specifically — or, if you changed `default-registry-alias`, the alias
+it names — and fail with a config error when it is missing.
 
 <Code
   code={`# Latest version

--- a/www/docs/src/content/docs/cli/commands/install.mdx
+++ b/www/docs/src/content/docs/cli/commands/install.mdx
@@ -58,8 +58,9 @@ described above.
 Installing by name (a **bare spec**) requires a registry to be
 configured — the `npm` alias has no built-in URL. Run
 [`vlt setup`](/cli/registries#getting-started-with-vlt-setup) once to
-configure your account's registries, otherwise these commands fail
-with a missing-registry error.
+configure your account's registries. `vlt install` (and `vlt update`,
+`vlt uninstall`, `vlt ci`) require `registries.npm` specifically, and
+fail with a config error when it is missing.
 
 <Code
   code={`# Latest version

--- a/www/docs/src/content/docs/cli/migration/from-npm.mdx
+++ b/www/docs/src/content/docs/cli/migration/from-npm.mdx
@@ -51,10 +51,12 @@ npm registry:
   lang="bash"
 />
 
-Install-related commands (`vlt install`, `vlt update`,
-`vlt uninstall`, `vlt ci`) require that alias specifically. A scalar
-`--registry` / `VLT_REGISTRY` is enough for other registry-hitting
-commands (for example `vlt ping`), but not for install.
+Commands that install packages (`vlt install`, `vlt update`,
+`vlt uninstall`, `vlt ci`, `vlx`/`vlt exec`) require that alias
+specifically (or the one named by `default-registry-alias`, if you
+changed it). A scalar `--registry` / `VLT_REGISTRY` is enough for
+other registry-hitting commands (for example `vlt ping`), but not for
+install.
 
 Or set it in `vlt.json`, pass `--registries npm=<url>` per command, or
 export `VLT_REGISTRIES`. See [Registries](/cli/registries).

--- a/www/docs/src/content/docs/cli/migration/from-npm.mdx
+++ b/www/docs/src/content/docs/cli/migration/from-npm.mdx
@@ -13,9 +13,9 @@ import { Code } from '@astrojs/starlight/components'
   code={`# Install vlt globally
 $ npm install -g vlt
 
-# Configure a registry -- vlt has no default
+# Configure the npm registry alias -- vlt has no default
 
-$ vlt config set registry=https://registry.npmjs.org/
+$ vlt config set registries=npm=https://registry.npmjs.org/
 
 # In your existing project, run:
 
@@ -42,19 +42,22 @@ If you have a vlt.io account, the guided path is
 [`vlt setup`](/cli/registries#getting-started-with-vlt-setup), which
 configures your account's registry aliases for you.
 
-To instead keep npm's behavior, point the registry at the public npm
-registry:
+To instead keep npm's behavior, point the `npm` alias at the public
+npm registry:
 
 <Code
-  code={`$ vlt config set registry=https://registry.npmjs.org/`}
+  code={`$ vlt config set registries=npm=https://registry.npmjs.org/`}
   title="Terminal"
   lang="bash"
 />
 
-Or set it in `vlt.json`, pass `--registry=<url>` per command, or
-export `VLT_REGISTRY`. `vlt login --registry=<url>` also writes the
-registry into your project's `vlt.json` on success. See
-[Registries](/cli/registries).
+Install-related commands (`vlt install`, `vlt update`,
+`vlt uninstall`, `vlt ci`) require that alias specifically. A scalar
+`--registry` / `VLT_REGISTRY` is enough for other registry-hitting
+commands (for example `vlt ping`), but not for install.
+
+Or set it in `vlt.json`, pass `--registries npm=<url>` per command, or
+export `VLT_REGISTRIES`. See [Registries](/cli/registries).
 
 ---
 

--- a/www/docs/src/content/docs/cli/registries.mdx
+++ b/www/docs/src/content/docs/cli/registries.mdx
@@ -31,10 +31,12 @@ The guided path is [`vlt setup`](#getting-started-with-vlt-setup),
 which configures your account's registry aliases so that
 `vlt install <pkg>` and `vlx` work out of the box.
 
-Install-related commands (`vlt install`, `vlt update`,
-`vlt uninstall`, `vlt ci`) additionally require the `registries.npm`
-alias — a scalar `--registry` / `VLT_REGISTRY` is not enough. When
-that alias is missing they fail with:
+Commands that install packages (`vlt install`, `vlt update`,
+`vlt uninstall`, `vlt ci`, `vlx`/`vlt exec`) additionally require the
+`registries.npm` alias — or, when `default-registry-alias` is set to
+something else, the alias it names. A scalar `--registry` /
+`VLT_REGISTRY` is not enough. When that alias is missing they fail
+with:
 
 ```
 Config Error: Missing npm registry configuration.

--- a/www/docs/src/content/docs/cli/registries.mdx
+++ b/www/docs/src/content/docs/cli/registries.mdx
@@ -31,6 +31,20 @@ The guided path is [`vlt setup`](#getting-started-with-vlt-setup),
 which configures your account's registry aliases so that
 `vlt install <pkg>` and `vlx` work out of the box.
 
+Install-related commands (`vlt install`, `vlt update`,
+`vlt uninstall`, `vlt ci`) additionally require the `registries.npm`
+alias — a scalar `--registry` / `VLT_REGISTRY` is not enough. When
+that alias is missing they fail with:
+
+```
+Config Error: Missing npm registry configuration.
+
+Install commands require the `registries.npm` alias.
+Run `vlt setup` to get configured.
+
+See https://docs.vlt.sh/cli for other ways to set a registry.
+```
+
 There are three ways to configure the registry directly, in increasing
 order of precedence:
 


### PR DESCRIPTION
The `registries.npm` alias has to be manually configured along with a `registry` in order for installs to work as expected.