### PR TITLE
fix(cli) project vlt.json settings override user-level vlt.json settings

### DIFF
--- a/src/cli-sdk/src/commands/login.ts
+++ b/src/cli-sdk/src/commands/login.ts
@@ -1,4 +1,5 @@
 import { RegistryClient } from '@vltpkg/registry-client'
+import { configWriteTarget } from '../config/index.ts'
 import { commandUsage } from '../config/usage.ts'
 import { missingRegistryError } from '../require-registry.ts'
 import type { CommandFn, CommandUsage } from '../index.ts'
@@ -13,7 +14,9 @@ export const usage: CommandUsage = () =>
                   There is no default registry, so a registry must either
                   already be configured or be provided with
                   \`--registry=<url>\`. On success the registry is written to
-                  the project's \`vlt.json\`.`,
+                  the project's \`vlt.json\`, so that it applies to this
+                  project only. Pass \`--config=user\` to configure it for
+                  every project instead.`,
     options: {
       registry: {
         value: '<url>',
@@ -23,6 +26,12 @@ export const usage: CommandUsage = () =>
       identity: {
         value: '<name>',
         description: 'Identity namespace used to store auth tokens.',
+      },
+      config: {
+        value: '<user | project>',
+        description:
+          'Which config file to write the registry to. Defaults to ' +
+          '`project`.',
       },
     },
   })
@@ -35,5 +44,7 @@ export const command: CommandFn<void> = async conf => {
   const rc = new RegistryClient(conf.options)
   await rc.login(registry)
   // persist the registry so subsequent commands are configured
-  await conf.addConfigToFile('project', { registry })
+  await conf.addConfigToFile(configWriteTarget(conf, 'project'), {
+    registry,
+  })
 }

--- a/src/cli-sdk/src/commands/setup.ts
+++ b/src/cli-sdk/src/commands/setup.ts
@@ -2,6 +2,8 @@ import { error } from '@vltpkg/error-cause'
 import { RegistryClient } from '@vltpkg/registry-client'
 import { defaultRegistries } from '@vltpkg/spec'
 import { createInterface } from 'node:readline/promises'
+import { configWriteTarget } from '../config/index.ts'
+import { registrySelectionFields } from '../config/merge-layers.ts'
 import { commandUsage } from '../config/usage.ts'
 import { stdout } from '../output.ts'
 import type { CommandFn, CommandUsage } from '../index.ts'
