### PR TITLE
fix stale dist-tag results in vlt view and vlx

### DIFF
--- a/src/package-info/src/index.ts
+++ b/src/package-info/src/index.ts
@@ -962,11 +962,14 @@ export class PackageInfoClient {
     // To revisit: put the requested representation on both the disk-cache
     // key and the in-flight coalescing key, and have the SWR child
     // (cache-revalidate / revalidate) re-request the same representation.
+    const f = spec.final
+    const movingSelector = f.distTag || f.range?.isAny
     const response = await (
       await this.getRegistryClient()
     ).request(pakuURL, {
       headers: { accept: 'application/json' },
       ...(useCache === false ? { useCache } : {}),
+      ...(movingSelector ? { forceRevalidate: true } : {}),
     })
     if (response.statusCode !== 200) {
       throw this.#resolveError(

--- a/src/registry-client/src/index.ts
+++ b/src/registry-client/src/index.ts
@@ -181,6 +181,13 @@ export type RegistryClientRequestOptions = Omit<
    * @internal
    */
   staleWhileRevalidate?: false
+
+  /**
+   * Revalidate a cached response even when it is still within max-age.
+   * Conditional request headers are still sent when available.
+   * @internal
+   */
+  forceRevalidate?: boolean
 }
 
 const { version } = loadPackageJson(
@@ -495,6 +502,7 @@ export class RegistryClient {
       signal,
       otp = (process.env.VLT_OTP ?? '').trim(),
       staleWhileRevalidate = true,
+      forceRevalidate = false,
     } = options
     let { trustIntegrity } = options
 
@@ -513,12 +521,17 @@ export class RegistryClient {
       : undefined
 
     const entry = buffer ? this.#decodeCached(buffer) : undefined
-    if (entry?.valid) {
+    if (entry?.valid && !forceRevalidate) {
       logRequest(url, 'cache', { method })
       return entry
     }
 
-    if (staleWhileRevalidate && entry?.staleWhileRevalidate && m) {
+    if (
+      !forceRevalidate &&
+      staleWhileRevalidate &&
+      entry?.staleWhileRevalidate &&
+      m
+    ) {
       // revalidate while returning the stale entry
       register(dirname(this.cache.path()), m, url)
       logRequest(url, 'stale', { method })

--- a/src/registry-client/test/index.ts
+++ b/src/registry-client/test/index.ts
@@ -888,6 +888,39 @@ t.test('staleWhileRevalidate', async t => {
     'revalidated, got fresh response',
   )
   await cache.promise()
+  rc.cache = cache
+})
+
+t.test('forceRevalidate bypasses fresh cache entries', async t => {
+  const rc = t.context.rc as RegistryClient
+  const key = `${registryURL}/abbrev`
+  const entry = new CacheEntry(
+    200,
+    toRawHeaders({
+      'content-type': 'application/json',
+      date: new Date(Date.now() - 20 * 60 * 1000).toUTCString(),
+      'cache-control': 'max-age=3600',
+      etag: '"old-etag"',
+    }),
+  )
+  entry.addBody(Buffer.from('{"cached":true}'))
+  const encoded = entry.encode()
+  rc.cache.set(
+    key,
+    Buffer.from(
+      encoded.buffer,
+      encoded.byteOffset,
+      encoded.byteLength,
+    ),
+  )
+  await rc.cache.promise()
+
+  const result = await rc.request(key, { forceRevalidate: true })
+  t.strictSame(
+    result.json(),
+    { hello: 'world' },
+    'fresh cache entry was conditionally revalidated',
+  )
 })
 
 t.test('undecodable cache entry is a miss', async t => {


### PR DESCRIPTION
close #1656 

## what changed

`vlt view` and `vlx` could keep returning old package metadata because cached packuments stayed usable for too long.. `vlx` also sets `stale-while-revalidate-factor` to `Infinity`

moving selectors like `latest` and bare package names now force `RegistryClient` to revalidate the cached response.. conditional request headers are still used so unchanged metadata stays cheap

pinned versions keep the existing cache behavior

## testing

- `npm test -- test/index.ts` in `src/registry-client`.. 160 assertions passed
- `npm test -- test/index.ts` in `src/package-info`.. 184 assertions passed
- `npm run format:check`
- `npm run lint:check`
- `vlr --recursive prepare`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved package metadata freshness for moving selectors, including distribution tags and flexible version ranges.
  - Requests for these selectors now revalidate against the registry instead of relying solely on fresh cached data.
  - Conditional caching remains supported while ensuring updated registry responses replace outdated cached results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->