### PR TITLE
If shas are missing, get them from Repr-Digest header (if set)

### DIFF
--- a/src/cli-sdk/src/commands/view.ts
+++ b/src/cli-sdk/src/commands/view.ts
@@ -376,7 +376,7 @@ export const command: CommandFn<ViewResult> = async conf => {
 
   // Fetch the full packument (needs time, maintainers) and resolved manifest
   const [packument, resolvedManifest] = await Promise.all([
-    pic.packument(spec),
+    pic.packument(spec, { full: true }),
     pic.manifest(spec),
   ])
   const manifest = resolvedManifest as Manifest

--- a/src/graph/src/reify/build.ts
+++ b/src/graph/src/reify/build.ts
@@ -13,6 +13,7 @@ import type { Node } from '../node.ts'
 import { nonEmptyList } from '../non-empty-list.ts'
 import { optionalFail } from './optional-fail.ts'
 import { binChmod } from './bin-chmod.ts'
+import { scriptsManifest } from './scripts-manifest.ts'
 
 /**
  * Returns an object mapping registries to the names of the packages built.
@@ -101,8 +102,9 @@ const visit = async (
   // currently nullish, that could happen in a scenario where the ideal
   // graph is from a lockfile and there's no actual graph available
   // to hydrate the manifest data from.
-  node.manifest ??= packageJson.read(node.resolvedLocation(scurry))
-  const { manifest } = node
+  const dir = node.resolvedLocation(scurry)
+  node.manifest ??= packageJson.read(dir)
+  const manifest = scriptsManifest(node.manifest, dir, packageJson)
   const { scripts = {} } = manifest
 
   const {

--- a/src/graph/src/reify/check-needed-build.ts
+++ b/src/graph/src/reify/check-needed-build.ts
@@ -2,7 +2,9 @@ import type { PathScurry } from 'path-scurry'
 import type { PackageJson } from '@vltpkg/package-json'
 import type { Diff } from '../diff.ts'
 import type { Node } from '../node.ts'
+import type { NormalizedManifest } from '@vltpkg/types'
 import { join } from 'node:path'
+import { scriptsManifest } from './scripts-manifest.ts'
 
 /**
  * Build data containing the queue of DepIDs that need building
@@ -47,16 +49,17 @@ const nodeNeedsBuild = (
   // If the manifest is not available on the node, read it from disk.
   // This can happen when the ideal graph is loaded from a lockfile
   // and there's no actual graph available to hydrate the manifest data from.
-  let manifest = node.manifest
-  if (!manifest) {
-    try {
-      manifest = packageJson.read(node.resolvedLocation(scurry))
-      node.manifest = manifest
-    } catch {
-      // If the manifest cannot be read (missing/corrupted), treat as
-      // "no build needed" to avoid failing the entire reification.
-      return false
-    }
+  // An abbreviated registry manifest carries `hasInstallScript` in place
+  // of `scripts` and is likewise resolved from disk.
+  let manifest: NormalizedManifest
+  try {
+    const dir = node.resolvedLocation(scurry)
+    node.manifest ??= packageJson.read(dir)
+    manifest = scriptsManifest(node.manifest, dir, packageJson)
+  } catch {
+    // If the manifest cannot be read (missing/corrupted), treat as
+    // "no build needed" to avoid failing the entire reification.
+    return false
   }
 
   const { scripts = {} } = manifest

--- a/src/graph/src/reify/scripts-manifest.ts
+++ b/src/graph/src/reify/scripts-manifest.ts
@@ -1,0 +1,16 @@
+import type { PackageJson } from '@vltpkg/package-json'
+import type { NormalizedManifest } from '@vltpkg/types'
+
+/**
+ * The manifest to consult for lifecycle scripts. An abbreviated registry
+ * manifest replaces `scripts` with `hasInstallScript`, in which case the
+ * extracted package.json at `dir` is canonical.
+ */
+export const scriptsManifest = (
+  manifest: NormalizedManifest,
+  dir: string,
+  packageJson: PackageJson,
+): NormalizedManifest =>
+  manifest.hasInstallScript && !manifest.scripts ?
+    packageJson.read(dir)
+  : manifest

--- a/src/graph/test/reify/build.ts
+++ b/src/graph/test/reify/build.ts
@@ -1,6 +1,7 @@
 import { joinDepIDTuple } from '@vltpkg/dep-id'
 import { PackageJson } from '@vltpkg/package-json'
 import type { RunOptions } from '@vltpkg/run'
+import { normalizeManifest } from '@vltpkg/types'
 import { Monorepo } from '@vltpkg/workspaces'
 import * as FSP from 'node:fs/promises'
 import * as FS from 'node:fs'
@@ -149,6 +150,16 @@ t.test(
       scurry: new PathScurry(projectRoot),
       loadManifests: true,
     })
+    // y arrives from the registry as an abbreviated manifest, so its
+    // install scripts have to be read from the extracted package.json
+    const ay = after.nodes.get(yid)
+    if (!ay) throw new Error('no y node in after??')
+    ay.manifest = normalizeManifest({
+      name: 'y',
+      version: '1.2.3',
+      hasInstallScript: true,
+      dependencies: { x: '1' },
+    })
     const bx = before.nodes.get(xid)
     const by = before.nodes.get(yid)
     if (!bx) throw new Error('no x node in before??')
@@ -210,6 +221,11 @@ t.test(
       t.ok(
         installRun.signal instanceof AbortSignal,
         'install run should have signal',
+      )
+      t.equal(
+        installRun.manifest?.scripts?.install,
+        'true',
+        'install run reads scripts from the extracted package.json',
       )
     }
 

--- a/src/graph/test/reify/scripts-manifest.ts
+++ b/src/graph/test/reify/scripts-manifest.ts
@@ -1,0 +1,44 @@
+import { PackageJson } from '@vltpkg/package-json'
+import { normalizeManifest } from '@vltpkg/types'
+import t from 'tap'
+import { scriptsManifest } from '../../src/reify/scripts-manifest.ts'
+
+const dir = t.testdir({
+  'package.json': JSON.stringify({
+    name: 'x',
+    version: '1.0.0',
+    scripts: { postinstall: 'node setup.js' },
+  }),
+})
+const packageJson = new PackageJson()
+
+t.test('returns a manifest that carries its own scripts', async t => {
+  const manifest = normalizeManifest({
+    name: 'x',
+    version: '1.0.0',
+    scripts: { postinstall: 'echo hi' },
+  })
+  t.equal(scriptsManifest(manifest, dir, packageJson), manifest)
+})
+
+t.test(
+  'returns a manifest with no install scripts at all',
+  async t => {
+    const manifest = normalizeManifest({
+      name: 'x',
+      version: '1.0.0',
+    })
+    t.equal(scriptsManifest(manifest, dir, packageJson), manifest)
+  },
+)
+
+t.test('reads package.json for an abbreviated manifest', async t => {
+  const manifest = normalizeManifest({
+    name: 'x',
+    version: '1.0.0',
+    hasInstallScript: true,
+  })
+  const res = scriptsManifest(manifest, dir, packageJson)
+  t.not(res, manifest)
+  t.strictSame(res.scripts, { postinstall: 'node setup.js' })
+})

--- a/src/package-info/src/index.ts
+++ b/src/package-info/src/index.ts
@@ -6,6 +6,7 @@ import { PackageJson } from '@vltpkg/package-json'
 import type { PickManifestOptions } from '@vltpkg/pick-manifest'
 import { pickManifest } from '@vltpkg/pick-manifest'
 import type {
+  CacheEntry,
   RegistryClient,
   RegistryClientOptions,
   RegistryClientRequestOptions,
@@ -44,12 +45,20 @@ const xdg = new XDG('vlt')
 export const delimiter = '~'
 
 /**
+ * vlt's abbreviated packument: corgi plus the fields the graph relies on
+ * (`license`, `time`, `hasInstallScript`), minus `dist.integrity` (the
+ * tarball response carries a `Repr-Digest` instead) and with
+ * `dist.tarball` relative to the registry base.
+ */
+export const VLT_PACKUMENT_MIME =
+  'application/vnd.vlt.packument-v1+json'
+
+/**
  * Accept header for packument requests. Prefers vlt's abbreviated
  * packument and falls back to the full one on registries that do not
  * know the type. See `PackageInfoClient.#fetchPackument`.
  */
-export const PACKUMENT_ACCEPT =
-  'application/vnd.vlt.packument-v1+json; q=1.0, application/json; q=0.8, */*'
+export const PACKUMENT_ACCEPT = `${VLT_PACKUMENT_MIME}; q=1.0, application/json; q=0.8, */*`
 
 /**
  * True when resolving `spec` can never select a prerelease, so the
@@ -66,6 +75,8 @@ const stableSuffices = (
   if (tag && tag !== 'latest') return false
   const { distTag, range } = spec.final
   if (distTag) return distTag === 'latest'
+  /* c8 ignore next 2 - a registry spec always has a tag or a range, and
+   * Spec never parses one with includePrerelease */
   if (!range || range.includePrerelease) return false
   return !range.set.some(c => c.tuples.some(admitsPrerelease))
 }
