### PR TITLE
Reduce disk write contention by reducing VLT_TAR_WRITE_LANES to 8

### DIFF
--- a/src/tar/src/unpack.ts
+++ b/src/tar/src/unpack.ts
@@ -93,7 +93,7 @@ const entryKey = (p: string) => (foldKeys ? p.toLowerCase() : p)
 // once; a per-tarball pool would multiply in-flight writeFile fds.
 const parseWriteLanes = (raw: string | undefined): number => {
   const n = Number(raw)
-  return Number.isFinite(n) && n >= 1 ? Math.floor(n) : 8;
+  return Number.isFinite(n) && n >= 1 ? Math.floor(n) : 8
 }
 const writeLaneLimit = parseWriteLanes(
   process.env.VLT_TAR_WRITE_LANES,

--- a/src/tar/src/unpack.ts
+++ b/src/tar/src/unpack.ts
@@ -93,7 +93,7 @@ const entryKey = (p: string) => (foldKeys ? p.toLowerCase() : p)
 // once; a per-tarball pool would multiply in-flight writeFile fds.
 const parseWriteLanes = (raw: string | undefined): number => {
   const n = Number(raw)
-  return Number.isFinite(n) && n >= 1 ? Math.floor(n) : 64
+  return Number.isFinite(n) && n >= 1 ? Math.floor(n) : 8;
 }
 const writeLaneLimit = parseWriteLanes(
   process.env.VLT_TAR_WRITE_LANES,


### PR DESCRIPTION
Parallel writes with a global maximum (specified with `VLT_TAR_WRITE_LANES`)
was added in #1745.

It's defaulted to 64 and I think it's been a contributor to me seeing
worse performance both on my 64 core laptop and Github's 4 vCPU's CI
runner.

Ultimately every lane results in a writeFile, and very writeFile resolves
onto libuv's threadpool, which defaults to 4 threads. So 64 lanes queue
onto 4 actual workers — the lane count controls how deep that queue gets,
not how much work happens at once.

I don't have a great way to provide benchmarks because my test machines
are noisy, but if it's a requirement for merging I can follow this up in
a few weeks once I'm home and my server is back online, but at 64 I
occasionally `vlt ci` runs double in length, and on my machine it was a
more consistent (and less significant) 10% slower.

Also, there's diminishing returns when doing lots of parallel writes to SSDs, and 64 sounds high to me. Might be better with RAID0 situations, but I assume we want to min/max for consumer and CI hardware.