@@ -51,6 +53,11 @@ export type SetupResult = {
   which: 'user' | 'project'
   /** the alias -> url map that was staged into config */
   registries: Record<string, string>
+  /**
+   * set when the config we wrote to is outranked for registry selection by
+   * the project's `vlt.json`, so the result won't take effect here.
+   */
+  shadowedByProject?: boolean
 }
 
 export const views = {
@@ -64,6 +71,14 @@ export const views = {
     ]
     for (const [name, url] of Object.entries(result.registries)) {
       lines.push(`  ${name} -> ${url}`)
+    }
+    if (result.shadowedByProject) {
+      lines.push(
+        '',
+        `Note: this project's vlt.json configures its own registries, and`,
+        'project config takes precedence. Re-run with `--config=project`',
+        'to configure this project instead.',
+      )
     }
     lines.push(
       '',
@@ -108,8 +123,7 @@ export const usage: CommandUsage = () =>
 
 export const command: CommandFn<SetupResult> = async conf => {
   const yes = !!conf.get('yes')
-  const which: 'user' | 'project' =
-    conf.get('config') === 'project' ? 'project' : 'user'
+  const which = configWriteTarget(conf, 'user')
 
   let rl: ReturnType<typeof createInterface> | undefined
   const ask = async (question: string): Promise<string> => {
@@ -144,15 +158,22 @@ export const command: CommandFn<SetupResult> = async conf => {
       registries[name] = accountRegistryURL(account, name)
     }
 
-    // 3. merge any user-supplied registry aliases (skip built-in defaults)
+    // 3. merge in registry aliases supplied for this invocation. aliases
+    // that came from a config file are left where they are: copying them
+    // would turn a project-local alias into a global one (or vice versa).
     const builtinRegistries = defaultRegistries as Record<
       string,
       string
     >
+    const fileRegistries: Record<string, string> = {
+      ...conf.layers.user?.registries,
+      ...conf.layers.project?.registries,
+    }
     for (const [name, url] of Object.entries(
       conf.options.registries,
     )) {
       if (builtinRegistries[name] === url) continue
+      if (fileRegistries[name] === url) continue
       registries[name] = normalizeRegistryURL(url)
     }
 
@@ -206,7 +227,21 @@ export const command: CommandFn<SetupResult> = async conf => {
     // 6. persist the staged registries (merged, not clobbered)
     await conf.addConfigToFile(which, { registries })
 
-    return { account, which, registries }
+    // writing the user config from inside a project that configures its own
+    // registries has no effect here, so say so rather than looking like it
+    // worked.
+    const shadowedByProject =
+      which === 'user' &&
+      registrySelectionFields.some(
+        f => f in (conf.layers.project ?? {}),
+      )
+
+    return {
+      account,
+      which,
+      registries,
+      ...(shadowedByProject ? { shadowedByProject } : undefined),
+    }
   } finally {
     if (rl) {
       rl.close()

--- a/src/cli-sdk/src/config/definition.ts
+++ b/src/cli-sdk/src/config/definition.ts
@@ -161,14 +161,22 @@ export const definition = j
    */
   .heading('Configuration')
   .description(
-    `If a \`vlt.json\` file is present in the root of the current project,
-     then that will be used as a source of configuration information.
+    `The \`vlt.json\` file in the XDG specified config directory is loaded
+     first, and then the \`vlt.json\` file in the root of the current
+     project, if present, is layered on top of it.
 
-     Next, the \`vlt.json\` file in the XDG specified config directory
-     will be checked, and loaded for any fields not set in the local project.
+     Scalar values are overridden by the innermost layer that sets them.
+     Object type values are merged together key by key. Set a field, or a
+     key within an object field, to \`null\` in the JSON configuration to
+     explicitly remove it.
 
-     Object type values will be merged together. Set a field to \`null\` in
-     the JSON configuration to explicitly remove it.
+     Registry *selection* is an exception, since \`--registry\` outranks any
+     \`--registries\` alias. A layer that sets any of \`registry\`,
+     \`registries\`, or \`default-registry-alias\` owns selection: the
+     \`registry\` and \`default-registry-alias\` it does *not* set are
+     dropped, rather than inherited from an outer layer. So a project that
+     configures its own registry is never sent to the user-level one, while
+     the aliases in the user config stay addressable by name.
 
      Command-specific fields may be set in a nested \`command\` object that
      overrides any options defined at the top level.
@@ -821,6 +829,24 @@ export const definition = j
       description: 'Show all commands, bins, and flags',
     },
   })
+
+/**
+ * The pristine `default` of every known config field, captured here at
+ * module load, before anything can call `jack.setConfigValues()`.
+ *
+ * Config layers are applied by overwriting jackspeak's defaults, and
+ * `setConfigValues()` can only set them. So when a layer stops setting a
+ * field (or removes it with `null`), the definitional default has to be
+ * put back explicitly, otherwise a value left behind by a previous apply
+ * would leak through.
+ */
+export const defaultValues: Record<string, unknown> =
+  Object.fromEntries(
+    Object.entries(definition.toJSON()).map(([field, def]) => [
+      field,
+      def.default,
+    ]),
+  )
 
 export const getSortedCliOptions = () => {
   const defs = definition.toJSON()

--- a/src/cli-sdk/src/config/index.ts
+++ b/src/cli-sdk/src/config/index.ts
@@ -2,8 +2,8 @@
  * Module that handles all vlt configuration needs
  *
  * Project-level configs are set in a `vlt.json` file in the local project
- * if present. This will override the user-level configs in the appropriate
- * XDG config path.
+ * if present, and are layered over the user-level configs in the appropriate
+ * XDG config path. See `./merge-layers.ts` for the layering rules.
  *
  * Command-specific configuration can be specified by putting options in a
  * field in the `command` object. For example:
@@ -43,11 +43,13 @@ import type { Commands, RecordField } from './definition.ts'
 import {
   commands,
   definition,
+  defaultValues,
   getCommand,
   isRecordField,
   recordFields,
 } from './definition.ts'
 import { merge } from './merge.ts'
+import { cloneLayer, mergeLayers } from './merge-layers.ts'
 export {
   commands,
   definition,
@@ -89,6 +91,32 @@ export type PairsAsRecords = ConfigOptionsNoExtras & {
   }
 }
 
+/**
+ * One `vlt.json` file's `config` object, in record form. Every field is
+ * optional, since a config file only sets what it sets.
+ */
+export type ConfigFileLayer = Partial<PairsAsRecords>
+
+/**
+ * `registries` alias names are used as spec prefixes, where `~` is
+ * reserved, and an empty name has nothing to prefix with.
+ */
+const assertRegistryKeys = (registries: unknown, file: string) => {
+  if (!registries || typeof registries !== 'object') return
+  const obj =
+    Array.isArray(registries) ?
+      reducePairs(registries as string[])
+    : (registries as RecordPairs)
+  for (const key of Object.keys(obj)) {
+    if (key === '' || key.includes('~')) {
+      throw error('Reserved character found in registries name', {
+        path: file,
+        found: key,
+      })
+    }
+  }
+}
+
 export const pairsToRecords = (
   obj:
     NonNullable<ConfigFileData> | OptionsResults<ConfigDefinitions>,
@@ -126,7 +154,14 @@ export const recordsToPairs = (obj: RecordPairs): RecordPairs => {
       .map(([k, v]) => [
         k,
         k === 'command' && v && typeof v === 'object' ?
-          recordsToPairs(v as RecordPairs)
+          // each command's own block gets converted too, mirroring
+          // pairsToRecords
+          Object.fromEntries(
+            Object.entries(v).map(([k, v]) => [
+              k,
+              recordsToPairs(v as RecordPairs),
+            ]),
+          )
         : (
           !v ||
           typeof v !== 'object' ||
@@ -460,9 +495,17 @@ export class Config {
     which: WhichConfig,
     values: NonNullable<ConfigFileData>,
   ) {
+    // normalize both sides to record form first, so that a record field
+    // written as a `key=value` list in an existing file is still merged key
+    // by key, rather than replaced wholesale.
     return this.writeConfigFile(
       which,
-      merge((await this.#maybeLoadConfigFile(which)) ?? {}, values),
+      merge(
+        pairsToRecords(
+          (await this.#maybeLoadConfigFile(which)) ?? {},
+        ),
+        pairsToRecords(values),
+      ),
     )
   }
 
@@ -488,57 +531,84 @@ export class Config {
       })
     }
 
-    const { command, ...values } = recordsToPairs(c as RecordPairs)
+    const { command, ...values } = c as RecordPairs
 
-    // Validate registries keys don't contain reserved ~ character
-    const registries = (c as RecordPairs).registries
-    if (registries && typeof registries === 'object') {
-      const registriesObj =
-        Array.isArray(registries) ?
-          reducePairs(registries)
-        : registries
-      for (const key of Object.keys(registriesObj)) {
-        if (key === '' || key.includes('~')) {
-          throw error('Reserved character found in registries name', {
-            path: file,
-            found: key,
-          })
+    assertRegistryKeys(values.registries, file)
+    if (command && typeof command === 'object') {
+      for (const opts of Object.values(command)) {
+        if (opts && typeof opts === 'object') {
+          assertRegistryKeys((opts as RecordPairs).registries, file)
         }
       }
     }
 
-    if (command) {
-      for (const [c, opts] of Object.entries(command)) {
-        const cmd = getCommand(c)
-        if (cmd && opts && typeof opts === 'object') {
-          // Validate registries in command-specific config
-          const cmdRegistries = (opts as RecordPairs).registries
-          if (cmdRegistries && typeof cmdRegistries === 'object') {
-            const cmdRegistriesObj =
-              Array.isArray(cmdRegistries) ?
-                reducePairs(cmdRegistries)
-              : cmdRegistries
-            for (const key of Object.keys(cmdRegistriesObj)) {
-              if (key === '' || key.includes('~')) {
-                throw error(
-                  'Reserved character found in registries name',
-                  {
-                    path: file,
-                    found: key,
-                  },
-                )
-              }
-            }
-          }
+    // validate this layer on its own, so that an invalid value is blamed on
+    // the file it actually came from. `mergeLayers` on a single layer just
+    // strips the `null`s, which mean "remove this field" rather than being
+    // a value jack should ever see.
+    const layer = cloneLayer(pairsToRecords(c as ConfigFileData))
+    const { command: _cmd, ...single } = mergeLayers([layer])
+    try {
+      this.jack.validate(recordsToPairs(single))
+    } catch (er) {
+      /* c8 ignore next - for TS */
+      if (er instanceof Error) {
+        // jack only attaches the source path when going through
+        // setConfigValues(), and the CLI's "Problem in Config File" banner
+        // keys off it.
+        /* c8 ignore next - jack always throws with a cause object */
+        const cause = typeof er.cause === 'object' ? er.cause : {}
+        er.cause = { ...cause, path: file }
+      }
+      throw er
+    }
 
-          this.commandValues[cmd] = merge<ConfigData>(
-            this.commandValues[cmd] ?? {},
-            opts as ConfigData,
-          )
-        }
+    this.#layers[file === find('user') ? 'user' : 'project'] = layer
+    this.#applyLayers()
+  }
+
+  /**
+   * The raw config data from each `vlt.json` file, normalized to record
+   * form, before the layers are merged together. `undefined` for a layer
+   * with no file, or a file with no `config` field.
+   */
+  get layers(): Readonly<{ [k in WhichConfig]?: ConfigFileLayer }> {
+    return this.#layers
+  }
+
+  #layers: { [k in WhichConfig]?: ConfigFileLayer } = {}
+
+  /**
+   * Recompute the jack defaults and {@link Config#commandValues} from
+   * {@link Config#layers}.
+   *
+   * Everything is derived from `#layers`, and every known field is applied,
+   * so this is idempotent: re-reading a config file (which
+   * `addConfigToFile` and `deleteConfigKeys` both do) can't stack the user
+   * layer back on top of the project layer, and a field a layer stopped
+   * setting goes back to its definitional default.
+   */
+  #applyLayers() {
+    const { command, ...values } = mergeLayers([
+      this.#layers.user,
+      this.#layers.project,
+    ])
+
+    this.commandValues = {}
+    for (const [c, opts] of Object.entries(command ?? {})) {
+      const cmd = getCommand(c)
+      if (cmd && opts && typeof opts === 'object') {
+        this.commandValues[cmd] = opts as ConfigData
       }
     }
-    this.jack.setConfigValues(values, file)
+
+    const pairs = recordsToPairs(values)
+    const applied: RecordPairs = {}
+    for (const [field, dflt] of Object.entries(defaultValues)) {
+      applied[field] = field in pairs ? pairs[field] : dflt
+    }
+    this.jack.setConfigValues(applied)
+    this.#options = undefined
   }
 
   /**
@@ -546,7 +616,17 @@ export class Config {
    * loaded, or undefined if not.
    */
   async #maybeLoadConfigFile(whichConfig: WhichConfig) {
-    return load('config', this.#validator, whichConfig)
+    const data = load('config', this.#validator, whichConfig)
+    if (
+      data === undefined &&
+      this.#layers[whichConfig] !== undefined
+    ) {
+      // the file (or its `config` field) went away, so the validator never
+      // ran. drop the layer it left behind.
+      delete this.#layers[whichConfig]
+      this.#applyLayers()
+    }
+    return data
   }
 
   /**
@@ -733,3 +813,18 @@ export type ParsedConfig = Config & {
  * A fully loaded {@link Config} object
  */
 export type LoadedConfig = ParsedConfig
+
+/**
+ * Which `vlt.json` a command that persists settings should write to.
+ *
+ * `--config=user` and `--config=project` are explicit. Anything else means
+ * the caller's own default, since `--config` also takes `all` (its default,
+ * meaningful only for `vlt config` reads).
+ */
+export const configWriteTarget = (
+  conf: Pick<LoadedConfig, 'get'>,
+  fallback: WhichConfig,
+): WhichConfig => {
+  const which = conf.get('config')
+  return which === 'user' || which === 'project' ? which : fallback
+}

--- a/src/cli-sdk/src/config/merge-layers.ts
+++ b/src/cli-sdk/src/config/merge-layers.ts
@@ -1,0 +1,154 @@
+/**
+ * Merge the `config` objects found in the user and project `vlt.json`
+ * files into the single set of values that gets applied to the
+ * {@link https://npmjs.com/jackspeak | jackspeak} definition.
+ *
+ * Layers are supplied outermost first (user, then project), and follow the
+ * rules documented in `vlt help` and at
+ * <https://docs.vlt.sh/cli/configuring>:
+ *
+ * - Scalar fields come from the innermost layer that sets them.
+ * - Object (`key=value` record) fields are merged key by key.
+ * - A `null` value removes a field, or a single key within a record field.
+ * - Registry *selection* belongs to a single layer, see
+ *   {@link registrySelectionFields}.
+ *
+ * Note that this operates on the record form of a config object (the shape
+ * it has in `vlt.json`), not on jackspeak's `key=value` string lists, so
+ * record fields can be merged per key. Run values through
+ * `pairsToRecords` first.
+ * @module
+ */
+
+import { isRecordField } from './definition.ts'
+
+/** One config layer, in record (not `key=value` pair) form. */
+export type ConfigLayer = Record<string, unknown>
+
+/**
+ * The fields that *select* which registry is used, as opposed to the
+ * catalogs of aliases that can be selected from.
+ */
+export const registrySelectors = [
+  'registry',
+  'default-registry-alias',
+] as const
+
+/**
+ * When a layer sets any of these, that layer owns registry selection: the
+ * {@link registrySelectors} it does *not* set are removed from the merged
+ * result, rather than inherited from an outer layer.
+ *
+ * Without this, a `registry` in the user `vlt.json` would outrank a
+ * project's `registries.npm`, since the `registry` scalar beats any alias
+ * in `requireRegistry()`. The alias catalogs are still merged, so aliases
+ * configured at the user level stay addressable by name.
+ *
+ * Deliberately narrow: `scoped-registries` and `jsr-registries` are purely
+ * additive, so adding one of those in a project must not drop the user's
+ * default registry.
+ */
+export const registrySelectionFields = [
+  'registry',
+  'registries',
+  'default-registry-alias',
+] as const
+
+const isObj = (v: unknown): v is Record<string, unknown> =>
+  !!v && typeof v === 'object' && !Array.isArray(v)
+
+/**
+ * Deep copy of a config layer, preserving `null` values.
+ *
+ * Layers are held onto for the life of the `Config` object, but the objects
+ * nested in them are shared with the `@vltpkg/vlt-json` cache, which
+ * `deleteConfigKeys` mutates in place. Copying keeps a stored layer an
+ * accurate snapshot of what was read.
+ */
+const cloneValue = (v: unknown): unknown =>
+  Array.isArray(v) ? (v as unknown[]).map(x => cloneValue(x))
+  : isObj(v) ?
+    Object.fromEntries(
+      Object.entries(v).map(([k, x]) => [k, cloneValue(x)]),
+    )
+  : v
+
+export const cloneLayer = <T>(data: T): T => cloneValue(data) as T
+
+/**
+ * Fold one record field's keys into the value from the outer layers.
+ * `null` removes a key. Returns `undefined` when nothing is left, so that
+ * the field falls back to its definitional default instead of applying an
+ * empty record.
+ */
+const mergeRecord = (
+  base: unknown,
+  add: Record<string, unknown>,
+): Record<string, unknown> | undefined => {
+  const result: Record<string, unknown> =
+    isObj(base) ? { ...base } : {}
+  for (const [k, v] of Object.entries(add)) {
+    if (v === null) delete result[k]
+    else result[k] = v
+  }
+  return Object.keys(result).length ? result : undefined
+}
+
+/**
+ * Fold the `command` object in, merging each command's block with the same
+ * rules as the top level.
+ */
+const mergeCommands = (
+  base: unknown,
+  add: Record<string, unknown>,
+): Record<string, unknown> | undefined => {
+  const result: Record<string, unknown> =
+    isObj(base) ? { ...base } : {}
+  for (const [cmd, opts] of Object.entries(add)) {
+    if (opts === null) delete result[cmd]
+    else if (isObj(opts)) {
+      result[cmd] = mergeLayers([
+        isObj(result[cmd]) ? result[cmd] : undefined,
+        opts,
+      ])
+    }
+  }
+  return Object.keys(result).length ? result : undefined
+}
+
+/**
+ * Merge config layers, outermost first. Layers are never mutated.
+ */
+export const mergeLayers = (
+  layers: (ConfigLayer | undefined)[],
+): ConfigLayer => {
+  const result: ConfigLayer = {}
+  for (const layer of layers) {
+    if (!isObj(layer)) continue
+    for (const [k, v] of Object.entries(layer)) {
+      if (k === 'command') {
+        const merged =
+          isObj(v) ? mergeCommands(result.command, v) : undefined
+        if (merged) result.command = merged
+        else delete result.command
+      } else if (v === null) {
+        delete result[k]
+      } else if (isRecordField(k) && isObj(v)) {
+        const merged = mergeRecord(result[k], v)
+        if (merged) result[k] = merged
+        else delete result[k]
+      } else {
+        result[k] = v
+      }
+    }
+
+    // the innermost layer that configures a registry at all owns which
+    // registry is selected.
+    if (registrySelectionFields.some(f => f in layer)) {
+      for (const f of registrySelectors) {
+        if (!(f in layer)) delete result[f]
+      }
+    }
+  }
+  return result
+}

--- a/src/cli-sdk/tap-snapshots/test/commands/login.ts.test.cjs
+++ b/src/cli-sdk/tap-snapshots/test/commands/login.ts.test.cjs
@@ -14,7 +14,7 @@ vlt login
 
 Authenticate against a registry, and store the token in the appropriate config file for later use.
 
-There is no default registry, so a registry must either already be configured or be provided with \`--registry=<url>\`. On success the registry is written to the project's \`vlt.json\`.
+There is no default registry, so a registry must either already be configured or be provided with \`--registry=<url>\`. On success the registry is written to the project's \`vlt.json\`, so that it applies to this project only. Pass \`--config=user\` to configure it for every project instead.
 
 ## Options
 
@@ -32,6 +32,14 @@ Identity namespace used to store auth tokens.
 
 \`\`\`
 --identity=<name>
+\`\`\`
+
+### config
+
+Which config file to write the registry to. Defaults to \`project\`.
+
+\`\`\`
+--config=<user | project>
 \`\`\`
 
 `

--- a/src/cli-sdk/tap-snapshots/test/config/index.ts.test.cjs
+++ b/src/cli-sdk/tap-snapshots/test/config/index.ts.test.cjs
@@ -5,7 +5,7 @@
  * Make sure to inspect the output below.  Do not ignore changes!
  */
 'use strict'
-exports[`test/config/index.ts > TAP > load both configs, project writes over userconfig > formatted options uses custom inspect 1`] = `
+exports[`test/config/index.ts > TAP > load both configs, layers merge with project taking precedence > formatted options uses custom inspect 1`] = `
 {
   'git-hosts': {
     github: 'https://github',
@@ -14,7 +14,7 @@ exports[`test/config/index.ts > TAP > load both configs, project writes over use
     gist: 'git+ssh://git@gist.github.com/$1.git',
     asdfasdf: 'https://example.com'
   },
-  projectRoot: '{CWD}/.tap/fixtures/test-config-index.ts-load-both-configs-project-writes-over-userconfig',
+  projectRoot: '{CWD}/.tap/fixtures/test-config-index.ts-load-both-configs-layers-merge-with-project-taking-precedence',
   catalog: undefined,
   catalogs: undefined,
   'jsr-registries': { jsr: 'https://npm.jsr.io/' },

--- a/src/cli-sdk/test/commands/login.ts
+++ b/src/cli-sdk/test/commands/login.ts
@@ -16,22 +16,39 @@ const { usage, command } = await t.mockImport<
 
 t.matchSnapshot(usage().usageMarkdown())
 
-t.test('logs in and persists the registry', async t => {
-  const added: [string, Record<string, unknown>][] = []
-  await command({
+const makeConf = (
+  config: string,
+  added: [string, Record<string, unknown>][],
+) =>
+  ({
     options: { registry: 'registry' },
+    get: (k: string) => (k === 'config' ? config : undefined),
     addConfigToFile: async (
       which: string,
       values: Record<string, unknown>,
     ) => {
       added.push([which, values])
     },
-  } as unknown as LoadedConfig)
+  }) as unknown as LoadedConfig
+
+t.test('logs in and persists the registry', async t => {
+  const added: [string, Record<string, unknown>][] = []
+  await command(makeConf('all', added))
   t.equal(loginCalled, 'registry')
   t.strictSame(
     added,
     [['project', { registry: 'registry' }]],
     'writes the registry to the project vlt.json',
+  )
+})
+
+t.test('--config=user writes the user config', async t => {
+  const added: [string, Record<string, unknown>][] = []
+  await command(makeConf('user', added))
+  t.strictSame(
+    added,
+    [['user', { registry: 'registry' }]],
+    'writes the registry to the user vlt.json',
   )
 })
 

--- a/src/cli-sdk/test/commands/setup.ts
+++ b/src/cli-sdk/test/commands/setup.ts
@@ -43,6 +43,10 @@ const makeConf = (
     config?: string
     positionals?: string[]
     registries?: Record<string, string>
+    layers?: {
+      user?: Record<string, unknown>
+      project?: Record<string, unknown>
+    }
   },
   added: Added[],
 ): LoadedConfig =>
@@ -53,6 +57,7 @@ const makeConf = (
       : k === 'config' ? opts.config
       : undefined,
     options: { registries: opts.registries ?? {} },
+    layers: opts.layers ?? {},
     addConfigToFile: async (
       which: string,
       values: Record<string, unknown>,
@@ -91,6 +96,15 @@ t.test('url + view helpers', async t => {
       registries: { npm: 'u', main: 'm' },
     }),
     /2 registry aliases/,
+  )
+  t.match(
+    mod.views.human({
+      account: 'acme',
+      which: 'user',
+      registries: { npm: 'u' },
+      shadowedByProject: true,
+    }),
+    /project config takes precedence/,
   )
 })
 
@@ -131,6 +145,55 @@ t.test('non-interactive with account + extras', async t => {
   t.equal(result.account, 'acme')
   t.equal(result.which, 'user')
 })
+
+t.test(
+  'aliases from a config file are left where they are',
+  async t => {
+    const added: Added[] = []
+    const { mod } = await loadSetup([])
+    const result = await mod.command(
+      makeConf(
+        {
+          yes: true,
+          positionals: ['acme'],
+          registries: {
+            fromUser: 'https://from-user/',
+            fromProject: 'https://from-project/',
+            moved: 'https://cli-override/',
+            fromCli: 'https://from-cli/',
+          },
+          layers: {
+            user: { registries: { fromUser: 'https://from-user/' } },
+            project: {
+              registries: {
+                fromProject: 'https://from-project/',
+                // same alias, different url: the effective value came from
+                // the CLI, so it is not a config-file alias
+                moved: 'https://project-value/',
+              },
+            },
+          },
+        },
+        added,
+      ),
+    )
+    t.strictSame(
+      result.registries,
+      {
+        npm: 'https://registry.vlt.io/acme/npm/',
+        main: 'https://registry.vlt.io/acme/main/',
+        moved: 'https://cli-override/',
+        fromCli: 'https://from-cli/',
+      },
+      'only account, CLI and interactive aliases are written',
+    )
+    t.equal(
+      result.shadowedByProject,
+      true,
+      'warns that the project vlt.json outranks the user config',
+    )
+  },
+)
 
 t.test('non-interactive requires an account', async t => {
   const added: Added[] = []

--- a/src/cli-sdk/test/config/index.ts
+++ b/src/cli-sdk/test/config/index.ts
@@ -10,6 +10,7 @@ import * as OS from 'node:os'
 import { resolve } from 'node:path'
 import { format } from 'node:util'
 import t from 'tap'
+import type { Test } from 'tap'
 import type { ConfigDefinitions } from '../../src/config/index.ts'
 
 const clearEnv = () => {
@@ -150,7 +151,7 @@ t.test('read and write a user config', async t => {
 })
 
 t.test(
-  'load both configs, project writes over userconfig',
+  'load both configs, layers merge with project taking precedence',
   async t => {
     const dir = t.testdir({
       'vlt.json':
@@ -203,14 +204,24 @@ t.test(
       },
     })
     const conf = await Config.load(dir + '/a/b')
-    t.equal(conf.get('registry'), 'https://registry.vlt.sh/')
+    t.equal(
+      conf.get('registry'),
+      undefined,
+      'project sets registries, so it owns registry selection and the ' +
+        'user-level registry no longer applies',
+    )
     t.equal(conf.get('tag'), 'beta')
     t.equal(conf.get('node-version'), '1.2.3')
     const regs = conf.getRecord('registries')
-    t.strictSame(regs, {
-      example: 'https://example.com',
-      foo: 'https://registry.foo',
-    })
+    t.strictSame(
+      regs,
+      {
+        example: 'https://example.com',
+        bar: 'https://registry.bar',
+        foo: 'https://registry.foo',
+      },
+      'record fields merge per key, project wins on conflict',
+    )
     t.equal(conf.getRecord('registries'), regs, 'memoized')
     t.strictSame(
       conf.getRecord('git-hosts'),
@@ -1125,5 +1136,284 @@ t.test('reloadFromDisk method', async t => {
   await t.resolves(
     conf.reloadFromDisk(),
     'second reloadFromDisk call completes',
+  )
+})
+
+t.test('config layers', async t => {
+  // Loading a Config mutates the module-level jack definition, so each case
+  // gets its own import of the module, and a cleared env, since parse()
+  // writes the values it resolved back out as VLT_* vars.
+  const layered = async (
+    t: Test,
+    user: Record<string, unknown>,
+    project: Record<string, unknown>,
+    argv: string[] = ['whoami'],
+  ) => {
+    const dir = t.testdir({
+      'vlt.json': JSON.stringify({ config: project }),
+      xdg: { 'vlt.json': JSON.stringify({ config: user }) },
+      '.git': {},
+    })
+    const { Config } = await t.mockImport<
+      typeof import('../../src/config/index.ts')
+    >('../../src/config/index.ts', {
+      '@vltpkg/xdg': {
+        XDG: class XDG {
+          config() {
+            return dir + '/xdg/vlt.json'
+          }
+          cache() {
+            return dir + '/default/cache'
+          }
+        },
+      },
+    })
+    clearEnv()
+    const conf = await Config.load(dir, argv, true)
+    return { conf, dir }
+  }
+
+  await t.test(
+    'a project registries alias beats a user registry',
+    async t => {
+      const { conf } = await layered(
+        t,
+        { registry: 'https://user/' },
+        { registries: { npm: 'https://project/' } },
+      )
+      t.equal(conf.options.registry, undefined)
+      const { requireRegistry } = await t.mockImport<
+        typeof import('../../src/require-registry.ts')
+      >('../../src/require-registry.ts')
+      t.equal(requireRegistry(conf), 'https://project/')
+    },
+  )
+
+  await t.test(
+    'a user default-registry-alias does not leak',
+    async t => {
+      const { conf } = await layered(
+        t,
+        {
+          'default-registry-alias': 'main',
+          registries: { main: 'https://user-main/' },
+        },
+        { registries: { npm: 'https://project/' } },
+      )
+      t.equal(conf.options['default-registry-alias'], 'npm')
+      const { hasNpmRegistry } = await t.mockImport<
+        typeof import('../../src/require-registry.ts')
+      >('../../src/require-registry.ts')
+      t.equal(
+        hasNpmRegistry(conf),
+        true,
+        'install commands are configured',
+      )
+      t.equal(
+        conf.options.registries.main,
+        'https://user-main/',
+        'the user alias is still addressable by name',
+      )
+    },
+  )
+
+  await t.test(
+    'a project alias adds to the user aliases',
+    async t => {
+      const { conf } = await layered(
+        t,
+        {
+          registries: {
+            npm: 'https://user-npm/',
+            main: 'https://user-main/',
+          },
+        },
+        { registries: { internal: 'https://internal/' } },
+      )
+      t.strictSame(conf.options.registries, {
+        gh: 'https://npm.pkg.github.com/',
+        npm: 'https://user-npm/',
+        main: 'https://user-main/',
+        internal: 'https://internal/',
+      })
+    },
+  )
+
+  await t.test('null removes a field', async t => {
+    const { conf } = await layered(
+      t,
+      { registry: 'https://user/', tag: 'beta' },
+      { registry: null },
+    )
+    t.equal(conf.options.registry, undefined)
+    t.equal(conf.get('tag'), 'beta', 'unrelated fields are untouched')
+  })
+
+  await t.test('null removes a single record key', async t => {
+    const { conf } = await layered(
+      t,
+      {
+        registries: {
+          npm: 'https://user-npm/',
+          main: 'https://user-main/',
+        },
+      },
+      { registries: { npm: null } },
+    )
+    t.strictSame(conf.options.registries, {
+      gh: 'https://npm.pkg.github.com/',
+      main: 'https://user-main/',
+    })
+  })
+
+  await t.test('command blocks are layered too', async t => {
+    const { conf } = await layered(
+      t,
+      { command: { publish: { registry: 'https://user/' } } },
+      {
+        command: {
+          publish: { registries: { npm: 'https://project/' } },
+        },
+      },
+      ['publish'],
+    )
+    t.equal(
+      conf.get('registry'),
+      undefined,
+      'the project command block owns registry selection',
+    )
+    t.strictSame(conf.getRecord('registries'), {
+      npm: 'https://project/',
+    })
+  })
+
+  await t.test('re-reading a config file is idempotent', async t => {
+    const { conf } = await layered(
+      t,
+      { registry: 'https://user/' },
+      { registries: { npm: 'https://project/' } },
+    )
+    // both of these re-run the user config validator
+    await conf.addConfigToFile('user', { tag: 'beta' })
+    await conf.deleteConfigKeys('user', ['tag'])
+    t.equal(
+      conf.options.registry,
+      undefined,
+      'the user layer did not get stacked back on top',
+    )
+    t.strictSame(
+      conf.options.registries,
+      { gh: 'https://npm.pkg.github.com/', npm: 'https://project/' },
+      'and neither did its registries',
+    )
+  })
+
+  await t.test('layers are exposed, and track writes', async t => {
+    const { conf } = await layered(
+      t,
+      { registries: { npm: 'https://user/', main: 'https://main/' } },
+      { tag: 'beta' },
+    )
+    t.strictSame(conf.layers.project, { tag: 'beta' })
+    t.strictSame(conf.layers.user?.registries, {
+      npm: 'https://user/',
+      main: 'https://main/',
+    })
+    await conf.deleteConfigKeys('user', ['registries.npm'])
+    t.strictSame(
+      conf.layers.user?.registries,
+      { main: 'https://main/' },
+      'a write to a file updates its layer',
+    )
+  })
+
+  await t.test('a vanished layer is dropped', async t => {
+    const { conf, dir } = await layered(
+      t,
+      { registry: 'https://user/' },
+      { registry: 'https://project/' },
+    )
+    t.equal(conf.options.registry, 'https://project/')
+    t.chdir(dir)
+    writeFileSync(dir + '/vlt.json', JSON.stringify({}))
+    // parse() round-trips the resolved values through VLT_* env vars, and
+    // env beats both config files.
+    clearEnv()
+    await conf.reloadFromDisk()
+    t.equal(conf.layers.project, undefined)
+    t.equal(
+      conf.options.registry,
+      'https://user/',
+      'falls back to the user config',
+    )
+  })
+
+  await t.test(
+    'an invalid value is blamed on its own file',
+    async t => {
+      const dir = t.testdir({
+        'vlt.json': JSON.stringify({ config: { tag: 'beta' } }),
+        xdg: {
+          'vlt.json': JSON.stringify({
+            config: { 'fetch-retries': 'not a number' },
+          }),
+        },
+        '.git': {},
+      })
+      const { Config } = await t.mockImport<
+        typeof import('../../src/config/index.ts')
+      >('../../src/config/index.ts', {
+        '@vltpkg/xdg': {
+          XDG: class XDG {
+            config() {
+              return dir + '/xdg/vlt.json'
+            }
+            cache() {
+              return dir + '/default/cache'
+            }
+          },
+        },
+      })
+      clearEnv()
+      await t.rejects(Config.load(dir, ['vlt'], true), {
+        cause: { path: dir + '/xdg/vlt.json', name: 'fetch-retries' },
+      })
+    },
+  )
+})
+
+t.test('configWriteTarget', async t => {
+  const { configWriteTarget } = await t.mockImport<
+    typeof import('../../src/config/index.ts')
+  >('../../src/config/index.ts')
+  const conf = (config: string) =>
+    ({ get: () => config }) as unknown as Parameters<
+      typeof configWriteTarget
+    >[0]
+  t.equal(configWriteTarget(conf('user'), 'project'), 'user')
+  t.equal(configWriteTarget(conf('project'), 'user'), 'project')
+  t.equal(configWriteTarget(conf('all'), 'user'), 'user')
+})
+
+t.test('pairsToRecords/recordsToPairs round-trip', async t => {
+  const { pairsToRecords, recordsToPairs } = await t.mockImport<
+    typeof import('../../src/config/index.ts')
+  >('../../src/config/index.ts')
+  const records = {
+    tag: 'beta',
+    registries: { npm: 'https://npm/' },
+    command: {
+      publish: { registries: { npm: 'https://publish/' } },
+    },
+  }
+  const pairs = recordsToPairs(records)
+  t.strictSame(pairs, {
+    tag: 'beta',
+    registries: ['npm=https://npm/'],
+    command: { publish: { registries: ['npm=https://publish/'] } },
+  })
+  t.strictSame(
+    pairsToRecords(pairs as Parameters<typeof pairsToRecords>[0]),
+    records,
   )
 })

--- a/src/cli-sdk/test/config/merge-layers.ts
+++ b/src/cli-sdk/test/config/merge-layers.ts
@@ -1,0 +1,235 @@
+import t from 'tap'
+import {
+  cloneLayer,
+  mergeLayers,
+  registrySelectionFields,
+  registrySelectors,
+} from '../../src/config/merge-layers.ts'
+
+t.test('scalars come from the innermost layer that sets them', t => {
+  t.strictSame(
+    mergeLayers([
+      { tag: 'latest', 'node-version': '1.2.3' },
+      { tag: 'beta' },
+    ]),
+    { tag: 'beta', 'node-version': '1.2.3' },
+  )
+  t.end()
+})
+
+t.test('missing and non-object layers are skipped', t => {
+  t.strictSame(mergeLayers([]), {})
+  t.strictSame(mergeLayers([undefined, { tag: 'beta' }]), {
+    tag: 'beta',
+  })
+  t.strictSame(
+    mergeLayers([
+      // a layer that isn't an object at all has nothing to contribute
+      'nope' as unknown as Record<string, unknown>,
+      { tag: 'beta' },
+    ]),
+    { tag: 'beta' },
+  )
+  t.end()
+})
+
+t.test('record fields merge key by key', t => {
+  t.strictSame(
+    mergeLayers([
+      { registries: { npm: 'user-npm', main: 'user-main' } },
+      { registries: { npm: 'project-npm', extra: 'project-extra' } },
+    ]).registries,
+    {
+      npm: 'project-npm',
+      main: 'user-main',
+      extra: 'project-extra',
+    },
+    'project wins on conflict, user-only keys survive',
+  )
+  t.strictSame(
+    mergeLayers([{ 'git-hosts': { a: 'A' } }, { tag: 'beta' }])[
+      'git-hosts'
+    ],
+    { a: 'A' },
+    'inherited when the inner layer says nothing',
+  )
+  t.strictSame(
+    mergeLayers([
+      // not an object: treated as an ordinary value, so that jack gets to
+      // be the thing that complains about it
+      { registries: 'nope' },
+    ]).registries,
+    'nope',
+  )
+  t.end()
+})
+
+t.test('null removes things', t => {
+  t.strictSame(
+    mergeLayers([
+      { registry: 'user', tag: 'beta' },
+      { registry: null },
+    ]),
+    { tag: 'beta' },
+    'a null scalar removes the field',
+  )
+  t.strictSame(
+    mergeLayers([{ registry: null }]),
+    {},
+    'null with nothing to remove',
+  )
+  t.strictSame(
+    mergeLayers([
+      { registries: { npm: 'user-npm', main: 'user-main' } },
+      { registries: { npm: null } },
+    ]).registries,
+    { main: 'user-main' },
+    'a null record key removes just that key',
+  )
+  t.strictSame(
+    mergeLayers([
+      { registries: { npm: 'user-npm' } },
+      { registries: { npm: null } },
+    ]),
+    {},
+    'removing the last key drops the field, rather than applying an empty record',
+  )
+  t.strictSame(
+    mergeLayers([
+      { registries: { npm: 'user-npm' } },
+      { registries: null },
+    ]),
+    {},
+    'a null record field removes the whole thing',
+  )
+  t.end()
+})
+
+t.test('registry selection belongs to one layer', t => {
+  t.strictSame(
+    mergeLayers([
+      { registry: 'user', registries: { main: 'user-main' } },
+      { registries: { npm: 'project-npm' } },
+    ]),
+    { registries: { main: 'user-main', npm: 'project-npm' } },
+    'a project `registries` shadows the user `registry`',
+  )
+  t.strictSame(
+    mergeLayers([
+      { 'default-registry-alias': 'main', registries: { main: 'u' } },
+      { registry: 'project' },
+    ]),
+    { registry: 'project', registries: { main: 'u' } },
+    'a project `registry` shadows the user `default-registry-alias`',
+  )
+  t.strictSame(
+    mergeLayers([
+      { registry: 'user', 'default-registry-alias': 'main' },
+      {
+        registries: { npm: 'p' },
+        'default-registry-alias': 'npm',
+      },
+    ]),
+    {
+      registries: { npm: 'p' },
+      'default-registry-alias': 'npm',
+    },
+    'selectors the inner layer does set are kept',
+  )
+  t.strictSame(
+    mergeLayers([
+      { registry: 'user' },
+      { 'scoped-registries': { '@acme': 'a' } },
+    ]),
+    { registry: 'user', 'scoped-registries': { '@acme': 'a' } },
+    'purely additive registry fields do not take over selection',
+  )
+  t.strictSame(
+    mergeLayers([{ registry: 'user' }, { tag: 'beta' }]),
+    { registry: 'user', tag: 'beta' },
+    'a layer with no registry config inherits the selectors',
+  )
+  t.strictSame(
+    registrySelectors.filter(
+      f => !registrySelectionFields.includes(f),
+    ),
+    [],
+    'every selector is also a trigger',
+  )
+  t.end()
+})
+
+t.test('command blocks merge with the same rules', t => {
+  t.strictSame(
+    mergeLayers([
+      {
+        command: {
+          publish: { registry: 'user', tag: 'latest' },
+          install: { bail: false },
+        },
+      },
+      {
+        command: {
+          publish: { registries: { npm: 'project-npm' } },
+        },
+      },
+    ]).command,
+    {
+      publish: { tag: 'latest', registries: { npm: 'project-npm' } },
+      install: { bail: false },
+    },
+  )
+  t.strictSame(
+    mergeLayers([
+      { command: { publish: { tag: 'latest' } } },
+      { command: { publish: null } },
+    ]),
+    {},
+    'a null command block is removed, and an empty command object dropped',
+  )
+  t.strictSame(
+    mergeLayers([
+      { command: { publish: { tag: 'latest' } } },
+      { command: null },
+    ]),
+    {},
+    'a null command field removes them all',
+  )
+  t.strictSame(
+    mergeLayers([{ command: { publish: 'nope' } }]),
+    {},
+    'a non-object command block is ignored',
+  )
+  t.end()
+})
+
+t.test('layers are not mutated', t => {
+  const user = {
+    registries: { npm: 'user-npm' },
+    command: { publish: { tag: 'latest' } },
+  }
+  const project = { registries: { npm: 'project-npm' } }
+  const merged = mergeLayers([user, project])
+  t.strictSame(user.registries, { npm: 'user-npm' })
+  t.not(merged.registries, user.registries)
+  t.not(merged.command, user.command)
+  t.end()
+})
+
+t.test('cloneLayer', t => {
+  const layer = {
+    registries: { npm: 'u', gone: null },
+    workspace: ['a', 'b'],
+    command: { publish: { registries: { npm: 'p' } } },
+    tag: 'latest',
+  }
+  const clone = cloneLayer(layer)
+  t.strictSame(clone, layer, 'same shape, nulls preserved')
+  t.not(clone.registries, layer.registries)
+  t.not(clone.workspace, layer.workspace)
+  t.not(
+    clone.command.publish.registries,
+    layer.command.publish.registries,
+  )
+  t.end()
+})

--- a/www/docs/src/content/docs/cli/commands/login.mdx
+++ b/www/docs/src/content/docs/cli/commands/login.mdx
@@ -12,3 +12,22 @@ Usage:
 
 Authenticate against a registry, and store the token in the
 appropriate config file for later use.
+
+There is no default registry, so a registry must either already be
+configured or be provided with `--registry=<url>`. On success the
+registry is written to the project's `vlt.json`, so that it applies to
+this project only.
+
+## Options
+
+| Flag                       | Description                                                        |
+| -------------------------- | ------------------------------------------------------------------ |
+| `--registry=<url>`         | Registry URL to authenticate against. Saved to `vlt.json`.         |
+| `--identity=<name>`        | Identity namespace used to store auth tokens.                      |
+| `--config=<user\|project>` | Which config file to write the registry to. Defaults to `project`. |
+
+## See also
+
+- [Working with Named Registries](/cli/registries)
+- [Authentication](/cli/auth)
+- [`vlt setup`](/cli/commands/setup)

--- a/www/docs/src/content/docs/cli/commands/setup.mdx
+++ b/www/docs/src/content/docs/cli/commands/setup.mdx
@@ -35,7 +35,16 @@ wizard.
 4. Loops to let you add any additional custom aliases (for partner or
    team registries), optionally authenticating against each.
 5. Writes the staged aliases into your user `vlt.json` (merging with,
-   not clobbering, existing entries).
+   not clobbering, existing entries). Aliases that already live in a
+   `vlt.json` are left where they are, so a project-local alias does
+   not get copied into your user config (or the reverse).
+
+If the project you run this in configures its own registries, the
+output says so:
+[project config takes precedence](/cli/configuring#registry-selection-across-layers)
+for registry selection, so writing your user config would not take
+effect there. Re-run with `--config=project` to configure that
+project.
 
 ## Options
 

--- a/www/docs/src/content/docs/cli/configuring.mdx
+++ b/www/docs/src/content/docs/cli/configuring.mdx
@@ -21,7 +21,7 @@ More documentation available at
 ## Subcommands
 
 ```
-cache, config, exec, exec-local, help, init, install, login, logout, list, ls, pkg, query, run-exec, run, token, uninstall, exec-cache, whoami
+access, bugs, build, cache, ci, config, create, deprecate, dist-tag, docs, exec, exec-cache, exec-local, help, init, add, install, list, login, logout, pack, ping, pkg, profile, publish, query, registry, repo, run-script, run, run-exec, setup, token, uninstall, unpublish, update, version, view, whoami
 ```
 
 Run `vlt <cmd> --help` for more information about a specific command
@@ -41,14 +41,30 @@ field, to `null` in the JSON configuration to explicitly remove it:
 
 ```json
 // ~/.config/vlt/vlt.json
-{ "config": { "registries": { "npm": "https://a/", "old": "https://b/" } } }
-
-// ./vlt.json
-{ "config": { "registries": { "npm": "https://c/", "old": null } } }
-
-// effective
-{ "registries": { "npm": "https://c/", "gh": "https://npm.pkg.github.com/" } }
+// User level config
+{
+  "config": {
+    "registries": { "npm": "https://a/", "old": "https://b/" }
+  }
+}
 ```
+
+```json
+// ./vlt.json
+// Project level config
+{ "config": { "registries": { "npm": "https://c/", "old": null } } }
+```
+
+```json
+// Effective parsed config
+{ "registries": { "npm": "https://c/" } }
+```
+
+> Note: The user level config file uses XDG paths that are
+> OS-specific, the example `~/.config/vlt/vlt.json` path used here
+> might not be the same path used in your system, to learn what is the
+> user level config location for your system, run:
+> `vlt config location --config=user`
 
 ### Registry selection across layers
 
@@ -63,9 +79,18 @@ the user-level one:
 
 ```json
 // ~/.config/vlt/vlt.json
-{ "config": { "registry": "https://user/", "registries": { "main": "https://main/" } } }
+// User level config
+{
+  "config": {
+    "registry": "https://user/",
+    "registries": { "main": "https://main/" }
+  }
+}
+```
 
+```json
 // ./vlt.json
+// Project level config
 { "config": { "registries": { "npm": "https://project/" } } }
 ```
 

--- a/www/docs/src/content/docs/cli/configuring.mdx
+++ b/www/docs/src/content/docs/cli/configuring.mdx
@@ -28,19 +28,57 @@ Run `vlt <cmd> --help` for more information about a specific command
 
 ## Configuration
 
-If a `vlt.json` file is present in the root of the current project,
-then the `config` field in that file that will be used as a source of
-configuration information. (This file is also used to define
-workspaces and other `vlt` behaviors.)
+The `vlt.json` file in the XDG specified config directory is loaded
+first. Then, if a `vlt.json` file is present in the root of the
+current project, the `config` field in that file is layered on top of
+it. (The project file is also used to define workspaces and other
+`vlt` behaviors.)
 
-Next, the `vlt.json` file in the XDG specified config directory will
-be checked, and loaded for any fields not set in the local project.
+Scalar values are overridden by the innermost layer that sets them.
+Object type values are merged together key by key, with the project
+file winning on conflict. Set a field, or a key within an object
+field, to `null` in the JSON configuration to explicitly remove it:
 
-Object type values will be merged together. Set a field to `null` in
-the JSON configuration to explicitly remove it.
+```json
+// ~/.config/vlt/vlt.json
+{ "config": { "registries": { "npm": "https://a/", "old": "https://b/" } } }
+
+// ./vlt.json
+{ "config": { "registries": { "npm": "https://c/", "old": null } } }
+
+// effective
+{ "registries": { "npm": "https://c/", "gh": "https://npm.pkg.github.com/" } }
+```
+
+### Registry selection across layers
+
+Registry selection is an exception to plain per-field layering,
+because `registry` outranks any `registries` alias. A layer that sets
+any of `registry`, `registries`, or `default-registry-alias` owns
+selection: the `registry` and `default-registry-alias` it does _not_
+set are dropped rather than inherited from an outer layer.
+
+So a project that configures its own registry is never quietly sent to
+the user-level one:
+
+```json
+// ~/.config/vlt/vlt.json
+{ "config": { "registry": "https://user/", "registries": { "main": "https://main/" } } }
+
+// ./vlt.json
+{ "config": { "registries": { "npm": "https://project/" } } }
+```
+
+resolves to `https://project/`. The user's `main` alias is still
+addressable as `main:` in a specifier, or with
+`vlt registry main <cmd>`.
+
+`scoped-registries` and `jsr-registries` are purely additive, so they
+do not take over selection.
 
 Command-specific fields may be set in a nested `command` object that
-overrides any options defined at the top level.
+overrides any options defined at the top level, following the same
+rules.
 
 For information about catalog configuration and the `catalog:`
 protocol, see the [Catalogs documentation](/cli/catalogs).

--- a/www/docs/src/content/docs/cli/registries.mdx
+++ b/www/docs/src/content/docs/cli/registries.mdx
@@ -96,11 +96,24 @@ user-level `registry`, rather than being sent to it.
 
 ```json
 // ~/.config/vlt/vlt.json
-{ "config": { "registry": "https://user/", "registries": { "main": "https://main/" } } }
+{
+  "config": {
+    "registry": "https://user/",
+    "registries": { "main": "https://main/" }
+  }
+}
+```
 
+```json
 // ./vlt.json
 { "config": { "registries": { "npm": "https://project/" } } }
 ```
+
+> Note: The user level config file uses XDG paths that are
+> OS-specific, the example `~/.config/vlt/vlt.json` path used here
+> might not be the same path used in your system, to learn what is the
+> user level config location for your system, run:
+> `vlt config location --config=user`
 
 In that project, bare specs and account commands resolve to
 `https://project/`. The user's `main` alias is still merged in and

--- a/www/docs/src/content/docs/cli/registries.mdx
+++ b/www/docs/src/content/docs/cli/registries.mdx
@@ -47,11 +47,11 @@ Run `vlt setup` to get configured.
 See https://docs.vlt.sh/cli for other ways to set a registry.
 ```
 
-There are three ways to configure the registry directly, in increasing
+There are four ways to configure the registry directly, in increasing
 order of precedence:
 
-1. **A `vlt.json` file**, either in your project or in your user
-   config directory. Either write it by hand:
+1. **The `vlt.json` in your user config directory**, which applies to
+   every project. Either write it by hand:
 
    ```json
    {
@@ -64,20 +64,50 @@ order of precedence:
    or set it with the CLI:
 
    ```bash
+   vlt config set registry=https://registry.npmjs.org/ --config=user
+   ```
+
+2. **The `vlt.json` in your project root**, which applies to that
+   project only:
+
+   ```bash
    vlt config set registry=https://registry.npmjs.org/
    ```
 
-2. **The `VLT_REGISTRY` environment variable**, which is handy in CI:
+3. **The `VLT_REGISTRY` environment variable**, which is handy in CI:
 
    ```bash
    VLT_REGISTRY=https://registry.npmjs.org/ vlt install
    ```
 
-3. **The `--registry` flag**, for a single command:
+4. **The `--registry` flag**, for a single command:
 
    ```bash
    vlt install --registry=https://registry.npmjs.org/
    ```
+
+### Project vs. user registry configuration
+
+A project's registry configuration always wins over the user-level
+one. Because `registry` outranks any `registries` alias, that holds
+even when the two layers use different fields: a project that sets
+`registries` (or `default-registry-alias`) and no `registry` drops the
+user-level `registry`, rather than being sent to it.
+
+```json
+// ~/.config/vlt/vlt.json
+{ "config": { "registry": "https://user/", "registries": { "main": "https://main/" } } }
+
+// ./vlt.json
+{ "config": { "registries": { "npm": "https://project/" } } }
+```
+
+In that project, bare specs and account commands resolve to
+`https://project/`. The user's `main` alias is still merged in and
+addressable as `main:` in a specifier, or with
+[`vlt registry main …`](/cli/commands/registry) — only the _selection_
+is taken over. See [Configuring](/cli/configuring) for the full
+layering rules.
 
 ### Bootstrapping with `vlt login`
 
@@ -89,6 +119,8 @@ already configured:
 ```bash
 vlt login --registry=https://registry.vlt.io/myorg/
 ```
+
+Pass `--config=user` to configure it for every project instead.
 
 There can be only one registry configured this way, and it is used as
 the fallback for all package registry resolutions. Normally, if an
@@ -126,6 +158,11 @@ Because the `npm` alias has no built-in URL, a fresh, unconfigured
 project cannot resolve bare specs until you configure one — the guided
 way to do that is `vlt setup`.
 
+Note that a project which sets `registries` without also setting
+`default-registry-alias` gets the default `npm` back, even if your
+user config points it somewhere else. Set it in the project `vlt.json`
+to route that project's bare specs through a different alias.
+
 ## Getting started with `vlt setup`
 
 `vlt setup` is the onboarding wizard for a vlt.io account. Sign up or
@@ -160,8 +197,16 @@ each. To run it unattended (for example in CI or a setup script):
 vlt setup my-account --yes --registries team=https://registry.example.com/
 ```
 
+Only the account aliases, aliases passed on the command line, and
+aliases you type at the prompt are written. Aliases that already live
+in a `vlt.json` are left where they are, so a project-local alias does
+not become a global one.
+
 Pass `--config=project` to write to the project's `vlt.json` instead
-of your user config.
+of your user config. If you run `vlt setup` inside a project that
+configures its own registries, it will say so — the project config
+takes precedence, so writing your user config would have no effect
+there.
 
 ## Targeting a specific registry
 


### PR DESCRIPTION
This PR ensures that project-level settings take precedence over
settings in the XDG vlt.json.

The settings objects are deeply merged, and `null` can be used on the
project level to explicitly clear a user-level one.

Lastly this adds a `--config` toggle on the setup command.

Fixes #1736