@@ -91,6 +102,11 @@ export type Resolution = {
   integrity?: Integrity
   signatures?: Exclude<Manifest['dist'], undefined>['signatures']
   spec: Spec
+  /**
+   * The manifest came from a vlt packument, which carries no
+   * `dist.integrity`: the tarball response must carry a `Repr-Digest`.
+   */
+  digestRequired?: boolean
 }
 
 export type PackageInfoClientOptions = RegistryClientOptions &
@@ -119,6 +135,12 @@ export type PackageInfoClientRequestOptions = PickManifestOptions &
      * (and the dist-tags pointing at them) removed; others ignore it.
      */
     stable?: boolean
+    /**
+     * Fetch the full packument (readme, maintainers, `dist.integrity`)
+     * rather than the abbreviated one. Bypasses the disk cache, which is
+     * keyed by URL alone, so the two representations never mix.
+     */
+    full?: boolean
   }
 
 export type PackageInfoClientExtractOptions =
@@ -168,6 +190,8 @@ export class PackageInfoClient {
   packageJson: PackageJson
   monorepo?: Monorepo
   #trustedIntegrities = new Map<string, Integrity>()
+  // `${registry}${name}` of every packument served as VLT_PACKUMENT_MIME
+  #vltPackuments = new Set<string>()
   #manifestCacheMinAge = Date.now() - manifestCacheMaxAge
   #cachePath: string
   // In-flight coalescing key is the packument URL, `?stable` included,
@@ -313,6 +337,7 @@ export class PackageInfoClient {
               await this.getTarPool()
             ).unpack(cached.body, target)
             logRequest(r.resolved, 'cache')
+            r.integrity ??= cached.integrity
             return r
           } catch (er) {
             // a systematically failing fast path (every entry still
@@ -366,27 +391,40 @@ export class PackageInfoClient {
 
           const buf = response.buffer()
 
-          // Verify network-delivered tarball bytes against dist.integrity.
-          // Skip cache-served bodies: they were verified on the fetch that
-          // populated the cache, and cache-unzip rewrites them un-gzipped
-          // so the gzip-hash can never match. Skip lockfile-sourced
-          // integrity: it was verified on first install.
-          if (r.integrity && !fromLockfile && !response.fromCache) {
-            const hash = createHash('sha512')
-            hash.update(buf)
-            const computed: Integrity = `sha512-${hash.digest('base64')}`
-            /* c8 ignore start - defense-in-depth: registry client's
-             * checkIntegrity() usually catches mismatches first. */
-            if (computed !== r.integrity) {
-              throw error('Tarball integrity check failed', {
-                code: 'EINTEGRITY',
-                spec,
-                url: r.resolved,
-                wanted: r.integrity,
-                found: computed,
-              })
+          if (r.integrity) {
+            // Verify network-delivered tarball bytes against dist.integrity.
+            // Skip cache-served bodies: they were verified on the fetch that
+            // populated the cache, and cache-unzip rewrites them un-gzipped
+            // so the gzip-hash can never match. Skip lockfile-sourced
+            // integrity: it was verified on first install.
+            if (!fromLockfile && !response.fromCache) {
+              const hash = createHash('sha512')
+              hash.update(buf)
+              const computed: Integrity = `sha512-${hash.digest('base64')}`
+              /* c8 ignore start - defense-in-depth: registry client's
+               * checkIntegrity() usually catches mismatches first. */
+              if (computed !== r.integrity) {
+                throw error('Tarball integrity check failed', {
+                  code: 'EINTEGRITY',
+                  spec,
+                  url: r.resolved,
+                  wanted: r.integrity,
+                  found: computed,
+                })
+              }
+              /* c8 ignore stop */
             }
-            /* c8 ignore stop */
+          } else if (response.fromCache) {
+            // the hash the body was stored under
+            r.integrity = response.integrity
+          } else {
+            // no dist.integrity: check against the digest the registry
+            // sent with the tarball, and hand the hash back so the
+            // lockfile pins it from now on
+            r.integrity = verifiedDigest(response, r.digestRequired, {
+              spec,
+              url: r.resolved,
+            })
           }
 
           return buf
@@ -690,6 +728,12 @@ export class PackageInfoClient {
               })
             }
             /* c8 ignore stop */
+          } else if (!integrity && !response.fromCache) {
+            verifiedDigest(
+              response,
+              this.#vltPackuments.has(`${f.registry}${f.name}`),
+              { spec, url: tarball },
+            )
           }
 
           return buf
@@ -1013,6 +1057,10 @@ export class PackageInfoClient {
         const { registry, name } = f
         if (!registry) throw noRegistryError(spec)
         const pakuURL = new URL(name, registry)
+        // a full representation neither reads nor feeds the coalescing
+        // map, which holds the abbreviated one
+        if (options.full)
+          return this.#fetchPackument(spec, options, pakuURL)
         const forced = isMovingSelector(f)
         // a moving selector must not ride along on a non-forced request:
         // that one can settle to a fresh-but-stale cache hit, which is
@@ -1078,8 +1126,12 @@ export class PackageInfoClient {
     const response = await (
       await this.getRegistryClient()
     ).request(pakuURL, {
-      headers: { accept: PACKUMENT_ACCEPT },
-      ...(useCache === false ? { useCache } : {}),
+      headers: {
+        accept: options.full ? 'application/json' : PACKUMENT_ACCEPT,
+      },
+      ...(useCache === false || options.full ?
+        { useCache: false }
+      : {}),
       // costs a conditional GET per moving selector on an otherwise warm
       // cache, install included. 304s are cheap but not free; the
       // alternative is serving a dist tag that moved (#1656).
@@ -1098,14 +1150,22 @@ export class PackageInfoClient {
         },
       )
     }
+    let paku: Packument
     try {
-      return response.json() as Packument
+      paku = response.json() as Packument
     } catch (er) {
       if (useCache !== false) {
         return this.#fetchPackument(spec, options, pakuURL, false)
       }
       throw er
     }
+    const { registry, name } = spec.final
+    if (response.contentType.startsWith(VLT_PACKUMENT_MIME)) {
+      this.#vltPackuments.add(`${registry}${name}`)
+    }
+    /* c8 ignore next - registry specs always have a registry */
+    if (registry) absolutizeTarballs(paku, registry)
+    return paku
   }
 
   async resolve(
@@ -1163,11 +1223,17 @@ export class PackageInfoClient {
         if (mani.dist) {
           const { integrity, tarball, signatures } = mani.dist
           if (tarball) {
-            const r = {
+            const r: Resolution = {
               resolved: tarball,
               integrity,
               signatures,
               spec,
+            }
+            if (
+              !integrity &&
+              this.#vltPackuments.has(`${f.registry}${f.name}`)
+            ) {
+              r.digestRequired = true
             }
             this.#resolutions.set(memoKey, r)
             return r
@@ -1282,5 +1348,43 @@ export class PackageInfoClient {
       this.#resolveError,
     )
     return er
+  }
+}
+
+/**
+ * The sha512 of a network-delivered tarball whose manifest carried no
+ * `dist.integrity`, checked against the RFC 9530 digest the registry sent
+ * alongside it. A registry that omits `dist.integrity` labels every
+ * tarball, so a missing digest fails when `required`.
+ */
+const verifiedDigest = (
+  response: CacheEntry,
+  required: boolean | undefined,
+  context: ErrorCauseOptions,
+): Integrity => {
+  const computed = response.integrityActual
+  const { digest } = response
+  if (digest ? digest !== computed : required) {
+    throw error('Tarball integrity check failed', {
+      code: 'EINTEGRITY',
+      wanted: digest,
+      found: computed,
+      ...context,
+    })
+  }
+  return computed
+}
+
+// vlt packuments carry dist.tarball relative to the registry base
+// (`foo/-/foo-1.0.0.tgz`), the form conventionalRegistryTarball builds.
+// Nothing downstream sees a relative URL: the manifest cache, the graph
+// and the lockfile all get the absolute one.
+const absolutizeTarballs = (paku: Packument, registry: string) => {
+  const base = registry.endsWith('/') ? registry : registry + '/'
+  for (const { dist } of Object.values(paku.versions)) {
+    const tarball = dist?.tarball
+    if (tarball && !/^[a-z][a-z0-9+.-]*:/i.test(tarball)) {
+      dist.tarball = String(new URL(tarball, base))
+    }
   }
 }

--- a/src/package-info/src/index.ts
+++ b/src/package-info/src/index.ts
@@ -51,6 +51,41 @@ export const delimiter = '~'
 export const PACKUMENT_ACCEPT =
   'application/vnd.vlt.packument-v1+json; q=1.0, application/json; q=0.8, */*'
 
+/**
+ * True when resolving `spec` can never select a prerelease, so the
+ * `?stable` packument is enough. A non-default tag, or a range with a
+ * prerelease in one of its comparators, admits prereleases; so does
+ * `*`, but it only picks one when no stable version exists, which
+ * {@link PackageInfoClient.manifest} covers by retrying with the full
+ * packument.
+ */
+const stableSuffices = (
+  spec: Spec,
+  { tag }: PickManifestOptions,
+): boolean => {
+  if (tag && tag !== 'latest') return false
+  const { distTag, range } = spec.final
+  if (distTag) return distTag === 'latest'
+  if (!range || range.includePrerelease) return false
+  return !range.set.some(c => c.tuples.some(admitsPrerelease))
+}
+
+// `^1` desugars to `>=1.0.0 <2.0.0-0`: the `-0` upper bound is the lowest
+// prerelease, there to exclude the 2.0.0 prereleases, not admit them.
+type RangeTuple = NonNullable<
+  Spec['range']
+>['set'][number]['tuples'][number]
+const admitsPrerelease = (t: RangeTuple): boolean => {
+  if (!Array.isArray(t)) return false
+  const [op, { prerelease }] = t
+  if (!prerelease?.length) return false
+  return !(
+    op === '<' &&
+    prerelease.length === 1 &&
+    prerelease[0] === 0
+  )
+}
+
 export type Resolution = {
   resolved: string
   integrity?: Integrity
@@ -78,6 +113,12 @@ export type PackageInfoClientRequestOptions = PickManifestOptions &
   RegistryClientRequestOptions & {
     /** dir to resolve `file://` specifiers against. Defaults to projectRoot. */
     from?: string
+    /**
+     * Only versions without a prerelease are needed. A registry that
+     * supports it serves a smaller `?stable` packument with prereleases
+     * (and the dist-tags pointing at them) removed; others ignore it.
+     */
+    stable?: boolean
   }
 
 export type PackageInfoClientExtractOptions =
@@ -129,11 +170,11 @@ export class PackageInfoClient {
   #trustedIntegrities = new Map<string, Integrity>()
   #manifestCacheMinAge = Date.now() - manifestCacheMaxAge
   #cachePath: string
-  // In-flight coalescing key is `${registry}${name}` — no representation
-  // component. Safe only because every caller requests the same full
-  // packument (see #fetchPackument). The one thing that does vary per
-  // caller is forceRevalidate, so record it and let a moving selector
-  // reuse a forced promise but never a non-forced one (see packument()).
+  // In-flight coalescing key is the packument URL, `?stable` included,
+  // like the disk cache; every caller requests the same representation
+  // (see #fetchPackument). The one thing that does vary per caller is
+  // forceRevalidate, so record it and let a moving selector reuse a
+  // forced promise but never a non-forced one (see packument()).
   #packumentPromises = new Map<
     string,
     { promise: Promise<Packument>; forced: boolean }
@@ -796,11 +837,21 @@ export class PackageInfoClient {
           }
         }
 
-        const mani = pickManifest(
-          await this.packument(f, options),
+        const stable = stableSuffices(spec, options)
+        let mani = pickManifest(
+          await this.packument(f, { ...options, stable }),
           spec,
           options,
         )
+        // the stable packument hides prerelease-only packages and
+        // dist-tags that point at a prerelease; the full one has them
+        if (!mani && stable) {
+          mani = pickManifest(
+            await this.packument(f, options),
+            spec,
+            options,
+          )
+        }
         if (!mani) throw this.#resolveError(spec, options)
 
         // Cache the manifest data. Skip paths already written this
@@ -961,19 +1012,26 @@ export class PackageInfoClient {
       case 'registry': {
         const { registry, name } = f
         if (!registry) throw noRegistryError(spec)
-        // Coalescing key has no representation component (see #fetchPackument).
-        const packumentKey = `${registry}${name}`
+        const pakuURL = new URL(name, registry)
         const forced = isMovingSelector(f)
-        const inflight = this.#packumentPromises.get(packumentKey)
         // a moving selector must not ride along on a non-forced request:
         // that one can settle to a fresh-but-stale cache hit, which is
         // exactly what forceRevalidate exists to avoid. the other
         // direction is fine -- a forced result is never staler.
         // costs at most one extra concurrent GET for the same packument
         // when both shapes are asked for at once.
+        // Coalesced per URL, like the disk cache; the representation is
+        // fixed by the accept header (see #fetchPackument). A full
+        // packument already in flight also serves a stable request.
+        if (options.stable) {
+          const full = this.#packumentPromises.get(String(pakuURL))
+          if (full && (!forced || full.forced)) return full.promise
+          pakuURL.search = '?stable'
+        }
+        const packumentKey = String(pakuURL)
+        const inflight = this.#packumentPromises.get(packumentKey)
         if (inflight && (!forced || inflight.forced))
           return inflight.promise
-        const pakuURL = new URL(name, registry)
         const promise = this.#fetchPackument(spec, options, pakuURL)
         const record = { promise, forced }
         this.#packumentPromises.set(packumentKey, record)

--- a/src/package-info/src/index.ts
+++ b/src/package-info/src/index.ts
@@ -43,6 +43,14 @@ const debug = debuglog('vlt')
 const xdg = new XDG('vlt')
 export const delimiter = '~'
 
+/**
+ * Accept header for packument requests. Prefers vlt's abbreviated
+ * packument and falls back to the full one on registries that do not
+ * know the type. See `PackageInfoClient.#fetchPackument`.
+ */
+export const PACKUMENT_ACCEPT =
+  'application/vnd.vlt.packument-v1+json; q=1.0, application/json; q=0.8, */*'
+
 export type Resolution = {
   resolved: string
   integrity?: Integrity
@@ -990,35 +998,29 @@ export class PackageInfoClient {
     pakuURL: URL,
     useCache?: false,
   ): Promise<Packument> {
-    // Always request the full packument (`application/json`), never the
-    // abbreviated "corgi" form:
-    //   accept: application/vnd.npm.install-v1+json; q=1.0,
+    // Request vlt's abbreviated packument, falling back to the full one:
+    //   accept: application/vnd.vlt.packument-v1+json; q=1.0,
     //           application/json; q=0.8, */*
     //
-    // Corgi is smaller (~−41% packument bytes, est. 1–3s on clean installs)
-    // but is disabled for two load-bearing reasons:
+    // npm's corgi (`application/vnd.npm.install-v1+json`) is never
+    // requested. The version entry returned here becomes `node.manifest`
+    // and is persisted to the hidden lockfile, and corgi drops `license`
+    // and `time`, so graph queries like `[license=MPL-2.0]` could not
+    // match a field that was never stored (shipped in 1.0.0-rc.33 via
+    // #1692, reverted in #1707). The vlt type guarantees both, and a
+    // registry that does not know it ignores it and serves the full
+    // packument, so the graph gets every field it relies on either way.
+    // The one shape difference is `scripts`, which the vlt type replaces
+    // with `hasInstallScript`; reify reads the extracted package.json in
+    // that case.
     //
-    // 1. Metadata loss reaches the lockfile. The version entry returned
-    //    here is `node.manifest` and is persisted to vlt-lock.json / the
-    //    hidden lockfile. Corgi drops `license` (also `time`, `readme`,
-    //    `maintainers`, `_rev`, `scripts`), so graph queries like
-    //    `[license=MPL-2.0]` cannot match a field that was never stored.
-    //    Shipped in 1.0.0-rc.33 via #1692 (8ba2b10c); 24 false-positive
-    //    edges in the dependency-check job on #1704
-    //    (`@resvg/resvg-wasm@2.6.2` MPL-2.0 in package.json, blank in the
-    //    stored graph); isolated in #1705; reverted in #1707.
-    //
-    // 2. The RegistryClient disk cache key is method + URL only — no
-    //    accept, no Vary — so a full-packument request can be served a
-    //    cached abbreviated body (and vice versa).
-    //
-    // To revisit: put the requested representation on both the disk-cache
-    // key and the in-flight coalescing key, and have the SWR child
-    // (cache-revalidate / revalidate) re-request the same representation.
+    // The RegistryClient disk cache key is method + URL only, so every
+    // packument request must use this same accept header, and the SWR
+    // revalidation child re-requests the representation it was given.
     const response = await (
       await this.getRegistryClient()
     ).request(pakuURL, {
-      headers: { accept: 'application/json' },
+      headers: { accept: PACKUMENT_ACCEPT },
       ...(useCache === false ? { useCache } : {}),
       // costs a conditional GET per moving selector on an otherwise warm
       // cache, install included. 304s are cheap but not free; the

--- a/src/package-info/tap-snapshots/test/index.ts.test.cjs
+++ b/src/package-info/tap-snapshots/test/index.ts.test.cjs
@@ -8,6 +8,7 @@
 exports[`test/index.ts > TAP > fails on non-200 response > expected not-found URLs 1`] = `
 Set {
   "/lodash",
+  "/lodash?stable",
   "/lodash.tgz",
   "/missing.tgz",
 }

--- a/src/package-info/test/index.ts
+++ b/src/package-info/test/index.ts
@@ -22,7 +22,7 @@ import type {
   PackageInfoClientRequestOptions,
 } from '../src/index.ts'
 import { CacheEntry } from '@vltpkg/registry-client/cache-entry'
-import { PackageInfoClient } from '../src/index.ts'
+import { PackageInfoClient, PACKUMENT_ACCEPT } from '../src/index.ts'
 
 t.saveFixture = true
 
@@ -2235,12 +2235,17 @@ t.test(
       1,
       'made one registry request',
     )
-    // Regression guard: #1692 briefly requested corgi and dropped license
-    // from stored manifests. See PackageInfoClient.#fetchPackument.
+    // Regression guard: #1692 briefly requested npm's corgi and dropped
+    // license from stored manifests. See PackageInfoClient.#fetchPackument.
     t.equal(
       coalescedPackumentAccept,
-      'application/json',
-      'requested the full packument',
+      PACKUMENT_ACCEPT,
+      'requested the vlt packument with a full-packument fallback',
+    )
+    t.notMatch(
+      coalescedPackumentAccept,
+      /vnd\.npm\.install/,
+      'never requests npm corgi',
     )
     t.equal(
       paku,

--- a/src/package-info/test/index.ts
+++ b/src/package-info/test/index.ts
@@ -101,7 +101,10 @@ const PORT = 15443 + Number(process.env.TAP_CHILD_ID || 0)
 const etag = '"yolo"'
 const server = createServer((req, res) => {
   res.setHeader('connection', 'close')
-  switch (req.url) {
+  // most routes serve the same document with or without `?stable`
+  const stable = !!req.url?.endsWith('?stable')
+  const path = stable ? req.url?.slice(0, -'?stable'.length) : req.url
+  switch (path) {
     case '/abbrev/-/abbrev-2.0.0.tgz': {
       abbrevTgzRequests++
       res.setHeader('content-type', 'application/octet-stream')
@@ -195,6 +198,57 @@ const server = createServer((req, res) => {
       )
       res.setHeader('cache-control', 'public, max-age=3600')
       res.setHeader('etag', tag)
+      res.setHeader('content-length', json.byteLength)
+      return res.end(json)
+    }
+    // prereleases and the dist-tags pointing at them are absent from the
+    // `?stable` document, as the vlt registry serves it
+    case '/stable-pkg': {
+      packumentRequests.push(String(req.url))
+      const mani = (version: string) => ({
+        name: 'stable-pkg',
+        version,
+        dist: {
+          tarball: `http://localhost:${PORT}/stable-pkg/-/stable-pkg-${version}.tgz`,
+        },
+      })
+      const versions: Record<string, unknown> = {
+        '1.0.0': mani('1.0.0'),
+        '1.1.0': mani('1.1.0'),
+      }
+      const distTags: Record<string, string> = { latest: '1.1.0' }
+      if (!stable) {
+        versions['2.0.0-beta.1'] = mani('2.0.0-beta.1')
+        distTags.next = '2.0.0-beta.1'
+      }
+      const json = Buffer.from(
+        JSON.stringify({
+          name: 'stable-pkg',
+          'dist-tags': distTags,
+          versions,
+        }),
+      )
+      res.setHeader('content-length', json.byteLength)
+      return res.end(json)
+    }
+    // only ever published prereleases
+    case '/pre-only': {
+      packumentRequests.push(String(req.url))
+      const json = Buffer.from(
+        JSON.stringify({
+          name: 'pre-only',
+          'dist-tags': stable ? {} : { latest: '1.0.0-beta.1' },
+          versions:
+            stable ?
+              {}
+            : {
+                '1.0.0-beta.1': {
+                  name: 'pre-only',
+                  version: '1.0.0-beta.1',
+                },
+              },
+        }),
+      )
       res.setHeader('content-length', json.byteLength)
       return res.end(json)
     }
@@ -356,6 +410,7 @@ let movingRequests = 0
 let movingLatest = '1.0.0'
 let coalescedPackumentRequests = 0
 let coalescedPackumentAccept: string | undefined
+const packumentRequests: string[] = []
 let abbrevTgzRequests = 0
 
 const defaultRegistry = `http://localhost:${PORT}/`
@@ -2415,4 +2470,89 @@ t.test('no registry configured', async t => {
   await t.rejects(manifest('abbrev@2.0.0', noRegistry), {
     cause: { code: 'ECONFIG' },
   })
+})
+
+t.test('stable packuments', async t => {
+  const pi = () =>
+    new PackageInfoClient({ ...options, cache: t.testdir() })
+  t.beforeEach(() => (packumentRequests.length = 0))
+
+  t.test('range that cannot match a prerelease', async t => {
+    const mani = await pi().manifest('stable-pkg@^1')
+    t.equal(mani.version, '1.1.0')
+    t.strictSame(packumentRequests, ['/stable-pkg?stable'])
+  })
+
+  t.test('latest tag', async t => {
+    const mani = await pi().manifest('stable-pkg@latest')
+    t.equal(mani.version, '1.1.0')
+    t.strictSame(packumentRequests, ['/stable-pkg?stable'])
+  })
+
+  t.test('any range', async t => {
+    const mani = await pi().manifest('stable-pkg')
+    t.equal(mani.version, '1.1.0')
+    t.strictSame(packumentRequests, ['/stable-pkg?stable'])
+  })
+
+  t.test('resolve() goes through the same path', async t => {
+    const res = await pi().resolve('stable-pkg@^1')
+    t.match(res.resolved, /stable-pkg-1\.1\.0\.tgz$/)
+    t.strictSame(packumentRequests, ['/stable-pkg?stable'])
+  })
+
+  t.test('other dist-tags need the full packument', async t => {
+    const mani = await pi().manifest('stable-pkg@next')
+    t.equal(mani.version, '2.0.0-beta.1')
+    t.strictSame(packumentRequests, ['/stable-pkg'])
+  })
+
+  t.test(
+    'a prerelease in the range needs the full packument',
+    async t => {
+      const mani = await pi().manifest('stable-pkg@^2.0.0-beta.0')
+      t.equal(mani.version, '2.0.0-beta.1')
+      t.strictSame(packumentRequests, ['/stable-pkg'])
+    },
+  )
+
+  t.test(
+    'a non-default tag option needs the full packument',
+    async t => {
+      const mani = await pi().manifest('stable-pkg', { tag: 'next' })
+      t.equal(mani.version, '2.0.0-beta.1')
+      t.strictSame(packumentRequests, ['/stable-pkg'])
+    },
+  )
+
+  t.test('packument() is never filtered', async t => {
+    const paku = await pi().packument('stable-pkg')
+    t.ok(paku.versions['2.0.0-beta.1'])
+    t.strictSame(packumentRequests, ['/stable-pkg'])
+  })
+
+  t.test(
+    'retries with the full packument for a prerelease-only package',
+    async t => {
+      const mani = await pi().manifest('pre-only@latest')
+      t.equal(mani.version, '1.0.0-beta.1')
+      t.strictSame(packumentRequests, [
+        '/pre-only?stable',
+        '/pre-only',
+      ])
+    },
+  )
+
+  t.test(
+    'still fails when the full packument has no match',
+    async t => {
+      await t.rejects(pi().manifest('stable-pkg@^3'), {
+        message: 'Could not resolve',
+      })
+      t.strictSame(packumentRequests, [
+        '/stable-pkg?stable',
+        '/stable-pkg',
+      ])
+    },
+  )
 })

--- a/src/package-info/test/index.ts
+++ b/src/package-info/test/index.ts
@@ -14,6 +14,7 @@ import { readdir, rmdir, utimes, writeFile } from 'node:fs/promises'
 import { createServer } from 'node:http'
 import { basename, resolve as pathResolve } from 'node:path'
 import { fileURLToPath, pathToFileURL } from 'node:url'
+import { createHash } from 'node:crypto'
 import t from 'tap'
 import { x as tarX } from 'tar'
 import type {
@@ -77,6 +78,9 @@ const pakuAbbrev = JSON.parse(
   readFileSync(pathResolve(fixtures, 'abbrev-full.json'), 'utf8'),
 )
 const tgzAbbrev = readFileSync(fixtures + '/abbrev-2.0.0.tgz')
+const tgzAbbrevSha512 = createHash('sha512')
+  .update(tgzAbbrev)
+  .digest('base64')
 const tgzFile = String(
   pathToFileURL(pathResolve(fixtures, 'abbrev-2.0.0.tgz')),
 )
@@ -370,6 +374,46 @@ const server = createServer((req, res) => {
       res.setHeader('content-type', 'application/json')
       res.setHeader('content-length', json.length)
       return res.end(json)
+    }
+    // vlt packuments: no dist.integrity, registry-relative tarball paths
+    case '/digest':
+    case '/digest-bad':
+    case '/digest-missing': {
+      const name = path.slice(1)
+      const json = JSON.stringify({
+        name,
+        'dist-tags': { latest: '1.0.0' },
+        versions: {
+          '1.0.0': {
+            name,
+            version: '1.0.0',
+            dist: { tarball: `${name}/-/${name}-1.0.0.tgz` },
+          },
+        },
+      })
+      res.setHeader(
+        'content-type',
+        'application/vnd.vlt.packument-v1+json',
+      )
+      res.setHeader('content-length', json.length)
+      return res.end(json)
+    }
+    case '/digest/-/digest-1.0.0.tgz': {
+      res.setHeader('content-type', 'application/octet-stream')
+      res.setHeader('content-length', tgzAbbrev.byteLength)
+      res.setHeader('repr-digest', `sha-512=:${tgzAbbrevSha512}:`)
+      return res.end(tgzAbbrev)
+    }
+    case '/digest-bad/-/digest-bad-1.0.0.tgz': {
+      res.setHeader('content-type', 'application/octet-stream')
+      res.setHeader('content-length', tgzAbbrev.byteLength)
+      res.setHeader('repr-digest', `sha-512=:${'0'.repeat(86)}==:`)
+      return res.end(tgzAbbrev)
+    }
+    case '/digest-missing/-/digest-missing-1.0.0.tgz': {
+      res.setHeader('content-type', 'application/octet-stream')
+      res.setHeader('content-length', tgzAbbrev.byteLength)
+      return res.end(tgzAbbrev)
     }
     case '/no-integrity/-/no-integrity-1.0.0.tgz': {
       // Serve a valid tarball for a package with no dist.integrity
@@ -2525,6 +2569,30 @@ t.test('stable packuments', async t => {
     },
   )
 
+  t.test(
+    'a moving selector only reuses a forced full request',
+    async t => {
+      const p = pi()
+      coalescedPackumentRequests = 0
+      // an exact-version packument request is not forced, so `latest`
+      // (forced, stable) cannot ride along and fetches on its own
+      await Promise.all([
+        p.packument('coalesced@2.0.0'),
+        p.manifest('coalesced@latest'),
+      ])
+      t.equal(coalescedPackumentRequests, 2)
+
+      // both forced: the stable request reuses the full one in flight
+      const q = pi()
+      coalescedPackumentRequests = 0
+      await Promise.all([
+        q.packument('coalesced'),
+        q.manifest('coalesced@latest'),
+      ])
+      t.equal(coalescedPackumentRequests, 1)
+    },
+  )
+
   t.test('packument() is never filtered', async t => {
     const paku = await pi().packument('stable-pkg')
     t.ok(paku.versions['2.0.0-beta.1'])
@@ -2555,4 +2623,108 @@ t.test('stable packuments', async t => {
       ])
     },
   )
+})
+
+t.test('tarballs labelled with a digest', async t => {
+  const pi = () =>
+    new PackageInfoClient({ ...options, cache: t.testdir() })
+  const integrity = `sha512-${tgzAbbrevSha512}`
+
+  t.test(
+    'relative tarball paths resolve against the registry',
+    async t => {
+      const res = await pi().resolve('digest@1.0.0')
+      t.match(res, {
+        resolved: `${defaultRegistry}digest/-/digest-1.0.0.tgz`,
+        integrity: undefined,
+        digestRequired: true,
+      })
+    },
+  )
+
+  t.test(
+    'resolve against a registry without a trailing slash',
+    async t => {
+      const p = new PackageInfoClient({
+        ...options,
+        registry: defaultRegistry.replace(/\/$/, ''),
+        cache: t.testdir(),
+      })
+      const res = await p.resolve('digest@1.0.0')
+      t.equal(
+        res.resolved,
+        `${defaultRegistry}digest/-/digest-1.0.0.tgz`,
+      )
+    },
+  )
+
+  t.test(
+    'extract verifies the digest and hands the hash back',
+    async t => {
+      const dir = t.testdir()
+      const p = pi()
+      const res = await p.extract('digest@1.0.0', `${dir}/a`)
+      t.equal(res.integrity, integrity)
+      await (await p.getRegistryClient()).cache.promise()
+
+      // a fresh resolution of the same tarball is served from the
+      // in-memory cache, hash included
+      const warm = await p.extract('digest@^1', `${dir}/b`)
+      t.equal(warm.integrity, integrity)
+
+      // and a fresh client unpacks it straight off the cache file
+      const cold = new PackageInfoClient({
+        ...options,
+        cache: (await p.getRegistryClient()).cache.path(),
+      })
+      const again = await cold.extract('digest@1.0.0', `${dir}/c`)
+      t.equal(again.integrity, integrity)
+    },
+  )
+
+  t.test('extract rejects a body that does not match', async t => {
+    const dir = t.testdir()
+    await t.rejects(pi().extract('digest-bad@1.0.0', dir), {
+      cause: { code: 'EINTEGRITY', found: integrity },
+    })
+  })
+
+  t.test(
+    'extract requires the digest for a vlt packument',
+    async t => {
+      const dir = t.testdir()
+      await t.rejects(pi().extract('digest-missing@1.0.0', dir), {
+        cause: { code: 'EINTEGRITY', wanted: undefined },
+      })
+    },
+  )
+
+  t.test(
+    'a plain packument without integrity still records the hash',
+    async t => {
+      const dir = t.testdir()
+      const res = await pi().extract('no-integrity@1.0.0', dir)
+      t.equal(res.integrity, integrity)
+    },
+  )
+
+  t.test('tarball() verifies the digest', async t => {
+    const buf = await pi().tarball('digest@1.0.0')
+    t.strictSame(buf, tgzAbbrev)
+    await t.rejects(pi().tarball('digest-bad@1.0.0'), {
+      cause: { code: 'EINTEGRITY' },
+    })
+    await t.rejects(pi().tarball('digest-missing@1.0.0'), {
+      cause: { code: 'EINTEGRITY' },
+    })
+  })
+
+  t.test('full packuments are requested as plain json', async t => {
+    coalescedPackumentRequests = 0
+    coalescedPackumentAccept = undefined
+    const paku = await pi().packument('coalesced', { full: true })
+    t.ok(paku.versions['2.0.0'])
+    t.equal(coalescedPackumentAccept, 'application/json')
+    t.equal(coalescedPackumentRequests, 1)
+  })
 })

--- a/src/query/src/pseudo/scripts.ts
+++ b/src/query/src/pseudo/scripts.ts
@@ -12,6 +12,9 @@ const nodeNeedsBuild = (node: NodeLike): boolean => {
   /* c8 ignore next */
   if (!manifest) return false
 
+  // abbreviated registry manifests replace `scripts` with this flag
+  if (manifest.hasInstallScript) return true
+
   const { scripts = {} } = manifest
 
   // Check for install lifecycle scripts

--- a/src/query/tap-snapshots/test/pseudo/scripts.ts.test.cjs
+++ b/src/query/tap-snapshots/test/pseudo/scripts.ts.test.cjs
@@ -53,6 +53,7 @@ exports[`test/pseudo/scripts.ts > TAP > selects packages that need to be built >
 Object {
   "edges": Array [],
   "nodes": Array [
+    "abbreviated-pkg",
     "install-pkg",
     "postinstall-pkg",
     "preinstall-pkg",

--- a/src/query/test/pseudo/scripts.ts
+++ b/src/query/test/pseudo/scripts.ts
@@ -69,6 +69,10 @@ t.test('selects packages that need to be built', async t => {
         scripts: { postinstall: 'echo post installing' },
       })
       const nodeWithoutScripts = createTestNode('no-scripts-pkg', {})
+      // abbreviated registry manifest: no scripts, only the flag
+      const nodeWithFlag = createTestNode('abbreviated-pkg', {
+        hasInstallScript: true,
+      })
 
       const res = await scripts(
         getState(':scripts', [
@@ -76,12 +80,18 @@ t.test('selects packages that need to be built', async t => {
           nodeWithPreinstall,
           nodeWithPostinstall,
           nodeWithoutScripts,
+          nodeWithFlag,
         ]),
       )
 
       t.strictSame(
         [...res.partial.nodes].map(n => n.name).sort(),
-        ['install-pkg', 'postinstall-pkg', 'preinstall-pkg'],
+        [
+          'abbreviated-pkg',
+          'install-pkg',
+          'postinstall-pkg',
+          'preinstall-pkg',
+        ],
         'should select packages with install lifecycle scripts',
       )
       t.matchSnapshot({

--- a/src/registry-client/src/cache-entry.ts
+++ b/src/registry-client/src/cache-entry.ts
@@ -430,6 +430,20 @@ export class CacheEntry {
   }
 
   /**
+   * The sha-512 member of an RFC 9530 `Repr-Digest` (or `Content-Digest`)
+   * response header, as an SRI string. A registry that serves packuments
+   * without `dist.integrity` labels each tarball this way instead.
+   */
+  get digest(): Integrity | undefined {
+    const value =
+      this.getHeaderString('repr-digest') ??
+      this.getHeaderString('content-digest')
+    const m =
+      value && /(?:^|,)\s*sha-512=:([A-Za-z0-9+/]{86}==):/.exec(value)
+    return m ? `sha512-${m[1]}` : undefined
+  }
+
+  /**
    * Give it a key, and it'll return the buffer of that header value
    */
   getHeader(h: string): Uint8Array | undefined {
@@ -451,6 +465,20 @@ export class CacheEntry {
    */
   setHeader(h: string, value: Uint8Array | string) {
     this.#headers = setRawHeader(this.#headers, h, value)
+  }
+
+  /**
+   * Remove a header, if present
+   */
+  deleteHeader(h: string) {
+    const key = h.toLowerCase()
+    for (let i = 0; i < this.#headers.length; i += 2) {
+      const k = this.#headers[i]
+      if (k && getDecodedValue(k).toLowerCase() === key) {
+        this.#headers.splice(i, 2)
+        return
+      }
+    }
   }
 
   /**

--- a/src/registry-client/src/cache-revalidate.ts
+++ b/src/registry-client/src/cache-revalidate.ts
@@ -12,9 +12,12 @@ export const register = (
   path: string,
   method: 'HEAD' | 'GET',
   url: string | URL,
+  accept?: string[] | string,
 ): void => {
   const r = registered.get(path) ?? new Set<string>()
-  const key = `${method} ${url}`
+  // `METHOD URL[ ACCEPT]`; a serialized URL never contains a space, so
+  // the child splits on the first two.
+  const key = `${method} ${url}${accept ? ` ${String(accept)}` : ''}`
   r.add(key)
   registered.set(path, r)
   if (!didProcessBeforeExitHook) {

--- a/src/registry-client/src/index.ts
+++ b/src/registry-client/src/index.ts
@@ -35,6 +35,7 @@ import type { JSONObj } from './cache-entry.ts'
 import { CacheEntry } from './cache-entry.ts'
 import { register } from './cache-revalidate.ts'
 import { bun, deno, node } from './env.ts'
+import { getHeader } from './get-header.ts'
 import { handleCacheHitResponse } from './handle-304-response.ts'
 import { otplease } from './otplease.ts'
 import { getDispatcher } from './proxy.ts'
@@ -642,8 +643,14 @@ export class RegistryClient {
       entry?.staleWhileRevalidate &&
       m
     ) {
-      // revalidate while returning the stale entry
-      register(dirname(this.cache.path()), m, url)
+      // revalidate while returning the stale entry, re-requesting the
+      // same representation since the cache key does not include accept
+      register(
+        dirname(this.cache.path()),
+        m,
+        url,
+        getHeader(options.headers, 'accept'),
+      )
       logRequest(url, 'stale', { method })
       return entry
     }

--- a/src/registry-client/src/index.ts
+++ b/src/registry-client/src/index.ts
@@ -80,6 +80,8 @@ export type CachedBody = {
   path: string
   /** the body, a view into the file's bytes */
   body: Buffer
+  /** the hash the entry was stored under, if it has one */
+  integrity?: Integrity
 }
 
 export type CacheableMethod = 'GET' | 'HEAD'
@@ -585,7 +587,11 @@ export class RegistryClient {
         ) {
           continue
         }
-        return { path, body: entry.buffer() }
+        return {
+          path,
+          body: entry.buffer(),
+          integrity: entry.integrity,
+        }
       }
       /* c8 ignore next */
     } catch {}
@@ -606,7 +612,7 @@ export class RegistryClient {
       staleWhileRevalidate = true,
       forceRevalidate = false,
     } = options
-    let { trustIntegrity } = options
+    const { trustIntegrity } = options
 
     const m = isCacheableMethod(method) ? method : undefined
     const { useCache = !!m } = options
@@ -745,12 +751,12 @@ export class RegistryClient {
       },
     )
 
-    if (result.getHeader('integrity')) {
-      trustIntegrity = true
-    }
-
-    if (result.isGzip && !trustIntegrity) {
-      result.checkIntegrity({ url })
+    // a server-sent integrity header is not evidence: only the caller's
+    // expectation, or a body read back from the cache, is trusted. the
+    // header is dropped so it can never be stored as the entry's hash.
+    if (!trustIntegrity && !result.fromCache) {
+      result.deleteHeader('integrity')
+      if (result.isGzip) result.checkIntegrity({ url })
     }
     // a forced revalidation must never replace a cached entry with an
     // error response -- the flat 200-only rule revalidate-entry.ts has.
@@ -763,7 +769,15 @@ export class RegistryClient {
     const clobbersCachedEntry =
       forceRevalidate && !!entry && result.statusCode !== 200
     if (useCache && !clobbersCachedEntry) {
-      // Get the encoded buffer from the cache entry
+      // content-address an artifact the caller had no expected hash for,
+      // so a later lookup by hash still finds it; packuments are not
+      // worth hashing. integrityActual also records the hash in the
+      // entry's headers, so it runs before encode().
+      const integrity =
+        result.integrity ??
+        (result.statusCode === 200 && !result.isJSON ?
+          result.integrityActual
+        : undefined)
       const buffer = result.encode()
       this.cache.set(
         key,
@@ -772,9 +786,7 @@ export class RegistryClient {
           buffer.byteOffset,
           buffer.byteLength,
         ),
-        {
-          integrity: result.integrity,
-        },
+        { integrity },
       )
     }
     return result

--- a/src/registry-client/src/revalidate-entry.ts
+++ b/src/registry-client/src/revalidate-entry.ts
@@ -55,6 +55,7 @@ export const revalidateEntry = async (
   rc: RegistryClient,
   method: 'GET' | 'HEAD',
   url: URL | string,
+  accept?: string,
 ): Promise<void> => {
   try {
     const u = typeof url === 'string' ? new URL(url) : url
@@ -86,6 +87,10 @@ export const revalidateEntry = async (
         'npm-session',
         randomUUID(),
       )
+      // the representation the entry was originally fetched with
+      if (accept) {
+        options.headers = addHeader(options.headers, 'accept', accept)
+      }
       setCacheHeaders(options, entry)
       options.headers = addHeader(
         options.headers,

--- a/src/registry-client/src/revalidate.ts
+++ b/src/registry-client/src/revalidate.ts
@@ -19,10 +19,29 @@ const revalidateConcurrency = (raw: string | undefined): number => {
     : defaultConcurrency
 }
 
+type Req = [
+  method: 'GET' | 'HEAD',
+  url: URL,
+  accept: string | undefined,
+]
+
+const parseReq = (line: string): Req | undefined => {
+  const method =
+    line.startsWith('GET ') ? 'GET'
+    : line.startsWith('HEAD ') ? 'HEAD'
+    : undefined
+  if (!method) return undefined
+  const rest = line.substring(method.length + 1)
+  const sp = rest.indexOf(' ')
+  return sp === -1 ?
+      [method, new URL(rest), undefined]
+    : [method, new URL(rest.substring(0, sp)), rest.substring(sp + 1)]
+}
+
 const runPool = async (
-  reqs: ['GET' | 'HEAD', URL][],
+  reqs: Req[],
   concurrency: number,
-  fn: (method: 'GET' | 'HEAD', url: URL) => Promise<void>,
+  fn: (...req: Req) => Promise<void>,
 ) => {
   let next = 0
   const n = Math.min(concurrency, reqs.length)
@@ -34,7 +53,7 @@ const runPool = async (
         const req = reqs[i]
         /* c8 ignore next */
         if (req === undefined) return
-        await fn(req[0], req[1])
+        await fn(...req)
       }
     }),
   )
@@ -47,7 +66,7 @@ export const main = async (
   if (!cache) {
     return false
   }
-  const reqs = await new Promise<['GET' | 'HEAD', URL][]>(res => {
+  const reqs = await new Promise<Req[]>(res => {
     const chunks: Buffer[] = []
     let chunkLen = 0
     input.on('data', (chunk: Buffer) => {
@@ -55,20 +74,11 @@ export const main = async (
       chunkLen += chunk.length
     })
     input.on('end', () => {
-      const reqs: ['GET' | 'HEAD', URL][] = Buffer.concat(
-        chunks,
-        chunkLen,
-      )
+      const reqs = Buffer.concat(chunks, chunkLen)
         .toString()
         .split('\0')
-        .filter(
-          i => !!i && (i.startsWith('GET ') || i.startsWith('HEAD ')),
-        )
-        .map(i =>
-          i.startsWith('GET ') ?
-            ['GET', new URL(i.substring('GET '.length))]
-          : ['HEAD', new URL(i.substring('HEAD '.length))],
-        )
+        .map(parseReq)
+        .filter(req => req !== undefined)
 
       res(reqs)
     })
@@ -82,7 +92,7 @@ export const main = async (
   await runPool(
     reqs,
     revalidateConcurrency(process.env.VLT_REVALIDATE_CONCURRENCY),
-    (method, url) => revalidateEntry(rc, method, url),
+    (method, url, accept) => revalidateEntry(rc, method, url, accept),
   )
 
   return true

--- a/src/registry-client/test/cache-entry.ts
+++ b/src/registry-client/test/cache-entry.ts
@@ -839,3 +839,45 @@ t.test('decodeHead / encodeHead', t => {
   t.type(constructed.headSize, 'number')
   t.end()
 })
+
+t.test('digest header', async t => {
+  const b64 = 'A'.repeat(86) + '=='
+  const entry = (h: Record<string, string>) =>
+    new CacheEntry(200, toRawHeaders(h))
+  t.equal(
+    entry({ 'repr-digest': `sha-512=:${b64}:` }).digest,
+    `sha512-${b64}`,
+  )
+  t.equal(
+    entry({ 'content-digest': `sha-512=:${b64}:` }).digest,
+    `sha512-${b64}`,
+    'content-digest is accepted too',
+  )
+  t.equal(
+    entry({
+      'repr-digest': `sha-256=:${'B'.repeat(43)}=:, sha-512=:${b64}:`,
+    }).digest,
+    `sha512-${b64}`,
+    'picks the sha-512 member of a dictionary',
+  )
+  t.equal(
+    entry({ 'repr-digest': `sha-256=:${'B'.repeat(43)}=:` }).digest,
+    undefined,
+  )
+  t.equal(
+    entry({ 'repr-digest': 'sha-512=:nope:' }).digest,
+    undefined,
+  )
+  t.equal(entry({}).digest, undefined)
+})
+
+t.test('deleteHeader', async t => {
+  const ce = new CacheEntry(
+    200,
+    toRawHeaders({ a: '1', Integrity: 'x', b: '2' }),
+  )
+  ce.deleteHeader('integrity')
+  t.strictSame(ce.headers, toRawHeaders({ a: '1', b: '2' }))
+  ce.deleteHeader('nope')
+  t.strictSame(ce.headers, toRawHeaders({ a: '1', b: '2' }))
+})

--- a/src/registry-client/test/cache-revalidate.ts
+++ b/src/registry-client/test/cache-revalidate.ts
@@ -45,6 +45,7 @@ t.test('registering the beforeExit event', async t => {
               'GET https://example.com/\x00',
               'HEAD https://example.com/2\x00',
               'GET https://example.com/3\x00',
+              'GET https://example.com/4 application/json; q=0.8, */*\x00',
             ])
           },
         }
@@ -55,6 +56,12 @@ t.test('registering the beforeExit event', async t => {
   register(t.testdirName, 'GET', 'https://example.com/')
   register(t.testdirName, 'HEAD', 'https://example.com/2')
   register(t.testdirName, 'GET', 'https://example.com/3')
+  register(
+    t.testdirName,
+    'GET',
+    'https://example.com/4',
+    'application/json; q=0.8, */*',
+  )
   t.equal(beHooks.length, 1)
   t.type(beHooks[0], 'function')
   beHooks[0]?.()

--- a/src/registry-client/test/index.ts
+++ b/src/registry-client/test/index.ts
@@ -5,6 +5,7 @@ import { linkSync, readFileSync } from 'node:fs'
 import { dirname, resolve } from 'node:path'
 import { gzipSync } from 'node:zlib'
 import type { Test } from 'tap'
+import { createHash } from 'node:crypto'
 import t from 'tap'
 import type { Dispatcher } from 'undici'
 import { CacheEntry } from '../src/cache-entry.ts'
@@ -378,13 +379,14 @@ t.test('register unzipping for gzip responses', async t => {
 
 t.test('integrity http header handling', async t => {
   const rc = t.context.rc as RegistryClient
-  const ok = await rc.request(`${registryURL}/some/tarball`, {
-    integrity:
-      'sha512-00000000000000000000000000000000000000000000000000000000000000000000000000000000000000==',
-  })
-  t.equal(
-    ok.integrity,
-    'sha512-00000000000000000000000000000000000000000000000000000000000000000000000000000000000000==',
+  // the registry echoes the expected integrity in a header, but the
+  // body does not hash to it: a server header is never trusted
+  await t.rejects(
+    rc.request(`${registryURL}/some/tarball`, {
+      integrity:
+        'sha512-00000000000000000000000000000000000000000000000000000000000000000000000000000000000000==',
+    }),
+    { cause: { code: 'EINTEGRITY' } },
   )
   const notOk = await rc.request(
     `${registryURL}/some/other/tarball`,
@@ -395,6 +397,29 @@ t.test('integrity http header handling', async t => {
   )
   t.match(notOk, { statusCode: 406 })
   await rc.cache.promise()
+})
+
+t.test('artifact with no expected integrity', async t => {
+  const dir = t.testdir()
+  const rc = new RC({ cache: dir })
+  const url = `${registryURL}/some/unlabelled/tarball`
+  const res = await rc.request(url)
+  const actual = `sha512-${createHash('sha512')
+    .update(res.buffer())
+    .digest('base64')}`
+  t.equal(res.integrity, undefined, 'nothing was expected')
+  t.equal(
+    res.getHeaderString('integrity'),
+    actual,
+    'the server-sent integrity header is replaced by the real hash',
+  )
+  await rc.cache.promise()
+
+  // a fresh client reads it back from disk, content-addressed
+  const again = new RC({ cache: dir })
+  const found = again.cachedBody(url, { integrity: actual })
+  t.equal(found?.path, again.cache.integrityPath(actual))
+  t.equal(found?.integrity, actual, 'stored under its hash')
 })
 
 t.test('follow redirects', { saveFixture: true }, async t => {

--- a/src/registry-client/test/revalidate-entry.ts
+++ b/src/registry-client/test/revalidate-entry.ts
@@ -60,6 +60,21 @@ t.test('missing cache file is a no-op', async t => {
   t.equal(hits, 0)
 })
 
+t.test('re-requests the representation it was given', async t => {
+  const accepts: (string | undefined)[] = []
+  const { url } = await listen(t, (req, res) => {
+    accepts.push(req.headers.accept)
+    res.statusCode = 304
+    res.end()
+  })
+  const rc = new RegistryClient({ cache: t.testdir() })
+  const target = `${url}/pkg`
+  await seed(rc, 'GET', target, jsonEntry({ etag: '"abc"' }))
+  await revalidateEntry(rc, 'GET', target)
+  await revalidateEntry(rc, 'GET', target, 'application/json')
+  t.strictSame(accepts, [undefined, 'application/json'])
+})
+
 t.test('truncated cache file is a no-op', async t => {
   let hits = 0
   const { url } = await listen(t, (_req, res) => {

--- a/src/registry-client/test/revalidate.ts
+++ b/src/registry-client/test/revalidate.ts
@@ -67,9 +67,11 @@ t.test('validate args', async t => {
 
 t.test('revalidate a url', async t => {
   let requests = 0
+  const accepts: (string | undefined)[] = []
   const server = createServer((req, res) => {
     t.equal(req.url, '/' + String(req.method))
     requests++
+    accepts.push(req.headers.accept)
     req.resume()
     res.setHeader('connection', 'close')
     res.end('ok')
@@ -99,9 +101,14 @@ t.test('revalidate a url', async t => {
         env: ENV,
       },
     )
-    cp.stdin.write(`GET ${reg}/GET\0HEAD ${reg}/HEAD\0`, () => {
-      cp.stdin.end()
-    })
+    // the accept is everything after the URL, spaces included
+    cp.stdin.write(
+      `GET ${reg}/GET\0HEAD ${reg}/HEAD\0` +
+        `GET ${reg}/GET application/vnd.vlt.packument-v1+json; q=1.0, application/json; q=0.8, */*\0`,
+      () => {
+        cp.stdin.end()
+      },
+    )
     cp.on('close', (status, signal) => {
       res({ status, signal })
     })
@@ -112,7 +119,12 @@ t.test('revalidate a url', async t => {
     signal: null,
   })
 
-  t.equal(requests, 2)
+  t.equal(requests, 3)
+  t.strictSame(accepts.sort(), [
+    'application/vnd.vlt.packument-v1+json; q=1.0, application/json; q=0.8, */*',
+    undefined,
+    undefined,
+  ])
 })
 
 t.test('pool caps in-flight requests', async t => {

--- a/src/run/src/index.ts
+++ b/src/run/src/index.ts
@@ -147,7 +147,10 @@ export type RunOptions = SharedOptions & {
   /**
    * Pass in a manifest to avoid having to read it at all
    */
-  manifest?: Pick<Manifest, 'scripts' | 'gypfile'>
+  manifest?: Pick<
+    Manifest,
+    'scripts' | 'gypfile' | 'hasInstallScript'
+  >
 
   /**
    * if the script is not defined in package.json#scripts, just ignore it and
@@ -252,12 +255,14 @@ const runImpl = async <
   // npm adds a `"install": "node-gyp rebuild"` if a binding.gyp
   // is present at the time of publish, EVEN IF it's not included
   // in the package. So, we need to read the actual package.json
-  // in those cases.
-  const untrustworthy = !!(
-    manifest?.gypfile &&
-    arg0 === 'install' &&
-    manifest.scripts?.install === 'node-gyp rebuild'
-  )
+  // in those cases. Likewise an abbreviated registry manifest only
+  // says `hasInstallScript`, and the scripts live on disk.
+  const untrustworthy =
+    !!manifest &&
+    ((manifest.gypfile === true &&
+      arg0 === 'install' &&
+      manifest.scripts?.install === 'node-gyp rebuild') ||
+      (manifest.hasInstallScript === true && !manifest.scripts))
   const pj =
     (untrustworthy ? undefined : manifest) ??
     packageJson.read(options.cwd)

--- a/src/run/test/index.ts
+++ b/src/run/test/index.ts
@@ -981,6 +981,40 @@ t.test('do not trust manifests npm mucks with', async t => {
 })
 
 t.test(
+  'read scripts from disk for abbreviated manifests',
+  async t => {
+    const cwd = t.testdir({
+      'package.json': JSON.stringify({
+        name: 'x',
+        version: '1.2.3',
+        scripts: { install: 'echo ok' },
+      }),
+    })
+    // an abbreviated registry manifest has no scripts to run
+    const manifest: Manifest = {
+      name: 'x',
+      version: '1.2.3',
+      hasInstallScript: true,
+    }
+    const res = await run({
+      cwd,
+      manifest,
+      arg0: 'install',
+      projectRoot: cwd,
+      color: true,
+    })
+    t.match(res, {
+      command: 'echo ok',
+      args: [],
+      status: 0,
+      signal: null,
+      stdout: 'ok',
+      stderr: '',
+    })
+  },
+)
+
+t.test(
   'detect binding.gyp and run implicit node-gyp rebuild',
   async t => {
     // Track what commands were executed

--- a/src/types/src/index.ts
+++ b/src/types/src/index.ts
@@ -853,6 +853,13 @@ export type Manifest = {
   bin?: Record<string, string> | string
   /** run-script actions for this package */
   scripts?: Record<string, string>
+  /**
+   * Set in place of `scripts` by abbreviated registry manifests (npm's
+   * `application/vnd.npm.install-v1+json` and vlt's
+   * `application/vnd.vlt.packument-v1+json`) when the package has an
+   * install, preinstall, or postinstall script.
+   */
+  hasInstallScript?: boolean
   /** supported run-time platforms this package can run on */
   engines?: Record<string, string>
   /** supported operating systems this package can run on */

--- a/src/vlx/src/install.ts
+++ b/src/vlx/src/install.ts
@@ -83,7 +83,7 @@ export const vlxInstall = async (
     JSON.stringify(manifest, null, 2) + '\n',
   )
 
-  await install({
+  const { graph } = await install({
     ...options,
     packageInfo,
     projectRoot: dir,
@@ -92,6 +92,17 @@ export const vlxInstall = async (
     // allow lifecycle scripts but filter out malware via security archive
     allowScripts: ':scripts:not(:malware)',
   })
+
+  // an abbreviated packument carries no integrity; the install hashed
+  // the tarball it extracted, so pin that
+  const installed = graph.mainImporter.edgesOut.get(pkgSpec.name)?.to
+  if (!manifest.vlx.integrity && installed?.integrity) {
+    manifest.vlx.integrity = installed.integrity
+    await writeFile(
+      resolve(dir, 'package.json'),
+      JSON.stringify(manifest, null, 2) + '\n',
+    )
+  }
 
   return vlxInfo(dir, options, manifest)
 }

--- a/src/vlx/test/install.ts
+++ b/src/vlx/test/install.ts
@@ -5,7 +5,7 @@ import { resolve } from 'node:path'
 import type { Test } from 'tap'
 import t from 'tap'
 import type { VlxOptions } from '../src/index.ts'
-import { mkdirSync } from 'node:fs'
+import { mkdirSync, readFileSync } from 'node:fs'
 
 const getVlxInstall = async (
   t: Test,
@@ -15,12 +15,18 @@ const getVlxInstall = async (
       path,
       options,
     }),
+    resolvedIntegrity = 'sha512-AO2ac6pjRB3SJmGJo+v5/aK6Omggp6fsLrs6wN9bd35ulu4cCwaAU9+7ZhXjeqHVkaHThLuzH0nZr0YpCDhygg==',
+    installedIntegrity,
   }: {
     mockVlxInfo?: (
       path: string,
       options: VlxOptions,
       manifest?: NormalizedManifest,
     ) => { path: string; options: VlxOptions }
+    /** what package-info resolves to before the install; null for none */
+    resolvedIntegrity?: string | null
+    /** what the install hashed while extracting */
+    installedIntegrity?: string
   } = {},
 ) => {
   const installs: [string, NormalizedManifest][] = []
@@ -31,6 +37,15 @@ const getVlxInstall = async (
     const { projectRoot, packageJson } = options
     t.equal(options['stale-while-revalidate-factor'], Infinity)
     installs.push([projectRoot, packageJson.read(projectRoot)])
+    return {
+      graph: {
+        mainImporter: {
+          edgesOut: new Map([
+            ['abbrev', { to: { integrity: installedIntegrity } }],
+          ]),
+        },
+      },
+    }
   }
 
   class MockPackageInfoClient {
@@ -38,8 +53,7 @@ const getVlxInstall = async (
       return {
         resolved:
           'https://registry.npmjs.org/abbrev/-/abbrev-3.0.1.tgz',
-        integrity:
-          'sha512-AO2ac6pjRB3SJmGJo+v5/aK6Omggp6fsLrs6wN9bd35ulu4cCwaAU9+7ZhXjeqHVkaHThLuzH0nZr0YpCDhygg==',
+        integrity: resolvedIntegrity ?? undefined,
       }
     }
   }
@@ -114,6 +128,30 @@ t.test('need an install, accept prompt with --yes', async t => {
   t.strictSame(installs[0]?.[1].dependencies, {
     abbrev: 'https://registry.npmjs.org/abbrev/-/abbrev-3.0.1.tgz',
   })
+})
+
+t.test('pins the integrity the install hashed', async t => {
+  const integrity = `sha512-${'a'.repeat(86)}==`
+  const { vlxInstall, options, expectedInstallDir, installs } =
+    await getVlxInstall(t, {
+      // an abbreviated packument resolves without one
+      resolvedIntegrity: null,
+      installedIntegrity: integrity,
+    })
+  await vlxInstall(
+    'abbrev',
+    { ...options, yes: true },
+    async () => 'no',
+  )
+  t.equal(
+    installs[0]?.[1].vlx?.integrity,
+    undefined,
+    'none before install',
+  )
+  const written = JSON.parse(
+    readFileSync(resolve(expectedInstallDir, 'package.json'), 'utf8'),
+  )
+  t.equal(written.vlx.integrity, integrity, 'recorded after install')
 })
 
 t.test('need no install, prompt not relevant', async t => {


### PR DESCRIPTION
This is part of an experiment to move sha digests out of packuments and move
them into HTTP response headers for tarballs.

The hashes compress terribly and the difference in gzip payload can be
dramatic.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>