### PR TITLE
feat(cli-sdk): add `vlt create pkg-example` command to clone "Publish your first package" demo package for vlt users

### DIFF
--- a/src/cli-sdk/package.json
+++ b/src/cli-sdk/package.json
@@ -28,7 +28,6 @@
     "@vltpkg/run": "workspace:*",
     "@vltpkg/security-archive": "workspace:*",
     "@vltpkg/spec": "workspace:*",
-    "@vltpkg/tar": "workspace:*",
     "@vltpkg/types": "workspace:*",
     "@vltpkg/url-open": "workspace:*",
     "@vltpkg/vlt-json": "workspace:*",

--- a/src/cli-sdk/package.json
+++ b/src/cli-sdk/package.json
@@ -28,6 +28,7 @@
     "@vltpkg/run": "workspace:*",
     "@vltpkg/security-archive": "workspace:*",
     "@vltpkg/spec": "workspace:*",
+    "@vltpkg/tar": "workspace:*",
     "@vltpkg/types": "workspace:*",
     "@vltpkg/url-open": "workspace:*",
     "@vltpkg/vlt-json": "workspace:*",

--- a/src/cli-sdk/src/commands/create.ts
+++ b/src/cli-sdk/src/commands/create.ts
@@ -2,15 +2,43 @@ import { exec, execFG } from '@vltpkg/run'
 import type { PromptFn } from '@vltpkg/vlx'
 import * as vlx from '@vltpkg/vlx'
 import { homedir } from 'node:os'
+import { resolve } from 'node:path'
 import { createInterface } from 'node:readline/promises'
 import { commandUsage } from '../config/usage.ts'
 import type { ExecResult } from '../exec-command.ts'
-import { ExecCommand } from '../exec-command.ts'
+import { ExecCommand, views as execViews } from '../exec-command.ts'
 import type { CommandFn, CommandUsage } from '../index.ts'
-import { styleTextStdout } from '../output.ts'
-export { views } from '../exec-command.ts'
+import { stdout, styleTextStdout } from '../output.ts'
+import { createPkgExample } from '../pkg-example.ts'
+import {
+  hasConfiguredRegistry,
+  missingRegistryError,
+} from '../require-registry.ts'
+import type { Views } from '../view.ts'
 
