### PR TITLE
spec: throw on undefined protocol prefixes

### DIFF
--- a/.cursor/rules/spec-parsing.mdc
+++ b/.cursor/rules/spec-parsing.mdc
@@ -81,6 +81,26 @@ aliases and bare specs resolve.
 `getOptions` merges user config **over** built-in defaults, so every
 built-in alias (`gh`, `jsr`) is user/service-overridable.
 
+## Undefined protocols
+
+A `<scheme>:` prefix that is neither built-in nor configured throws
+`Protocol custom: is not defined`.
+
+**Built-in:** `catalog:`, `workspace:`, `registry:`, `file:`, `http:`,
+`https:`, `git:`, `git+ssh:`, `git+http:`, `git+https:`, `git+file:`.
+The `default-registry-alias` (default `npm`) is always treated as known.
+
+**Configured:** keys of `registries`, `git-hosts`, and `jsr-registries`
+(plus built-in defaults `gh`, `github`, `gitlab`, `bitbucket`, `gist`,
+`jsr`).
+
+Windows drive letters (`C:/x`) and hostnames (`notgithub.com:user/repo`)
+are not schemes and keep their existing parse behavior. Dist-tags like
+`latest` / `next-9` are unchanged.
+
+pnpm/yarn protocols (`link:`, `portal:`, `patch:`) and unconfigured
+aliases (`custom:`, `vlt:`) throw.
+
 ## Defaults
 
 ```typescript

--- a/src/graph/test/ideal/get-importer-specs.ts
+++ b/src/graph/test/ideal/get-importer-specs.ts
@@ -115,7 +115,9 @@ t.test('empty graph and something to add', async t => {
       new Map(
         Object.entries({
           bar: asDependency({
-            spec: Spec.parse('bar@custom:bar@^1.1.1'),
+            spec: Spec.parse('bar@custom:bar@^1.1.1', {
+              registries: { custom: 'http://example.com' },
+            }),
             type: 'dev',
           }),
           foo: asDependency({

--- a/src/spec/src/browser.ts
+++ b/src/spec/src/browser.ts
@@ -93,6 +93,45 @@ export const getOptions = (
     : defaultGitHostArchives,
 })
 
+// RFC3986 scheme chars minus `.`, min 2 chars. Excludes windows drive
+// letters (`C:/x`) and hostnames (`notgithub.com:user/repo`).
+const protocolRE = /^([a-zA-Z][a-zA-Z0-9+-]+):/
+
+const builtinProtocols = new Set([
+  'catalog',
+  'workspace',
+  'registry',
+  'file',
+  'http',
+  'https',
+  'git',
+  'git+ssh',
+  'git+http',
+  'git+https',
+  'git+file',
+])
+
+/**
+ * Return the scheme if `str` starts with a protocol that is neither
+ * built-in nor configured, otherwise `undefined`.
+ */
+const unknownProtocol = (
+  str: string,
+  options: SpecOptionsFilled,
+): string | undefined => {
+  const p = protocolRE.exec(str)?.[1]
+  return (
+      p === undefined ||
+        builtinProtocols.has(p) ||
+        p === options['default-registry-alias'] ||
+        options.registries[p] !== undefined ||
+        options['git-hosts'][p] !== undefined ||
+        options['jsr-registries'][p] !== undefined
+    ) ?
+      undefined
+    : p
+}
+
 /**
  * Various nameless scenarios that are handled in the
  * standard spec parsing and should return an unknown name.
@@ -128,7 +167,8 @@ const startsWithSpecIdentifier = (
     ...Object.keys(options['git-hosts']),
     ...Object.keys(options.registries),
     ...Object.keys(options['jsr-registries']),
-  ].some(key => spec.startsWith(`${key}:`))
+  ].some(key => spec.startsWith(`${key}:`)) ||
+  unknownProtocol(spec, options) !== undefined
 
 /**
  * Returns the location in which the first `@` value is found in a given
@@ -352,6 +392,7 @@ export class Spec implements SpecLike<Spec> {
       assertPathSafeName(this.name, this.spec)
     } else {
       this.spec = spec
+      this.#assertKnownProtocol(spec)
       // Check if this spec starts with a known registry identifier
       // but exclude git specs like 'git@github:a/b'
       if (
@@ -602,6 +643,8 @@ export class Spec implements SpecLike<Spec> {
       return
     }
 
+    this.#assertKnownProtocol(this.bareSpec)
+
     // legacy! once upon a time, `user/project` was a shorthand for pulling
     // packages from github, instead of the more verbose and explicit
     // `github:user/project`.
@@ -790,6 +833,23 @@ export class Spec implements SpecLike<Spec> {
     }
     this.spec = this.name + '@' + this.bareSpec
     return this.subspec
+  }
+
+  #assertKnownProtocol(str: string) {
+    const proto = unknownProtocol(str, this.options)
+    if (proto === undefined) return
+    throw this.#error(`Protocol ${proto}: is not defined`, {
+      found: `${proto}:`,
+      validOptions: [
+        ...new Set([
+          ...builtinProtocols,
+          this.options['default-registry-alias'],
+          ...Object.keys(this.options.registries),
+          ...Object.keys(this.options['git-hosts']),
+          ...Object.keys(this.options['jsr-registries']),
+        ]),
+      ].map(p => `${p}:`),
+    })
   }
 
   #error(message: string, extra: ErrorCauseOptions = {}) {

--- a/src/spec/test/browser.ts
+++ b/src/spec/test/browser.ts
@@ -1062,6 +1062,86 @@ t.test('catalogs', async t => {
   )
 })
 
+t.test('undefined protocols', t => {
+  const protocolError = (proto: string, spec: string) => ({
+    message: `Protocol ${proto}: is not defined`,
+    cause: { spec, found: `${proto}:` },
+  })
+
+  t.throws(
+    () => Spec.parse('x', 'custom:1.x'),
+    protocolError('custom', 'x@custom:1.x'),
+  )
+  t.throws(
+    () => Spec.parseArgs('custom:foo'),
+    protocolError('custom', '(unknown)@custom:foo'),
+  )
+  t.throws(
+    () => Spec.parse('x@vlt:1.x'),
+    protocolError('vlt', 'x@vlt:1.x'),
+  )
+  t.throws(
+    () => Spec.parse('vlt:foo@1'),
+    protocolError('vlt', 'vlt:foo@1'),
+  )
+  t.throws(
+    () => Spec.parse('x', 'link:../x'),
+    protocolError('link', 'x@link:../x'),
+  )
+  t.throws(
+    () => Spec.parse('x', 'portal:../x'),
+    protocolError('portal', 'x@portal:../x'),
+  )
+  t.throws(
+    () => Spec.parse('x', 'patch:foo@1'),
+    protocolError('patch', 'x@patch:foo@1'),
+  )
+
+  t.equal(Spec.parse('x', 'C:/x/y').type, 'file')
+  t.equal(Spec.parse('x', 'C:\\x\\y').distTag, 'C:\\x\\y')
+  t.equal(Spec.parse('x', 'notgithub.com:user/foo').type, 'git')
+  t.equal(Spec.parse('x', 'user/foo#semver:^1').type, 'git')
+  t.equal(Spec.parse('x@not-git@hostname.com:some/repo').type, 'git')
+  t.equal(Spec.parse('x', 'next-9').distTag, 'next-9')
+  t.equal(Spec.parse('x', 'latest').distTag, 'latest')
+  t.equal(Spec.parse('x', 'git@github.com:u/r').type, 'git')
+  t.equal(Spec.parse('npm:foo@1').type, 'registry')
+
+  t.equal(
+    Spec.parse('x', 'custom:foo@1', {
+      registries: { custom: 'https://example.com/' },
+    }).namedRegistry,
+    'custom',
+  )
+  t.equal(
+    Spec.parse('x', 'myhost:a/b', {
+      'git-hosts': {
+        myhost: 'git+ssh://git@myhost.com:$1/$2.git',
+      },
+    }).namedGitHost,
+    'myhost',
+  )
+  t.equal(
+    Spec.parse('x', 'deno:@a/b@1', {
+      'jsr-registries': { deno: 'https://jsr.example.com/' },
+    }).namedJsrRegistry,
+    'deno',
+  )
+
+  t.match(
+    Spec.parse('gh:@octocat/hello-world@1.0.0', defaultOptions),
+    { namedRegistry: 'gh' },
+  )
+  t.throws(() => Spec.parse('github:user/foo'), {
+    message: 'Invalid package name: not usable as a path segment',
+  })
+  t.throws(() => Spec.parse('https://server.com/foo.tgz'), {
+    message: 'Invalid package name: not usable as a path segment',
+  })
+
+  t.end()
+})
+
 t.test('isSpec', async t => {
   // Valid Spec instance
   const validSpec = Spec.parse('foo@1.2.3')

--- a/src/spec/test/index.ts
+++ b/src/spec/test/index.ts
@@ -644,3 +644,83 @@ t.test('spec with registry:undefined has no registry', async t => {
   const s = Spec.parse('foo@1.x', { registry: undefined })
   t.equal(s.registry, undefined)
 })
+
+t.test('undefined protocols', t => {
+  const protocolError = (proto: string, spec: string) => ({
+    message: `Protocol ${proto}: is not defined`,
+    cause: { spec, found: `${proto}:` },
+  })
+
+  t.throws(
+    () => Spec.parse('x', 'custom:1.x'),
+    protocolError('custom', 'x@custom:1.x'),
+  )
+  t.throws(
+    () => Spec.parseArgs('custom:foo'),
+    protocolError('custom', '(unknown)@custom:foo'),
+  )
+  t.throws(
+    () => Spec.parse('x@vlt:1.x'),
+    protocolError('vlt', 'x@vlt:1.x'),
+  )
+  t.throws(
+    () => Spec.parse('vlt:foo@1'),
+    protocolError('vlt', 'vlt:foo@1'),
+  )
+  t.throws(
+    () => Spec.parse('x', 'link:../x'),
+    protocolError('link', 'x@link:../x'),
+  )
+  t.throws(
+    () => Spec.parse('x', 'portal:../x'),
+    protocolError('portal', 'x@portal:../x'),
+  )
+  t.throws(
+    () => Spec.parse('x', 'patch:foo@1'),
+    protocolError('patch', 'x@patch:foo@1'),
+  )
+
+  t.equal(Spec.parse('x', 'C:/x/y').type, 'file')
+  t.equal(Spec.parse('x', 'C:\\x\\y').distTag, 'C:\\x\\y')
+  t.equal(Spec.parse('x', 'notgithub.com:user/foo').type, 'git')
+  t.equal(Spec.parse('x', 'user/foo#semver:^1').type, 'git')
+  t.equal(Spec.parse('x@not-git@hostname.com:some/repo').type, 'git')
+  t.equal(Spec.parse('x', 'next-9').distTag, 'next-9')
+  t.equal(Spec.parse('x', 'latest').distTag, 'latest')
+  t.equal(Spec.parse('x', 'git@github.com:u/r').type, 'git')
+  t.equal(Spec.parse('npm:foo@1').type, 'registry')
+
+  t.equal(
+    Spec.parse('x', 'custom:foo@1', {
+      registries: { custom: 'https://example.com/' },
+    }).namedRegistry,
+    'custom',
+  )
+  t.equal(
+    Spec.parse('x', 'myhost:a/b', {
+      'git-hosts': {
+        myhost: 'git+ssh://git@myhost.com:$1/$2.git',
+      },
+    }).namedGitHost,
+    'myhost',
+  )
+  t.equal(
+    Spec.parse('x', 'deno:@a/b@1', {
+      'jsr-registries': { deno: 'https://jsr.example.com/' },
+    }).namedJsrRegistry,
+    'deno',
+  )
+
+  t.match(
+    Spec.parse('gh:@octocat/hello-world@1.0.0', defaultOptions),
+    { namedRegistry: 'gh' },
+  )
+  t.throws(() => Spec.parse('github:user/foo'), {
+    message: 'Invalid package name: not usable as a path segment',
+  })
+  t.throws(() => Spec.parse('https://server.com/foo.tgz'), {
+    message: 'Invalid package name: not usable as a path segment',
+  })
+
+  t.end()
+})


### PR DESCRIPTION
Reject bareSpecs/single-string specs that start with an unconfigured <scheme>: (e.g. `custom:`, `vlt:`, `link:`) instead of treating them as dist-tags or bogus git shorthands.

Add `unknownProtocol()` checks in the constructor and parseArgs, plus regression tests and spec-parsing docs.

Fix graph test to configure custom registry.