### PR TITLE
fix: remove /:slug -> /api/markdown/:slug Accept-header redirect

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 tmp
 
 /.turbo
+/.vercel
 /docs
 /node_modules
 # install-generated skill mounts (vltpkg/vltpkg#1540)

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "url": "git+https://github.com/vltpkg/vltpkg.git"
   },
   "author": "vlt technology inc. <support@vlt.sh> (http://vlt.sh)",
+  "workspaces": ["src/*", "infra/*", "www/*"],
   "devDependencies": {
     "@eslint/js": "catalog:",
     "@types/node": "catalog:",

--- a/vercel.json
+++ b/vercel.json
@@ -27,18 +27,6 @@
       "source": "/migration/from-npm",
       "destination": "/cli/migration/from-npm",
       "permanent": true
-    },
-    {
-      "source": "/:slug((?!api/)(?!.*\\$).*)",
-      "has": [
-        {
-          "type": "header",
-          "key": "accept",
-          "value": "(.*)text/markdown(.*)"
-        }
-      ],
-      "destination": "/api/markdown/:slug",
-      "permanent": false
     }
   ]
 }

--- a/vercel.json
+++ b/vercel.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
-  "ignoreCommand": "git cat-file -e \"$VERCEL_GIT_PREVIOUS_SHA\" 2>/dev/null && git diff --quiet \"$VERCEL_GIT_PREVIOUS_SHA\" \"$VERCEL_GIT_COMMIT_SHA\" -- www/docs/ || exit 1",
+  "ignoreCommand": "git cat-file -e \"$VERCEL_GIT_PREVIOUS_SHA\" 2>/dev/null && git diff --quiet \"$VERCEL_GIT_PREVIOUS_SHA\" \"$VERCEL_GIT_COMMIT_SHA\" -- www/docs/ vercel.json || exit 1",
   "headers": [
     {
       "source": "/",

--- a/www/docs/astro.config.mts
+++ b/www/docs/astro.config.mts
@@ -37,6 +37,9 @@ export default defineConfig({
     ],
   },
   output: 'server',
+  // Requires the Vercel project's Output Directory setting to be unset/auto —
+  // pointing it at a subpath (e.g. .vercel/output or .vercel/output/static)
+  // breaks the Build Output API's function/routing detection.
   adapter: vercel(),
   integrations: [
     starlight({

--- a/www/docs/package.json
+++ b/www/docs/package.json
@@ -68,7 +68,7 @@
   },
   "scripts": {
     "astro": "astro",
-    "build": "astro check && astro build",
+    "build": "astro check && astro build && node --experimental-strip-types --no-warnings ./scripts/relocate-vercel-output.mts",
     "dev": "astro dev",
     "dev:rebuild": "VLT_DOCS_REBUILD=true astro dev",
     "format": "prettier --write . --log-level warn --ignore-path ../../.prettierignore --cache",

--- a/www/docs/scripts/relocate-vercel-output.mts
+++ b/www/docs/scripts/relocate-vercel-output.mts
@@ -11,8 +11,8 @@
  * guessing a static `dist` output and the deploy fails or serves
  * an incomplete site (functions/routes silently dropped).
  */
-import { existsSync, rmSync, renameSync } from 'node:fs'
-import { resolve } from 'node:path'
+import { existsSync, mkdirSync, rmSync, renameSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
 
 const from = resolve(import.meta.dirname, '../.vercel/output')
 const to = resolve(import.meta.dirname, '../../../.vercel/output')
@@ -22,6 +22,7 @@ if (!existsSync(from)) {
   process.exit(1)
 }
 
+mkdirSync(dirname(to), { recursive: true })
 rmSync(to, { recursive: true, force: true })
 renameSync(from, to)
 console.log(`relocate-vercel-output: moved output to ${to}`)

--- a/www/docs/scripts/relocate-vercel-output.mts
+++ b/www/docs/scripts/relocate-vercel-output.mts
@@ -1,0 +1,27 @@
+/**
+ * Moves the Astro Vercel adapter's build output to the repo root.
+ *
+ * `@astrojs/vercel` always writes `.vercel/output` next to
+ * `astro.config.mts` (i.e. `www/docs/.vercel/output`). The Vercel
+ * project's Root Directory is the repo root (required so the
+ * typedoc step can read sibling workspaces like `src/graph`), and
+ * Vercel's Build Output API auto-detection only looks for
+ * `.vercel/output` at Root Directory — it does not search nested
+ * directories. Without this relocation, Vercel falls back to
+ * guessing a static `dist` output and the deploy fails or serves
+ * an incomplete site (functions/routes silently dropped).
+ */
+import { existsSync, rmSync, renameSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+const from = resolve(import.meta.dirname, '../.vercel/output')
+const to = resolve(import.meta.dirname, '../../../.vercel/output')
+
+if (!existsSync(from)) {
+  console.error(`relocate-vercel-output: nothing found at ${from}`)
+  process.exit(1)
+}
+
+rmSync(to, { recursive: true, force: true })
+renameSync(from, to)
+console.log(`relocate-vercel-output: moved output to ${to}`)


### PR DESCRIPTION
## Summary
- Removes the Accept-header redirect in `vercel.json` that was causing `/api/markdown/*` (and the "Copy as markdown" button) to 404 in production — the markdown route itself already handles content negotiation.
- Fixes the `ignoreCommand` diff path so it also watches root `vercel.json`, not just `www/docs/` — previously, changes to root `vercel.json` (like the fix above) were silently skipped by git-triggered deploys.
- Attempted fix at a deeper, previously-undiagnosed deployment bug: `@astrojs/vercel` always writes its Build Output API output to `www/docs/.vercel/output`, but this project's Vercel Root Directory is the repo root (required so the typedoc step can read sibling workspaces like `src/graph`). Vercel's Build Output API auto-detection only looks for `.vercel/output` at Root Directory, so it never found the adapter's output — depending on the project's Output Directory setting, this caused either a full build failure, total 404s on every route, or a partial deployment where static pages worked but all serverless routes (including `/api/markdown/*`) 404'd. Adds a build step (`www/docs/scripts/relocate-vercel-output.mts`) that moves the adapter's output to the repo root after build, matching where Vercel's auto-detection actually looks.

## Test plan
- [ ] Confirm the deploy for this branch serves `/` and nested pages with 200s
- [ ] Confirm `/api/markdown/:slug` and the "Copy as markdown" button work end-to-end
- [ ] Merge and verify the same on `docs.vlt.io`

## Known issue / follow-ups (not fixed in this PR)
- `/api/markdown/:slug` still 500s at runtime (`Cannot find package 'react'`) once the routing/output bugs above are fixed. Root cause isolated to `@astrojs/vercel@8.2.11`: it de-nests the server entry to `dist/server/...` but copies traced dependencies preserving their original repo-relative paths (via vlt's virtual store), so copied files never land on Node's actual module-resolution ancestor chain. `includeFiles` and `vite.ssr.noExternal` workarounds were tried and rejected (bloat / duplicate-React-instance crashes respectively).
- Two candidate follow-ups, not yet started:
  1. **Upgrade `@astrojs/vercel`** (currently pinned `8.2.11`, latest `11.0.8` — three majors behind). Monorepo/Build-Output-API handling has evolved significantly across that span. Should be scoped as its own task: check peer-dependency requirements against Astro core at each major version (a core bump may be required or may independently help — unclear, treat as part of the same investigation, not a separate decision), bump on an isolated branch, and re-validate with the local build→deploy→curl loop established in this PR before merging.
  2. **Decouple typedoc generation of `src/*` from `www/docs`'s own build** — the more foundational fix. If typedoc content were generated as an independent step rather than `www/docs`'s build reaching across the monorepo live, Root Directory could move to `www/docs` to match what `@astrojs/vercel` expects natively, likely eliminating the `workspaces` field fix, `relocate-vercel-output.mts`, and probably the `react` tracing bug — all three stem from the same Root-Directory-mismatch root cause. Bigger scope: needs a real design for how generated content gets produced/synced into `www/docs/src/content/` (or a fetched build artifact).