### PR TITLE
fix: preserve swr factor when decoding cache entries

### DIFF
--- a/src/registry-client/src/cache-entry.ts
+++ b/src/registry-client/src/cache-entry.ts
@@ -623,7 +623,10 @@ export class CacheEntry {
    * and this static method will decode it into a CacheEntry representing
    * the cached response.
    */
-  static decode(buffer: Uint8Array): CacheEntry {
+  static decode(
+    buffer: Uint8Array,
+    options: CacheEntryOptions = {},
+  ): CacheEntry {
     const parsed = CacheEntry.#parseHead(buffer)
     if (!parsed) return emptyCacheEntry
     const body = buffer.subarray(parsed.headSize)
@@ -640,6 +643,7 @@ export class CacheEntry {
         integrity: parsed.integrity,
         trustIntegrity: true,
         contentLength: body.byteLength,
+        ...options,
       },
     )
     c.#fromCache = true

--- a/src/registry-client/src/index.ts
+++ b/src/registry-client/src/index.ts
@@ -426,7 +426,10 @@ export class RegistryClient {
   #decodeCached(buffer: Uint8Array): CacheEntry | undefined {
     const hit = this.#decoded.get(buffer)
     if (hit) return hit
-    const entry = CacheEntry.decode(buffer)
+    const entry = CacheEntry.decode(buffer, {
+      'stale-while-revalidate-factor':
+        this.staleWhileRevalidateFactor,
+    })
     // statusCode 0 == undecodable, and a cached JSON body that fails
     // to parse is corrupt. Treat both as a total miss: the caller
     // refetches without conditional headers, so a fresh response

--- a/src/registry-client/test/cache-entry.ts
+++ b/src/registry-client/test/cache-entry.ts
@@ -470,6 +470,36 @@ t.test('decode adopts body without copying', t => {
   t.end()
 })
 
+t.test(
+  'decode preserves stale-while-revalidate factor when provided',
+  t => {
+    const src = new CacheEntry(
+      200,
+      toRawHeaders({
+        date: new Date(Date.now() - 10 * 60 * 1000).toUTCString(),
+        'cache-control': 'max-age=300',
+        'content-type': 'application/json',
+      }),
+    )
+    src.addBody(Buffer.from('{"ok":true}'))
+    const enc = src.encode()
+
+    t.equal(
+      CacheEntry.decode(enc).staleWhileRevalidate,
+      true,
+      'default decode still uses the class default factor',
+    )
+    t.equal(
+      CacheEntry.decode(enc, {
+        'stale-while-revalidate-factor': 1,
+      }).staleWhileRevalidate,
+      false,
+      'callers can preserve their configured factor when decoding',
+    )
+    t.end()
+  },
+)
+
 t.test('decode does not eagerly parse json', t => {
   const orig = JSON.parse
   let calls = 0


### PR DESCRIPTION
closes #1802

## summary
fixes the cached-read path so `RegistryClient` preserves its configured `staleWhileRevalidateFactor` when decoding cache entries..

## testing
- npm test -- test/cache-entry.ts
- npm run typecheck