-export const needsRegistry = true
+export type PkgExampleResult = { targetDir: string }
+
+const isPkgExampleResult = (
+  result: ExecResult | PkgExampleResult,
+): result is PkgExampleResult => 'targetDir' in result
+
+export const views = {
+  human: result => {
+    if (isPkgExampleResult(result)) {
+      stdout(`Created package in ${prettyPath(result.targetDir)}`)
+      return
+    }
+    return execViews.human(result)
+  },
+  json: result =>
+    isPkgExampleResult(result) ? result : execViews.json(result),
+} as const satisfies Views<ExecResult | PkgExampleResult>
+
+// The generic create-* flow needs a registry (checked below, once we
+// know the initializer isn't `pkg-example`), but `pkg-example` scaffolds
+// from GitHub and must stay usable by beginners with no registry
+// configured -- so this can't be a static needsRegistry pre-check.
+export const needsRegistry = false
 
 export const usage: CommandUsage = () =>
   commandUsage({
@@ -33,6 +61,10 @@ export const usage: CommandUsage = () =>
                   data directory.
     `,
     examples: {
+      'pkg-example my-package': {
+        description:
+          'Scaffold a minimal publishable package for the "publish your first package" tutorial',
+      },
       'react-app my-app': {
         description: 'Create a new React app using create-react-app',
       },
@@ -87,13 +119,25 @@ Is this ok? (y) `,
   return response
 }
 
-export const command: CommandFn<ExecResult> = async conf => {
+export const command: CommandFn<
+  ExecResult | PkgExampleResult
+> = async conf => {
   const [initializer, ...args] = conf.positionals
 
   if (!initializer) {
     throw new Error(
       'Missing required argument: <initializer>\n\nUsage: vlt create <initializer> [args...]',
     )
+  }
+
+  if (initializer === 'pkg-example') {
+    const targetDir = resolve(args[0] ?? '.')
+    await createPkgExample(targetDir)
+    return { targetDir }
+  }
+
+  if (!hasConfiguredRegistry(conf)) {
+    throw missingRegistryError()
   }
 
   // Transform the initializer to a create-* package name

--- a/src/cli-sdk/src/pkg-example.ts
+++ b/src/cli-sdk/src/pkg-example.ts
@@ -1,10 +1,9 @@
-import { unpack } from '@vltpkg/tar/unpack'
-import { cp, mkdtemp, readdir, rm } from 'node:fs/promises'
-import { tmpdir } from 'node:os'
-import { join } from 'node:path'
+import { spawn } from '@vltpkg/git'
+import { PackageInfoClient } from '@vltpkg/package-info'
+import { readdir } from 'node:fs/promises'
 
-const TARBALL_URL =
-  'https://codeload.github.com/vltpkg/package-examples/tar.gz/main'
+const PKG_EXAMPLE_SPEC =
+  'pkg-example@git+https://github.com/vltpkg/package-examples.git#main::path:packages/vlt'
 
 /**
  * Scaffold the `packages/vlt` example from `vltpkg/package-examples`
@@ -25,16 +24,12 @@ export const createPkgExample = async (
     )
   }
 
-  const res = await fetch(TARBALL_URL)
-  const tarData = Buffer.from(await res.arrayBuffer())
+  await spawn(['--version']).catch((err: unknown) => {
+    throw new Error(
+      'git is required to scaffold this example. Install git and make sure it is available in your PATH.',
+      { cause: err },
+    )
+  })
 
-  const scratch = await mkdtemp(join(tmpdir(), 'vlt-pkg-example-'))
-  try {
-    await unpack(tarData, scratch)
-    await cp(join(scratch, 'packages', 'vlt'), targetDir, {
-      recursive: true,
-    })
-  } finally {
-    await rm(scratch, { recursive: true, force: true })
-  }
+  await new PackageInfoClient().extract(PKG_EXAMPLE_SPEC, targetDir)
 }

--- a/src/cli-sdk/src/pkg-example.ts
+++ b/src/cli-sdk/src/pkg-example.ts
@@ -1,0 +1,43 @@
+import { unpack } from '@vltpkg/tar/unpack'
+import { cp, mkdtemp, readdir, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+const TARBALL_URL =
+  'https://codeload.github.com/vltpkg/package-examples/tar.gz/main'
+
+/**
+ * Scaffold the `packages/vlt` example from `vltpkg/package-examples`
+ * into `targetDir`, for the "publish your first package" tutorial.
+ */
+export const createPkgExample = async (
+  targetDir: string,
+): Promise<void> => {
+  const existing = await readdir(targetDir).catch((err: unknown) => {
+    /* c8 ignore start */
+    if ((err as NodeJS.ErrnoException).code !== 'ENOENT') throw err
+    /* c8 ignore stop */
+    return []
+  })
+  if (existing.length) {
+    throw new Error(
+      `Target directory "${targetDir}" already exists and is not empty`,
+    )
+  }
+
+  const res = await fetch(TARBALL_URL)
+  const tarData = Buffer.from(await res.arrayBuffer())
+
+  const scratchParent = await mkdtemp(
+    join(tmpdir(), 'vlt-pkg-example-'),
+  )
+  const scratch = join(scratchParent, 'extract')
+  try {
+    await unpack(tarData, scratch)
+    await cp(join(scratch, 'packages', 'vlt'), targetDir, {
+      recursive: true,
+    })
+  } finally {
+    await rm(scratchParent, { recursive: true, force: true })
+  }
+}

--- a/src/cli-sdk/src/pkg-example.ts
+++ b/src/cli-sdk/src/pkg-example.ts
@@ -28,16 +28,13 @@ export const createPkgExample = async (
   const res = await fetch(TARBALL_URL)
   const tarData = Buffer.from(await res.arrayBuffer())
 
-  const scratchParent = await mkdtemp(
-    join(tmpdir(), 'vlt-pkg-example-'),
-  )
-  const scratch = join(scratchParent, 'extract')
+  const scratch = await mkdtemp(join(tmpdir(), 'vlt-pkg-example-'))
   try {
     await unpack(tarData, scratch)
     await cp(join(scratch, 'packages', 'vlt'), targetDir, {
       recursive: true,
     })
   } finally {
-    await rm(scratchParent, { recursive: true, force: true })
+    await rm(scratch, { recursive: true, force: true })
   }
 }

--- a/src/cli-sdk/tap-snapshots/test/commands/create.ts.test.cjs
+++ b/src/cli-sdk/tap-snapshots/test/commands/create.ts.test.cjs
@@ -32,6 +32,11 @@ installs it performs is done in vlt's XDG data directory.
 
   Examples
 
+    Scaffold a minimal publishable package for the "publish your first package"
+    tutorial
+
+    ​vlt create pkg-example my-package
+
     Create a new React app using create-react-app
 
     ​vlt create react-app my-app

--- a/src/cli-sdk/test/commands/create.ts
+++ b/src/cli-sdk/test/commands/create.ts
@@ -6,6 +6,10 @@ import t from 'tap'
 import type { LoadedConfig } from '../../src/config/index.ts'
 import type { ExecResult } from '../../src/exec-command.ts'
 
+const NPM_REGISTRY_OPTIONS = {
+  registries: { npm: 'https://registry.npmjs.org' },
+}
+
 t.test('prettyPath', async t => {
   const { prettyPath } = await t.mockImport<
     typeof import('../../src/commands/create.ts')
@@ -111,7 +115,7 @@ t.test('command', async t => {
     let calledResolve = false
     const mockOptions = {
       'script-shell': 'this will be deleted',
-      registries: { npm: 'https://registry.npmjs.org' },
+      ...NPM_REGISTRY_OPTIONS,
     }
     const result = {
       status: 0,
@@ -159,9 +163,7 @@ t.test('command', async t => {
 
   t.test('scoped package transformation', async t => {
     let calledResolve = false
-    const mockOptions = {
-      registries: { npm: 'https://registry.npmjs.org' },
-    }
+    const mockOptions = { ...NPM_REGISTRY_OPTIONS }
     const result = {
       status: 0,
       signal: null,
@@ -217,9 +219,7 @@ t.test('command', async t => {
 
   t.test('scoped package without name', async t => {
     let calledResolve = false
-    const mockOptions = {
-      registries: { npm: 'https://registry.npmjs.org' },
-    }
+    const mockOptions = { ...NPM_REGISTRY_OPTIONS }
     const result = {
       status: 0,
       signal: null,
@@ -258,9 +258,7 @@ t.test('command', async t => {
   })
 
   t.test('with allow-scripts option', async t => {
-    const mockOptions = {
-      registries: { npm: 'https://registry.npmjs.org' },
-    }
+    const mockOptions = { ...NPM_REGISTRY_OPTIONS }
     const result = {
       status: 0,
       signal: null,
@@ -300,9 +298,7 @@ t.test('command', async t => {
 
   t.test('--yes flag auto-accepts prompts', async t => {
     let promptUsed: PromptFn | undefined
-    const mockOptions = {
-      registries: { npm: 'https://registry.npmjs.org' },
-    }
+    const mockOptions = { ...NPM_REGISTRY_OPTIONS }
     const result = {
       status: 0,
       signal: null,
@@ -404,9 +400,7 @@ t.test('command', async t => {
   })
 
   t.test('when vlx.resolve returns undefined', async t => {
-    const mockOptions = {
-      registries: { npm: 'https://registry.npmjs.org' },
-    }
+    const mockOptions = { ...NPM_REGISTRY_OPTIONS }
     const { command } = await t.mockImport<
       typeof import('../../src/commands/create.ts')
     >('../../src/commands/create.ts', {

--- a/src/cli-sdk/test/commands/create.ts
+++ b/src/cli-sdk/test/commands/create.ts
@@ -1,6 +1,7 @@
 import { Spec } from '@vltpkg/spec'
 import { unload } from '@vltpkg/vlt-json'
 import type { PromptFn, VlxOptions } from '@vltpkg/vlx'
+import { resolve } from 'node:path'
 import t from 'tap'
 import type { LoadedConfig } from '../../src/config/index.ts'
 import type { ExecResult } from '../../src/exec-command.ts'
@@ -61,10 +62,57 @@ t.test('usage', async t => {
   t.matchSnapshot(USAGE, 'usage')
 })
 
+t.test('views', async t => {
+  const { views } = await t.mockImport<
+    typeof import('../../src/commands/create.ts')
+  >('../../src/commands/create.ts')
+  unload()
+
+  t.test('pkg-example result', async t => {
+    const logs = t.capture(console, 'log').args
+    const result = { targetDir: '/some/path/my-package' }
+    t.equal(views.human(result), undefined)
+    t.strictSame(logs(), [
+      ['Created package in /some/path/my-package'],
+    ])
+    t.strictSame(views.json(result), result)
+  })
+
+  t.test('exec result delegates to exec-command views', async t => {
+    const result = {
+      status: 0,
+      signal: null,
+      stdout: '',
+      stderr: '',
+    } as unknown as ExecResult
+    t.equal(views.human(result), undefined)
+    t.equal(views.json(result), undefined)
+  })
+})
+
 t.test('command', async t => {
+  t.test(
+    'throws missing-registry error when no registry configured',
+    async t => {
+      const { command } = await t.mockImport<
+        typeof import('../../src/commands/create.ts')
+      >('../../src/commands/create.ts')
+      unload()
+      const conf = {
+        positionals: ['react-app', 'my-app'],
+        options: { registries: {} },
+        get: (_key: string) => undefined,
+      } as unknown as LoadedConfig
+      await t.rejects(command(conf), /Missing registry configuration/)
+    },
+  )
+
   t.test('basic package transformation', async t => {
     let calledResolve = false
-    const mockOptions = { 'script-shell': 'this will be deleted' }
+    const mockOptions = {
+      'script-shell': 'this will be deleted',
+      registries: { npm: 'https://registry.npmjs.org' },
+    }
     const result = {
       status: 0,
       signal: null,
@@ -111,7 +159,9 @@ t.test('command', async t => {
 
   t.test('scoped package transformation', async t => {
     let calledResolve = false
-    const mockOptions = {}
+    const mockOptions = {
+      registries: { npm: 'https://registry.npmjs.org' },
+    }
     const result = {
       status: 0,
       signal: null,
@@ -167,7 +217,9 @@ t.test('command', async t => {
 
   t.test('scoped package without name', async t => {
     let calledResolve = false
-    const mockOptions = {}
+    const mockOptions = {
+      registries: { npm: 'https://registry.npmjs.org' },
+    }
     const result = {
       status: 0,
       signal: null,
@@ -206,7 +258,9 @@ t.test('command', async t => {
   })
 
   t.test('with allow-scripts option', async t => {
-    const mockOptions = {}
+    const mockOptions = {
+      registries: { npm: 'https://registry.npmjs.org' },
+    }
     const result = {
       status: 0,
       signal: null,
@@ -246,7 +300,9 @@ t.test('command', async t => {
 
   t.test('--yes flag auto-accepts prompts', async t => {
     let promptUsed: PromptFn | undefined
-    const mockOptions = {}
+    const mockOptions = {
+      registries: { npm: 'https://registry.npmjs.org' },
+    }
     const result = {
       status: 0,
       signal: null,
@@ -290,8 +346,67 @@ t.test('command', async t => {
     t.equal(answer, 'y', '--yes auto-accepts prompts')
   })
 
+  t.test('pkg-example', async t => {
+    let calledWith: string | undefined
+    const { command } = await t.mockImport<
+      typeof import('../../src/commands/create.ts')
+    >('../../src/commands/create.ts', {
+      '../../src/pkg-example.ts': {
+        createPkgExample: async (targetDir: string) => {
+          calledWith = targetDir
+        },
+      },
+      '@vltpkg/vlx': {
+        resolve: async () => {
+          throw new Error('vlx.resolve should not be called')
+        },
+      },
+      '../../src/exec-command.ts': {
+        views: {},
+        ExecCommand: class {
+          async run(): Promise<never> {
+            throw new Error('ExecCommand should not be used')
+          }
+        },
+      },
+    })
+    unload()
+    const conf = {
+      positionals: ['pkg-example', 'my-package'],
+      options: {},
+      get: (_key: string) => undefined,
+    } as unknown as LoadedConfig
+    const result = await command(conf)
+    t.equal(calledWith, resolve('my-package'))
+    t.strictSame(result, { targetDir: resolve('my-package') })
+  })
+
+  t.test('pkg-example defaults target dir to cwd', async t => {
+    let calledWith: string | undefined
+    const { command } = await t.mockImport<
+      typeof import('../../src/commands/create.ts')
+    >('../../src/commands/create.ts', {
+      '../../src/pkg-example.ts': {
+        createPkgExample: async (targetDir: string) => {
+          calledWith = targetDir
+        },
+      },
+    })
+    unload()
+    const conf = {
+      positionals: ['pkg-example'],
+      options: {},
+      get: (_key: string) => undefined,
+    } as unknown as LoadedConfig
+    const result = await command(conf)
+    t.equal(calledWith, resolve('.'))
+    t.strictSame(result, { targetDir: resolve('.') })
+  })
+
   t.test('when vlx.resolve returns undefined', async t => {
-    const mockOptions = {}
+    const mockOptions = {
+      registries: { npm: 'https://registry.npmjs.org' },
+    }
     const { command } = await t.mockImport<
       typeof import('../../src/commands/create.ts')
     >('../../src/commands/create.ts', {

--- a/src/cli-sdk/test/pkg-example.ts
+++ b/src/cli-sdk/test/pkg-example.ts
@@ -23,8 +23,7 @@ t.test(
   'copies packages/vlt contents into an empty target directory',
   async t => {
     const originalFetch = globalThis.fetch
-    globalThis.fetch = (async () =>
-      new Response(fakeRepoTar()))
+    globalThis.fetch = async () => new Response(fakeRepoTar())
     t.teardown(() => {
       globalThis.fetch = originalFetch
     })

--- a/src/cli-sdk/test/pkg-example.ts
+++ b/src/cli-sdk/test/pkg-example.ts
@@ -1,0 +1,73 @@
+import { readFile, readdir } from 'node:fs/promises'
+import { resolve } from 'node:path'
+import t from 'tap'
+import { makeTar } from '../../tar/test/fixtures/make-tar.ts'
+import { createPkgExample } from '../src/pkg-example.ts'
+
+const PREFIX = 'vltpkg-package-examples-abc1234'
+
+const fakeRepoTar = () => {
+  const pkgJson = JSON.stringify({ name: '@YOUR-ACCOUNT/my-package' })
+  return makeTar([
+    {
+      path: `${PREFIX}/packages/vlt/package.json`,
+      size: pkgJson.length,
+    },
+    pkgJson,
+    { path: `${PREFIX}/packages/npm/package.json`, size: 2 },
+    '{}',
+  ])
+}
+
+t.test(
+  'copies packages/vlt contents into an empty target directory',
+  async t => {
+    const originalFetch = globalThis.fetch
+    globalThis.fetch = (async () =>
+      new Response(fakeRepoTar()))
+    t.teardown(() => {
+      globalThis.fetch = originalFetch
+    })
+
+    const dir = t.testdir()
+    const target = resolve(dir, 'my-package')
+
+    await createPkgExample(target)
+
+    t.strictSame(
+      JSON.parse(
+        await readFile(resolve(target, 'package.json'), 'utf8'),
+      ),
+      { name: '@YOUR-ACCOUNT/my-package' },
+      'vlt example package.json was copied into the target dir',
+    )
+    t.strictSame(
+      await readdir(target),
+      ['package.json'],
+      'only the packages/vlt subset was copied, not other example packages',
+    )
+  },
+)
+
+t.test(
+  'refuses to overwrite a non-empty target directory',
+  async t => {
+    const dir = t.testdir({
+      'my-package': {
+        'existing-file.txt': 'do not touch me',
+      },
+    })
+    const target = resolve(dir, 'my-package')
+
+    await t.rejects(
+      createPkgExample(target),
+      /already exists and is not empty/,
+      'rejects before ever fetching or touching the filesystem',
+    )
+    t.strictSame(
+      await readdir(target),
+      ['existing-file.txt'],
+      'existing contents are left untouched',
+    )
+  },
+)

--- a/src/cli-sdk/test/pkg-example.ts
+++ b/src/cli-sdk/test/pkg-example.ts
@@ -1,31 +1,31 @@
-import { readFile, readdir } from 'node:fs/promises'
+import { readdir } from 'node:fs/promises'
 import { resolve } from 'node:path'
 import t from 'tap'
-import { makeTar } from '../../tar/test/fixtures/make-tar.ts'
-import { createPkgExample } from '../src/pkg-example.ts'
-
-const PREFIX = 'vltpkg-package-examples-abc1234'
-
-const fakeRepoTar = () => {
-  const pkgJson = JSON.stringify({ name: '@YOUR-ACCOUNT/my-package' })
-  return makeTar([
-    {
-      path: `${PREFIX}/packages/vlt/package.json`,
-      size: pkgJson.length,
-    },
-    pkgJson,
-    { path: `${PREFIX}/packages/npm/package.json`, size: 2 },
-    '{}',
-  ])
-}
 
 t.test(
-  'copies packages/vlt contents into an empty target directory',
+  'extracts packages/vlt from package-examples into an empty target directory',
   async t => {
-    const originalFetch = globalThis.fetch
-    globalThis.fetch = async () => new Response(fakeRepoTar())
-    t.teardown(() => {
-      globalThis.fetch = originalFetch
+    let versionChecked = false
+    let extractedSpec: unknown
+    let extractedTarget: unknown
+    const { createPkgExample } = await t.mockImport<
+      typeof import('../src/pkg-example.ts')
+    >('../src/pkg-example.ts', {
+      '@vltpkg/git': {
+        spawn: async (args: string[]) => {
+          t.strictSame(args, ['--version'])
+          versionChecked = true
+          return {}
+        },
+      },
+      '@vltpkg/package-info': {
+        PackageInfoClient: class {
+          async extract(spec: unknown, target: unknown) {
+            extractedSpec = spec
+            extractedTarget = target
+          }
+        },
+      },
     })
 
     const dir = t.testdir()
@@ -33,24 +33,64 @@ t.test(
 
     await createPkgExample(target)
 
-    t.strictSame(
-      JSON.parse(
-        await readFile(resolve(target, 'package.json'), 'utf8'),
-      ),
-      { name: '@YOUR-ACCOUNT/my-package' },
-      'vlt example package.json was copied into the target dir',
+    t.equal(versionChecked, true, 'checked for a working git binary')
+    t.equal(
+      extractedSpec,
+      'pkg-example@git+https://github.com/vltpkg/package-examples.git#main::path:packages/vlt',
+      'resolved the packages/vlt subpath from package-examples',
     )
-    t.strictSame(
-      await readdir(target),
-      ['package.json'],
-      'only the packages/vlt subset was copied, not other example packages',
-    )
+    t.equal(extractedTarget, target)
   },
 )
+
+t.test('throws a clear error when git is not available', async t => {
+  const { createPkgExample } = await t.mockImport<
+    typeof import('../src/pkg-example.ts')
+  >('../src/pkg-example.ts', {
+    '@vltpkg/git': {
+      spawn: async () => {
+        throw new Error('spawn git ENOENT')
+      },
+    },
+    '@vltpkg/package-info': {
+      PackageInfoClient: class {
+        async extract() {
+          throw new Error('should not be called')
+        }
+      },
+    },
+  })
+
+  const dir = t.testdir()
+  const target = resolve(dir, 'my-package')
+
+  await t.rejects(
+    createPkgExample(target),
+    /git is required to scaffold this example/,
+    'rejects with a tutorial-specific error instead of the raw spawn failure',
+  )
+})
 
 t.test(
   'refuses to overwrite a non-empty target directory',
   async t => {
+    const { createPkgExample } = await t.mockImport<
+      typeof import('../src/pkg-example.ts')
+    >('../src/pkg-example.ts', {
+      '@vltpkg/git': {
+        spawn: async () => {
+          throw new Error('should not be called')
+        },
+      },
+      '@vltpkg/package-info': {
+        PackageInfoClient: class {
+          async extract() {
+            throw new Error('should not be called')
+          }
+        },
+      },
+    })
+
     const dir = t.testdir({
       'my-package': {
         'existing-file.txt': 'do not touch me',
@@ -61,7 +101,7 @@ t.test(
     await t.rejects(
       createPkgExample(target),
       /already exists and is not empty/,
-      'rejects before ever fetching or touching the filesystem',
+      'rejects before ever checking git or touching the filesystem',
     )
     t.strictSame(
       await readdir(target),


### PR DESCRIPTION
## Summary

Implements feedback from demo https://github.com/vltpkg/vlt.io/issues/1889  to use `vlt create` as a CLI-based way for beginners to retrieve a publishable demo package for the ["publish your first package"]() tutorial.

- Adds `vlt create pkg-example [target-dir]`, a special-cased path in `vlt create` that scaffolds the `packages/vlt` example from [`vltpkg/package-examples/packages/vlt`](https://github.com/vltpkg/package-examples/tree/main/packages/vlt) into a target directory.

- Fixed a registry-gating bug found during verification: `create.ts`'s static `needsRegistry = true` would have blocked `pkg-example` for any user without a configured registry, before `command()` ever ran. Moved the check inline (after the `pkg-example` early return, following the `login.ts` precedent) so the generic `create-*` flow still requires a registry but `pkg-example` doesn't.
- Cleaned up `createPkgExample`'s scratch-dir handling (removed a redundant nested subdirectory — `unpack()` already tolerates its target existing) and deduped a repeated test fixture across `create.ts`'s test file.

## Test plan
- [x] `vlr test` — full `src/cli-sdk` suite green (2247/2248, 1 pre-existing unrelated todo), including `posttest` typecheck
- [x] `vlr format` / `vlr lint` — clean
- [x] Manual smoke test against the real `vltpkg/package-examples` repo: correct scaffold, `@YOUR-ACCOUNT` placeholder intact, conflict-check rejects non-empty target dirs, both `json` and `human` view output verified

