### PR TITLE
fix(tar): delete completed requests from Pool.pending

### DIFF
--- a/src/tar/src/pool.ts
+++ b/src/tar/src/pool.ts
@@ -44,6 +44,8 @@ export class Pool {
     const ur = this.pending.get(id)
     /* c8 ignore next */
     if (!ur) return
+    // request is done, stop holding its tarball buffer in memory
+    this.pending.delete(id)
     if (isResponseOK(m)) {
       ur.resolve()
       /* c8 ignore start - nearly impossible in normal circumstances */

--- a/src/tar/test/pool.ts
+++ b/src/tar/test/pool.ts
@@ -88,6 +88,7 @@ t.test('unpack all the things!', async t => {
       true,
     )
   }
+  t.equal(p.pending.size, 0, 'pending must be empty after unpack')
 })
 
 t.test('unpack all the things, but flattened', async t => {
@@ -108,6 +109,7 @@ t.test('unpack all the things, but flattened', async t => {
       true,
     )
   }
+  t.equal(p.pending.size, 0, 'pending must be empty after unpack')
   t.end()
 })
 


### PR DESCRIPTION
Closes #1792

`Pool#onMessage()` resolved/rejected a completed `UnpackRequest` but never removed it from `this.pending`, so every unpacked tarball's buffer stayed referenced in memory for the life of the process.

### Fix: 
delete the request from pending immediately when the worker reports completion, before resolving or rejecting the promise.

### Test plan

- [x] New assertions in `src/tar/test/pool.ts` — `pending.size === 0` after both existing "unpack all the things" tests complete
